### PR TITLE
Adding toBBoxString method to LatLngBounds

### DIFF
--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -56,6 +56,10 @@ L.LatLngBounds = L.Class.extend({
 		
 		return (sw2.lat >= sw.lat) && (ne2.lat <= ne.lat) &&
 				(sw2.lng >= sw.lng) && (ne2.lng <= ne.lng);
+	},
+		
+	toBBoxString: function() {
+		return this._southWest.lng + "," + this._southWest.lat + "," + this._northEast.lng + "," + this._northEast.lat;
 	}
 });
 


### PR DESCRIPTION
Adding "toBBoxString" method to LatLngBounds. I'm following the OpenSearch Geo spec which is different than what was originally request in #216. If this is acceptable and pulled I'll update the docs as well.
