### PR TITLE
Patch for L.Control#setPosition

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -13,11 +13,16 @@ L.Control = L.Class.extend({
 	},
 
 	setPosition: function (position) {
+		var map = this._map;
+
+		if (map) {
+			map.removeControl(this);
+		}
+
 		this.options.position = position;
 
-		if (this._map) {
-			this._map.removeControl(this);
-			this._map.addControl(this);
+		if (map) {
+			map.addControl(this);
 		}
 	},
 


### PR DESCRIPTION
Previous code resulted in errors.

First, by setting this.options.position before removing the control from the map, the map was looking in the wrong control container for the control to be removed.

Second, during the call to `removeControl`, `this._map` is unset so the subsequent call to `addControl` would always fail since `this._map` is undefined.

The proposed may not be perfect but it at least works.
