### PR TITLE
Wrong default icon path on old IE in certain cases.

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -37,18 +37,15 @@ L.Icon.Default.imagePath = (function () {
 	var scripts = document.getElementsByTagName('script'),
 	    leafletRe = /\/?leaflet[\-\._]?([\w\-\._]*)\.js\??/;
 
-	var i, len, src, matches;
+	var i, len, src, matches, path;
 
 	for (i = 0, len = scripts.length; i < len; i++) {
 		src = scripts[i].src;
 		matches = src.match(leafletRe);
 
 		if (matches) {
-			if (src.split(leafletRe)[0]) {
-				return src.split(leafletRe)[0] + '/images';
-			} else {
-				return 'images';
-			}
+			path = src.split(leafletRe)[0];
+			return (path ? path + '/' : '') + 'images';
 		}
 	}
 }());


### PR DESCRIPTION
In IE 7(and presumably IE 6) if leaflet.js is in the same directory as the page that is calling it, then the location of the image folder will be resolved as "undefined/images" instead of the full path + "/images" This seems to stem from IE 7 returning the relative urls unchanged instead of converting them to absolute ones like newer browsers. 
