### PR TITLE
Popup minHeight option

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -145,8 +145,8 @@ L.Popup = L.Class.extend({
 			container.className += scrolledClass;
 		} else {
 			if (height < minHeight) {
-                                container.style.height = minHeight + 'px';
-                        }
+				container.style.height = minHeight + 'px';
+			}
 
 			container.className = container.className.replace(scrolledClass, '');
 		}


### PR DESCRIPTION
I use popups to show small pictures (<img> tag).
The map does not pan correctly in my case.

East and west bounds can be fixed with minWidth option. 
I face a problem with the North boundary. 

here is example: http://k4.ce.ms:8080/lf.html

click on the left marker to see the problem.
click on the right marker to see how minHeight works.
PS: You have one try to see the problem . 
Browser will cache the picture. Most likely you will not see the problem again.  
