### PR TITLE
Allow clicks to pass thru non clickable paths

### DIFF
--- a/debug/tests/svg_clicks.html
+++ b/debug/tests/svg_clicks.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+
+	<link rel="stylesheet" href="../css/screen.css" />
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+	<script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script type="text/javascript">
+
+	var map;
+	var myLayerGroup = new L.LayerGroup();
+
+	initmap();
+
+	function initmap() {
+	  // set up the map
+	  map = new L.Map('map');
+
+	  // create the tile layer with correct attribution
+	  var osmUrl = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png';
+	  var osm = new L.TileLayer(osmUrl, { minZoom: 1, maxZoom: 17 });
+	  map.addLayer(osm);
+	  map.fitBounds(new L.LatLngBounds([51,7],[51,7]));
+	  
+	  var route = L.polyline([
+	    [51, 7.000],
+	    [51.002, 7.004],
+	    [51.004, 7.006]
+	  ]).addTo(map).on('click',function(e){console.log('bottom')})
+
+	  var route2 = L.polyline([
+	    [51, 7.000],
+	    [51.002, 7.004]
+	  ],
+	  { clickable:false,color:'#f00' }
+	  ).addTo(map); 
+	  
+	  // when the mouse hovers over the red route2, you cannot click through the blue route1 beneath
+	};
+
+	</script>
+</body>
+</html>

--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -64,6 +64,9 @@ L.Path = L.Path.extend({
 		if (this.options.pointerEvents) {
 			this._path.setAttribute('pointer-events', this.options.pointerEvents);
 		}
+		if (!this.options.clickable && !this.options.pointerEvents) {
+			this._path.setAttribute('pointer-events', 'none');
+		}
 		this._updateStyle();
 	},
 


### PR DESCRIPTION
Objects with clickable == false should allow clicks to fall thru to objects beneath.

I'm not exactly sure how we want to handle this in regards to https://github.com/Leaflet/Leaflet/pull/1053, but this handles the case @DennisSchiefer presented in issue #1281.

Example test page included.
