### PR TITLE
Add Leaflet-semicircle to plugin list

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -98,6 +98,15 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 			<a href="https://github.com/jieter">Jieter</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/ismyrnow/Leaflet.functionaltilelayer">Leaflet.FunctionalTileLayer</a>
+		</td><td>
+			Allows you to define tile layer URLs using a function, with support for jQuery deferreds.
+		</td><td>
+			<a href="https://github.com/ismyrnow">Ishmael Smyrnow</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Created a plugin that other leaflet users might find useful. The use case is fetching tiles asynchronously, allowing the URLs to be resolved with an ajax request or IndexedDB query.
