### PR TITLE
Ability to pad a LatLngBounds by a %

### DIFF
--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -26,6 +26,17 @@ L.LatLngBounds = L.Class.extend({
 		}
 	},
 
+	// extends the bounds by a percentage
+	padBounds: function (/*Number*/ bufferRatio) {
+		var heightBuffer = Math.abs(this._southWest.lat - this._northEast.lat) * bufferRatio,
+			widthBuffer = Math.abs(this._southWest.lng - this._northEast.lng) * bufferRatio;
+
+		return new L.LatLngBounds(
+			new L.LatLng(this._southWest.lat - heightBuffer, this._southWest.lng - widthBuffer),
+			new L.LatLng(this._northEast.lat + heightBuffer, this._northEast.lng + widthBuffer)
+		);
+	},
+
 	getCenter: function () /*-> LatLng*/ {
 		return new L.LatLng(
 				(this._southWest.lat + this._northEast.lat) / 2,


### PR DESCRIPTION
Updated `LatLngBounds` to provide the functionality to extend the bounds by a %.

**Use case**
When a group of markers are displayed on the map sometimes they touch the edge of the window. This can mean that part of the marker is not visible. This could be true for other items that are displayed on the map.

The way I am using it is I have an array of markers that has a `LatLngBounds` to represent the bounds of those markers. When the map is loaded I want to show all markers in the map viewport (without any right on the edge).

To test you can add the following code to the map.html debug file (I didn't think a minor function would deserve a new debug file so didn't commit it).

`<button id="padbounds">Pad bounds by 5%</button>`

```
function padBounds () {
    map.fitBounds(map.getBounds().padBounds(0.05));
}
L.DomUtil.get('padbounds').onclick = padBounds;
```
