### PR TITLE
Make Marker options.opacity/setOpacity set the Shadow opacity as well as the marker opacity

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -211,7 +211,7 @@ L.Marker = L.Class.extend({
 		}
 	},
 
-	_updateOpacity: function (opacity) {
+	_updateOpacity: function () {
 		L.DomUtil.setOpacity(this._icon, this.options.opacity);
 		if (this._shadow) {
 			L.DomUtil.setOpacity(this._shadow, this.options.opacity);


### PR DESCRIPTION
Otherwise your shadow can end up more visible than your marker: setOpacity(0)
