### PR TITLE
svg vector layers top work when map is inside absolute positioned containers

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -165,7 +165,9 @@ L.Map.include({
 
 	_animatePathZoom: function (e) {
 		var scale = this.getZoomScale(e.zoom),
-		    offset = this._getCenterOffset(e.center)._multiplyBy(-scale)._add(this._pathViewport.min);
+		    offset = this.options.absolutePosition 
+		                  ? this._getCenterOffset(e.center)._multiplyBy(-scale)
+		                  : this._getCenterOffset(e.center)._multiplyBy(-scale)._add(this._pathViewport.min);
 
 		this._pathRoot.style[L.DomUtil.TRANSFORM] =
 		        L.DomUtil.getTranslateString(offset) + ' scale(' + scale + ') ';
@@ -205,7 +207,9 @@ L.Map.include({
 		root.setAttribute('width', width);
 		root.setAttribute('height', height);
 		root.setAttribute('viewBox', [min.x, min.y, width, height].join(' '));
-                     root.setAttribute('style', ['width:', width, "; height:", height, ';'].join(''));
+		if(this.options.absolutePosition) {
+                        root.setAttribute('style', ['width:', width, "px; height:", height, 'px; top:', min.y, 'px; left:', min.x,'px;'].join(''));
+                        }
 		if (L.Browser.mobileWebkit) {
 			pane.appendChild(root);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -17,7 +17,8 @@ L.Map = L.Class.extend({
 
 		fadeAnimation: L.DomUtil.TRANSITION && !L.Browser.android23,
 		trackResize: true,
-		markerZoomAnimation: L.DomUtil.TRANSITION && L.Browser.any3d
+		markerZoomAnimation: L.DomUtil.TRANSITION && L.Browser.any3d,
+		absolutePosition: false // Path.SVG is not properly handled when the map is within containers that already use absolute positionnint.   
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)


### PR DESCRIPTION
I had problems to correctly handle svg layers for a map built in ancestors containers that were absolute positioned (e.g. in an Ext.Window Class in the case you use ExtJs).

In this situation, the SVG element is rendered with width and height equal to 0 and its position is in disarray (offset calculation is not correct). 

To use this fix, set options.useAbsolute to true when creating the map, and it should work again,
Cheers
C. 
