### PR TITLE
Adds support for transforms of offsetParents in L.DomUtil.getViewportOff...

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -34,8 +34,21 @@ L.DomUtil = {
 		do {
 			top += el.offsetTop || 0;
 			left += el.offsetLeft || 0;
+			
+			// on webkit browser also check for translation transforms
+			if (L.Browser.webkit3d) {
+				var transformStyle = window.getComputedStyle(el).webkitTransform;
+				if (transformStyle && transformStyle !== 'none') {
+					var curTransform = new window.WebKitCSSMatrix(transformStyle);
+					var translateX = curTransform.m41;
+					var translateY = curTransform.m42;
+					top  += translateY || 0;
+					left += translateX || 0;
+				}
+			}
+			
 			pos = L.DomUtil.getStyle(el, 'position');
-
+			
 			if (el.offsetParent === docBody && pos === 'absolute') { break; }
 
 			if (pos === 'fixed') {


### PR DESCRIPTION
This fixes an issue with double click/taps and pinch zoom gestures if the map container is placed inside an element that has a translation transform applied to it. While this only fixes issues in webkit browsers, it may serve as a good starting point for further improvements. It may also not resolve issues with scaled or otherwise transformed containers.
