### PR TITLE
Allow null GeoJSON geometries.

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -21,11 +21,8 @@ L.GeoJSON = L.FeatureGroup.extend({
 		if (features) {
 			for (i = 0, len = features.length; i < len; i++) {
 				// Only add this if geometry or geometries are set and not null
-				if ((typeof features[i].geometries !== undefined && features[i].geometries !== null) &&
-					(typeof features[i].geometry !== undefined && features[i].geometry !== null)) {
-
+				if (features[i].geometries || features[i].geometry) {
 					this.addData(features[i]);
-
 				}
 			}
 			return this;


### PR DESCRIPTION
This change checks if a geometry/ies in GeoJSON are set as null, in which case it will skip it.

I tried to follow the coding style for conditionals but I couldn't find any long if statements like the one I'm contributing. Should there be a better way to format this?

Related to issue #1235
