### PR TITLE
The ability to put DOM 'class' attribute onto svg path elements

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -83,23 +83,28 @@ L.DomUtil = {
 	},
 
 	hasClass: function (el, name) {
-		return (el.className.length > 0) &&
-				new RegExp("(^|\\s)" + name + "(\\s|$)").test(el.className);
+		var cls = el.getAttribute("class") || "";
+		return cls && (cls.length > 0) &&
+				new RegExp("(^|\\s)" + name + "(\\s|$)").test(cls);
 	},
 
 	addClass: function (el, name) {
 		if (!L.DomUtil.hasClass(el, name)) {
-			el.className += (el.className ? ' ' : '') + name;
+			var cls = el.getAttribute("class") || "";
+			var newcls = cls + (cls.length ? " " : "") + name;
+			el.setAttribute("class", newcls);
 		}
 	},
 
 	removeClass: function (el, name) {
-		el.className = el.className.replace(/(\S+)\s*/g, function (w, match) {
+		var cls = el.getAttribute("class");
+		cls = cls.replace(/(\S+)\s*/g, function (w, match) {
 			if (match === name) {
 				return '';
 			}
 			return w;
 		}).replace(/^\s+/, '');
+		el.setAttribute("class", cls);
 	},
 
 	setOpacity: function (el, value) {

--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -25,6 +25,9 @@ L.Path = L.Path.extend({
 		this._container = this._createElement('g');
 
 		this._path = this._createElement('path');
+		this._path.id = this.options.id;
+		L.DomUtil.addClass(this._path, this.options.className);
+
 		this._container.appendChild(this._path);
 
 		this._map._pathRoot.appendChild(this._container);
@@ -70,7 +73,7 @@ L.Path = L.Path.extend({
 	_initEvents: function () {
 		if (this.options.clickable) {
 			if (L.Browser.svg || !L.Browser.vml) {
-				this._path.setAttribute('class', 'leaflet-clickable');
+				L.DomUtil.addClass(this._path, "leaflet-clickable");
 			}
 
 			L.DomEvent.addListener(this._container, 'click', this._onMouseClick, this);
@@ -121,7 +124,7 @@ L.Map.include({
 			this._panes.overlayPane.appendChild(this._pathRoot);
 
 			if (this.options.zoomAnimation) {
-				this._pathRoot.setAttribute('class', ' leaflet-zoom-animated');
+				L.DomUtil.addClass(this._pathRoot, 'leaflet-zoom-animated');
 				this.on('zoomanim', this._animatePathZoom);
 				this.on('zoomend', this._endPathZoom);
 			}

--- a/src/layer/vector/Path.VML.js
+++ b/src/layer/vector/Path.VML.js
@@ -39,6 +39,9 @@ L.Path = L.Browser.svg || !L.Browser.vml ? L.Path : L.Path.extend({
 		container.coordsize = '1 1';
 
 		this._path = this._createElement('path');
+		this._path.id = this.options.id;
+		L.DomUtil.addClass(this._path, this.options.className);
+
 		container.appendChild(this._path);
 
 		this._map._pathRoot.appendChild(container);

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -21,7 +21,10 @@ L.Path = L.Class.extend({
 		fillColor: null, //same as color by default
 		fillOpacity: 0.2,
 
-		clickable: true
+		clickable: true,
+
+		className: null,
+		id: null
 	},
 
 	initialize: function (options) {

--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -16,6 +16,8 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 	_initElements: function () {
 		this._map._initPathRoot();
 		this._ctx = this._map._canvasCtx;
+		this._path.id = this.options.id;
+		L.DomUtil.addClass(this._path, this.options.className);
 	},
 
 	_updateStyle: function () {


### PR DESCRIPTION
at least in Chrome, svg.g.path was sensitive to el.className accessor, so I changed them to getAttribute/setAttribute and things began working much better.  Further, I added a way to add class names to path elements as you create them.
