### PR TITLE
Fix JSHint issues with my last pull

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -41,9 +41,10 @@
 		return supported;
 	}()),
 		ieversion = ie && (function () {
-			var re  = new RegExp("msie ([0-9]{1,}[\.0-9]{0,})");
-			if (re.exec(ua) != null)
+			var re  = new RegExp("msie ([0-9]{1,}[\\.0-9]{0,})");
+			if (re.exec(ua) !== null) {
 				return parseFloat(RegExp.$1);
+			}
 			return null;
 		}());
 


### PR DESCRIPTION
I'm trying out sublimetext with automatic JSHint-ing now, so I shouldn't make this mistake again!
