### PR TITLE
Fire a "tileunload" when tiles removed

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -176,15 +176,17 @@ L.TileLayer = L.Class.extend({
 				
 				// remove tile if it's out of bounds
 				if (x < bounds.min.x || x > bounds.max.x || y < bounds.min.y || y > bounds.max.y) {
-
-					this.fire("tileunload", {tile: this._tiles[key], url: this._tiles[key].src});
-
+					
+					var tile = this._tiles[key];
+					this.fire("tileunload", {tile: tile, url: tile.src});
+					
 					// evil, don't do this! crashes Android 3, produces load errors, doesn't solve memory leaks
 					// this._tiles[key].src = ''; 
 					
-					if (this._tiles[key].parentNode == this._container) {
-						this._container.removeChild(this._tiles[key]);
+					if (tile.parentNode == this._container) {
+						this._container.removeChild(tile);
 					}
+					// could be tile...?
 					delete this._tiles[key];
 				}
 			}


### PR DESCRIPTION
I load json data along with the tiles, and want to get rid of this data when a tile is not availabe anymore to save memory. 
So a "tileunload" analogue to "tileload" would be nice. 
This change fires a "tileunload" for the tiles panned out view if "unloadInvisibleTiles" is set.
