### PR TITLE
Added 'zoomstart' event

### DIFF
--- a/src/handler/TouchZoom.js
+++ b/src/handler/TouchZoom.js
@@ -28,7 +28,9 @@ L.Handler.TouchZoom = L.Handler.extend({
 		
 		this._moved = false;
 		this._zooming = true;
-
+		
+		this._map.fire('zoomstart');
+		
 		this._centerOffset = viewCenter.subtract(this._startCenter);
 
 		L.DomEvent.addListener(document, 'touchmove', this._onTouchMove, this);

--- a/src/map/ext/Map.PanAnimation.js
+++ b/src/map/ext/Map.PanAnimation.js
@@ -3,6 +3,9 @@ L.Map.include(!(L.Transition && L.Transition.implemented()) ? {} : {
 		zoom = this._limitZoom(zoom);
 		var zoomChanged = (this._zoom != zoom);
 
+		if (zoomChanged)
+			this.fire('zoomstart');
+		
 		if (this._loaded && !forceReset && this._layers) {
 			// difference between the new and current centers in pixels
 			var offset = this._getNewTopLeftPoint(center).subtract(this._getTopLeftPoint());


### PR DESCRIPTION
Hi Vladimir 

In my project I've to hide some elements before the zoom animation starts. When the animation finishes I've to add new (e.g. more detailed) elements.

Till now there was just a 'zoomend' event. So added the 'zoomstart' event to the TouchZoom and Map.PanAnimation classes. I think this makes also the API more complete. 

Thanks for your great work
Fabio
