### PR TITLE
checking that map still exists before proceeding with resize event, #1101

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -574,9 +574,11 @@ L.Map = L.Class.extend({
 	},
 
 	_onResize: function () {
-		L.Util.cancelAnimFrame(this._resizeRequest);
-		this._resizeRequest = L.Util.requestAnimFrame(
+		if (L.DomUtil.get(this._container.id)) {
+			L.Util.cancelAnimFrame(this._resizeRequest);
+			this._resizeRequest = L.Util.requestAnimFrame(
 		        this.invalidateSize, this, false, this._container);
+		}
 	},
 
 	_onMouseClick: function (e) {


### PR DESCRIPTION
@javisantana mentioned three options in issue #1101, here is the third.

Though personally, I would lean towards option 1 "add a method to destroy the map and remove that binding". Thoughts @mourner?
