### PR TITLE
Make sure TileLayer load event is fired

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -350,6 +350,13 @@ L.TileLayer = L.Class.extend({
 		tile.src     = this.getTileUrl(tilePoint, zoom);
 	},
 
+    _tileLoaded: function () {
+        this._tilesToLoad--;
+        if (!this._tilesToLoad) {
+            this.fire('load');
+        }
+    },
+
 	_tileOnLoad: function (e) {
 		var layer = this._layer;
 
@@ -360,10 +367,7 @@ L.TileLayer = L.Class.extend({
 			url: this.src
 		});
 
-		layer._tilesToLoad--;
-		if (!layer._tilesToLoad) {
-			layer.fire('load');
-		}
+        layer._tileLoaded();
 	},
 
 	_tileOnError: function (e) {
@@ -378,5 +382,7 @@ L.TileLayer = L.Class.extend({
 		if (newUrl) {
 			this.src = newUrl;
 		}
-	}
+
+        layer._tileLoaded();
+    }
 });


### PR DESCRIPTION
The load event for a tile layer is only fired after all tiles are loaded.  However, the previous code only took into account successful tile loads.  It is legitimate for a tile load to cause an error - you might be zoomed out on a map and are pulling a non-existent tiles around the edge (especially on indoors maps).  This patch takes into account both successful and unsuccessful tile loads.
