### PR TITLE
Adding link to a new Minimap plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -273,6 +273,15 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 			<a href="https://github.com/kajic">Robert Kajic</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Norkart/Leaflet-MiniMap">Leaflet.MiniMap</a>
+		</td><td>
+			A small minimap showing the map at a different scale to aid navigation.
+		</td><td>
+			<a href="https://github.com/robpvn">Robert Nordan</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
This adds a link to our new Minimap plugin for Leaflet. Should I announce it on the Google group as well or is it enough adding it here?
