### PR TITLE
Set the exact z-index of a marker

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -127,7 +127,7 @@ L.Marker = L.Class.extend({
 			L.DomUtil.setPosition(this._shadow, pos);
 		}
 
-		icon.style.zIndex = pos.y + this.options.zIndexOffset;
+		icon.style.zIndex = this.options.zIndexOffset;
 	},
 
 	_initInteraction: function () {


### PR DESCRIPTION
If the z-index of a marker is set by calling setZIndexOffset the passed value is correctly set 
in the options of the marker but the marker itself is redrawn (in _reset) with a different value. 
The y position of the marker (pos.y) is added on top of the passed value. 

That way it is impossible to set a specific z-index for a marker.
