### PR TITLE
L.Map#invalidateSize calls #getSize on a global object

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -177,9 +177,9 @@ L.Map = L.Class.extend({
 	},
 	
 	invalidateSize: function() {
-		var oldSize = map.getSize();
+		var oldSize = this.getSize();
 		this._sizeChanged = true;
-		this._rawPanBy(oldSize.subtract(map.getSize()).divideBy(2));
+		this._rawPanBy(oldSize.subtract(this.getSize()).divideBy(2));
 		
 		this.fire('move');
 		


### PR DESCRIPTION
`L.Map#invalidateSize` assumes there is a global object `map` that is an instance of `L.Map`.
Instead it should call its instance method.

I guess this is just a leftover from some prototyping. :)
Fix is attached.

Keep up the great work! I really enjoy this map client.

Cheers,

Chris
