### PR TITLE
ie6 filter clearing fix

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -104,7 +104,7 @@ L.DomUtil = {
 
 	setOpacity: function (el, value) {
 		if (L.Browser.ie) {
-		    el.style.filter = value !== 1 ? 'alpha(opacity=' + Math.round(value * 100) + ')' : '';
+		    el.style.filter += value !== 1 ? 'alpha(opacity=' + Math.round(value * 100) + ')' : '';
 		} else {
 			el.style.opacity = value;
 		}


### PR DESCRIPTION
Are we in 2012? Yes we are!

This is a "man vs machine" challenge rather than a real issue.

I'm working on a fork of Leaflet based on the master branch and I noticed that when you use the prehistoric IE6, marker icons disappears.

This is because the `setOpacity` method of `DomUtil` class resets the filter when opacity is 1.

Nice, but in this way it resets the `AlphaImageLoader` filter too, and it will result in an empty icon

Hope it helps

Best regards

GT
