### PR TITLE
Fix issue 1226: IE10 "Invalid argument" error in version 0.5 defining retina

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -21,7 +21,7 @@
 	    mobile = typeof orientation !== undefined + '',
 	    msTouch = (window.navigator && window.navigator.msPointerEnabled && window.navigator.msMaxTouchPoints),
 	    retina = (('devicePixelRatio' in window && window.devicePixelRatio > 1) ||
-	              ('matchMedia' in window && window.matchMedia("") && window.matchMedia("(min-resolution:144dpi)").matches)),
+	              ('matchMedia' in window && window.matchMedia("(min-resolution:144dpi)") && window.matchMedia("(min-resolution:144dpi)").matches)),
 
 	    doc = document.documentElement,
 	    ie3d = ie && ('transition' in doc.style),


### PR DESCRIPTION
https://github.com/CloudMade/Leaflet/issues/1226

Credit to @dreamfall for the fix.
