### PR TITLE
Add zoom to leaflet-popup-content-wrapper to fix popup style in IE7

### DIFF
--- a/dist/leaflet.ie.css
+++ b/dist/leaflet.ie.css
@@ -27,6 +27,9 @@
 .leaflet-popup-content-wrapper, .leaflet-popup-tip {
 	border: 1px solid #bbb;
 	}
+.leaflet-popup-content-wrapper {
+	zoom: 1;
+	}
 
 .leaflet-control-zoom {
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#3F000000',EndColorStr='#3F000000');


### PR DESCRIPTION
Fixes #1114
