### PR TITLE
fixed setOpacity in IE7 and IE8

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -14,6 +14,7 @@
 	    android = ua.indexOf('android') !== -1,
 	    android23 = ua.search('android [23]') !== -1,
 	    ie7 = ie && !document.querySelector && ua.search('msie 7') !== -1,
+	    ie8 = ie && ua.search('msie 8') !== -1,
 
 	    mobile = typeof orientation !== undefined + '',
 	    msTouch = window.navigator && window.navigator.msPointerEnabled &&
@@ -63,6 +64,7 @@
 		ie: ie,
 		ie6: ie6,
 		ie7: ie7,
+        ie8: ie8,
 		webkit: webkit,
 
 		android: android,

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -142,18 +142,12 @@ L.DomUtil = {
 	},
 
 	setOpacity: function (el, value) {
-
 		if ('opacity' in el.style) {
 			el.style.opacity = value;
-
 		} else if ('filter' in el.style) {
-
-			var filter = false,
-			    filterName = 'DXImageTransform.Microsoft.Alpha';
-
+			var filterName = 'alpha';
 			value = Math.round(value * 100);
-
-			el.style.filter = ' progid:' + filterName + '(opacity=' + value + ')';
+			el.style.filter = filterName + '(opacity=' + value + ')';
 		}
 	},
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -186,14 +186,20 @@ L.TileLayer = L.Class.extend({
 	},
 
 	_updateOpacity: function () {
-		if (!L.Browser.ie7) {
-			L.DomUtil.setOpacity(this._container, this.options.opacity);
-		}
-
-		// stupid webkit hack to force redrawing of tiles
 		var i,
 		    tiles = this._tiles;
 
+		if (!L.Browser.ie7 && !L.Browser.ie8) {
+			L.DomUtil.setOpacity(this._container, this.options.opacity);
+		} else {
+			for (i in tiles) {
+				if (tiles.hasOwnProperty(i)) {
+					L.DomUtil.setOpacity(tiles[i], this.options.opacity);
+				}
+			}
+        }
+
+		// stupid webkit hack to force redrawing of tiles
 		if (L.Browser.webkit) {
 			for (i in tiles) {
 				if (tiles.hasOwnProperty(i)) {
@@ -202,13 +208,6 @@ L.TileLayer = L.Class.extend({
 			}
 		}
 
-		if (L.Browser.ie7) {
-			for (i in tiles) {
-				if (tiles.hasOwnProperty(i)) {
-					tiles[i].style.filter = 'alpha(opacity=' + (this.options.opacity * 100) + ')';
-				}
-			}
-		}
 
 	},
 
@@ -482,8 +481,9 @@ L.TileLayer = L.Class.extend({
 	_createTile: function () {
 		var tile = this._tileImg.cloneNode(false);
 		tile.onselectstart = tile.onmousemove = L.Util.falseFn;
-		if (L.Browser.ie7 && this.options.opacity !== undefined) {
-			tile.style.filter = 'alpha(opacity=' + (this.options.opacity * 100) + ')';
+		// in IE7 and IE8 should be set per tile
+		if ((L.Browser.ie7 || L.Browser.ie8) && this.options.opacity !== undefined) {
+			L.DomUtil.setOpacity(tile, this.options.opacity);
 		}
 
 		return tile;


### PR DESCRIPTION
setOpacity is not working in IE7 and IE8  

you can check it in the following link (changes the opacity each 2 seconds). It uses the leaflet 0.5 hosted in the CDN (I tested with the current master and i get the same behavior)

example: http://bl.ocks.org/d/4942923/
code: https://gist.github.com/javisantana/4942923

this is the version with the patch applied

example: http://bl.ocks.org/d/4942985/
code: https://gist.github.com/javisantana/4942985

I'm not pretty sure if that is the best way to manage the opacity for IE7 since the opacity for all the tiles should be changed to work.
