### PR TITLE
moved viewreset event handler to a callback function

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -42,11 +42,7 @@ L.TileLayer = L.Class.extend({
 		this._createTileProto();
 
 		// set up events
-		map.on('viewreset',
-			function(e) {
-				this._reset(e.hard);
-			},
-			this);
+		map.on('viewreset', this._resetCallback, this);
 
 		if (this.options.updateWhenIdle) {
 			map.on('moveend', this._update, this);
@@ -63,7 +59,7 @@ L.TileLayer = L.Class.extend({
 		this._map.getPanes().tilePane.removeChild(this._container);
 		this._container = null;
 
-		this._map.off('viewreset', this._reset, this);
+		this._map.off('viewreset', this._resetCallback, this);
 
 		if (this.options.updateWhenIdle) {
 			this._map.off('moveend', this._update, this);
@@ -110,6 +106,10 @@ L.TileLayer = L.Class.extend({
 
 			this._setOpacity(this.options.opacity);
 		}
+	},
+
+	_resetCallback: function(e) {
+		this._reset(e.hard);
 	},
 
 	_reset: function(clearOldContainer) {


### PR DESCRIPTION
- before event handler wasn't removed and causing this event to fire on removed layers as well
