### PR TITLE
fix setIcon in Marker.js

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -54,6 +54,7 @@ L.Marker = L.Class.extend({
 		this.options.icon = icon;
 		
 		this._initIcon();
+		this._reset();
 	},
 	
 	_initIcon: function() {


### PR DESCRIPTION
I also needed a highlight marker such as HooliganQC#209

After execute setIcon to change the icon, had no position.
I added the method `this._reset` after `this._initIcon` in `Marker.setIcon`.
