### PR TITLE
polyline: Remove deleted marker from internal list

### DIFF
--- a/src/layer/vector/Polyline.Edit.js
+++ b/src/layer/vector/Polyline.Edit.js
@@ -124,6 +124,7 @@ L.Handler.PolyEdit = L.Handler.extend({
 		if (marker._middleRight) {
 			this._markerGroup.removeLayer(marker._middleRight);
 		}
+		this._markers.splice(i, 1);
 		this._poly.spliceLatLngs(i, 1);
 		this._updateIndexes(i, -1);
 		this._poly.fire('edit');


### PR DESCRIPTION
When marker is deleted from line it's left in internal _markers list.
