### PR TITLE
Add setZIndex to LayerGroup

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -84,7 +84,7 @@ L.LayerGroup = L.Class.extend({
 		}
 	},
 
-	setZIndex: function(zIndex) {
+	setZIndex: function (zIndex) {
 		return this.invoke('setZIndex', zIndex);
 	}
 });


### PR DESCRIPTION
Add setZIndex to LayerGroup to allow LayerGroups to work better with layers control. Fixes #1096
