### PR TITLE
Change _propagateEvent to be careful that it doesn't overwrite e.layer

### DIFF
--- a/spec/runner.html
+++ b/spec/runner.html
@@ -43,7 +43,10 @@
 	<script type="text/javascript" src="suites/dom/DomUtilSpec.js"></script>
 
 	<!-- /layer -->
+	<script type="text/javascript" src="suites/layer/FeatureGroupSpec.js"></script>
 	<script type="text/javascript" src="suites/layer/TileLayerSpec.js"></script>
+
+	<!-- /layer/vector/ -->
 	<script type="text/javascript" src="suites/layer/vector/CircleSpec.js"></script>
 	<script type="text/javascript" src="suites/layer/vector/CircleMarkerSpec.js"></script>
 	<script type="text/javascript" src="suites/layer/vector/PolylineGeometrySpec.js"></script>

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -1,0 +1,36 @@
+﻿describe('CircleMarker', function () {
+	describe("#_propagateEvent", function () {
+		var map, marker;
+		beforeEach(function () {
+			map = L.map(document.createElement('div'));
+			map.setView([0, 0], 1);
+			marker = L.marker([0, 0]);
+		});
+		describe("when a Marker is added to multiple FeatureGroups ", function () {
+			it("e.layer should be the Marker", function () {
+				var fg1 = L.featureGroup(),
+				    fg2 = L.featureGroup();
+
+				fg1.addLayer(marker);
+				fg2.addLayer(marker);
+
+				var wasClicked = 0;
+				fg2.on('click', function(e) {
+					expect(e.layer == marker).toBe(true);
+					expect(e.target === fg2).toBe(true);
+					wasClicked |= 1;
+				});
+
+				fg1.on('click', function (e) {
+					expect(e.layer == marker).toBe(true);
+					expect(e.target === fg1).toBe(true);
+					wasClicked |= 2;
+				});
+
+				marker.fire('click', { type: 'click' });
+
+				expect(wasClicked).toBe(3);
+			});
+		});
+	});
+});

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -68,7 +68,9 @@ L.FeatureGroup = L.LayerGroup.extend({
 	},
 
 	_propagateEvent: function (e) {
-		e.layer  = e.target;
+		if (!e.layer) {
+			e.layer = e.target;
+		}
 		e.target = this;
 
 		this.fire(e.type, e);


### PR DESCRIPTION
if it is already set. Allows markers to be in multiple FeatureGroups and have the events come through correctly. See the test for details.

Fixes leaflet/Leaflet.markercluster#128

The old behaviour was broken in this case (e.layer would become a FeatureGroup). I can't think of any case the new behaviour would be undesirable, but maybe you can mourner?
Thanks :)
