### PR TITLE
Fixed mis-spelling of Path.VML.js in deps.js.

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -82,7 +82,7 @@ var deps = {
 	},
 	
 	PathVML: {
-		src: ['layer/vector/PathVML.js'],
+		src: ['layer/vector/Path.VML.js'],
 		desc: 'VML fallback for vector rendering core (IE 6-8).'
 	},
 	


### PR DESCRIPTION
The custom builder is currently broken for a custom building including PathVML, because a period is missing from Path.VML.js in deps.js. Fixed here.
