### PR TITLE
TileLayer load event is only fired once

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -206,14 +206,17 @@ L.TileLayer = L.Class.extend({
 
 		var fragment = document.createDocumentFragment();
 
-		this._tilesToLoad = queue.length;
+		if (queue.length > 0) {
 
-		var k, len;
-		for (k = 0, len = this._tilesToLoad; k < len; k++) {
-			this._addTile(queue[k], fragment);
+			this._tilesToLoad = queue.length;
+
+			var k, len;
+			for (k = 0, len = this._tilesToLoad; k < len; k++) {
+				this._addTile(queue[k], fragment);
+			}
+
+			this._container.appendChild(fragment);
 		}
-
-		this._container.appendChild(fragment);
 	},
 
 	_removeOtherTiles: function (bounds) {


### PR DESCRIPTION
I don't really know if this is a bug or a feature. The load event of a TileLayer is only fired once. My expectation (and understanding of the underlying code) is that this event should be fired every time there are no tiles of the TileLayer left to load. 

This example demonstrates the possible bug. http://jsfiddle.net/kGCPb/4/  
Zoom in and out and you will see the load event (in the debug console) only once after the initialization of the map. Every pan/zoom of the map after that results in a negative number of _tilesToLoad of the TileLayer. But the event is only fired if the _tilesToLoad is zero.

I think this bug was already issued before as part of another bug. https://github.com/CloudMade/Leaflet/issues/177

Anyway. Adding this line (like proposed in the issue of lapinos03) should fix that problem. 

``` javascript
_addTilesFromCenterOut: function (bounds) {
  var queue = [],
  center = bounds.getCenter();

  var j, i;
  for (j = bounds.min.y; j <= bounds.max.y; j++) {
    for (i = bounds.min.x; i <= bounds.max.x; i++) {
      if (!((i + ':' + j) in this._tiles)) {
        queue.push(new L.Point(i, j));
      }
    }
  }

  // load tiles in order of their distance to center
  queue.sort(function (a, b) {
    return a.distanceTo(center) - b.distanceTo(center);
  });

  var fragment = document.createDocumentFragment();

  // New line
  if(queue.length == 0) return;

  this._tilesToLoad = queue.length;

  console.log(this._tilesToLoad);

  var k, len;
    for (k = 0, len = this._tilesToLoad; k < len; k++) {
        this._addTile(queue[k], fragment);
    }

    this._container.appendChild(fragment);
},
```
