### PR TITLE
Change marker click tracking. Only care if the map has been dragged if we are not draggable.

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -218,7 +218,7 @@ L.Marker = L.Class.extend({
 
 		if (wasDragged) { return; }
 
-		if (this._map.dragging && this._map.dragging.moved()) { return; }
+		if ((!this.dragging || !this.dragging._enabled) && this._map.dragging && this._map.dragging.moved()) { return; }
 
 		this.fire(e.type, {
 			originalEvent: e


### PR DESCRIPTION
If we are draggable and we get a possible click then we don't need to care if the map was dragged as we would have been handling the drag.

Fixes #1223
