### PR TITLE
Minor fixups for IE 10 support

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -10,6 +10,7 @@
 	L.Browser = {
 		ie: ie,
 		ie6: ie && !window.XMLHttpRequest,
+		ie3d: ie && ('transition' in document.createElement('div').style),
 
 		webkit: webkit,
 		webkit3d: webkit && ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()),
@@ -53,6 +54,6 @@
 			return touchSupported;
 		}())
 	};
-	L.Browser.any3d = !!L.Browser.webkit3d || !!L.Browser.gecko3d || !!L.Browser.opera3d;
+	L.Browser.any3d = !!L.Browser.webkit3d || !!L.Browser.gecko3d || !!L.Browser.opera3d || !!L.Browser.ie3d;
 		
 }());

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -155,7 +155,7 @@ L.DomUtil = {
 
 L.Util.extend(L.DomUtil, {
 	TRANSITION: L.DomUtil.testProp(['transition', 'webkitTransition', 'OTransition', 'MozTransition', 'msTransition']),
-	TRANSFORM: L.DomUtil.testProp(['transformProperty', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform']),
+	TRANSFORM: L.DomUtil.testProp(['transform', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform']),
 	BACKFACEVISIBILITY: L.DomUtil.testProp(['backfaceVisibility', 'WebkitBackfaceVisibility', 'OBackfaceVisibility', 'MozBackfaceVisibility', 'msBackfaceVisibility']),
 
 	TRANSLATE_OPEN: 'translate' + (L.Browser.webkit3d ? '3d(' : '('),


### PR DESCRIPTION
This gets the marker zoom animations going in IE 10.
The map tiles zoom animation is a bit wonky, I'm not going to fix it at this stage as it works correctly in all other browsers. Will re-test when IE 10 is closer to release.

Not sure if multi-touch support will work as I don't have a device.
Tested with Release Preview in a VirtualBox VM.
