### PR TITLE
Added support for different CRS for each L.TileLayer.WMS instance

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -363,6 +363,11 @@ L.Map = L.Class.extend({
 		return this.options.crs.pointToLatLng(L.point(point), zoom);
 	},
 
+	reproject: function (crs, point, zoom, unbounded) { // (CRS, Point[, Number, Boolean]) -> Point
+		crs = (typeof crs === 'undefined' ? this.options.crs : crs);
+		return crs.project(this.unproject(point, zoom, unbounded));
+	},
+	
 	layerPointToLatLng: function (point) { // (Point)
 		var projectedPoint = L.point(point).add(this._initialTopLeftPoint);
 		return this.unproject(projectedPoint);


### PR DESCRIPTION
This is a partial implementation of issue #942 which only affects L.TileLayer.WMS.

It turned out to be pretty easy to add support for different CRS for each L.TileLayer.WMS instance. I just had to add a small reproject method to L.Map which default to old algorithm in L.TileLayer.WMS.getTileUrl when L.TileLayer.WMS.option.crs (L.CRS instance) is not set (default: undefined). When set, L.Map.reproject uses this to reproject given point and zoom (L.Point) from L.Map.options.crs to given L.CRS (in this case L.TileLayer.WMS.options.crs is set, otherwise L.Map.options.crs as before).

_Example usage_

``` javascript
var map = L.map('map'),
    url = ... ,
    options = { ... , crs: L.CRS.EPSG4326};
L.tileLayer.wms(url, options).addTo(map);
```

which force `EPSG:4326` to be used in WMS requests instead of `EPSG:3857` which `map` now by default uses.

<!---
@huboard:{"order":30.166015625}
-->
