### PR TITLE
Fix bug in bind causing loss of arguments

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -17,7 +17,7 @@ L.Util = {
 	},
 
 	bind: function (fn, obj) { // (Function, Object) -> Function
-		var args = Array.prototype.slice.call(arguments, 2);
+		var args = arguments.length > 2 ? Array.prototype.slice.call(arguments, 2) : null;
 		return function () {
 			return fn.apply(obj, args || arguments);
 		};


### PR DESCRIPTION
Because of empty Arrays being truthy, the binary comparison caused the empty `args` to be passed to the function instead of `arguments`.

Fixes issue #574
