### PR TITLE
Fixes Issue 1204: Adds the border width to the viewport offset calculation

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -38,7 +38,7 @@ L.DomUtil = {
 			
 			//add borders
 			top += parseInt(L.DomUtil.getStyle(el, "borderTopWidth"), 10) || 0;
-            left += parseInt(L.DomUtil.getStyle(el, "borderLeftWidth"), 10) || 0;
+			left += parseInt(L.DomUtil.getStyle(el, "borderLeftWidth"), 10) || 0;
 
 			pos = L.DomUtil.getStyle(el, 'position');
 


### PR DESCRIPTION
With this fix leaflet creates accurate mouse events when the map-div has css borders.
