### PR TITLE
Update zoom control buttons with proper state on baselayer switch

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -24,7 +24,7 @@ L.Control.Zoom = L.Control.extend({
 	},
 
 	onRemove: function (map) {
-		map.off('zoomend', this._updateDisabled, this);
+		map.off('zoomend baselayerchange', this._updateDisabled, this);
 	},
 
 	_zoomIn: function (e) {


### PR DESCRIPTION
Updates zoom button state on basemap change so that the disabled states are correct for current layer.

Fixes #1328
