### PR TITLE
Handle arrays of feature collections, #1298

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -21,9 +21,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 		if (features) {
 			for (i = 0, len = features.length; i < len; i++) {
 				// Only add this if geometry or geometries are set and not null
-				if (features[i].features) {
-					this.addData(features[i].features);
-				} else if (features[i].geometries || features[i].geometry) {
+				if (features[i].geometries || features[i].geometry || features[i].features) {
 					this.addData(features[i]);
 				}
 			}


### PR DESCRIPTION
This allows for arrays of FeatureCollections, which previously would be bypassed.
I tested it with the feature-group-bounds test and a modified geojson-sample.js.

This references issue #1298.
