### PR TITLE
Bring markers to front when mouseover

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -173,7 +173,7 @@ L.Marker = L.Class.extend({
 		this._updateZIndex();
 	},
 
-	_updateZIndex: function() {
+	_updateZIndex: function () {
 		var offset = this._broughtToFrontOffset || 0;
 		this._icon.style.zIndex = this._zIndex + offset;
 	},


### PR DESCRIPTION
The need for this functionality is more apparent when using the Leaflet.iconlabel plugin. As the icons label is a sibling to the icon the label will appear under a marker that is further down the screen (will have higher z-index). This pull fixes the issue.

This will also mean that when using different icons, the one that the user is over will show.

Added a couple of options to L.Marker: `bringToFront` and `bringToFrontZOffset`. Could probably turn the functionality off by default if necessary.

If accepted I will also update the docs.
