### PR TITLE
Dragging a marker should not trigger a map click event.

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -203,10 +203,11 @@ L.Marker = L.Class.extend({
 	},
 
 	_onMouseClick: function (e) {
-		if (this.hasEventListeners(e.type)) {
+		var wasDragged = this.dragging && this.dragging.moved();
+		if (this.hasEventListeners(e.type) || wasDragged) {
 			L.DomEvent.stopPropagation(e);
 		}
-		if (this.dragging && this.dragging.moved()) { return; }
+		if (wasDragged) { return; }
 		if (this._map.dragging && this._map.dragging.moved()) { return; }
 		this.fire(e.type, {
 			originalEvent: e


### PR DESCRIPTION
Fixing a bug I introduced.

With 0.4.5: http://jsfiddle.net/sqgUc/4/
With master: http://jsfiddle.net/sqgUc/3/
