### PR TITLE
Ensure minimum and maximum zoom levels are updated when layers are added and/or removed

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -502,10 +502,12 @@ L.Map = L.Class.extend({
 		this._layersMinZoom = 0;
 		this._layersMaxZoom = Infinity;
 		for (i in this._layers) {
-		var layer = this._layers[i];
+			var layer = this._layers[i];
 			// TODO getMaxZoom, getMinZoom in ILayer (instead of options)
-			this._layersMinZoom = Math.max(this._layersMinZoom, layer.options.minZoom);
-			this._layersMaxZoom = Math.min(this._layersMaxZoom, layer.options.maxZoom);
+			if (layer.options) {
+				this._layersMinZoom = Math.max(this._layersMinZoom, layer.options.minZoom ? layer.options.minZoom : 0);
+				this._layersMaxZoom = Math.min(this._layersMaxZoom, layer.options.maxZoom ? layer.options.maxZoom : Infinity);
+			}
 		}
 	},
 


### PR DESCRIPTION
This fixes an issue where adding and removing layers (for example with the layers control) with different zoom level constraints, did not update _layersMinZoom and _layersMaxZoom to reflect the current set of layers, but rather to the "least common denominator" of all layers that had ever been added.
