### PR TITLE
MOD Events Core Object, make removal less expensive, use various optimizations

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -8,10 +8,10 @@ L.Mixin = {};
 
 L.Mixin.Events = {
 	
-	addEventListener: function (types, fn, context) { // (String, Function[, Object]) or (Object[, Object])
-		var events = this[key] = this[key] || {},
-			type, i, len;
-		
+	addEventListener: function (types, fn, context)  { // (String, Function[, Object]) or (Object[, Object])
+		var events = this[key] || (this[key] = {}),
+			type, i, j, tmp;
+	
 		// Types can be a map of types/handlers
 		if (typeof types === 'object') {
 			for (type in types) {
@@ -22,27 +22,57 @@ L.Mixin.Events = {
 			
 			return this;
 		}
-		
+
+		if (!context) {context = this; }
 		types = L.Util.splitWords(types);
-		
-		for (i = 0, len = types.length; i < len; i++) {
-			events[types[i]] = events[types[i]] || [];
-			events[types[i]].push({
-				action: fn,
-				context: context || this
-			});
+	
+		// events: {<type>:[{fn:fn, ctxz:[ctx]}}
+		// addition, look events, iterate fnz, push ctx
+		// invocation, look events, iterate fnz, iterate ctxz
+		// removal, look events, iterate fnz, a) with ctx, iterate ctx, splice, b) without ctx, splice fn entry
+
+		for (i = types.length; i--;) {
+			// look events, define conditional
+			tmp = (events[types[i]] || (events[types[i]] = []));
+			// iterate fnz
+			for (j = tmp.length; j--;) {
+				if (tmp[j].fn === fn) {
+					tmp = tmp[j];
+					break;
+				}
+			}
+			if (j < 0) {
+			  // not found
+				tmp.push({
+					fn: fn,
+					ctxz: [context]
+				});
+			}
+			else {
+			  // found, append ctx
+			  // assume no duplicates
+			  // START DEBUG, look for duplicates
+			  //for (j=tmp1.ctxz.length; j--;) {
+			  //  if (tmp1.ctxz[j] === context)
+			  //    throw new Error("Duplicate event entry found, type:"+types[i]+", fn: "+fn+". Others might exist");
+			  //}
+			  // END DEBUG
+				tmp.ctxz.push(context);
+			}
 		}
-		
+	
 		return this;
 	},
 
 	hasEventListeners: function (type) { // (String) -> Boolean
-		return (key in this) && (type in this[key]) && (this[key][type].length > 0);
+		var tmp;
+		return ((tmp = this[key]) !== undefined) && ((tmp = tmp[type]) !== undefined) && (tmp.length > 0);
 	},
 
+	// NOTE: When invoked without context, the remove operation is much faster
 	removeEventListener: function (types, fn, context) { // (String[, Function, Object]) or (Object[, Object])
-		var events = this[key],
-			type, i, len, listeners, j;
+		var events = this[key] || (this[key] = {}),
+		  type, i, k, listeners, j, tmp;
 		
 		if (typeof types === 'object') {
 			for (type in types) {
@@ -50,27 +80,50 @@ L.Mixin.Events = {
 					this.removeEventListener(type, types[type], fn);
 				}
 			}
-			
+		  
 			return this;
 		}
 		
 		types = L.Util.splitWords(types);
 
-		for (i = 0, len = types.length; i < len; i++) {
-
-			if (this.hasEventListeners(types[i])) {
-				listeners = events[types[i]];
-				
-				for (j = listeners.length - 1; j >= 0; j--) {
-					if (
-						(!fn || listeners[j].action === fn) &&
-						(!context || (listeners[j].context === context))
-					) {
-						listeners.splice(j, 1);
+		for (i = types.length ; i--;) {
+			if (undefined === (listeners = events[types[i]])) {
+				continue;
+			}
+		
+			if (!fn) {
+				if (context) {
+					throw new Error("LOGICAL: When fn is undefined, context should be undefined too.");
+				}
+				// remove all event listeners of this type (for all contexts)
+				listeners.length = 0;
+			}
+			else {
+				// listeners size depends on API complexity
+				for (j = listeners.length ; j-- ;) {
+					tmp = listeners[j]; // tmp={fn: fn, ctxz:[]}
+					if (tmp.fn === fn) {
+						if (!context) {
+						   // remove this event listener for all contexts, fast
+							listeners.splice(j, 1);
+						}
+						else {
+							tmp = tmp.ctxz;
+							for (k = tmp.length; k--;) {
+								if (tmp[k] === context) {
+									// remove this event listener for this context
+									tmp.splice(k, 1);
+									// ASSUME no duplicate context exists (same evt type, same listener)
+									break; // k
+								}
+							}
+						}
+						// listener found
+						break; // j
 					}
 				}
 			}
-		}
+		} // for i
 		
 		return this;
 	},
@@ -81,14 +134,18 @@ L.Mixin.Events = {
 		}
 
 		var event = L.Util.extend({
-			type: type,
-			target: this
-		}, data);
+				type: type,
+				target: this
+			}, data),
+			listeners = this[key][type],
+			tmp, tmp1, i, j;
 
-		var listeners = this[key][type].slice();
-
-		for (var i = 0, len = listeners.length; i < len; i++) {
-			listeners[i].action.call(listeners[i].context || this, event);
+		for (i = listeners.length; i--;) {
+			tmp = listeners[i];
+			tmp1 = tmp.ctxz;
+			for (j = tmp1.length; j--;) {
+				tmp.fn.call(tmp1[j], event);
+			}
 		}
 
 		return this;


### PR DESCRIPTION
This is implement the first of the three optimization that I referred to the first comment on [this blog post](http://leafletjs.com/2012/10/25/leaflet-0-4-5-bugfix-release-and-plans-for-0.5.html). These aim at optimizing the handling of geoJSON layers with thousands of sublayers.

Refactor the Events Core Object so that the removal operation is not so much expensive is it was before. This reduces event removal cost at least to 1/3 (as conducted by test measures). This is apparent when removing event handlers from an already bloated map object.

We pay this with a slight increase in addition time, but this is negligible.

PR with other mods and example will follow
