### PR TITLE
Add has layer to layer group

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -45,7 +45,7 @@ L.LayerGroup = L.Class.extend({
 
 		var id = L.stamp(layer);
 		return this._layers.hasOwnProperty(id);
-	}
+	},
 
 	clearLayers: function () {
 		this.eachLayer(this.removeLayer, this);


### PR DESCRIPTION
Add the method `hasLayer` to L.LayerGroup. Return false if layer is not present of checking for null value. Respons to #1282 
