### PR TITLE
Documentation for new options parameter for L.Map.locate

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -538,9 +538,9 @@ map.addLayer(cloudmade);</code></pre>
 				<td>Checks if the map container size changed and updates the map if so &mdash; call it after you've changed the map size dynamically.</td>
 			</tr>
 			<tr>
-				<td><code>locate()</code></td>
+				<td><code>locate( &lt;Object&gt;&nbsp;<code>options?</code> )</code></td>
 				<td><code>this</code></td>
-				<td>Tries to locate the user using Geolocation API, firing <code>locationfound</code> event with location data on success or <code>locationerror</code> event on failure.<!-- Usage example:
+				<td>Tries to locate the user using Geolocation API, firing <code>locationfound</code> event with location data on success or <code>locationerror</code> event on failure. Options are PositionOptions from the <a href="http://dev.w3.org/geo/api/spec-source.html#position-options">W3C Geolocation API</a>.<!-- Usage example:
 				<pre><code class="javascript">map
 	.on('locationfound', function(e) { map.fitBounds(e.bounds); })
 	.on('locationerror', function(e) { alert(e.message); })

--- a/src/map/ext/Map.Geolocation.js
+++ b/src/map/ext/Map.Geolocation.js
@@ -3,12 +3,14 @@
  */
 
 L.Map.include({
-	locate: function() {
+	locate: function(/*Object*/ options) {
+		var opts = {timeout: 10000};
+		L.Util.extend(opts, options); // W3C Geolocation API Spec position options, http://dev.w3.org/geo/api/spec-source.html#position-options
 		if (navigator.geolocation) {
 			navigator.geolocation.getCurrentPosition(
 					L.Util.bind(this._handleGeolocationResponse, this),
 					L.Util.bind(this._handleGeolocationError, this),
-					{timeout: 10000});
+					opts);
 		} else {
 			this.fire('locationerror', {
 				code: 0,


### PR DESCRIPTION
Adding options to L.Map.locate that follows the PositionOptions spec for the W3C Geolocation API. You can now pass "enableHighAccuracy" and "maximumAge" to get fresh, accurate positions.
