### PR TITLE
When removing tiles, set tile element src to the empty image URL only if the tile element is an image

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -358,7 +358,7 @@ L.TileLayer = L.Class.extend({
 			this._container.removeChild(tile);
 		}
 
-		if (!L.Browser.android) { //For https://github.com/CloudMade/Leaflet/issues/137
+		if (!L.Browser.android && tile.tagName === "IMG") { //For https://github.com/CloudMade/Leaflet/issues/137
 			tile.src = L.Util.emptyImageUrl;
 		}
 
@@ -490,7 +490,7 @@ L.TileLayer = L.Class.extend({
 		var layer = this._layer;
 
 		//Only if we are loading an actual image
-		if (this.src !== L.Util.emptyImageUrl) {
+		if (this.src !== L.Util.emptyImageUrl || this.tagName !== "IMG") {
 			L.DomUtil.addClass(this, 'leaflet-tile-loaded');
 
 			layer.fire('tileload', {


### PR DESCRIPTION
When a tile is removed in TileLayer, its src attribute is set to L.Util.emptyImageUrl, but this doesn't make sense for subclasses, like TileLayer.Canvas. Also, _tileOnLoad currently checks the src attribute before adding the "leaflet-tile-loaded" class and firing a "tileload" event, which doesn't make sense for non-image tile layers. With the reuseTiles option on, this prevents the "leaflet-tile-loaded" class from being added to reused tiles.

This changes _removeTile and _tileOnLoad to only set or check the src attribute if the tile element is an IMG element.
