### PR TITLE
Handler.MarkerDrag marker move event fix

### DIFF
--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -47,7 +47,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		marker._latlng = latlng;
 
 		marker
-			.fire('move')
+			.fire('move', { latlng: latlng })
 			.fire('drag');
 	},
 


### PR DESCRIPTION
Commit 4da0cb0104 added `latlng` to the 'move' event for `L.Marker`. This pull adds the `latlng` into the 'move' event triggered when a marker is dragged. `_movePopup` expects the event to have a `latlng`.
