### PR TITLE
LayerGroup removeLayer problem on removing layers solved

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -31,11 +31,11 @@ L.LayerGroup = L.Class.extend({
 	removeLayer: function (layer) {
 		var id = L.stamp(layer);
 
-		delete this._layers[id];
-
-		if (this._map) {
+		if (this._layers[id] && this._map) {
 			this._map.removeLayer(layer);
 		}
+		
+		delete this._layers[id];
 
 		return this;
 	},


### PR DESCRIPTION
The removeLayer function removed layers even if it did not belong to it.
So, I changed the if condition to even check for the existence of layer
with in the layer group. To do this, I also moved the delete statement
after the if statement.
