### PR TITLE
mousemove events need to propagate through path layers

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -134,7 +134,9 @@ L.Path = L.Path.extend({
 		if (e.type === 'contextmenu') {
 			L.DomEvent.preventDefault(e);
 		}
-		L.DomEvent.stopPropagation(e);
+		if (e.type !== 'mousemove') {
+			L.DomEvent.stopPropagation(e);
+		}
 	}
 });
 


### PR DESCRIPTION
Otherwise you cannot drag the map through them. Refs #1046
