### PR TITLE
hasLayer not checking for null

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -192,6 +192,8 @@ L.Map = L.Class.extend({
 	},
 
 	hasLayer: function (layer) {
+		if (!layer) { return false; }
+
 		var id = L.stamp(layer);
 		return this._layers.hasOwnProperty(id);
 	},


### PR DESCRIPTION
Return false when checking for a null object in L.Map.hasLayer, in
response to issue #1282.
