### PR TITLE
Fix `this._map is null` error caused by 14ba939

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -46,7 +46,7 @@ L.Path = L.Class.extend({
 	},
 	
 	onRemove: function(map) {
-		this._map = null;
+		this._map = map;
 		
 		map._pathRoot.removeChild(this._container);
 		


### PR DESCRIPTION
Fixed onRemove function setting "this._map = map". Commit 14ba939 was causing errors when a layer was removed- see #327 & #307
