### PR TITLE
Remove LatLngBounds reference Bounds documentation

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -3259,7 +3259,7 @@ map.panBy(new L.Point(200, 300));</code></pre>
 		<td>Creates a Bounds object from two coordinates (usually top-left and bottom-right corners).</td>
 	</tr>
 	<tr>
-		<td><code><b>L.LatLngBounds</b>(
+		<td><code><b>L.Bounds</b>(
 			<nobr>&lt;<a href="#point">Point</a>[]&gt; <i>points</i> )</nobr>
 		</code></td>
 


### PR DESCRIPTION
Looks like the `LatLng` sneaked in here...
