### PR TITLE
Polyline layer leaves markers behind if removed in editing state

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -63,6 +63,8 @@ L.Path = L.Class.extend({
 	onRemove: function (map) {
 		map._pathRoot.removeChild(this._container);
 
+		// Need to fire remove event before we set _map to null as the event hooks might need the object
+		this.fire('remove');
 		this._map = null;
 
 		if (L.Browser.vml) {
@@ -70,8 +72,6 @@ L.Path = L.Class.extend({
 			this._stroke = null;
 			this._fill = null;
 		}
-
-		this.fire('remove');
 
 		map.off({
 			'viewreset': this.projectLatlngs,


### PR DESCRIPTION
If the fire event gets fired after the _map is set to null, when a polyline is removed from the map while it is in editing state it leaves all its smaller editing markers behind. Calling it before the _map is set to null ensures proper cleanup of the polyline.
