### PR TITLE
Add LatLngBounds.getLeft/getBottom/getRight/getTop

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -55,4 +55,19 @@ describe('LatLngBounds', function() {
 		});
 
 	});
+
+	describe('#getNorthWest', function () {
+		it('should return a proper north-west LatLng', function() {
+			expect(a.getNorthWest()).toEqual(new L.LatLng(a.getNorth(), a.getWest()));
+		});
+
+	});
+
+	describe('#getSouthEast', function () {
+		it('should return a proper south-east LatLng', function() {
+			expect(a.getSouthEast()).toEqual(new L.LatLng(a.getSouth(), a.getEast()));
+		});
+
+	});
+
 });

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -66,11 +66,11 @@ L.LatLngBounds.prototype = {
 	},
 
 	getNorthWest: function () {
-		return new L.LatLng(this._northEast.lat, this._southWest.lng);
+		return new L.LatLng(this.getNorth(), this.getWest());
 	},
 
 	getSouthEast: function () {
-		return new L.LatLng(this._southWest.lat, this._northEast.lng);
+		return new L.LatLng(this.getSouth(), this.getEast());
 	},
 
 	getWest: function () {


### PR DESCRIPTION
The `toBBoxString` shortcut is very handy, but not all GIS support the "left,bottom,right,top" string.

So I figured that some left, bottom, right, top separate getters could be helpful.

See for example:
- [Notinatim](http://open.mapquestapi.com/nominatim/) `viewbox` is using left,top,right,bottom
- [JOSM](https://github.com/yohanboniface/Leaflet.EditInOSM/blob/master/Leaflet.EditInOSM.js#L67) remote listener expects separate left, bottom, right, top parameters
- [Overpass API](http://wiki.openstreetmap.org/wiki/Overpass_API) is using "minimum lat, minimum lng, maximum lat, maximum lng" (which is bottom, left, top, right) bbox string

Added specs also.

In case you are OK to add it in Leaflet core, we will need to document it, which is not done at the moment.

Thanks!

Yohan
