### PR TITLE
Bugfix: Proper cleanup of marker editing handler when it is disabled.

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Leaflet-Fork</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+		<nature>com.aptana.projects.webnature</nature>
+	</natures>
+</projectDescription>

--- a/src/layer/vector/Polyline.Edit.js
+++ b/src/layer/vector/Polyline.Edit.js
@@ -23,7 +23,7 @@ L.Handler.PolyEdit = L.Handler.extend({
 	removeHooks: function () {
 		if (this._poly._map) {
 			this._poly._map.removeLayer(this._markerGroup);
-		} 
+		}
 		delete this._markerGroup;
 		delete this._markers;
 	},


### PR DESCRIPTION
This fixes a critical bug which occurs if editing is enabled, disabled
and enabled again. Since line 16 checks for existence of marker group
reference, markers never get reinitiated, causing the handler to use
the old ones, which may have been changed in the last editing session.
