### PR TITLE
Position tiles with transform for safari to get around animation errors.

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -4,6 +4,7 @@
 		ie6 = ie && !window.XMLHttpRequest,
 		webkit = ua.indexOf("webkit") !== -1,
 		gecko = ua.indexOf("gecko") !== -1,
+		safari = ua.indexOf("safari") !== -1 && ua.indexOf("chrome") === -1,
 		opera = window.opera,
 		android = ua.indexOf("android") !== -1,
 		android23 = ua.search("android [23]") !== -1,
@@ -50,6 +51,8 @@
 		opera: opera,
 		android: android,
 		android23: android23,
+
+		safari: safari && !mobile,
 
 		ie3d: ie3d,
 		webkit3d: webkit3d,

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -315,7 +315,8 @@ L.TileLayer = L.Class.extend({
 
 		// get unused tile - or create a new tile
 		var tile = this._getTile();
-		L.DomUtil.setPosition(tile, tilePos, true);
+		//Chrome 20 layouts much faster with top/left (Verify with timeline, frames), Safari 5.1.7 has display issues with top/left and requires transform instead. (Other browsers don't currently care)
+		L.DomUtil.setPosition(tile, tilePos, !L.Browser.safari);
 
 		this._tiles[key] = tile;
 


### PR DESCRIPTION
For error #800

Chrome does layout positioning much faster if you use top/left (Verify in chromium in timeline, frames).
Safari (Mac) has issues during animations if you use top/left for tile positioning, so use transform there.

Other browsers don't seem to care, so they use top/left. (Tested on FF, IE9, Chrome, Opera, Mac Safari, iPad, Android 4, Android 4 Chrome)
