### PR TITLE
Fix map reference for _onDragEnd method.

### DIFF
--- a/src/handler/MapDrag.js
+++ b/src/handler/MapDrag.js
@@ -63,7 +63,7 @@ L.Handler.MapDrag = L.Handler.extend({
 	},
 
 	_onDragEnd: function() {
-		map.fire('moveend');
-		map.fire('dragend');
+		this._map.fire('moveend');
+		this._map.fire('dragend');
 	}
 });


### PR DESCRIPTION
The recent change to _onDragEnd broke it since they reference an undefined variable map.
