### PR TITLE
Use john resig's constructor to return objects without 'new' keyword

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -2,12 +2,16 @@
  * Class powers the OOP facilities of the library. Thanks to John Resig and Dean Edwards for inspiration!
  */
 
-L.Class = function() {}; 
+L.Class = function() {};
 
 L.Class.extend = function(/*Object*/ props) /*-> Class*/ {
-	
+
 	// extended class with the new prototype
 	var NewClass = function() {
+    if ( !(this instanceof arguments.callee) ){
+      return new arguments.callee(arguments);
+    }
+
 		if (this.initialize) {
 			this.initialize.apply(this, arguments);
 		}
@@ -17,16 +21,16 @@ L.Class.extend = function(/*Object*/ props) /*-> Class*/ {
 	var F = function() {};
 	F.prototype = this.prototype;
 	var proto = new F();
-	
+
 	proto.constructor = NewClass;
 	NewClass.prototype = proto;
-	
+
 	// add superclass access
 	NewClass.superclass = this.prototype;
-	
+
 	// add class name
 	//proto.className = props;
-	
+
 	//inherit parent's statics
 	for (var i in this) {
 		if (this.hasOwnProperty(i) && i != 'prototype' && i != 'superclass') {
@@ -39,13 +43,13 @@ L.Class.extend = function(/*Object*/ props) /*-> Class*/ {
 		L.Util.extend(NewClass, props.statics);
 		delete props.statics;
 	}
-	
+
 	// mix includes into the prototype
 	if (props.includes) {
 		L.Util.extend.apply(null, [proto].concat(props.includes));
 		delete props.includes;
 	}
-	
+
 	// merge options
 	if (props.options && proto.options) {
 		props.options = L.Util.extend({}, proto.options, props.options);
@@ -53,14 +57,14 @@ L.Class.extend = function(/*Object*/ props) /*-> Class*/ {
 
 	// mix given properties into the prototype
 	L.Util.extend(proto, props);
-	
+
 	// allow inheriting further
 	NewClass.extend = arguments.callee;
-	
+
 	// method for adding properties to prototype
 	NewClass.include = function(props) {
 		L.Util.extend(this.prototype, props);
 	};
-	
+
 	return NewClass;
 };

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -3,6 +3,10 @@
 */
 
 L.LatLng = function(/*Number*/ rawLat, /*Number*/ rawLng, /*Boolean*/ noWrap) {
+	if (! (this instanceof arguments.callee)) {
+	  return new arguments.callee(arguments);
+	}
+
 	var lat = parseFloat(rawLat),
 		lng = parseFloat(rawLng);
 	

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -3,6 +3,9 @@
  */
 
 L.Point = function(/*Number*/ x, /*Number*/ y, /*Boolean*/ round) {
+  if ( !(this instanceof arguments.callee) ){
+   return new L.Point(x, y);
+  }
 	this.x = (round ? Math.round(x) : x);
 	this.y = (round ? Math.round(y) : y);
 };
@@ -11,56 +14,56 @@ L.Point.prototype = {
 	add: function(point) {
 		return this.clone()._add(point);
 	},
-	
+
 	_add: function(point) {
 		this.x += point.x;
 		this.y += point.y;
-		return this;		
+		return this;
 	},
-		
+
 	subtract: function(point) {
 		return this.clone()._subtract(point);
 	},
-	
+
 	// destructive subtract (faster)
 	_subtract: function(point) {
 		this.x -= point.x;
 		this.y -= point.y;
 		return this;
 	},
-	
+
 	divideBy: function(num, round) {
 		return new L.Point(this.x/num, this.y/num, round);
 	},
-	
+
 	multiplyBy: function(num) {
 		return new L.Point(this.x * num, this.y * num);
 	},
-	
+
 	distanceTo: function(point) {
 		var x = point.x - this.x,
 			y = point.y - this.y;
 		return Math.sqrt(x*x + y*y);
 	},
-	
+
 	round: function() {
 		return this.clone()._round();
 	},
-	
+
 	// destructive round
 	_round: function() {
 		this.x = Math.round(this.x);
 		this.y = Math.round(this.y);
 		return this;
 	},
-	
+
 	clone: function() {
 		return new L.Point(this.x, this.y);
 	},
-	
+
 	toString: function() {
-		return 'Point(' + 
-				L.Util.formatNum(this.x) + ', ' + 
-				L.Util.formatNum(this.y) + ')'; 
+		return 'Point(' +
+				L.Util.formatNum(this.x) + ', ' +
+				L.Util.formatNum(this.y) + ')';
 	}
 };


### PR DESCRIPTION
Some time ago, I came across John Resig's studies on [javascript class instantiation](http://ejohn.org/blog/simple-class-instantiation/). Since then, I've found the 'new' keyword to be a bit of a wart on the language. 

In John's post, he defines a constructor style that supports instantiating objects without the 'new' keyword -- namely by testing for the context in the constructor to be an instance of the class you're creating, and if not, returning the appropriate type.

Most things extend L.Class, so I patched that first.

This enables you to write either of these:

var foo = new L.Point(x, y);

or

var foo = L.Point(x, y);

Without this patch, the second code snippet will always return undefined. My feeling is that returning a real object is always preferable to returning undefined. Your thoughts? I'm open to suggestions.
