### PR TITLE
Add support for custom units in scale control

### DIFF
--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -42,7 +42,26 @@
 		});
 
 		map.addControl(layersControl);
-		map.addControl(new L.Control.Scale());
+		map.addControl(new L.Control.Scale({
+			metric: true,
+			imperial: true,
+			// Custom scale in nautical miles
+			custom: function(maxMeters, leafletDefaultRoundingFunction) {
+				var maxNauticalMiles = maxMeters / 1852, 
+					nauticalMiles;
+					
+				if(maxMeters >= 1852) {
+					nauticalMiles = leafletDefaultRoundingFunction(maxNauticalMiles);
+				} else {
+					nauticalMiles = maxNauticalMiles > 0.1 ? Math.round(maxNauticalMiles * 10) / 10 : Math.round(maxNauticalMiles * 100) / 100;
+				}
+
+				return {
+					caption: nauticalMiles + ' nm',
+					ratio: nauticalMiles / maxNauticalMiles
+				}
+			}
+		}));
 
 	</script>
 </body>

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -227,11 +227,14 @@
 	text-shadow: 1px 1px 1px #fff;
 	background-color: rgba(255, 255, 255, 0.5);
 	}
-.leaflet-control-scale-line:nth-child(2) {
+.leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;
 	padding-top: 1px;
 	border-bottom: none;
 	margin-top: -2px;
+	}
+.leaflet-control-scale-line:not(:first-child):not(:last-child) {
+	border-bottom: 2px solid #777;
 	}
 
 .leaflet-touch .leaflet-control-attribution, .leaflet-touch .leaflet-control-layers {

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -4,6 +4,7 @@ L.Control.Scale = L.Control.extend({
 		maxWidth: 100,
 		metric: true,
 		imperial: true,
+		custom: undefined,
 		updateWhenIdle: false
 	},
 
@@ -19,6 +20,9 @@ L.Control.Scale = L.Control.extend({
 		}
 		if (options.imperial) {
 			this._iScale = L.DomUtil.create('div', className + '-line', container);
+		}
+		if (options.custom) {
+			this._cScale = L.DomUtil.create('div', className + '-line', container);
 		}
 
 		map.on(options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
@@ -52,6 +56,10 @@ L.Control.Scale = L.Control.extend({
 		if (options.imperial && maxMeters) {
 			this._updateImperial(maxMeters);
 		}
+
+		if (options.custom && maxMeters) {
+			this._updateCustom(maxMeters);
+		}
 	},
 
 	_updateMetric: function (maxMeters) {
@@ -79,6 +87,13 @@ L.Control.Scale = L.Control.extend({
 			scale.style.width = this._getScaleWidth(feet / maxFeet) + 'px';
 			scale.innerHTML = feet + ' ft';
 		}
+	},
+
+	_updateCustom: function (maxMeters) {
+		var scale = this._cScale
+			result = this.options.custom(maxMeters, this._getRoundNum);
+		scale.style.width = this._getScaleWidth(result.ratio) + 'px';
+		scale.innerHTML = result.caption;
 	},
 
 	_getScaleWidth: function (ratio) {


### PR DESCRIPTION
This is meant as a more lightweight (yet also more flexible) solution to the nautical miles scale proposed in https://github.com/CloudMade/Leaflet/pull/839, not introducing any more (unit) specific code (rounding functions, etc.) into the leaflet core, but instead allowing leaflet users to implement any custom scale via a simple callback function.

Would this be more appropriate to go into leaflet core?

Commit message with details:
Custom unit works via a callback that is passed the current
maximum scale in meters and supposed to return a hash containing
a caption (number and unit) to be displayed in the scale control
and a ratio (rounded meters / max meters) for correct sizing of
the scale control.

For convenience and consistency, the callback also receives a
reference to the default leaflet scale control rounding function.

Styles have been more made slightly more generic to (theoretically)
support an infinite number of scales (treating the first and last
ones as special).

The controls example has be amended with an example of a custom
scale (nautical miles).
