### PR TITLE
Update custom icon documentation

### DIFF
--- a/examples/custom-icons.html
+++ b/examples/custom-icons.html
@@ -57,14 +57,14 @@
 
 			map.setView(new L.LatLng(51.5, -0.09), 13).addLayer(cloudmade);
 
-			var LeafIcon = L.Icon.extend({
+			var LeafIcon = L.Icon.extend({options: {
 				iconUrl: '../docs/images/leaf-green.png',
 				shadowUrl: '../docs/images/leaf-shadow.png',
 				iconSize: new L.Point(38, 95),
 				shadowSize: new L.Point(68, 95),
 				iconAnchor: new L.Point(22, 94),
 				popupAnchor: new L.Point(-3, -76)
-			});
+			}});
 
 			var greenIcon = new LeafIcon(),
 				redIcon = new LeafIcon('../docs/images/leaf-red.png'),


### PR DESCRIPTION
L.Icon.extend now takes "options" as a member of an object, rather than just the object itself.  The documentation should reflect this (and may have led to issue 619).
