### PR TITLE
Optimize _requestUpdate in Path.Canvas.

### DIFF
--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -10,9 +10,7 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 	statics: {
 		//CLIP_PADDING: 0.02, // not sure if there's a need to set it to a small value
 		CANVAS: true,
-		SVG: false,
-
-		_updateRequest: null
+		SVG: false
 	},
 
 	redraw: function () {
@@ -44,9 +42,8 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 	},
 
 	_requestUpdate: function () {
-		if (this._map && L.Path._updateRequest === null) {
+		if (this._map && !L.Path._updateRequest) {
 			L.Path._updateRequest = L.Util.requestAnimFrame(this._fireMapMoveEnd, this._map);
-			console.log('requested ' + L.Path._updateRequest);
 		}
 	},
 


### PR DESCRIPTION
Don't repeatedly request and cancel animation frames (previous code wasn't actually canceling the requests anyway!).
Fixes #950
