### PR TITLE
Don't fade in a currently shown popup when clicking marker again

### DIFF
--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -4,7 +4,7 @@
 
 L.Marker.include({
 	openPopup: function () {
-		if (this._popup && this._map) {
+		if (this._popup && this._map && !this._map.hasLayer(this._popup)) {
 			this._popup.setLatLng(this._latlng);
 			this._map.openPopup(this._popup);
 		}


### PR DESCRIPTION
Clicking an marker with an open popup causes the popup to fade in again.This disables that.

References issue #560.

(@mourner, if you would rather make it close instead, as was mentioned as one of the ideas in the issue, let me know.)
