### PR TITLE
Fix feature detection for IE9 when drawing SVG paths

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -69,7 +69,7 @@ L.Path = L.Path.extend({
 	// TODO remove duplication with L.Map
 	_initEvents: function () {
 		if (this.options.clickable) {
-			if (!L.Browser.vml) {
+			if (L.Browser.svg || !L.Browser.vml) {
 				this._path.setAttribute('class', 'leaflet-clickable');
 			}
 


### PR DESCRIPTION
Without this fix, SVG elements in IE9 don't receive the "leaflet-clickable" class.
