### PR TITLE
Determine zoom in TileLayer.Canvas#_loadTile rather than expecting a zoom argument

### DIFF
--- a/src/layer/tile/TileLayer.Canvas.js
+++ b/src/layer/tile/TileLayer.Canvas.js
@@ -36,7 +36,9 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 		return tile;
 	},
 
-	_loadTile: function (tile, tilePoint, zoom) {
+	_loadTile: function (tile, tilePoint) {
+		var zoom = this._getZoomForUrl();
+		
 		tile._layer = this;
 		tile._tilePoint = tilePoint;
 		tile._zoom = zoom;


### PR DESCRIPTION
TileLayer.Canvas#_loadTile expects a zoom argument when called from TileLayer#_addTile, but the zoom argument is not passed anymore (looks like it was removed in c50aaabd). This adds a call to _getZoomForUrl to determine the zoom.
