### PR TITLE
properly removing property from an event object.

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -59,7 +59,7 @@ L.DomEvent = {
 		} else if ('detachEvent' in obj) {
 			obj.detachEvent("on" + type, handler);
 		}
-		obj[key] = null;
+		delete obj[key];
 	},
 
 	_checkMouse: function(el, e) {


### PR DESCRIPTION
before this it was impossible to register same event after it has been removed.
