### PR TITLE
Handling clicks on paths with L_PREFER_CANVAS, #1215

### DIFF
--- a/debug/tests/click_on_canvas.html
+++ b/debug/tests/click_on_canvas.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leaflet debug page</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+
+    <link rel="stylesheet" href="../css/screen.css" />
+    <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+
+    <script>
+        L_PREFER_CANVAS = true;
+        $(document).ready(function() {
+            var map = L.map('map', {
+                minZoom: 1,
+                maxZoom: 19,
+                center: [51.505, -0.09],
+                zoom: 9
+            });
+
+            var polygons = new L.FeatureGroup();
+            var points = [[51.505, -0.01], [51.505, -0.09], [51.55, -0.09]];
+
+            polygons.addLayer(
+            new L.Polyline(
+            points, {
+                weight: 2,
+                opacity: 1,
+                smoothFactor: 1,
+                color: 'red'
+            }));
+
+            polygons.on('click', function(m) {
+                // m.layer is the clicked polygon here
+                //m.layer.bindPopup('hello!').openPopup();
+                console.log(m.layer)
+            });
+
+            polygons.addTo(map);
+        });
+    </script>
+
+    <script src="../leaflet-include.js"></script>
+</head>
+<body>
+    <div id="map"></div>
+</body>
+</html>

--- a/debug/tests/click_on_canvas_broken.html
+++ b/debug/tests/click_on_canvas_broken.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leaflet debug page</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.css" />
+    <link rel="stylesheet" href="../css/screen.css" />
+    <script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+
+    <script>
+        L_PREFER_CANVAS = true;
+        $(document).ready(function() {
+            var map = L.map('map', {
+                minZoom: 1,
+                maxZoom: 19,
+                center: [51.505, -0.09],
+                zoom: 9
+            });
+
+            var polygons = new L.FeatureGroup();
+            var points = [[51.505, -0.01], [51.505, -0.09], [51.55, -0.09]];
+
+            polygons.addLayer(
+            new L.Polyline(
+            points, {
+                weight: 2,
+                opacity: 1,
+                smoothFactor: 1,
+                color: 'red'
+            }));
+
+            polygons.on('click', function(m) {
+                // m.layer is the clicked polygon here
+                //m.layer.bindPopup('hello!').openPopup();
+                console.log(m.layer)
+            });
+
+            polygons.addTo(map);
+        });
+    </script>
+
+    <script src="http://cdn.leafletjs.com/leaflet-0.4.5/leaflet.js"></script>
+</head>
+<body>
+    <div id="map"></div>
+</body>
+</html>

--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -127,7 +127,12 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 
 	_onClick: function (e) {
 		if (this._containsPoint(e.layerPoint)) {
-			this.fire('click', e);
+			this.fire('click', {
+				latlng: e.latlng,
+				layerPoint: e.layerPoint,
+				containerPoint: e.containerPoint,
+				originalEvent: e
+			});
 		}
 	}
 });


### PR DESCRIPTION
Take a look at my two tests to see the difference...You will see how in "_broken", the map is getting logged, as noted in issue discussion.

In the unbroken one, m.layer now refers to the proper clicked reference, not the map.I figured I would I try to follow the SVG's version as closely, and that seemed to help.

References #1215 
