### PR TITLE
Forgot to prevent the default action on Path-right click

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -84,6 +84,11 @@ L.Path = L.Path.extend({
 		if (this._map.dragging && this._map.dragging.moved()) {
 			return;
 		}
+
+		if (e.type === 'contextmenu') {
+			L.DomEvent.preventDefault(e);
+		}
+
 		this._fireMouseEvent(e);
 	},
 


### PR DESCRIPTION
See subject, right clicks on Path and subclasses can be catched now and the default action is prevented.
