### PR TITLE
Geolocation API position options

### DIFF
--- a/src/map/ext/Map.Geolocation.js
+++ b/src/map/ext/Map.Geolocation.js
@@ -3,12 +3,14 @@
  */
 
 L.Map.include({
-	locate: function() {
+	locate: function(/*Object*/ options) {
+		var opts = {timeout: 10000};
+		L.Util.extend(opts, options); // W3C Geolocation API Spec position options, http://dev.w3.org/geo/api/spec-source.html#position-options
 		if (navigator.geolocation) {
 			navigator.geolocation.getCurrentPosition(
 					L.Util.bind(this._handleGeolocationResponse, this),
 					L.Util.bind(this._handleGeolocationError, this),
-					{timeout: 10000});
+					opts);
 		} else {
 			this.fire('locationerror', {
 				code: 0,


### PR DESCRIPTION
Adding options to L.Map.locate that follows the PositionOptions spec for the W3C Geolocation API. You can now pass "enableHighAccuracy" and "maximumAge" to get fresh, accurate positions.
