### PR TITLE
Fix box zoom opacity in < IE8.

### DIFF
--- a/dist/leaflet.ie.css
+++ b/dist/leaflet.ie.css
@@ -42,3 +42,6 @@
 .leaflet-control-attribution, .leaflet-control-layers {
 	background: white;
 	}
+.leaflet-zoom-box {
+	filter: alpha(opacity=50);
+	}


### PR DESCRIPTION
Currently when using box zoom in old IE you get a white box with no opacity.
