### PR TITLE
Marker._map is undefined in Marker.bindPopup()

### DIFF
--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -5,7 +5,9 @@
 L.Marker.include({
 	openPopup: function () {
 		this._popup.setLatLng(this._latlng);
-		this._map.openPopup(this._popup);
+		if (this._map) {
+			this._map.openPopup(this._popup);
+		}
 
 		return this;
 	},


### PR DESCRIPTION
This would occur when the Map has never been set/reset.
'this._map' is now tested before being accessed with a call to Map.openPopup().
