### PR TITLE
Provide the hooks needed for writing plugins / extensions to scale control

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -227,11 +227,14 @@
 	text-shadow: 1px 1px 1px #fff;
 	background-color: rgba(255, 255, 255, 0.5);
 	}
-.leaflet-control-scale-line:nth-child(2) {
+.leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;
 	padding-top: 1px;
 	border-bottom: none;
 	margin-top: -2px;
+	}
+.leaflet-control-scale-line:not(:first-child):not(:last-child) {
+	border-bottom: 2px solid #777;
 	}
 
 .leaflet-touch .leaflet-control-attribution, .leaflet-touch .leaflet-control-layers {

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -14,12 +14,7 @@ L.Control.Scale = L.Control.extend({
 		    container = L.DomUtil.create('div', className),
 		    options = this.options;
 
-		if (options.metric) {
-			this._mScale = L.DomUtil.create('div', className + '-line', container);
-		}
-		if (options.imperial) {
-			this._iScale = L.DomUtil.create('div', className + '-line', container);
-		}
+		this._addScales(options, className, container);
 
 		map.on(options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
 		this._update();
@@ -29,6 +24,16 @@ L.Control.Scale = L.Control.extend({
 
 	onRemove: function (map) {
 		map.off(this.options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
+	},
+
+	_addScales: function(options, className, container) {
+		if (options.metric) {
+			this._mScale = L.DomUtil.create('div', className + '-line', container);
+		}
+
+		if (options.imperial) {
+			this._iScale = L.DomUtil.create('div', className + '-line', container);
+		}
 	},
 
 	_update: function () {
@@ -45,6 +50,10 @@ L.Control.Scale = L.Control.extend({
 			maxMeters = dist * (options.maxWidth / size.x);
 		}
 
+		this._updateScales(options, maxMeters);
+	},
+
+	_updateScales: function (options, maxMeters) {
 		if (options.metric && maxMeters) {
 			this._updateMetric(maxMeters);
 		}


### PR DESCRIPTION
Separate the creation of scales as well as the updating of them into
separate methods, which allows for plugins to overwrite these methods
in order to add an extra scale and update it.

Update style to support n scales instead of exactly one or two.

See https://github.com/CloudMade/Leaflet/pull/844 for details...
