### PR TITLE
Order-of-initialization problem with setView()/getBounds()/moveend

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1,1 +1,14 @@
-describe("Map", noSpecs);
+describe("Map", function () {
+	describe("#getBounds", function () {
+		it("is safe to call from within a moveend callback during initial load (#1027)", function () {
+			var c = document.createElement('div'),
+				map = L.map(c);
+
+			map.on("moveend", function () {
+			  map.getBounds();
+			});
+
+			map.setView([51.505, -0.09], 13);
+		});
+	});
+});

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -517,6 +517,9 @@ L.Map = L.Class.extend({
 
 		this._tileLayersToLoad = this._tileLayersNum;
 
+		var loading = !this._loaded;
+		this._loaded = true;
+
 		this.fire('viewreset', {hard: !preserveMapOffset});
 
 		this.fire('move');
@@ -527,8 +530,7 @@ L.Map = L.Class.extend({
 
 		this.fire('moveend', {hard: !preserveMapOffset});
 
-		if (!this._loaded) {
-			this._loaded = true;
+		if (loading) {
 			this.fire('load');
 		}
 	},


### PR DESCRIPTION
I would expect the following to work:

```
var map = L.map('map');

map.on("moveend", function () {
  map.getBounds();
});

map.setView([51.505, -0.09], 13);
```

Instead, it produces the error "Set map center and zoom first."

Fiddle: http://jsfiddle.net/pTaeU/2/
