### PR TITLE
can't add scale control to uninitialized map

### DIFF
--- a/spec/runner.html
+++ b/spec/runner.html
@@ -23,6 +23,7 @@
 
 	<!-- /control -->
 	<script type="text/javascript" src="suites/control/Control.LayersSpec.js"></script>
+	<script type="text/javascript" src="suites/control/Control.ScaleSpec.js"></script>
 
 	<!-- /core -->
 	<script type="text/javascript" src="suites/core/UtilSpec.js"></script>

--- a/spec/suites/control/Control.ScaleSpec.js
+++ b/spec/suites/control/Control.ScaleSpec.js
@@ -1,0 +1,6 @@
+describe("Control.Scale", function () {
+	it("can be added to an unloaded map", function () {
+		var map = L.map(document.createElement('div'));
+		new L.Control.Scale().addTo(map);
+	})
+});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1,4 +1,31 @@
 describe("Map", function () {
+	describe("#whenReady", function () {
+		describe("when the map has not yet been loaded", function () {
+			it("calls the callback when the map is loaded", function () {
+				var map = L.map(document.createElement('div')),
+					spy = jasmine.createSpy();
+
+				map.whenReady(spy);
+				expect(spy).not.toHaveBeenCalled();
+
+				map.setView([0, 0], 1);
+				expect(spy).toHaveBeenCalled();
+			})
+		});
+
+		describe("when the map has already been loaded", function () {
+			it("calls the callback immediately", function () {
+				var map = L.map(document.createElement('div')),
+					spy = jasmine.createSpy();
+
+				map.setView([0, 0], 1);
+				map.whenReady(spy);
+
+				expect(spy).toHaveBeenCalled();
+			});
+		});
+	});
+
 	describe("#getBounds", function () {
 		it("is safe to call from within a moveend callback during initial load (#1027)", function () {
 			var c = document.createElement('div'),

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -17,7 +17,7 @@ L.Control.Scale = L.Control.extend({
 		this._addScales(options, className, container);
 
 		map.on(options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
-		this._update();
+		map.whenReady(this._update, this);
 
 		return container;
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -162,16 +162,10 @@ L.Map = L.Class.extend({
             layer.on('load', this._onTileLayerLoad, this);
 		}
 
-		var onMapLoad = function () {
+		this.whenReady(function () {
 			layer.onAdd(this);
 			this.fire('layeradd', {layer: layer});
-		};
-
-		if (this._loaded) {
-			onMapLoad.call(this);
-		} else {
-			this.on('load', onMapLoad, this);
-		}
+		}, this);
 
 		return this;
 	},
@@ -604,6 +598,15 @@ L.Map = L.Class.extend({
 			clearTimeout(this._clearTileBgTimer);
 			this._clearTileBgTimer = setTimeout(L.Util.bind(this._clearTileBg, this), 500);
 		}
+	},
+
+	whenReady: function (callback, context) {
+		if (this._loaded) {
+			callback.call(context || this, this);
+		} else {
+			this.on('load', callback, context);
+		}
+		return this;
 	},
 
 


### PR DESCRIPTION
This throws an error:

```
var map = L.map('map');
L.control.scale().addTo(map);​
```

http://jsfiddle.net/CtJu7/1/

Can we special-case `map.on('load', callback)` to work like jQuery load, triggering the callback immediately if the map has already been loaded? Then `Scale#onAdd` could do:

```
map.on(options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
map.on('load', this_update, this);
```

And [this](https://github.com/CloudMade/Leaflet/blob/ec16ea8ace2d387090886301d379f69eada2fe77/src/map/Map.js#L170-L174) code could be refactored.

I'll send a PR if you agree.
