### PR TITLE
Allow popups that are bound to markers to have new content set

### DIFF
--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -44,7 +44,9 @@ L.Marker.include({
 	},
 
 	setPopupContent: function (content) {
-		this._popup.setContent(content);
+		if (this._popup) {
+			this._popup.setContent(content);
+		}
 		return this;
 	},
 


### PR DESCRIPTION
Uses the existing setContent of Popup.

Fixes #618
