### PR TITLE
 Fix #1094 (Remove popup during viewreset)

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -189,6 +189,8 @@ L.Popup = L.Class.extend({
 	},
 
 	_updatePosition: function () {
+		if (!this._map) { return; }
+
 		var pos = this._map.latLngToLayerPoint(this._latlng),
 			is3d = L.Browser.any3d,
 			offset = this.options.offset;


### PR DESCRIPTION
If a popup is removed from the map during viewreset we still try to remove it from the map, check we are still on the map first.
