### PR TITLE
Check for undefined for popup content

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -93,7 +93,8 @@ L.Popup = L.Class.extend({
 	
 	_updateContent: function() {
 		//TODO accept DOM nodes along with HTML strings
-		this._contentNode.innerHTML = this._content;
+		if (this._content != undefined)
+			this._contentNode.innerHTML = this._content;
 	},
 	
 	_updateLayout: function() {


### PR DESCRIPTION
Added check on popup content variable for undefined to prevent content being to string 'undefined' when setContent hasn't been called yet
