### PR TITLE
Add cardinal accessors to LatLngBounds

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -20,4 +20,28 @@ describe('LatLngBounds', function() {
 			expect(c.isValid()).toBeTruthy();
 		});
 	});
+
+	describe('#getSouthLat', function() {
+		it('returns the latitude of the southern bound', function() {
+			expect(a.getSouthLat()).toBe(14);
+		});
+	});
+
+	describe('#getWestLng', function() {
+		it('returns the longitude of the western bound', function() {
+			expect(a.getWestLng()).toBe(12);
+		});
+	});
+
+	describe('#getNorthLat', function() {
+		it('returns the latitude of the northern bound', function() {
+			expect(a.getNorthLat()).toBe(30);
+		});
+	});
+
+	describe('#getEastLng', function() {
+		it('returns the longitude of the eastern bound', function() {
+			expect(a.getEastLng()).toBe(40);
+		});
+	});
 });

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -73,6 +73,22 @@ L.LatLngBounds = L.Class.extend({
 		return new L.LatLng(this._southWest.lat, this._northEast.lng, true);
 	},
 
+	getSouthLat: function () {
+		return this._southWest.lat;
+	},
+
+	getWestLng: function () {
+		return this._southWest.lng;
+	},
+
+	getNorthLat: function () {
+		return this._northEast.lat;
+	},
+
+	getEastLng: function () {
+		return this._northEast.lng;
+	},
+
 	contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean
 		if (typeof obj[0] === 'number' || obj instanceof L.LatLng) {
 			obj = L.latLng(obj);


### PR DESCRIPTION
When retrieving individual bounds, `bounds.getNorthLat()` reads
better than `bounds.getNorthWest().lat`.
