### PR TITLE
Vector layers do not stop propagation of mouse events that they fire

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -138,6 +138,7 @@ L.Path = L.Path.extend({
 			containerPoint: containerPoint,
 			originalEvent: e
 		});
+		L.DomEvent.stopPropagation(e);
 	}
 });
 


### PR DESCRIPTION
Marker stops propagation of mouse events that it receives (except for mousedown events) but Path layers do not.  For example, if you dblclick on a Marker the Marker fires a dblclick event and the map does not.  If you dblclick on a Polygon the Polygon fires a dblclick event AND the map fires a dblclick event.
See jsfiddle: http://jsfiddle.net/fr9Uj/
When you double click on the polygon you see two console logs: "polygon doubleclicked" and "map doubleclicked" where I would expect to just see "polygon doubleclicked".

This was mainly an issue for me when I tried to add a context menu to a Path.  When I received a contextmenu event for a Path I would show one menu and a different one when I received a contextmenu event for the Map but since I was receiving both (first the Path event then the Map event) I would always just show the Map context menu when right clicking on a Path.
