### PR TITLE
Add tile layer with polygonal boundary

### DIFF
--- a/debug/map/canvas-boundary.html
+++ b/debug/map/canvas-boundary.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+	
+	<link rel="stylesheet" href="../css/screen.css" />
+	
+	<script src="../leaflet-include.js"></script>
+	<script src="../../src/layer/tile/TileLayer.BoundaryCanvas.js"></script>
+</head>
+<body>
+
+	<div id="map" style="width: 600px; height: 600px; border: 1px solid #ccc"></div>
+
+	<script type="text/javascript">
+
+    var testGeom = {"type":"POLYGON","coordinates":[
+        [[[36.375733,56.475540], [37.661133,56.699837], [39.089356,56.402508], [39.572754,55.627130], [39.155274,55.051062], [38.089600,54.817004], [36.672364,54.886732], [35.727541,55.377699], [35.815432,56.072117], [36.375733,56.475540]],
+         [[37.488099,55.890415], [37.372743,55.810070], [37.380983,55.728008], [37.485353,55.600703], [37.677613,55.577371], [37.825929,55.639560], [37.839662,55.763641], [37.820436,55.837900], [37.589723,55.905846], [37.488099,55.890415]]],
+        
+        [[[41.539307,57.370676], [43.077393,57.471439], [43.813477,57.329104], [43.692627,56.572696], [43.352051,55.664406], [41.978760,55.321357], [40.759278,55.352667], [40.111084,55.874975], [40.187989,56.536291], [40.627442,56.958829], [41.539307,57.370676]]]
+    ]};
+    
+    //convert test data to latlng array
+    var latLngGeom = [],
+        c, r, k;
+    for (c = 0; c < testGeom.coordinates.length; c++) {
+        latLngGeom[c] = [];
+        for (r = 0; r < testGeom.coordinates[c].length; r++) {
+            latLngGeom[c][r] = [];
+            for (k = 0; k < testGeom.coordinates[c][r].length; k++){
+                latLngGeom[c][r].push(new L.LatLng(testGeom.coordinates[c][r][k][1], testGeom.coordinates[c][r][k][0]));
+            }
+        }
+    }
+    
+    var map = new L.Map('map'),
+        cloudmadeUrl = 'http://{s}.tile.cloudmade.com/BC9A493B41014CAABB98F0471D759707/997/256/{z}/{x}/{y}.png',
+        cloudmadeAttribution = 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade';
+    
+    var osm = new L.TileLayer.BoundaryCanvas(cloudmadeUrl, {boundary: latLngGeom, attribution: cloudmadeAttribution});
+    
+    map.setView(new L.LatLng(55.7, 38), 7).addLayer(osm);
+		
+	</script>
+</body>
+</html>

