### PR TITLE
Added support for dashed strokes.

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -59,6 +59,11 @@ L.Path = L.Path.extend({
 			this._path.setAttribute('stroke', this.options.color);
 			this._path.setAttribute('stroke-opacity', this.options.opacity);
 			this._path.setAttribute('stroke-width', this.options.weight);
+			if (this.options.dashArray) {
+				this._path.setAttribute('stroke-dasharray', this.options.dashArray);
+			} else {
+				this._path.removeAttribute('stroke-dasharray');
+			}
 		} else {
 			this._path.setAttribute('stroke', 'none');
 		}

--- a/src/layer/vector/Path.VML.js
+++ b/src/layer/vector/Path.VML.js
@@ -72,6 +72,11 @@ L.Path = L.Browser.svg || !L.Browser.vml ? L.Path : L.Path.extend({
 			stroke.weight = options.weight + 'px';
 			stroke.color = options.color;
 			stroke.opacity = options.opacity;
+			if (options.dashArray) {
+				stroke.dashStyle = options.dashArray;
+			} else {
+				stroke.dashStyle = '';
+			}
 		} else if (stroke) {
 			container.removeChild(stroke);
 			this._stroke = null;

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -18,6 +18,7 @@ L.Path = L.Class.extend({
 	options: {
 		stroke: true,
 		color: '#0033ff',
+		dashArray: null,
 		weight: 5,
 		opacity: 0.5,
 


### PR DESCRIPTION
We have a use case where we style the stroke of a vector shape as dashed. Initially I thought to do this with  css. SVG supported this, VML did not :(

This pull adds the stroke property dasharray/dashstyle to paths. VML needs a string or lengths separated by spaces and SVG can take both space separated or comma separated.

http://msdn.microsoft.com/en-us/library/bb264085(v=vs.85).aspx
https://developer.mozilla.org/en/SVG/Attribute/stroke-dasharray

Tested in IE7, IE8-9 (via IE9), FF, Chrome & Safari.

I haven't updated the docs yet. I notice you're working on them at the moment. Would you like me to add this property to the gh-pages-master branch (assuming this pull is accepted)?
