### PR TITLE
Correct TileLayer zIndex behaviour on bringToBack

### DIFF
--- a/debug/tests/bringtoback.html
+++ b/debug/tests/bringtoback.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+
+	<link rel="stylesheet" href="../css/screen.css" />
+	<script src="../leaflet-include.js"></script>
+	<script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+</head>
+<body>
+
+	<div id="map"></div>
+	<button id="foo">Click to add layer, then zoom out or in</button>
+
+	<script type="text/javascript">
+
+	var map = new L.Map('map', { center: new L.LatLng(45.50144, -122.67599), zoom: 4 });
+
+	var demoUrl='http://server.arcgisonline.com/ArcGIS/rest/services/Demographics/USA_Average_Household_Size/MapServer/tile/{z}/{y}/{x}';
+	var demoMap = new L.TileLayer(demoUrl, { maxZoom: 19, attribution: 'Tiles: &copy; Esri' });
+
+	map.addLayer(demoMap);
+
+	$('#foo').click(function() {
+		var topoUrl='http://server.arcgisonline.com/ArcGIS/rest/services/USA_Topo_Maps/MapServer/tile/{z}/{y}/{x}';
+	var topoMap = new L.TileLayer(topoUrl, { maxZoom: 19, attribution: 'Tiles: &copy; Esri' });
+	map.addLayer(topoMap);
+	topoMap.bringToBack();
+	});
+	</script>
+</body>
+</html>

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -181,7 +181,7 @@ L.TileLayer = L.Class.extend({
 			}
 		}
 
-		this._container.style.zIndex = isFinite(edgeZIndex) ? edgeZIndex + compare(1, -1) : '';
+		this.options.zIndex = this._container.style.zIndex = (isFinite(edgeZIndex) ? edgeZIndex : 0) + compare(1, -1);
 	},
 
 	_updateOpacity: function () {


### PR DESCRIPTION
Previously if you had 2 Tile Layers, neither of which had a zindex we'd set the zIndex to 0 on bringToBack and not remember it. On zoom it would revert and the layer would go behind.
Also Add a test page for tile layer zIndex.

Fixes #959
