### PR TITLE
make version a number not a string

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -1,7 +1,6 @@
-
 (function (root) {
 	root.L = {
-		VERSION: '0.4',
+		VERSION: 0.4,
 
 		ROOT_URL: root.L_ROOT_URL || (function () {
 			var scripts = document.getElementsByTagName('script'),


### PR DESCRIPTION
would make numeric determination of version compatibility easier 
