### PR TITLE
Allow pointer-events to be set via options passed to shape

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -57,6 +57,9 @@ L.Path = L.Path.extend({
 		if (this.options.fill) {
 			this._path.setAttribute('fill-rule', 'evenodd');
 		}
+		if (this.options.pointerEvents) {
+			this._path.setAttribute('pointer-events', this.options.pointerEvents);
+		}
 		this._updateStyle();
 	},
 


### PR DESCRIPTION
Allow the pointer-events attribute to be set on SVG shapes.
http://www.w3.org/TR/SVG/interact.html#PointerEventsProperty
