### PR TITLE
polyline: Fix old position of middle point

### DIFF
--- a/src/layer/vector/Polyline.Edit.js
+++ b/src/layer/vector/Polyline.Edit.js
@@ -34,7 +34,8 @@ L.Handler.PolyEdit = L.Handler.extend({
 	},
 
 	_initMarkers: function () {
-		this._markerGroup = new L.LayerGroup();
+		if (!this._markerGroup)
+			this._markerGroup = new L.LayerGroup();
 		this._markers = [];
 
 		var latlngs = this._poly._latlngs,


### PR DESCRIPTION
When marker position changed and middle point is clicked (not dragged)
old coordinates are used for new point.
