### PR TITLE
IsValid for Bounds and LatLngBounds

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -1,1 +1,23 @@
-describe('LatLngBounds', noSpecs);
+describe('LatLngBounds', function() {
+	var a, c;
+	
+	beforeEach(function() {
+		a = new L.Bounds(
+			new L.Point(14, 12),
+			new L.Point(30, 40));
+		c = new L.Bounds();
+	});
+	
+	describe('#isValid', function() {
+		it('should return true if properly set up', function() {
+			expect(a.isValid()).toBeTruthy();
+		});
+		it('should return false if is invalid', function() {
+			expect(c.isValid()).toBeFalsy();
+		});
+		it('should be valid if extended', function() {
+			c.extend([0, 0]);
+			expect(c.isValid()).toBeTruthy();
+		});
+	});
+});

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -1,15 +1,16 @@
 describe('Bounds', function() {
-	var a, b;
+	var a, b, c;
 	
 	beforeEach(function() {
 		a = new L.Bounds(
 			new L.Point(14, 12),
 			new L.Point(30, 40));
 		b = new L.Bounds([
-   			new L.Point(20, 12),
-   			new L.Point(14, 20),
-   			new L.Point(30, 40)
-   		]);
+			new L.Point(20, 12),
+			new L.Point(14, 20),
+			new L.Point(30, 40)
+		]);
+		c = new L.Bounds();
 	});
 	
 	describe('constructor', function() {
@@ -40,14 +41,27 @@ describe('Bounds', function() {
 			expect(a.getCenter()).toEqual(new L.Point(22, 26));
 		});
 	});
-    
+	
 	describe('#contains', function() {
-	    it('should contains other bounds or point', function() {
-	        a.extend(new L.Point(50, 10));
-	        expect(a.contains(b)).toBeTruthy();
-	        expect(b.contains(a)).toBeFalsy();
-	        expect(a.contains(new L.Point(24, 25))).toBeTruthy();
-	        expect(a.contains(new L.Point(54, 65))).toBeFalsy();
-	    });
+		it('should contains other bounds or point', function() {
+			a.extend(new L.Point(50, 10));
+			expect(a.contains(b)).toBeTruthy();
+			expect(b.contains(a)).toBeFalsy();
+			expect(a.contains(new L.Point(24, 25))).toBeTruthy();
+			expect(a.contains(new L.Point(54, 65))).toBeFalsy();
+		});
+	});
+	
+	describe('#isValid', function() {
+		it('should return true if properly set up', function() {
+			expect(a.isValid()).toBeTruthy();
+		});
+		it('should return false if is invalid', function() {
+			expect(c.isValid()).toBeFalsy();
+		});
+		it('should be valid if extended', function() {
+			c.extend([0, 0]);
+			expect(c.isValid()).toBeTruthy();
+		});
 	});
 });

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -122,6 +122,10 @@ L.LatLngBounds = L.Class.extend({
 
 		return this._southWest.equals(bounds.getSouthWest()) &&
 		       this._northEast.equals(bounds.getNorthEast());
+	},
+
+	isValid: function () {
+		return !!(this._southWest && this._northEast);
 	}
 });
 

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -78,8 +78,11 @@ L.Bounds = L.Class.extend({
 			yIntersects = (max2.y >= min.y) && (min2.y <= max.y);
 
 		return xIntersects && yIntersects;
-	}
+	},
 
+	isValid: function () {
+		return !!(this.min && this.max);
+	}
 });
 
 L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])


### PR DESCRIPTION
Implemented isValid() function for Bounds and LatLngBounds. Fixes issue #966. Added specification as well. 

Example usage:

``` javascript
data = L.geoJson([]); // data may come from user input/ ajax
bounds = data.getBounds()
if (bounds.isValid()) {
  map.fitBounds(bounds);
}
```
