### PR TITLE
Fix FeatureGroup.removeLayer removing popups

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -26,7 +26,11 @@ L.FeatureGroup = L.LayerGroup.extend({
 
 		L.LayerGroup.prototype.removeLayer.call(this, layer);
 
-		return this.invoke('unbindPopup');
+		if (this._popupContent) {
+			return this.invoke('unbindPopup');
+		} else {
+			return this;
+		}
 	},
 
 	bindPopup: function (content) {


### PR DESCRIPTION
When removing a marker from a FeatureGroup, only remove the popup if it was put there by the FeatureGroup.

Refs danzel/Leaflet.markercluster#24
