### PR TITLE
Fix for fitBounds while using crs.Simple projection

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -286,7 +286,7 @@ L.Map = L.Class.extend({
 			zoom++;
 			nePoint = this.project(ne, zoom);
 			swPoint = this.project(sw, zoom);
-			boundsSize = new L.Point(nePoint.x - swPoint.x, swPoint.y - nePoint.y);
+			boundsSize = new L.Point(Math.abs(nePoint.x - swPoint.x), Math.abs(swPoint.y - nePoint.y));
 
 			if (!inside) {
 				zoomNotFound = boundsSize.x <= size.x && boundsSize.y <= size.y;


### PR DESCRIPTION
We are using Leaflet as a tiled image view, not for maps. When using the crs.Simple projection the fitBounds method wasn't always working. We tracked this down the negative distances being calculated in the getBoundsZoom function. Making sure these distances are always positive fixes the problem.
