### PR TITLE
Add leaflet.utfgrid to plugins

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -203,6 +203,15 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/danzel/Leaflet.utfgrid">Leaflet.utfgrid</a>
+		</td><td>
+			Provides a utfgrid interaction handler for leaflet a very small footprint.
+		</td><td>
+			<a href="https://github.com/danzel">Dave Leaver</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/kartena/Leaflet.EditableHandlers">Leaflet.EditableHandlers</a>
 		</td><td>
 			A set of plugins that includes circle editing, measuring tool, and label for polygon sides.


### PR DESCRIPTION
We were using wax for utfgrid support, but it was huge (100kb) and various levels of broken in leaflet.

I've reimplemented it in 4kb of javascript :-)

http://danzel.github.com/Leaflet.utfgrid/example/map.html
