### PR TITLE
Adding id element as an option to the Marker.

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -8,6 +8,7 @@ L.Marker = L.Class.extend({
 
 	options: {
 		icon: new L.Icon.Default(),
+		id: '',
 		title: '',
 		clickable: true,
 		draggable: false,
@@ -105,6 +106,10 @@ L.Marker = L.Class.extend({
 
 			if (options.title) {
 				this._icon.title = options.title;
+			}
+			
+			if (options.id) {
+				this._icon.id = options.id;
 			}
 
 			this._initInteraction();


### PR DESCRIPTION
This patch gives the ability to specify a user id as Marker option, which is then added to the img tag, so the img is retrievable programatically.

So from the classic

`marker = L.marker([50.5, 30.5], options={"title" : 123}).addTo(map);`
which result to 

```
<img src="dist/images/marker-icon.png" class="leaflet-marker-icon  leaflet-clickable leaflet-zoom-animated" style="margin-left: -13px; margin-top: -41px; width: 25px; height: 41px; -webkit-transform: translate3d(940px, 341px, 0px); z-index: 341; " title="123">
```

now it is possible to pass also an `id`
`marker = L.marker([50.5, 30.5], options={"title" : 123, "id"=123}).addTo(map);`
which render to

```
<img src="dist/images/marker-icon.png" class="leaflet-marker-icon  leaflet-clickable leaflet-zoom-animated" style="margin-left: -12px; margin-top: -41px; width: 25px; height: 41px; -webkit-transform: translate3d(576px, 282px, 0px); z-index: 282; " title="123" id="123">
```

I was thinking to update the docs as well, however I was unsure if I had to do the push request in gh-pages.

this is the snippet:

```
    <tr>
        <td><code><b>id</b></code></td>
        <td><code>String</code></td>
        <td><code><span class="string">''</span></code></td>
        <td>Id added to the img tag associated with the marker.</td>
    </tr>
```

which should be added to the Marker options.

<!---
@huboard:{"order":50.75}
-->
