### PR TITLE
Workaround for popup #close link persistence in Firefox status bar

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -408,6 +408,7 @@
 	text-decoration: none;
 	font-weight: bold;
 	background: transparent;
+	cursor: pointer;
 	}
 .leaflet-container a.leaflet-popup-close-button:hover {
 	color: #999;

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -116,7 +116,6 @@ L.Popup = L.Class.extend({
 		if (this.options.closeButton) {
 			closeButton = this._closeButton =
 			        L.DomUtil.create('a', prefix + '-close-button', container);
-			closeButton.href = '#close';
 			closeButton.innerHTML = '&#215;';
 
 			L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this);


### PR DESCRIPTION
See #1200
