### PR TITLE
Fixed bugs on polyline editing regarding edge cases

### DIFF
--- a/src/layer/vector/Polyline.Edit.js
+++ b/src/layer/vector/Polyline.Edit.js
@@ -99,17 +99,29 @@ L.Handler.PolyEdit = L.Handler.extend({
 	},
 
 	_onMarkerClick: function (e) {
+		// Default action on marker click is to remove that marker, but if we remove the marker when latlng count < 3, we don't have a valid polyline anymore
+		if (this._poly._latlngs.length < 3) {
+			return;
+		}
+		
 		var marker = e.target,
 		    i = marker._index;
+		
+		// Check existence of previous and next markers since they wouldn't exist for edge points on the polyline
+		if (marker._prev && marker._next) {
+			this._createMiddleMarker(marker._prev, marker._next);
+			this._updatePrevNext(marker._prev, marker._next);
+		}
 
-		this._createMiddleMarker(marker._prev, marker._next);
-		this._updatePrevNext(marker._prev, marker._next);
-
-		this._markerGroup
-			.removeLayer(marker._middleLeft)
-			.removeLayer(marker._middleRight)
-			.removeLayer(marker);
-
+		// The marker itself is guaranteed to exist and present in the layer, since we managed to click on it
+		this._markerGroup.removeLayer(marker);
+		// Check for the existence of middle left or middle right
+		if (marker._middleLeft) {
+			this._markerGroup.removeLayer(marker._middleLeft);
+		}
+		if (marker._middleRight) {
+			this._markerGroup.removeLayer(marker._middleRight);
+		}
 		this._poly.spliceLatLngs(i, 1);
 		this._updateIndexes(i, -1);
 		this._poly.fire('edit');


### PR DESCRIPTION
This commit fixes couple bugs. One of them is polylines (or polygons)
can be  reduced to a single point by clicking on markers to remove
them. Second, if an edge point is clicked for a polyline (not
applicable to polygons since they are a circular linked list) code
produces a js error since previous or next might not be present.
