### PR TITLE
Corrected the way L.Map.locateAndSetView() handles the 'options' parameter

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -550,7 +550,7 @@ L.Map = L.Class.extend({
 
 		if (type === 'contextmenu') {
 			L.DomEvent.preventDefault(e);
-		}		
+		}
 		
 		this.fire(type, {
 			latlng: this.mouseEventToLatLng(e),

--- a/src/map/ext/Map.Geolocation.js
+++ b/src/map/ext/Map.Geolocation.js
@@ -42,7 +42,7 @@ L.Map.include({
 		options = L.Util.extend({
 			maxZoom: maxZoom || Infinity,
 			setView: true
-		});
+		}, options);
 		return this.locate(options);
 	},
 


### PR DESCRIPTION
Corrected the way L.Map.locateAndSetView() handles the 'options' parameter so that it is not overriden with the defaults anymore. Also removed some trailing spaces in 'src/map/Map.js'.
(Messed up the title of the commit a bit. First timer, eh... :p)
