### PR TITLE
Fix semicolons, breaking, whitespace, duplicate var statements.

### DIFF
--- a/spec/suites/control/Control.ScaleSpec.js
+++ b/spec/suites/control/Control.ScaleSpec.js
@@ -2,5 +2,5 @@ describe("Control.Scale", function () {
 	it("can be added to an unloaded map", function () {
 		var map = L.map(document.createElement('div'));
 		new L.Control.Scale().addTo(map);
-	})
+	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -22,7 +22,7 @@ describe('Events', function() {
 			obj.addEventListener('test', spy2);
 			obj.addEventListener('other', spy3);
 			obj.addEventListener({ test: spy4, other: spy5 });
-			obj.addEventListener({'test other': spy6 })
+			obj.addEventListener({'test other': spy6 });
 
 			expect(spy).not.toHaveBeenCalled();
 			expect(spy2).not.toHaveBeenCalled();

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -50,7 +50,7 @@ describe('DomUtil', function() {
 			el.className = 'foo bar barz';
 			L.DomUtil.removeClass(el, 'bar');
 			expect(el.className).toEqual('foo barz');
-		})
+		});
 	});
 
 	describe('#documentIsLtr', function () {

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -5,9 +5,9 @@ describe('LatLng', function() {
 			expect(a.lat).toEqual(25);
 			expect(a.lng).toEqual(74);
 
-			var a = new L.LatLng(-25, -74);
-			expect(a.lat).toEqual(-25);
-			expect(a.lng).toEqual(-74);
+			var b = new L.LatLng(-25, -74);
+			expect(b.lat).toEqual(-25);
+			expect(b.lng).toEqual(-74);
 		});
 
 		it('should throw error if invalid lat or lng', function () {

--- a/spec/suites/geo/ProjectionSpec.js
+++ b/spec/suites/geo/ProjectionSpec.js
@@ -1,10 +1,10 @@
 xdescribe("Projection.Mercator", function() {
 	var p = L.Projection.Mercator;
-	
+
 	beforeEach(function() {
 		function almostEqual(a, b, p) {
 			return Math.abs(a - b) <= (p || 1.0E-12);
-		};
+		}
 		this.addMatchers({
 			toAlmostEqual: function(expected, margin) {
 				var p1 = this.actual,
@@ -13,7 +13,7 @@ xdescribe("Projection.Mercator", function() {
 			}
 		});
 	});
-	
+
 
 	describe("#project", function() {
 		it("should do projection properly", function() {
@@ -21,7 +21,7 @@ xdescribe("Projection.Mercator", function() {
 			expect(p.project(new L.LatLng(0, 0))).toAlmostEqual(new L.Point(0, 0));
 			expect(p.project(new L.LatLng(90, 180))).toAlmostEqual(new L.Point(-Math.PI, Math.PI));
 			expect(p.project(new L.LatLng(-90, -180))).toAlmostEqual(new L.Point(-Math.PI, -Math.PI));
-			
+
 			expect(p.project(new L.LatLng(50, 30))).toAlmostEqual(new L.Point(0.523598775598, 1.010683188683));
 		});
 	});
@@ -31,11 +31,11 @@ xdescribe("Projection.Mercator", function() {
 			function pr(point) {
 				return p.project(p.unproject(point));
 			}
-			
+
 			expect(pr(new L.Point(0, 0))).toAlmostEqual(new L.Point(0, 0));
 			expect(pr(new L.Point(-Math.PI, Math.PI))).toAlmostEqual(new L.Point(-Math.PI, Math.PI));
 			expect(pr(new L.Point(-Math.PI, -Math.PI))).toAlmostEqual(new L.Point(-Math.PI, -Math.PI));
-			
+
 			expect(pr(new L.Point(0.523598775598, 1.010683188683))).toAlmostEqual(new L.Point(0.523598775598, 1.010683188683));
 		});
 	});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -36,8 +36,8 @@ describe("Map", function () {
 	});
 
 	describe("#getBounds", function () {
-		it("is safe to call from within a moveend callback during initial "
-		   + "load (#1027)", function () {
+		it("is safe to call from within a moveend callback during initial " +
+		   "load (#1027)", function () {
 			map.on("moveend", function () {
 			  map.getBounds();
 			});
@@ -47,8 +47,8 @@ describe("Map", function () {
 	});
 
 	describe("#getMinZoom and #getMaxZoom", function () {
-		it("The minZoom and maxZoom options overrides any"
-		   + " minZoom and maxZoom set on layers", function () {
+		it("The minZoom and maxZoom options overrides any" +
+		   " minZoom and maxZoom set on layers", function () {
 			   var c = document.createElement('div'),
 				   map = L.map(c, { minZoom: 5, maxZoom: 10 });
 			   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 }).addTo(map);
@@ -85,7 +85,7 @@ describe("Map", function () {
 				   expect(spy).not.toHaveBeenCalled();
 				   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 }).addTo(map);
 				   expect(spy).not.toHaveBeenCalled();
-			   	   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 5 }).addTo(map);
+				   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 5 }).addTo(map);
 				   expect(spy).not.toHaveBeenCalled();
 
 			   });


### PR DESCRIPTION
Looks like jshint coverage is not hitting tests and they had quite a few issues.
