### PR TITLE
fix IE8 error with calling call() on window.clearTimeout()

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -120,7 +120,10 @@ L.Util = {
 
 	var cancelFn = window.cancelAnimationFrame ||
 			getPrefixed('CancelAnimationFrame') ||
-			getPrefixed('CancelRequestAnimationFrame') || window.clearTimeout;
+			getPrefixed('CancelRequestAnimationFrame') ||
+			function (id) {
+				window.clearTimeout(id);
+			};
 
 
 	L.Util.requestAnimFrame = function (fn, context, immediate, element) {


### PR DESCRIPTION
In IE8 <code>L.Util.cancelAnimFrame</code> uses <code>window.clearTimeout()</code> as its cancelFn. I am getting "Object doesn't support this property or method" errors when cancelFn.call(window, id) is called.

It seems that native functions in IE8 don't have <code> .call() or .apply()</code> methods. A simple solution here is to wrap window.clearTimeout() in a anonymous function.

Alternatively cancelFn could be called directly eg: <code>cancelFn(id)</code> as window is the default context anyway. I favoured the first approach in this pull request as I wasn't sure if not explicitly setting the window context would cause problems in other browsers.
