### PR TITLE
Return created HTML element in Control.Layers._addItem

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -174,6 +174,8 @@ L.Control.Layers = L.Control.extend({
 
 		var container = obj.overlay ? this._overlaysList : this._baseLayersList;
 		container.appendChild(label);
+
+		return label;
 	},
 
 	_onInputClick: function () {


### PR DESCRIPTION
Goal is to make easier and DRYer to customize one baselayer/overlay HTML element
when extending Control.Layers class.

Thanks!
