### PR TITLE
L.TileLayer.redraw() does return this.

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1648,7 +1648,7 @@ var map = L.map('map', {
 	</tr>
 	<tr>
 		<td><code><b>redraw</b>()</code></td>
-		<td>this</td>
+		<td><code><span class="keyword">this</span></code></td>
 		<td>Causes the layer to clear all the tiles and request them again.</td>
 	</tr>
 	<tr>
@@ -1812,7 +1812,7 @@ canvasTiles.drawTile = function(canvas, tilePoint, zoom) {
 	</tr>
 	<tr>
 		<td><code><b>redraw</b>()</code></td>
-		<td>-</td>
+		<td><code><span class="keyword">this</span></code></td>
 		<td>Calling <code>redraw</code> will cause the <code>drawTile</code> method to be called for all tiles. May be used for updating dynamic content drawn on the Canvas</td>
 	</tr>
 </table>


### PR DESCRIPTION
Another small one. Or is it intentional?

`L.TileLayer.Canvas` does not return `this` and is correctly documented, but why doesn't it?