--- a/src/layer/tile/TileLayer.BoundaryCanvas.js
+++ b/src/layer/tile/TileLayer.BoundaryCanvas.js
@@ -1,0 +1,219 @@
+﻿L.TileLayer.BoundaryCanvas = L.TileLayer.Canvas.extend({
+	options: {
+        // all rings of boundary should be without self-intersections or intersections with other rings
+        // zero-winding fill algorithm is used in canvas, so holes should have opposite direction to exterior ring
+        // boundary can be
+        // LatLng[] - simple polygon
+        // LatLng[][] - polygon with holes
+        // LatLng[][][] - multipolygon
+        boundary: null
+	},
+
+	initialize: function (url, options) {
+		L.Util.setOptions(this, options);
+        this._url = url;
+        this._boundaryCache = {}; //cache index "x:y:z"
+        this._mercBoundary = null;
+        this._mercBbox = null;
+	},
+    
+    //lazy calculation of layer's boundary in map's projection. Bounding box is also calculated
+    _getOriginalMercBoundary: function () {
+
+        if (this._mercBoundary) {
+            return this._mercBoundary;
+        }
+
+        this._mercBoundary = [];
+        var b = this.options.boundary,
+            c, r, p,
+            mercComponent,
+            mercRing,
+            compomentBbox;
+
+        
+        if (!(b[0] instanceof Array)) {
+            b = [[b]];
+        } else if (!(b[0][0] instanceof Array)) {
+            b = [b];
+        }
+
+        for (c = 0; c < b.length; c++) {
+            mercComponent = [];
+            for (r = 0; r < b[c].length; r++) {
+                mercRing = [];
+                for (p = 0; p < b[c][r].length; p++) {
+                    mercRing.push(this._map.project(b[c][r][p], 0));
+                }
+                mercComponent.push(mercRing);
+            }
+            this._mercBoundary.push(mercComponent);
+        }
+
+        this._mercBbox = new L.Bounds();
+        for (c = 0; c < this._mercBoundary.length; c++) {
+            compomentBbox = new L.Bounds(this._mercBoundary[c][0]);
+            this._mercBbox.extend(compomentBbox.min);
+            this._mercBbox.extend(compomentBbox.max);
+        }
+
+        return this._mercBoundary;
+    },
+
+    // Calculates intersection of original boundary geometry and tile boundary.
+    // Uses quadtree as cache to speed-up intersection.
+    // Return 
+    //   {isOut: true} if no intersection,  
+    //   {isIn: true} if tile is fully inside layer's boundary
+    //   {geometry: <LatLng[][][]>} otherwise
+    _getTileGeometry: function (x, y, z, skipIntersectionCheck) {
+        if ( !this.options.boundary) {
+            return {isOut: true};
+        }
+    
+        var cacheID = x + ":" + y + ":" + z,
+            zCoeff = Math.pow(2, z),
+            parentState,
+            clippedGeom = [],
+            iC, iR,
+            clippedComponent,
+            clippedExternalRing,
+            clippedHoleRing,
+            isRingBbox = function (ring, bbox) {
+                if (ring.length !== 4) {
+                    return false;
+                }
+
+                var p;
+                for (p = 0; p < 4; p++) {
+                    if ((ring[p].x !== bbox.min.x && ring[p].x !== bbox.max.x) ||
+                        (ring[p].y !== bbox.min.y && ring[p].y !== bbox.max.y)) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+
+        if (this._boundaryCache[cacheID]) {
+            return this._boundaryCache[cacheID];
+        }
+
+        var mercBoundary = this._getOriginalMercBoundary(),
+            ts = this.options.tileSize,
+            tileBbox = new L.Bounds(new L.Point(x * ts / zCoeff, y * ts / zCoeff), new L.Point((x + 1) * ts / zCoeff, (y + 1) * ts / zCoeff));
+
+        //fast check intersection
+        if (!skipIntersectionCheck && !tileBbox.intersects(this._mercBbox)) {
+            return {isOut: true};
+        }
+
+        if (z === 0) {
+            this._boundaryCache[cacheID] = {geometry: mercBoundary};
+            return this._boundaryCache[cacheID];
+        }
+
+        parentState = this._getTileGeometry(Math.floor(x / 2), Math.floor(y / 2), z - 1, true);
+
+        if (parentState.isOut || parentState.isIn) {
+            return parentState;
+        }
+
+        for (iC = 0; iC < parentState.geometry.length; iC++) {
+            clippedComponent = [];
+            clippedExternalRing = L.PolyUtil.clipPolygon(parentState.geometry[iC][0], tileBbox);
+            if (clippedExternalRing.length === 0) {
+                continue;
+            }
+
+            clippedComponent.push(clippedExternalRing);
+
+            for (iR = 1; iR < parentState.geometry[iC].length; iR++) {
+                clippedHoleRing = L.PolyUtil.clipPolygon(parentState.geometry[iC][iR], tileBbox);
+                if (clippedHoleRing.length > 0) {
+                    clippedComponent.push(clippedHoleRing);
+                }
+            }
+            clippedGeom.push(clippedComponent);
+        }
+
+        if (clippedGeom.length === 0) { //we are outside of all multipolygon components
+            this._boundaryCache[cacheID] = {isOut: true};
+            return this._boundaryCache[cacheID];
+        }
+
+        for (iC = 0; iC < clippedGeom.length; iC++) {
+            if (isRingBbox(clippedGeom[iC][0], tileBbox)) {
+                //inside exterior rings and no holes
+                if (clippedGeom[iC].length === 1) {
+                    this._boundaryCache[cacheID] = {isIn: true};
+                    return this._boundaryCache[cacheID];
+                }
+            } else { //intersect exterior ring
+                this._boundaryCache[cacheID] = {geometry: clippedGeom};
+                return this._boundaryCache[cacheID];
+            }
+
+            for (iR = 1; iR < clippedGeom[iC].length; iR++) {
+                if (!isRingBbox(clippedGeom[iC][iR], tileBbox)) { //inside exterior ring, but have intersection with hole
+                    this._boundaryCache[cacheID] = {geometry: clippedGeom};
+                    return this._boundaryCache[cacheID];
+                }
+            }
+        }
+
+        //we are inside all holes in geometry
+        this._boundaryCache[cacheID] = {isOut: true};
+        return this._boundaryCache[cacheID];
+    },
+
+	drawTile: function (canvas, tilePoint, zoom) {
+        var ts = this.options.tileSize,
+            tileX = ts * tilePoint.x,
+            tileY = ts * tilePoint.y,
+            zCoeff = Math.pow(2, zoom),
+            ctx = canvas.getContext('2d'),
+            imageObj = new Image(),
+            _this = this,
+            setPattern = function () {
+            
+            var state = _this._getTileGeometry(tilePoint.x, tilePoint.y, zoom),
+                c, r, p,
+                pattern,
+                geom;
+
+            if (state.isOut) {
+                return;
+            }
+
+            if (!state.isIn) {
+                geom = state.geometry;
+                ctx.beginPath();
+
+                for (c = 0; c < geom.length; c++) {
+                    for (r = 0; r < geom[c].length; r++) {
+                        if (geom[c][r].length === 0) {
+                            continue;
+                        }
+
+                        ctx.moveTo(geom[c][r][0].x * zCoeff - tileX, geom[c][r][0].y * zCoeff - tileY);
+                        for (p = 1; p < geom[c][r].length; p++) {
+                            ctx.lineTo(geom[c][r][p].x * zCoeff - tileX, geom[c][r][p].y * zCoeff - tileY);
+                        }
+                    }
+                }
+                ctx.clip();
+            }
+
+            pattern = ctx.createPattern(imageObj, "repeat");
+            ctx.beginPath();
+            ctx.rect(0, 0, canvas.width, canvas.height);
+            ctx.fillStyle = pattern;
+            ctx.fill();
+        };
+        
+        imageObj.onload = function () {
+            setTimeout(setPattern, 0); //IE9 bug - black tiles appear randomly if call setPattern() without timeout
+        }
+        imageObj.src = this.getTileUrl(tilePoint, zoom);
+	}
+});


### PR DESCRIPTION
It is implementation of tile vector layer with arbitrary polygonal boundary using HTML5 Canvas for clipping tiles. Polygons with holes and multipolygons are also supported. Usage example is also added.

Maybe, it is good candidate for a plugin, but I've found no information about them...
