### PR TITLE
getContainer() method for L.Map

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -322,6 +322,10 @@ L.Map = L.Class.extend({
 	getPanes: function () {
 		return this._panes;
 	},
+	
+	getContainer: function () {
+		return this._container;
+	},
 
 
 	// conversion methods


### PR DESCRIPTION
This just adds a getContainer() method to L.Map as per the Leaflet documentation.
