### PR TITLE
Fix for calculation of Scrolling offset

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -117,7 +117,7 @@ L.DomEvent = {
 			y = e.pageY ? e.pageY : e.clientY + 
 					document.body.scrollTop + document.documentElement.scrollTop,
 			pos = new L.Point(x, y);
-			
+			pos=pos.add(L.DomUtil.getCumulativeScroll(container))
 		return (container ? 
 					pos.subtract(L.DomUtil.getCumulativeOffset(container)) : pos);
 	},

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -28,7 +28,16 @@ L.DomUtil = {
 			el = el.offsetParent;
 		} while (el);
 		return new L.Point(left, top);
-	},
+	},getCumulativeScroll: function(el){
+        var top=0,
+            left=0;
+        do {
+            top+=el.scrollTop || 0;
+            left+=el.scrollLeft || 0;
+            el=el.parentNode;
+        }while(el);
+        return new L.Point(left,top)
+    },
 	
 	create: function(tagName, className, container) {
 		var el = document.createElement(tagName);


### PR DESCRIPTION
the current implementation only accounts scrolling offset of the body but not from other parent elements. I added a method to the Dom Util that iterates through the container parents and sums up the offsets. I tested it in my implementation and it fixed to issue i posted here https://github.com/CloudMade/Leaflet/issues/206
