### PR TITLE
Popup fit after resize

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -243,25 +243,17 @@ L.Popup = L.Class.extend({
 		    dx = 0,
 		    dy = 0;
 
-		if (containerPos.x < 0) {
-			dx = containerPos.x - padding.x;
-		}
 		if (containerPos.x + containerWidth > size.x) {
 			dx = containerPos.x + containerWidth - size.x + padding.x;
-			if (dx > containerPos.x) {
-			    // we do not want to scroll the left border out
-			    dx = containerPos.x;
-			}
 		}
-		if (containerPos.y < 0) {
-			dy = containerPos.y - padding.y;
+		if (containerPos.x - dx < 0) {
+			dx = containerPos.x - padding.x;
 		}
 		if (containerPos.y + containerHeight > size.y) {
 			dy = containerPos.y + containerHeight - size.y + padding.y;
-			if (dy > containerPos.y) {
-			    // we do not want to scroll the top border out
-			    dy = containerPos.y;
-			}
+		}
+		if (containerPos.y - dy < 0) {
+			dy = containerPos.y - padding.y;
 		}
 
 		if (dx || dy) {


### PR DESCRIPTION
I have made a change to let the popup keep in view even after an image resize, my usecase is using a map full-screen on Android and a popup containing a FORM: when I press any text input the (sometimes huge) keyboard pops up and the screen real estate is 40% the size it was before and the popup is generally hidden by it. With this patch the popup keeps on screen (using the same logic it currently already does on appearing, only done also on resize).
I'm not sure this is a feature you'd want in general, but it was essential to me and, just in case, I'm opening this request to ease the import.
The second and third commit are because the solution used in the first lead to "bouncing" when the popup doesn't fit on screen.
