### PR TITLE
POC of a i18n system

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -5,6 +5,7 @@ var deps = {
 		      'core/Class.js',
 		      'core/Events.js',
 		      'core/Browser.js',
+		      'core/I18n.js',
 		      'geometry/Point.js',
 		      'geometry/Bounds.js',
 		      'geometry/Transformation.js',

--- a/debug/leaflet-include.js
+++ b/debug/leaflet-include.js
@@ -7,6 +7,7 @@
 		'core/Class.js',
 		'core/Events.js',
 		'core/Browser.js',
+		'core/I18n.js',
 
 		'geometry/Point.js',
 		'geometry/Bounds.js',

--- a/spec/runner.html
+++ b/spec/runner.html
@@ -29,6 +29,7 @@
 	<script type="text/javascript" src="suites/core/UtilSpec.js"></script>
 	<script type="text/javascript" src="suites/core/ClassSpec.js"></script>
 	<script type="text/javascript" src="suites/core/EventsSpec.js"></script>
+	<script type="text/javascript" src="suites/core/I18nSpec.js"></script>
 
 	<!-- /geometry -->
 	<script type="text/javascript" src="suites/geometry/PointSpec.js"></script>

--- a/spec/suites/core/I18nSpec.js
+++ b/spec/suites/core/I18nSpec.js
@@ -1,0 +1,33 @@
+describe("I18n", function() {
+
+    beforeEach(function() {
+        var fr = {
+            "Simple phrase to translate": "Une simple phrase à traduire",
+            "A phrase with a {variable} to translate": "Une phrase à traduire avec une {variable}"
+        };
+        L.registerLocale('fr', fr);
+        L.setLocale('fr');
+    });
+
+    it("should translate simple sentences", function() {
+        expect(L._("Simple phrase to translate")).toEqual("Une simple phrase à traduire");
+    });
+
+    it("should translate sentences with a variable", function() {
+        expect(L._("A phrase with a {variable} to translate", {variable: "foo"})).toEqual("Une phrase à traduire avec une foo");
+    });
+
+    it("should not fail if a variable is missing", function() {
+        expect(L._("A phrase with a {variable} to translate")).toEqual("Une phrase à traduire avec une {variable}");
+    });
+
+    it("should not fail if the translation is missing", function() {
+        expect(L._("A missing translation")).toEqual("A missing translation");
+    });
+
+    it("should not fail if the locale is missing", function() {
+        L.setLocale('foo');
+        expect(L._("Simple phrase to translate")).toEqual("Simple phrase to translate");
+    });
+
+});

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -85,7 +85,7 @@ L.Control.Layers = L.Control.extend({
 
 			var link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
 			link.href = '#';
-			link.title = 'Layers';
+			link.title = L._('Layers');
 
 			if (L.Browser.touch) {
 				L.DomEvent

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -14,9 +14,9 @@ L.Control.Zoom = L.Control.extend({
 		this._map = map;
 
 		this._zoomInButton = this._createButton(
-		        '+', 'Zoom in',  className + '-in',  container, this._zoomIn,  this);
+		        '+', L._('Zoom in'),  className + '-in',  container, this._zoomIn,  this);
 		this._zoomOutButton = this._createButton(
-		        '-', 'Zoom out', className + '-out', container, this._zoomOut, this);
+		        '-', L._('Zoom out'), className + '-out', container, this._zoomOut, this);
 
 		map.on('zoomend', this._updateDisabled, this);
 

--- a/src/core/I18n.js
+++ b/src/core/I18n.js
@@ -1,0 +1,25 @@
+/*
+ * L.i18n handles locales registration and string translation.
+ */
+
+L.locales = {};
+L.locale = null;
+L.registerLocale = function registerLocale(code, locale) {
+    L.locales[code] = L.Util.extend({}, L.locales[code], locale);
+};
+L.setLocale = function setLocale(code) {
+    L.locale = code;
+};
+L.i18n = L._ = function translate(string, data) {
+    if (L.locale && L.locales[L.locale] && L.locales[L.locale][string]) {
+        string = L.locales[L.locale][string];
+    }
+    try {
+        // Do not fail if some data is missing;
+        // A bad translation should not break the app
+        string = L.Util.template(string, data);
+    }
+    catch (err) {/*pass*/}
+
+    return string;
+};

--- a/src/locale/fr.js
+++ b/src/locale/fr.js
@@ -1,0 +1,8 @@
+var fr = {
+    // Control.Zoom.js
+    "Zoom out": "Dézoomer",
+    "Zoom in": "Zoomer",
+    // Control.Layers.js,
+    "Layers": "Couches"
+};
+L.registerLocale('fr', fr);


### PR DESCRIPTION
Hi!

While working on a i18n feature for [Leaflet.Storage](https://github.com/yohanboniface/Leaflet.Storage), I though it should be more convenient to have all Leaflet plugins share the same system. That's why a suggest to add it in Leaflet core instead of making a plugin. Making a plugin (say Leaflet.I18n) means making it a dependency for all the other plugins, so I think it will not work.

So here is a suggestion.

The API is:
- to make a string translatable, just call `L._` (shortcut for `L.i18n`), like this:

```
L._("The phrase I want to be translatable");
L._("A complex sentence with a {variable}", {variable: "my value"});
```
- one or more `locale/{locale_code}.js` should be provided, something like:

```
var mylocale = {
    "Simple phrase to translate": "Une simple phrase à traduire",
    "A sentence with a {variable}": "Une phrase avec une {variable}",
};
```
- the locale must register itself, doing something like:

```
L.registerLocale('fr', mylocale);
```

 This can be done more than once. For example, every plugin can add it's translations for some locale without overriding all the already registered strings. However, if the same string for the same locale is registered twice, the last wins.
- end user must load the `locale/` files provided by Leaflet, or plugins
- end user must set his locale, doing so:

```
L.setLocale('fr');
```

And then all the translatable strings available will be translated :).

Of course, i18n is optional: unless one locale has been set, the behaviour is unchanged.

Insolved:
- Not sure of the better way to make the locale available in the `dist/` module. I just think that each end user must only load the locales he wants

Of course, some documentation of this will be needed, if merged.

Thanks for reviewing!

Yohan
