### PR TITLE
Robust array type check for cross-frame support

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -97,6 +97,10 @@ L.Util = {
 		});
 	},
 
+	isArray: function (obj) {
+		return (Object.prototype.toString.call(obj) === '[object Array]');
+	},
+
 	emptyImageUrl: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 };
 

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -74,7 +74,7 @@ L.latLng = function (a, b) { // (LatLng) or ([Number, Number]) or (Number, Numbe
 	if (a instanceof L.LatLng) {
 		return a;
 	}
-	if (a instanceof Array) {
+	if (L.Util.isArray(a)) {
 		return new L.LatLng(a[0], a[1]);
 	}
 	if (isNaN(a)) {

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -100,7 +100,7 @@ L.point = function (x, y, round) {
 	if (x instanceof L.Point) {
 		return x;
 	}
-	if (x instanceof Array) {
+	if (L.Util.isArray(x)) {
 		return new L.Point(x[0], x[1]);
 	}
 	if (isNaN(x)) {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -15,7 +15,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 	},
 
 	addData: function (geojson) {
-		var features = geojson instanceof Array ? geojson : geojson.features,
+		var features = L.Util.isArray(geojson) ? geojson : geojson.features,
 		    i, len;
 
 		if (features) {

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -10,7 +10,7 @@ L.Polygon = L.Polyline.extend({
 	initialize: function (latlngs, options) {
 		L.Polyline.prototype.initialize.call(this, latlngs, options);
 
-		if (latlngs && (latlngs[0] instanceof Array) && (typeof latlngs[0][0] !== 'number')) {
+		if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
 			this._latlngs = this._convertLatLngs(latlngs[0]);
 			this._holes = latlngs.slice(1);
 		}

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -88,7 +88,7 @@ L.Polyline = L.Path.extend({
 	_convertLatLngs: function (latlngs) {
 		var i, len;
 		for (i = 0, len = latlngs.length; i < len; i++) {
-			if (latlngs[i] instanceof Array && typeof latlngs[i][0] !== 'number') {
+			if (L.Util.isArray(latlngs[i]) && typeof latlngs[i][0] !== 'number') {
 				return;
 			}
 			latlngs[i] = L.latLng(latlngs[i]);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -466,7 +466,7 @@ L.Map = L.Class.extend({
 	},
 
 	_initLayers: function (layers) {
-		layers = layers ? (layers instanceof Array ? layers : [layers]) : [];
+		layers = layers ? (L.Util.isArray(layers) ? layers : [layers]) : [];
 
 		this._layers = {};
 		this._zoomBoundLayers = {};


### PR DESCRIPTION
In a multi-frame DOM environment, if setView is called with an array for
the first parameter, a subsequent call to getBounds raises "Invalid
LatLng object" exception. This is the case if the array passed to
setView was created outside the iFrame that contains the map. It causes
the array test using "instanceof" in L.latLng to fail, and
_initialTopLeftPoint to not being properly initialized.

Thank you to Juriy Zaytsev for the full explaination:
http://perfectionkills.com/instanceof-considered-harmful-or-how-to-write-a-robust-isarray/
John Resig and Dean Edwards post comments and concur.
