### PR TITLE
GeoJSON GeometryCollection passes consisent params to pointToLayer

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -91,19 +91,19 @@ L.Util.extend(L.GeoJSON, {
 			latlngs = this.coordsToLatLngs(coords, 1);
 			return new L.MultiPolyline(latlngs);
 
-		case "MultiPolygon":
+		case 'MultiPolygon':
 			latlngs = this.coordsToLatLngs(coords, 2);
 			return new L.MultiPolygon(latlngs);
 
-		case "GeometryCollection":
-            for (i = 0, len = geometry.geometries.length; i < len; i++) {
-                layer = this.geometryToLayer({
-                    "geometry": geometry.geometries[i],
-                    "type": "Feature",
-                    "properties": geojson.properties
-                }, pointToLayer);
-                layers.push(layer);
-            }
+		case 'GeometryCollection':
+			for (i = 0, len = geometry.geometries.length; i < len; i++) {
+				layer = this.geometryToLayer({
+					geometry: geometry.geometries[i],
+					type: 'Feature',
+					properties: geojson.properties
+				}, pointToLayer);
+				layers.push(layer);
+			}
 			return new L.FeatureGroup(layers);
 
 		default:


### PR DESCRIPTION
code that deals with [this issue](https://github.com/Leaflet/Leaflet/issues/1082) so that pointToLayer passes consistent parameters when it's called on GeometryCollections.
