### PR TITLE
Support reversed zoom coordinates

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -17,6 +17,7 @@ L.TileLayer = L.Class.extend({
 		continuousWorld: false,
 		noWrap: false,
 		zoomOffset: 0,
+		zoomReverse: false,
 
 		unloadInvisibleTiles: L.Browser.mobile,
 		updateWhenIdle: L.Browser.mobile
@@ -209,7 +210,7 @@ L.TileLayer = L.Class.extend({
 		var tilePos = this._getTilePos(tilePoint),
 			zoom = this._map.getZoom(),
 			key = tilePoint.x + ':' + tilePoint.y,
-			tileLimit = Math.pow(2, (zoom + this.options.zoomOffset));
+			tileLimit = Math.pow(2, this._getOffsetZoom(zoom));
 
 		// wrap tile coordinates
 		if (!this.options.continuousWorld) {
@@ -240,6 +241,14 @@ L.TileLayer = L.Class.extend({
 
 		container.appendChild(tile);
 	},
+	
+	_getOffsetZoom: function(zoom) {
+		if (this.options.zoomReverse) {
+			return (this.options.maxZoom - zoom) + this.options.zoomOffset;
+		} else {
+			return zoom + this.options.zoomOffset;
+		}
+	},
 
 	_getTilePos: function (tilePoint) {
 		var origin = this._map.getPixelOrigin(),
@@ -256,7 +265,7 @@ L.TileLayer = L.Class.extend({
 
 		return L.Util.template(this._url, L.Util.extend({
 			s: s,
-			z: zoom + this.options.zoomOffset,
+			z: this._getOffsetZoom(zoom),
 			x: tilePoint.x,
 			y: tilePoint.y
 		}, this._urlParams));


### PR DESCRIPTION
This pull adds a `zoomReverse` option to the `TileLayer` class for reversing the order of zoom levels. The option is disabled by default.
