### PR TITLE
Added Conditional in Circle.js to Prevent Exceptions

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -73,6 +73,7 @@ L.Circle = L.Path.extend({
 	},
 
 	_checkIfEmpty: function () {
+        if(!this._map) return false;
 		var vp = this._map._pathViewport,
 			r = this._radius,
 			p = this._point;


### PR DESCRIPTION
L.GeoJSON.prototype.clearLayers() results in fatal exceptions in Circle.js. I added a check for this._map. If it's not there, it returns false and everybody can go on about their business.
