### PR TITLE
Detect retina displays and adjust tileSize accordingly

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -29,14 +29,13 @@ L.TileLayer = L.Class.extend({
 		L.Util.setOptions(this, options);
 
 		// detecting retina displays, adjusting tileSize and zoom levels
-		if (this.options.detectRetina
-			&& window.devicePixelRatio > 1
-			&& options.maxZoom > 0
-		){
-			this.options.tileSize >>= 1;
-			options.zoomOffset++;
-			if (options.minZoom > 0) options.minZoom--;
-			options.maxZoom--;
+		if (this.options.detectRetina && window.devicePixelRatio > 1 && this.options.maxZoom > 0) {
+			this.options.tileSize = Math.floor(this.options.tileSize / 2);
+			this.options.zoomOffset++;
+			if (this.options.minZoom > 0) {
+			   this.options.minZoom--;
+			}
+			this.options.maxZoom--;
 		}
 
 		this._url = url;


### PR DESCRIPTION
Should fix CloudMade/Leaflet#582.

Related external links:
- [Detect retina displays with javascript](http://briancray.com/2011/05/05/detect-retina-displays-with-javascript/) — Brian Cray, May 5, 2011.
- [Адаптируем графику под Retina экран](http://habrahabr.ru/post/139682/) — [Егор Хмелёв](http://habrahabr.ru/users/hmelyoff/), 10 марта 2012 г.
