### PR TITLE
Map.invalidateSize() could cause an antialiasing artifact on WebKit

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -253,10 +253,7 @@ L.Map = L.Class.extend({
 			return this;
 		}
 
-		var panBy = oldSize.subtract(this.getSize()).divideBy(2);
-		panBy.x = Math.round(panBy.x);
-		panBy.y = Math.round(panBy.y);
-		this._rawPanBy(panBy);
+		this._rawPanBy(oldSize.subtract(this.getSize()).divideBy(2, true));
 
 		this.fire('move');
 


### PR DESCRIPTION
Map.invalidateSize() could cause an antialiasing artifact on WebKit when the map has an odd width and/or height. Rounding the pan offset fixes the issue for me.

To reproduce, set the width of the map to 100% in debug/map/map.html
Then resize the browser window (with a browser using WebKit - I am running Chrome 17.0.963.46 on OSX)
Half of the refreshes will produce blurred (antialiased) versions of the map.

PS: Leaflet is my first github fork - and this is my first pull request, so please bear with me if I am not following the correct procedure.

PPS: Leaflet is _SO_ awesome!
