### PR TITLE
Make the android hacks only happen for android 2 and 3.

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -6,6 +6,7 @@
 		gecko = ua.indexOf("gecko") !== -1,
 		opera = window.opera,
 		android = ua.indexOf("android") !== -1,
+		android23 = ua.search("android [23]") !== -1,
 		mobile = typeof orientation !== undefined + '' ? true : false,
 		doc = document.documentElement,
 		ie3d = ie && ('transition' in doc.style),
@@ -47,6 +48,7 @@
 		gecko: gecko,
 		opera: opera,
 		android: android,
+		android23: android23,
 
 		ie3d: ie3d,
 		webkit3d: webkit3d,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -15,7 +15,7 @@ L.Map = L.Class.extend({
 		layers: Array,
 		*/
 
-		fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android,
+		fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android23,
 		trackResize: true,
 		markerZoomAnimation: true
 	},

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -1,5 +1,5 @@
 L.Map.mergeOptions({
-	zoomAnimation: L.DomUtil.TRANSITION && !L.Browser.android && !L.Browser.mobileOpera
+	zoomAnimation: L.DomUtil.TRANSITION && !L.Browser.android23 && !L.Browser.mobileOpera
 });
 
 L.Map.include(!L.DomUtil.TRANSITION ? {} : {
@@ -58,7 +58,7 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 		// it breaks touch zoom which Anroid doesn't support anyway, so that's a really ugly hack
 
 		// TODO work around this prettier
-		if (L.Browser.android) {
+		if (L.Browser.android23) {
 			tileBg.style[transform + 'Origin'] = origin.x + 'px ' + origin.y + 'px';
 			scaleStr = 'scale(' + scale + ')';
 		} else {
@@ -83,7 +83,7 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 
 		// If foreground layer doesn't have many tiles but bg layer does, keep the existing bg layer and just zoom it some more
 		// (disable this for Android due to it not supporting double translate)
-		if (!L.Browser.android && tileBg &&
+		if (!L.Browser.android23 && tileBg &&
 				this._getLoadedTilesPercentage(tileBg) > 0.5 &&
 				this._getLoadedTilesPercentage(tilePane) < 0.5) {
 

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -5,7 +5,7 @@
 L.Map.mergeOptions({
 	dragging: true,
 
-	inertia: !L.Browser.android,
+	inertia: !L.Browser.android23,
 	inertiaDeceleration: L.Browser.touch ? 3000 : 2000, // px/s^2
 	inertiaMaxSpeed:     L.Browser.touch ? 1500 : 1000, // px/s
 	inertiaThreshold:    L.Browser.touch ? 32   : 16, // ms

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -3,7 +3,7 @@
  */
 
 L.Map.mergeOptions({
-	touchZoom: L.Browser.touch && !L.Browser.android
+	touchZoom: L.Browser.touch && !L.Browser.android23
 });
 
 L.Map.TouchZoom = L.Handler.extend({


### PR DESCRIPTION
On 4 (and hopefully future version) actually seem to do everything correct (Tested in chrome and the native browser).
Multitouch etc all work :)

Also tested that android 2 still does everything the un-awesome way.
