### PR TITLE
Add zIndex support to L.TileLayer

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -11,7 +11,8 @@
 .leaflet-popup-pane,
 .leaflet-overlay-pane svg,
 .leaflet-zoom-box,
-.leaflet-image-layer { /* TODO optimize classes */
+.leaflet-image-layer,
+.leaflet-layer { /* TODO optimize classes */
 	position: absolute;
 	}
 .leaflet-container {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -12,6 +12,7 @@ L.TileLayer = L.Class.extend({
 		subdomains: 'abc',
 		errorTileUrl: '',
 		attribution: '',
+		zIndex: 0,
 		opacity: 1,
 		tms: false,
 		continuousWorld: false,
@@ -124,6 +125,13 @@ L.TileLayer = L.Class.extend({
 		return this;
 	},
 
+	setZIndex: function (zIndex) {
+		this.options.zIndex = zIndex;
+		this._updateZIndex();
+
+		return this;
+	},
+
 	setUrl: function (url, noRedraw) {
 		this._url = url;
 
@@ -141,6 +149,12 @@ L.TileLayer = L.Class.extend({
 			this._update();
 		}
 		return this;
+	},
+
+	_updateZIndex: function () {
+		if (this._container) {
+			this._container.style.zIndex = this.options.zIndex;
+		}
 	},
 
 	_updateOpacity: function () {
@@ -165,6 +179,8 @@ L.TileLayer = L.Class.extend({
 
 		if (!this._container || tilePane.empty) {
 			this._container = L.DomUtil.create('div', 'leaflet-layer');
+
+			this._updateZIndex();
 
 			if (this._insertAtTheBottom && first) {
 				tilePane.insertBefore(this._container, first);


### PR DESCRIPTION
I had a problem where I needed to have three tile layers displayed in a strict order:
- base map layer (L.TileLayer)
- street overlay (L.TileLayer.WMS)
- marker overlay (L.TileLayer.WMS)

The street and marker WMS overlays can be toggled on and off by the user, so having a z-index set on each layer allows this order to be maintained as they are added and removed from the map.
