### PR TITLE
minZoom, maxZoom documentation for Map

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -275,6 +275,18 @@ map.addLayer(cloudmade);</code></pre>
 				<td>depends</td>
 				<td>Whether the tile fade animation is enabled. By default it's enabled in all browsers that support CSS3 Transitions except Android.</td>
 			</tr>
+			<tr>
+				<td><code>minZoom</code></td>
+				<td><code>Number</code></td>
+				<td>0</td>
+				<td>Minimum zoom level of map. This overrides any minZoom set on a layer.</td>
+			</tr>
+			<tr>
+				<td><code>maxZoom</code></td>
+				<td><code>Number</code></td>
+				<td>18</td>
+				<td>Maximum zoom level of map. This overrides any maxZoom set on a layer.</td>
+			</tr>
 		</table>
 		
 		<h3 id="map-properties">Properties</h3>


### PR DESCRIPTION
I assumed the default values were the same for a TileLayer (0, 18). Should close #139.
