### PR TITLE
need a baselayerchange event

### DIFF
--- a/spec/happen.js
+++ b/spec/happen.js
@@ -1,0 +1,93 @@
+// https://github.com/tmcw/happen
+
+!(function(context) {
+    var h = {};
+
+    // Make inheritance bearable: clone one level of properties
+    function extend(child, parent) {
+        for (var property in parent) {
+            if (typeof child[property] == 'undefined') {
+                child[property] = parent[property];
+            }
+        }
+        return child;
+    }
+
+    h.once = function(x, o) {
+        var evt;
+
+        if (o.type.slice(0, 3) === 'key') {
+            if (typeof Event === 'function') {
+                evt = new Event(o.type);
+                evt.keyCode = o.keyCode || 0;
+                evt.charCode = o.charCode || 0;
+                evt.shift = o.shift || false;
+                evt.meta = o.meta || false;
+                evt.ctrl = o.ctrl || false;
+                evt.alt = o.alt || false;
+            } else {
+                evt = document.createEvent('KeyboardEvent');
+                // https://developer.mozilla.org/en/DOM/event.initKeyEvent
+                // https://developer.mozilla.org/en/DOM/KeyboardEvent
+                evt[(evt.initKeyEvent) ? 'initKeyEvent'
+                    : 'initKeyboardEvent'](
+                    o.type, //  in DOMString typeArg,
+                    true,   //  in boolean canBubbleArg,
+                    true,   //  in boolean cancelableArg,
+                    null,   //  in nsIDOMAbstractView viewArg,  Specifies UIEvent.view. This value may be null.
+                    o.ctrl || false,  //  in boolean ctrlKeyArg,
+                    o.alt || false,  //  in boolean altKeyArg,
+                    o.shift || false,  //  in boolean shiftKeyArg,
+                    o.meta || false,  //  in boolean metaKeyArg,
+                    o.keyCode || 0,     //  in unsigned long keyCodeArg,
+                    o.charCode || 0       //  in unsigned long charCodeArg);
+                );
+            }
+        } else {
+            evt = document.createEvent('MouseEvents');
+            // https://developer.mozilla.org/en/DOM/event.initMouseEvent
+            evt.initMouseEvent(o.type,
+                true, // canBubble
+                true, // cancelable
+                window, // 'AbstractView'
+                o.clicks || 0, // click count
+                o.screenX || 0, // screenX
+                o.screenY || 0, // screenY
+                o.clientX || 0, // clientX
+                o.clientY || 0, // clientY
+                o.ctrl || 0, // ctrl
+                o.alt || false, // alt
+                o.shift || false, // shift
+                o.meta || false, // meta
+                o.button || false, // mouse button
+                null // relatedTarget
+            );
+        }
+
+        x.dispatchEvent(evt);
+    };
+
+    var shortcuts = ['click', 'mousedown', 'mouseup', 'mousemove', 'keydown', 'keyup', 'keypress'],
+        s, i = 0;
+
+    while (s = shortcuts[i++]) {
+        h[s] = (function(s) {
+            return function(x, o) {
+                h.once(x, extend(o || {}, { type: s }));
+            };
+        })(s);
+    }
+
+    h.dblclick = function(x, o) {
+        h.once(x, extend(o || {}, {
+            type: 'dblclick',
+            clicks: 2
+        }));
+    };
+
+    this.happen = h;
+
+    if (typeof module !== 'undefined') {
+        module.exports = this.happen;
+    }
+})(this);

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" type="text/css" href="jasmine/jasmine.css">
 	<script type="text/javascript" src="jasmine/jasmine.js"></script>
 	<script type="text/javascript" src="jasmine/jasmine-html.js"></script>
+	<script type="text/javascript" src="happen.js"></script>
 
 	<!-- source files -->
 
@@ -19,6 +20,9 @@
 
 	<script type="text/javascript" src="suites/SpecHelper.js"></script>
 	<script type="text/javascript" src="suites/LeafletSpec.js"></script>
+
+	<!-- /control -->
+	<script type="text/javascript" src="suites/control/Control.LayersSpec.js"></script>
 
 	<!-- /core -->
 	<script type="text/javascript" src="suites/core/UtilSpec.js"></script>

--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -1,0 +1,32 @@
+describe("Control.Layers", function () {
+	var map;
+
+	beforeEach(function () {
+		map = L.map(document.createElement('div'));
+	});
+
+	describe("baselayerchange event", function () {
+		it("is fired on input that changes the base layer", function () {
+			var baseLayers = {"Layer 1": L.tileLayer(), "Layer 2": L.tileLayer()},
+				layers = L.control.layers(baseLayers).addTo(map),
+				spy = jasmine.createSpy();
+
+			map.on('baselayerchange', spy);
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[0]);
+
+			expect(spy).toHaveBeenCalled();
+			expect(spy.mostRecentCall.args[0].layer).toBe(baseLayers["Layer 1"]);
+		});
+
+		it("is not fired on input that doesn't change the base layer", function () {
+			var overlays = {"Marker 1": L.marker([0, 0]), "Marker 2": L.marker([0, 0])},
+				layers = L.control.layers({}, overlays).addTo(map),
+				spy = jasmine.createSpy();
+
+			map.on('baselayerchange', spy);
+			happen.click(layers._overlaysList.getElementsByTagName("input")[0]);
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -177,17 +177,25 @@ L.Control.Layers = L.Control.extend({
 	_onInputClick: function () {
 		var i, input, obj,
 			inputs = this._form.getElementsByTagName('input'),
-			inputsLen = inputs.length;
+			inputsLen = inputs.length,
+			baseLayer;
 
 		for (i = 0; i < inputsLen; i++) {
 			input = inputs[i];
 			obj = this._layers[input.layerId];
 
-			if (input.checked) {
-				this._map.addLayer(obj.layer, !obj.overlay);
-			} else {
+			if (input.checked && !this._map.hasLayer(obj.layer)) {
+				this._map.addLayer(obj.layer);
+				if (!obj.overlay) {
+					baseLayer = obj.layer;
+				}
+			} else if (!input.checked && this._map.hasLayer(obj.layer)) {
 				this._map.removeLayer(obj.layer);
 			}
+		}
+
+		if (baseLayer) {
+			this._map.fire('baselayerchange', {layer: baseLayer})
 		}
 	},
 


### PR DESCRIPTION
Detecting when the base layer has changed (e.g. from clicking in a `Layers` control) is harder than it should be.

The Layers control does not define the order in which it adds and removes layers, so input that changes the base layer may result in a `layeradd` event followed by a `layerremove` event, or a `layerremove` event followed by a `layeradd` event. This means that any handlers that are bound to either or both events cannot assume that the map has exactly one base layer. It may have zero, one or two depending on the order of events.

I suggest that the `Layers` control trigger a `baselayerchange` event on the map after responding to input that changes the base layer. This event would be triggered after the other layer events, and it would include a `layer` property set to the resulting base layer.
