### PR TITLE
Allow previously created popups to be used with bindPopup

### DIFF
--- a/debug/tests/reuse_popups.html
+++ b/debug/tests/reuse_popups.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+	
+	<link rel="stylesheet" href="../css/screen.css" />
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
+
+	<script>
+		var map = L.map('map');
+
+		var marker = L.marker([51.5, -0.09])
+			.bindPopup("<b>Hello world!</b><br />I am a popup.")
+			.addTo(map);
+			//.openPopup();
+
+		var marker2 = L.marker([51.525, -0.09])
+			.addTo(map);
+
+		map.setView([51.505, -0.09], 13);
+
+		var cloudmade = L.tileLayer('http://{s}.tile.cloudmade.com/{key}/{styleId}/256/{z}/{x}/{y}.png', {
+			attribution: 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
+			maxZoom: 18,
+			key: 'BC9A493B41014CAABB98F0471D759707',
+			styleId: 997
+		}).addTo(map);
+
+		var a_popup = L.popup().setContent('Previously created')
+		
+		marker2.bindPopup(a_popup);
+	</script>
+</body>
+</html>

--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -37,8 +37,13 @@ L.Marker.include({
 			    .on('move', this._movePopup, this);
 		}
 
-		this._popup = new L.Popup(options, this)
-			.setContent(content);
+		if (content instanceof L.Popup) {
+			L.setOptions(content, options);
+			this._popup = content;
+		} else {
+			this._popup = new L.Popup(options, this)
+				.setContent(content);
+		}
 
 		return this;
 	},


### PR DESCRIPTION
Sets up bindPopup to use an existing popup if provided instead of creating a new one.
I could see how this could be quite useful for certain scenarios.

References issue #1208
