### PR TITLE
Fix tile zoom animation in latest chrome canary

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -163,11 +163,10 @@ L.DomUtil = {
 
 	getScaleString: function (scale, origin) {
 
-		var preTranslateStr = L.DomUtil.getTranslateString(origin),
-			scaleStr = ' scale(' + scale + ') ',
-			postTranslateStr = L.DomUtil.getTranslateString(origin.multiplyBy(-1));
+		var preTranslateStr = L.DomUtil.getTranslateString(origin.add(origin.multiplyBy(-1 * scale))),
+		    scaleStr = ' scale(' + scale + ') ';
 
-		return preTranslateStr + scaleStr + postTranslateStr;
+		return preTranslateStr + scaleStr;
 	},
 
 	setPosition: function (el, point, disable3D) { // (HTMLElement, Point[, Boolean])

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -61,11 +61,6 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 
 		clearTimeout(this._clearTileBgTimer);
 
-		//dumb FireFox hack, I have no idea why this magic zero translate fixes the scale transition problem
-		if (L.Browser.gecko || window.opera || L.Browser.ie3d) {
-			tileBg.style[transform] += ' translate(0,0)';
-		}
-
 		L.Util.falseFn(tileBg.offsetWidth); //hack to make sure transform is updated before running animation
 
 		var scaleStr = L.DomUtil.getScaleString(scale, origin),


### PR DESCRIPTION
And remove the translate(0,0) hack for other browsers as this fixes it too :-) Fixes #1056
