### PR TITLE
_tileLayersToLoad Cleanup

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -152,7 +152,8 @@ L.Map = L.Class.extend({
 		// TODO looks ugly, refactor!!!
 		if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
 			this._tileLayersNum++;
-			layer.on('load', this._onTileLayerLoad, this);
+            this._tileLayersToLoad++;
+            layer.on('load', this._onTileLayerLoad, this);
 		}
 
 		var onMapLoad = function () {
@@ -181,7 +182,8 @@ L.Map = L.Class.extend({
 		// TODO looks ugly, refactor
 		if (this.options.zoomAnimation && L.TileLayer && (layer instanceof L.TileLayer)) {
 			this._tileLayersNum--;
-			layer.off('load', this._onTileLayerLoad, this);
+            this._tileLayersToLoad--;
+            layer.off('load', this._onTileLayerLoad, this);
 		}
 
 		return this.fire('layerremove', {layer: layer});


### PR DESCRIPTION
When a tileLayer is added or removed from a map, the _tileLayersNum property is appropriately updated but the _tileLayersToLoad is not.  It is not updated until resetView, but that is called after  the method _onTileLayerLoad is called.  Thus, if you add one tile layer the _tileLayersToLoad is zero and when _onTileLayerLoad is called the values is decremented to -1.

This in the end doesn't make a difference on the initial zoom level of a map because _onTileLayerLoad also checks to see if there is a background tile layer, which there is not until after a first zoom.  However, this seems to me a bug waiting to happen, thus the patch.
