### PR TITLE
Fix boxzoom for ie7

### DIFF
--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -56,8 +56,8 @@ L.Map.BoxZoom = L.Handler.extend({
 		L.DomUtil.setPosition(box, newPos);
 
 		// TODO refactor: remove hardcoded 4 pixels
-		box.style.width  = (Math.abs(offset.x) - 4) + 'px';
-		box.style.height = (Math.abs(offset.y) - 4) + 'px';
+		box.style.width  = (Math.max(0, Math.abs(offset.x) - 4)) + 'px';
+		box.style.height = (Math.max(0, Math.abs(offset.y) - 4)) + 'px';
 	},
 
 	_onMouseUp: function (e) {


### PR DESCRIPTION
Fix boxzoom for ie7, was trying to set negative width which is a JS error
