### PR TITLE
Add a L.DomEvent.only shortcut

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -124,6 +124,12 @@ L.DomEvent = {
 		return L.DomEvent.preventDefault(e).stopPropagation(e);
 	},
 
+	only: function (obj, type, fn, context) {
+		return L.DomEvent
+			.on(obj, type, L.DomEvent.stop)
+			.on(obj, type, fn, context);
+	},
+
 	getMousePosition: function (e, container) {
 
 		var body = document.body,


### PR DESCRIPTION
I'm often doing pieces of code like:

```
L.DomEvent
    .on(element, "click", L.DomEvent.stop)
    .on(element, "click", myfunc)
```

So I wonder if some shortcut can save us this kind of boilerplate.

Here is some suggestion. Actually, I'm not sure of the name of such a shortcut. I've used `only`, but it doesn't exactly say "prevent-and-stop-and-add-one". Others options can be `reset`, `stopAndAdd`, `exclusive`...

Of course, I can add this on my own code. But maybe other users can feel the same need.

Anyway, feel free to trash it if it's not "core-proof" ;)
