### PR TITLE
Fix error in initializing map in hidden iframe in Firefox

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -17,7 +17,7 @@
 	    mobile = typeof orientation !== undefined + '',
 	    msTouch = (window.navigator && window.navigator.msPointerEnabled && window.navigator.msMaxTouchPoints),
 	    retina = (('devicePixelRatio' in window && window.devicePixelRatio > 1) ||
-	              ('matchMedia' in window && window.matchMedia("(min-resolution:144dpi)").matches)),
+	              ('matchMedia' in window && window.matchMedia("") && window.matchMedia("(min-resolution:144dpi)").matches)),
 
 	    doc = document.documentElement,
 	    ie3d = ie && ('transition' in doc.style),


### PR DESCRIPTION
Firefox `window.matchMedia("(min-resolution:144dpi)")` returns null if it is called on hidden iframe. So we need to check if `window.matchMedia("")` is not null before calling another method on it.
