### PR TITLE
Enable cleaner overriding of TileLayer#getTileUrl

### DIFF
--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -48,8 +48,6 @@ L.TileLayer.WMS = L.TileLayer.extend({
 
 	getTileUrl: function (tilePoint, zoom) { // (Point, Number) -> String
 
-		this._adjustTilePoint(tilePoint);
-
 		var map = this._map,
 		    crs = map.options.crs,
 		    tileSize = this.options.tileSize,

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -416,11 +416,9 @@ L.TileLayer = L.Class.extend({
 	// image-specific code (override to implement e.g. Canvas or SVG tile layer)
 
 	getTileUrl: function (tilePoint) {
-		this._adjustTilePoint(tilePoint);
-
 		return L.Util.template(this._url, L.extend({
 			s: this._getSubdomain(tilePoint),
-			z: this._getZoomForUrl(),
+			z: tilePoint.z,
 			x: tilePoint.x,
 			y: tilePoint.y
 		}, this.options));
@@ -443,6 +441,8 @@ L.TileLayer = L.Class.extend({
 		if (this.options.tms) {
 			tilePoint.y = limit - tilePoint.y - 1;
 		}
+
+		tilePoint.z = this._getZoomForUrl();
 	},
 
 	_getSubdomain: function (tilePoint) {
@@ -479,6 +479,7 @@ L.TileLayer = L.Class.extend({
 		tile.onload  = this._tileOnLoad;
 		tile.onerror = this._tileOnError;
 
+		this._adjustTilePoint(tilePoint);
 		tile.src     = this.getTileUrl(tilePoint);
 	},
 


### PR DESCRIPTION
Moved the called to _adjustTilePoint outside of getTileUrl, and moved the
call to _getZoomForUrl into _adjustTilePoint. This allows getTileUrl to use
x, y, z directly without any calls to private methods.
