### PR TITLE
ADD clickable option to FeatureGroup/GeoJSON

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -5,12 +5,26 @@
 L.FeatureGroup = L.LayerGroup.extend({
 	includes: L.Mixin.Events,
 
+	options: {
+		clickable: true
+	},
+
+	initialize: function (layers, options) {
+		L.LayerGroup.prototype.initialize.call(this, layers, options);
+	},
+
 	addLayer: function (layer) {
 		if (this._layers[L.Util.stamp(layer)]) {
 			return this;
 		}
 
-		layer.on('click dblclick mouseover mouseout mousemove contextmenu', this._propagateEvent, this);
+		if (this.options.clickable) {
+			layer.on('click dblclick mouseover mouseout mousemove contextmenu', this._propagateEvent, this);
+		}
+
+		// NOTE: Mutates initial object, could be problem if it is reattached standalone, but avoids uneccasary overhead
+		if (!layer.options) { layer.options = {}; }
+		layer.options.clickable = this.options.clickable;
 
 		L.LayerGroup.prototype.addLayer.call(this, layer);
 
@@ -22,7 +36,9 @@ L.FeatureGroup = L.LayerGroup.extend({
 	},
 
 	removeLayer: function (layer) {
-		layer.off('click dblclick mouseover mouseout mousemove contextmenu', this._propagateEvent, this);
+		if (this.options.clickable) {
+			layer.off('click dblclick mouseover mouseout mousemove contextmenu', this._propagateEvent, this);
+		}
 
 		L.LayerGroup.prototype.removeLayer.call(this, layer);
 

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -85,7 +85,7 @@ L.Util.extend(L.GeoJSON, {
 				layer = pointToLayer ? pointToLayer(geojson, latlng) : new L.Marker(latlng);
 				layers.push(layer);
 			}
-			return new L.FeatureGroup(layers);
+			return new L.FeatureGroup(layers, {clickable: this.options.clickable});
 
 		case 'LineString':
 			latlngs = this.coordsToLatLngs(coords);
@@ -108,7 +108,7 @@ L.Util.extend(L.GeoJSON, {
 				layer = this.geometryToLayer(geometry.geometries[i], pointToLayer);
 				layers.push(layer);
 			}
-			return new L.FeatureGroup(layers);
+			return new L.FeatureGroup(layers, {clickable: this.options.clickable});
 
 		default:
 			throw new Error('Invalid GeoJSON object.');

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -3,7 +3,8 @@
  */
 
 L.LayerGroup = L.Class.extend({
-	initialize: function (layers) {
+	initialize: function (layers, options) {
+		L.Util.setOptions(this, options);
 		this._layers = {};
 
 		var i, len;


### PR DESCRIPTION
This is implement the second of the three optimization that I referred to the first comment on [this blog post](http://leafletjs.com/2012/10/25/leaflet-0-4-5-bugfix-release-and-plans-for-0.5.html). These aim at optimizing the handling of geoJSON layers with thousands of sublayers.

Namely it adds a clickable option to LayerGroup & GeoJSON, that disables attaching DOM event handlers for layers that we do not intent to handle mouse events.

PR with other mods and example will follow
