### PR TITLE
IE needs translate(0,0) hack to animate right too. Fixes #870.

### DIFF
--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -62,7 +62,7 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 		clearTimeout(this._clearTileBgTimer);
 
 		//dumb FireFox hack, I have no idea why this magic zero translate fixes the scale transition problem
-		if (L.Browser.gecko || window.opera) {
+		if (L.Browser.gecko || window.opera || L.Browser.ie3d) {
 			tileBg.style[transform] += ' translate(0,0)';
 		}
 


### PR DESCRIPTION
Fix found by oliverheilig, thanks!

I propose this be merged to the stable branch as well so IE10 users get an awesome experience too!
