### PR TITLE
Attribution control only works after it's added to map.

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -1,10 +1,13 @@
 L.Control.Attribution = L.Class.extend({
+	initialize: function (prefix) {
+		this._prefix = prefix || 'Powered by <a href="http://leaflet.cloudmade.com">Leaflet</a>';
+		this._attributions = {};
+	},
+	
 	onAdd: function (map) {
 		this._container = L.DomUtil.create('div', 'leaflet-control-attribution');
 		L.DomEvent.disableClickPropagation(this._container);
 		this._map = map;
-		this._prefix = 'Powered by <a href="http://leaflet.cloudmade.com">Leaflet</a>';
-		this._attributions = {};
 		this._update();
 	},
 


### PR DESCRIPTION
Creating an Attribution control and setting its prefix or adding attributions before the control is added to a map causes an error to occur and the prefix and attributions are reset when the control is added to the map.

```
var attrib = new L.Control.Attribution;
attrib.setPrefix( "My Prefix" );
attrib.addAttribution( "Copyright &copy; 2012 Ace III" ); //error

map.addControl( attrib ); //prefix and attributions reset whenever control is added
```
