### PR TITLE
Enable class inheratence in CoffeeSCript

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -60,6 +60,7 @@ L.Class.extend = function (props) {
 	proto._initHooks = [];
 
 	var parent = this;
+	NewClass.__super__ = parent.prototype;
 	// add method for calling all hooks
 	proto.callInitHooks = function () {
 


### PR DESCRIPTION
pull request for #1314 to get leaflet classes to extend right in CoffeeScript, based on [this update to backbone](https://github.com/documentcloud/backbone/commit/1d57168c8f436f1f9b20a5fa7f13495610931b22) which added the same functionality to backbone.
