### PR TITLE
Detect retina displays and adjust wmsParams.width and wmsParams.height accordingly

### DIFF
--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -13,7 +13,12 @@ L.TileLayer.WMS = L.TileLayer.extend({
 		this._url = url;
 
 		var wmsParams = L.Util.extend({}, this.defaultWmsParams);
-		wmsParams.width = wmsParams.height = this.options.tileSize;
+
+		if (options.detectRetina && window.devicePixelRatio > 1) {
+			wmsParams.width = wmsParams.height = this.options.tileSize * 2;
+		} else {
+			wmsParams.width = wmsParams.height = this.options.tileSize;
+		}
 
 		for (var i in options) {
 			// all keys that are not TileLayer options go to WMS params


### PR DESCRIPTION
Porting #586 to `TileLayer.WMS.js` as requested in #789.

For WMS layers, if I understand correctly, it is enough to double `wmsParams.width` and `wmsParams.height` for retina displays, leaving everything else intact.
