### PR TITLE
load the css files from the script

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -43,11 +43,11 @@ function getBase(s){
     var len = s.length;
     var url;
         if(len===1){
-             url=s[0]
+             url=s[0].src
         }//if it's the only script
         else{
             for(var i = 0;i<len;i++){
-                var tu=s[i];
+                var tu=s[i].src;
                 var ta=tu.split("/")
                 if(ta[ta.length-1]==="leaflet.js"){
                     url=tu;


### PR DESCRIPTION
Instead of those 2 css links one inside of a conditional comment, we could have the script load the 2 css files not sure if this has been brought up before, the closest thing I could find was [this issue](https://github.com/CloudMade/Leaflet/issues/979).

The biggest benefit of something like this (besides only having one link to put in instead of 3) would be the ability to get rid of the conditional comment for a slightly more nuanced approach to css along the lines of [modernizr](http://modernizr.com/).
