### PR TITLE
Fix Opacity in IE10

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -39,10 +39,18 @@
 		div = null;
 
 		return supported;
-	}());
+	}()),
+		ieversion = ie && (function () {
+			var re  = new RegExp("msie ([0-9]{1,}[\.0-9]{0,})");
+			if (re.exec(ua) != null)
+				return parseFloat(RegExp.$1);
+			return null;
+		}());
 
 	L.Browser = {
+		ua: ua,
 		ie: ie,
+		iefilter: ie && ieversion < 9,
 		ie6: ie6,
 		webkit: webkit,
 		gecko: gecko,

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -106,8 +106,8 @@ L.DomUtil = {
 	},
 
 	setOpacity: function (el, value) {
-		if (L.Browser.ie) {
-		    el.style.filter += value !== 1 ? 'alpha(opacity=' + Math.round(value * 100) + ')' : '';
+		if (L.Browser.iefilter) {
+			el.style.filter += value !== 1 ? 'alpha(opacity=' + Math.round(value * 100) + ')' : '';
 		} else {
 			el.style.opacity = value;
 		}


### PR DESCRIPTION
IE9 also uses style.opacity rather than the filter.

http://caniuse.com/#feat=css-opacity
Regex from http://msdn.microsoft.com/en-us/library/ms537509(v=vs.85).aspx
