### PR TITLE
Fix viewport offset calculation in Firefox (fixes issue #1322)

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -29,6 +29,7 @@ L.DomUtil = {
 		    left = 0,
 		    el = element,
 		    docBody = document.body,
+		    docEl = document.documentElement,
 		    pos,
 		    ie7 = L.Browser.ie7;
 
@@ -45,8 +46,8 @@ L.DomUtil = {
 			if (el.offsetParent === docBody && pos === 'absolute') { break; }
 
 			if (pos === 'fixed') {
-				top  += docBody.scrollTop  || 0;
-				left += docBody.scrollLeft || 0;
+				top  += docBody.scrollTop  || docEl.scrollTop  || 0;
+				left += docBody.scrollLeft || docEl.scrollLeft || 0;
 				break;
 			}
 			el = el.offsetParent;


### PR DESCRIPTION
`document.body.scrollTop/Left` is always `0` in Firefox, but `document.documentElement.scrollTop/Left` can be used instead.

Probably it was only forgotten to add, because `L.DomEvent.getMousePosition` does it right  already (uses both).
