### PR TITLE
Two typos

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1354,7 +1354,7 @@ var map = L.map('map', {
 	<tr>
 		<td><code><b>offset</b></code></td>
 		<td><code><a href="#point">Point</a></code></td>
-		<td><code><nobr>Point(<span class="number">0</span>, <span class="number">0</span>)</nobr>
+		<td><code><nobr>Point(<span class="number">0</span>, <span class="number">6</span>)</nobr>
 		</code></td>
 		<td>The offset of the popup position. Useful to control the anchor of the popup when opening it on some overlays.</td>
 	</tr>
@@ -5197,7 +5197,7 @@ draggable.enable();
 		</code></td>
 
 		<td>-</td>
-		<td>Should contain all clean up code that removes the overlay's elements from the DOM and removes listeners preciously added in <code>onAdd</code>. Called on <code>map.removeLayer(layer)</code>.</td>
+		<td>Should contain all clean up code that removes the overlay's elements from the DOM and removes listeners previously added in <code>onAdd</code>. Called on <code>map.removeLayer(layer)</code>.</td>
 	</tr>
 </table>
 


### PR DESCRIPTION
Fixing typos ("preciously" should be "previously"), the default values of offset for L.Popup are (0,6), not (0,0).
