### PR TITLE
Rename animateMarkerZoom to markerZoomAnimation to match other animation options.

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -25,7 +25,7 @@ L.Marker = L.Class.extend({
 
 		map.on('viewreset', this._reset, this);
 
-		if (map.options.zoomAnimation && map.options.animateMarkerZoom) {
+		if (map.options.zoomAnimation && map.options.markerZoomAnimation) {
 			map.on('zoomanim', this._zoomAnimation, this);
 		}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -16,7 +16,7 @@ L.Map = L.Class.extend({
 
 		fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android,
 		trackResize: true,
-		animateMarkerZoom: true
+		markerZoomAnimation: true
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)
@@ -433,7 +433,7 @@ L.Map = L.Class.extend({
 		panes.markerPane = this._createPane('leaflet-marker-pane');
 		panes.popupPane = this._createPane('leaflet-popup-pane');
 
-		if (!this.options.animateMarkerZoom) {
+		if (!this.options.markerZoomAnimation) {
 			panes.markerPane.className += ' leaflet-zoom-hide';
 			panes.shadowPane.className += ' leaflet-zoom-hide';
 			panes.popupPane.className += ' leaflet-zoom-hide';


### PR DESCRIPTION
After looking at the documentation I realised this option should probably follow the existing naming of the animation options. Small update to do so :)
