### PR TITLE
Add tileBounds option to limit tile loading to a given region

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -44,7 +44,7 @@ L.TileLayer = L.Class.extend({
 		}
 
 		if (options.bounds) {
-			options.bounds = L.LatLngBounds(options.bounds);
+			options.bounds = L.latLngBounds(options.bounds);
 		}
 
 		this._url = url;


### PR DESCRIPTION
If someone needs to add a tile overlay that is limited to a given region (ex. city) we need a way to limit the tile requests to this region.
