### PR TITLE
Fix Bounds.contains method in case if obj argument is instance of L.Point

### DIFF
--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -40,4 +40,14 @@ describe('Bounds', function() {
 			expect(a.getCenter()).toEqual(new L.Point(22, 26));
 		});
 	});
+    
+	describe('#contains', function() {
+	    it('should contains other bounds or point', function() {
+	        a.extend(new L.Point(50, 10));
+	        expect(a.contains(b)).toBeTruthy();
+	        expect(b.contains(a)).toBeFalsy();
+	        expect(a.contains(new L.Point(24, 25))).toBeTruthy();
+	        expect(a.contains(new L.Point(54, 65))).toBeFalsy();
+	    });
+	});
 });

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -37,7 +37,7 @@ L.Bounds = L.Class.extend({
 			min = obj.min;
 			max = obj.max;
 		} else {
-			max = max = obj;
+			min = max = obj;
 		}
 		
 		return (min.x >= this.min.x) && 


### PR DESCRIPTION
see diff..
