### PR TITLE
Add support for maps with position: fixed

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -408,7 +408,7 @@ L.Map = L.Class.extend({
 
 		var position = L.DomUtil.getStyle(container, 'position');
 
-		if (position !== 'absolute' && position !== 'relative') {
+		if (position !== 'absolute' && position !== 'relative' && position !== 'fixed') {
 			container.style.position = 'relative';
 		}
 


### PR DESCRIPTION
Since position: fixed sets up a new positioning context just like absolute and relative, it would be nice if it were allowed as a way to position a map.
