### PR TITLE
Make L.TileLayer._update obey min/max Zoom of layer

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -138,7 +138,12 @@ L.TileLayer = L.Class.extend({
 
 	_update: function () {
 		var bounds = this._map.getPixelBounds(),
+			zoom = this._map.getZoom(),
 			tileSize = this.options.tileSize;
+			
+		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+			return;
+		}
 
 		var nwTilePoint = new L.Point(
 				Math.floor(bounds.min.x / tileSize),


### PR DESCRIPTION
The layer has the properties minZoom and maxZoom, but they are not being used when updating the layer (e.g. after zooming). This makes the _update command obey these properties of the layer.
Without it the _update will generate 404 errors while fetching tiles of which the owner of the script already knows they are not there.
