### PR TITLE
Fix for issue #1404

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -46,7 +46,7 @@ L.Draggable = L.Class.extend({
 	},
 
 	_onDown: function (e) {
-		if ((!L.Browser.touch && e.shiftKey) ||
+		if (e.shiftKey ||
 		    ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 
 		L.DomEvent.preventDefault(e);


### PR DESCRIPTION
Box-zooming doesn't work properly in Firefox 18 : the map is dragged, while drawing the box.

Firefox 18 now implements W3C touch events, so L.Browser.touch is true. However we don't have to check whether the browser enables touch event to enable box-zooming.
