### PR TITLE
Tweaked DOM util opacity to only apply in IE when opacity !== 1

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -98,7 +98,7 @@ L.DomUtil = {
 
 	setOpacity: function (el, value) {
 		if (L.Browser.ie) {
-			el.style.filter = 'alpha(opacity=' + Math.round(value * 100) + ')';
+		    el.style.filter = value !== 1 ? 'alpha(opacity=' + Math.round(value * 100) + ')' : '';
 		} else {
 			el.style.opacity = value;
 		}


### PR DESCRIPTION
Had a few issues working with IE and transparent markers.  Essentially, the transparent areas of the markers were being displayed with a black background and disabling the filter style fixed the problem.

Not an ideal fix, I know, but tried a few different things (accessing the msFilter property as per http://www.quirksmode.org/css/opacity.html) but had no luck.
