### PR TITLE
Check this.edit is set

### DIFF
--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -90,7 +90,7 @@ L.Polyline = L.Path.extend({
 	onAdd: function (map) {
 		L.Path.prototype.onAdd.call(this, map);
 
-		if (this.editing.enabled()) {
+		if (this.editing && this.editing.enabled()) {
 			this.editing.addHooks();
 		}
 	},


### PR DESCRIPTION
this.edit is not always set for polygons - this happens to us for example when loading from geojson.  This patch makes sure that this.editing is set before checking whether editing is enabled.
