### PR TITLE
Support more granularity in zoom levels

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -274,6 +274,7 @@ L.Map = L.Class.extend({
 
 		var size = this.getSize(),
 		    zoom = this.options.minZoom || 0,
+		    zoomStep = this.options.zoomStep || 1,
 		    maxZoom = this.getMaxZoom(),
 		    ne = bounds.getNorthEast(),
 		    sw = bounds.getSouthWest(),
@@ -283,11 +284,11 @@ L.Map = L.Class.extend({
 		    zoomNotFound = true;
 
 		if (inside) {
-			zoom--;
+			zoom -= zoomStep;
 		}
 
 		do {
-			zoom++;
+			zoom += zoomStep;
 			nePoint = this.project(ne, zoom);
 			swPoint = this.project(sw, zoom);
 
@@ -306,7 +307,7 @@ L.Map = L.Class.extend({
 			return null;
 		}
 
-		return inside ? zoom : zoom - 1;
+		return inside ? zoom : zoom - zoomStep;
 	},
 
 	getSize: function () {

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -108,9 +108,10 @@ L.Map.TouchZoom = L.Handler.extend({
 		    center = map.layerPointToLatLng(origin),
 
 		    oldZoom = map.getZoom(),
+		    zoomStep = map.options.zoomStep || 1,
 		    floatZoomDelta = map.getScaleZoom(this._scale) - oldZoom,
 		    roundZoomDelta = (floatZoomDelta > 0 ?
-		            Math.ceil(floatZoomDelta) : Math.floor(floatZoomDelta)),
+		            Math.ceil(floatZoomDelta / zoomStep) : Math.floor(floatZoomDelta / zoomStep)) * zoomStep,
 
 		    zoom = map._limitZoom(oldZoom + roundZoomDelta);
 


### PR DESCRIPTION
Support more granularity in zoom levels (e.g. zoomStep=0.5) that can be used, with providers that produce those levels, to have smaller changes in zoom level after a pinch operation, or a better fit with fit-to-bounds operations.

<!---
@huboard:{"order":87.5}
-->
