### PR TITLE
Add unbindPopup() and closePopup() methods to Path objects

### DIFF
--- a/src/layer/vector/Path.Popup.js
+++ b/src/layer/vector/Path.Popup.js
@@ -20,6 +20,15 @@ L.Path.include({
 		return this;
 	},
 
+	unbindPopup: function () {
+		if (this._popup) {
+			this._popup = null;
+			this.off('click', this._openPopup);
+			this._openPopupAdded = false;
+		}
+		return this;
+	},
+
 	openPopup: function (latlng) {
 
 		if (this._popup) {
@@ -32,8 +41,18 @@ L.Path.include({
 		return this;
 	},
 
+	closePopup: function () {
+		if (this._popup) {
+			this._popup._close();
+		}
+
+		return this;
+	},
+
 	_openPopup: function (e) {
-		this._popup.setLatLng(e.latlng);
-		this._map.openPopup(this._popup);
+		if (this._popup) {
+			this._popup.setLatLng(e.latlng);
+			this._map.openPopup(this._popup);
+		}
 	}
 });


### PR DESCRIPTION
I needed unbind and close methods for popups on Path objects, and saw Markers have them but Paths don't.
