### PR TITLE
Fix up zoom fixes on Touch

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -22,8 +22,7 @@ L.Control.Zoom = L.Control.extend({
 			.on(link, 'click', L.DomEvent.stopPropagation)
 			.on(link, 'click', L.DomEvent.preventDefault)
 			.on(link, 'click', fn, context)
-			.on(link, 'dblclick', L.DomEvent.stopPropagation)
-			.on(link, 'dblclick', L.DomEvent.preventDefault);
+			.on(link, 'dblclick', L.DomEvent.stopPropagation);
 
 		return link;
 	}

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -33,11 +33,13 @@ L.Util.extend(L.DomEvent, {
 
 		obj.addEventListener(touchstart, onTouchStart, false);
 		obj.addEventListener(touchend, onTouchEnd, false);
+		return this;
 	},
 
 	removeDoubleTapListener: function (obj, id) {
 		var pre = '_leaflet_';
 		obj.removeEventListener(obj, obj[pre + 'touchstart' + id], false);
 		obj.removeEventListener(obj, obj[pre + 'touchend' + id], false);
+		return this;
 	}
 });


### PR DESCRIPTION
Fake doubleTap handler wasn't returning itself, breaking the chaining. Remove the preventDefault on dblclick as it does nothing.

Turns out this fix doesn't prevent double tap on the zoom button on touch devices, may yet fix this.
