### PR TITLE
fix L.Polyline.closestLayerPoint

### DIFF
--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -202,8 +202,8 @@ L.LineUtil = {
 
         var sqDistValue = dx * dx + dy * dy;
         var value;
-        if (sqDist){
-            value = sqDistValue
+        if (sqDist) {
+            value = sqDistValue;
         } else {
             value = new L.Point(x, y);
             value._sqDist = sqDistValue;

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -68,7 +68,7 @@ L.Polyline = L.Path.extend({
 				if (point._sqDist < minDistance) {
 					minDistance = point._sqDist;
 					minPoint = point;
-                    minPoint.startSegIndex = i-1;
+                    minPoint.startSegIndex = i - 1;
                     minPoint.endSegIndex = i;
 				}
 			}


### PR DESCRIPTION
closestLayerPoint doesn't work. Because after it calls L.LineUtil._sqClosestPointOnSegment it checks "_sqDist" property of returned point. But that function doesn't set that property. 

I changed somу lines in order to use this method
