### PR TITLE
Keyboard Handler

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -180,9 +180,15 @@ var deps = {
 		desc: 'Enables zooming to bounding box by shift-dragging the map.'
 	},
 
+	Focus: {
+		src: ['map/handler/Map.Focus.js'],
+		desc: 'Enables map to gain focus.'
+	},
+
 	Keyboard: {
 		src: ['map/handler/Map.Keyboard.js'],
-		desc: 'Enables keyboard pan/zoom when map is active.'
+		deps: ['Focus'],
+		desc: 'Enables keyboard pan/zoom when map is focused.'
 	},
 
 	MarkerDrag: {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -338,6 +338,9 @@ a.leaflet-active {
 .leaflet-container {
 	background: #ddd;
 	}
+.leaflet-container-nofocus {
+	outline:0;
+}
 .leaflet-container a {
 	color: #0078A8;
 	}

--- a/src/map/handler/Map.Focus.js
+++ b/src/map/handler/Map.Focus.js
@@ -1,0 +1,69 @@
+/*
+ * L.Handler.Focus is used internally by L.Map to make the map focusable.
+ */
+
+L.Map.mergeOptions({
+    focus: true
+});
+
+L.Map.Focus = L.Handler.extend({
+	_focused: false,
+
+	initialize: function (map) {
+		this._map = map;
+		this._container = map._container;
+
+		this._makeFocusable();
+		this._focused = false;
+	},
+
+	addHooks: function () {
+		var container = this._container;
+		L.DomEvent
+			.addListener(container, 'focus', this.onFocus, this)
+			.addListener(container, 'blur', this.onBlur, this)
+			.addListener(container, 'click', this.onClick, this);
+	},
+
+	removeHooks: function () {
+		var container = this._container;
+		L.DomEvent
+			.removeListener(container, 'focus', this.onFocus, this)
+			.removeListener(container, 'blur', this.onBlur, this)
+			.removeListener(container, 'click', this.onClick, this);
+	},
+
+	onClick: function (e) {
+		if (!this._focused) {
+			this._container.focus();
+		}
+	},
+
+	onFocus: function (e) {
+		this._focused = true;
+		this._map.fire('focus');
+	},
+
+	onBlur: function (e) {
+		this._focused = false;
+		this._map.fire('blur');
+	},
+
+	_makeFocusable: function () {
+		var map = this._map, container = this._container;
+
+		
+		// While we want the map to be "focusable", we don't want the map to
+		// appear focused (i.e. no outline etc...)
+		L.DomUtil.addClass(container, 'leaflet-container-nofocus');
+
+		// Allows user to tab to the container.
+		//  -1 => User can focus container by clicks, but not tabs
+		//   0 => User can focus container by clicks or tabs. Order is based on
+		//        DOM source order.
+		//   N => User can focus container by clicks or tabs. N = tab order.
+		container.tabIndex = "0";
+	}
+});
+
+L.Map.addInitHook('addHandler', 'focus', L.Map.Focus);


### PR DESCRIPTION
This implements a feature requested in issue #646.

Implementation tested in all browsers I have access to and I see no reason why it shouldn't work in additional browsers. The biggest obstacle is the event.keyCode for the various keys in different browsers. Implementation is done such that as new keyCodes are found in different browsers they can easily be supported by the handler. I would request additional browsers be tested. Not sure on the feasibility of support on mobile platforms.

Currently known to work on:

Mac OSX 10.6.8
- Safari 5.1.1
- Firefox 11
- Chrome 18

Windows 7
- IE 8
- IE 9
- Firefox 4
- Chrome 18

Implementation adds a "keyboard" option for the L.Map configuration options. Default set to `true`, enables keyboard navigation when the most recent click was on the map. Can be set to `false` to disable this navigation.

Implementation supports variable panning distance and zoom level jumping by calling `setPanOffset` and `setZoomOffset` respectively. Both methods accept an integer parameter. In the former method the integer is the number of pixels to pan by when panning. In the latter offset the integer is the number of zoom levels to step in/out when zooming. Passing a negative integer to either method is supported and will effectively invert the controls. Note: A wrapper method could be added to the map for convenience. Currently a user would have to do something like the following to call these methods. (Seems unclean as-is)

```
// Pan by 100 pixels when an arrow key is pressed
map.keyboard.setPanOffset(100);

// Zoom in/out 2 zoom levels when +/- is pressed.
map.keyboard.setZoomOffset(2);
```

Default pan offset is 50 pixels. Default zoom offset is 1 zoom level.
