### PR TITLE
Add transparency back to attribution control for lte IE 8

### DIFF
--- a/dist/leaflet.ie.css
+++ b/dist/leaflet.ie.css
@@ -44,5 +44,5 @@
 .leaflet-control-layers-toggle {
 	}
 .leaflet-control-attribution, .leaflet-control-layers {
-	background: white;
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr=#B2FFFFFF,endColorstr=#B2FFFFFF);
 	}


### PR DESCRIPTION
This should close #318. Not sure what happened here... https://github.com/CloudMade/Leaflet/commit/03075f092802bec90fdd9507a18bda3eaad9bfdc#diff-6
