### PR TITLE
Omit "should" in spec descriptions

### DIFF
--- a/spec/suites/LeafletSpec.js
+++ b/spec/suites/LeafletSpec.js
@@ -1,5 +1,5 @@
 describe('L#noConflict', function() {
-	it('should restore the previous L value and return Leaflet namespace', function(){
+	it('restores the previous L value and returns Leaflet namespace', function(){
 
 		expect(L.version).toBeDefined();
 

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -1,5 +1,5 @@
 function noSpecs() {
-	xit('should have specs');
+	xit('has no specs');
 }
 
 if (!Array.prototype.map) {

--- a/spec/suites/control/Control.AttributionSpec.js
+++ b/spec/suites/control/Control.AttributionSpec.js
@@ -10,23 +10,23 @@ describe("Control.Attribution", function () {
 		container = control.getContainer();
 	});
 
-	it("should contain just prefix if no attributions added", function () {
+	it("contains just prefix if no attributions added", function () {
 		expect(container.innerHTML).toEqual('prefix');
 	});
 
 	describe('#addAttribution', function () {
-		it('should add one attribution correctly', function () {
+		it('adds one attribution correctly', function () {
 			control.addAttribution('foo');
 			expect(container.innerHTML).toEqual('prefix | foo');
 		});
 
-		it('should not add duplicate attributions', function () {
+		it('adds no duplicate attributions', function () {
 			control.addAttribution('foo');
 			control.addAttribution('foo');
 			expect(container.innerHTML).toEqual('prefix | foo');
 		});
 
-		it('should add several attributions listed with comma', function () {
+		it('adds several attributions listed with comma', function () {
 			control.addAttribution('foo');
 			control.addAttribution('bar');
 			expect(container.innerHTML).toEqual('prefix | foo, bar');
@@ -34,13 +34,13 @@ describe("Control.Attribution", function () {
 	});
 
 	describe('#removeAttribution', function () {
-		it('should remove attribution correctly', function () {
+		it('removes attribution correctly', function () {
 			control.addAttribution('foo');
 			control.addAttribution('bar');
 			control.removeAttribution('foo');
 			expect(container.innerHTML).toEqual('prefix | bar');
 		});
-		it('should do nothing if removing attribution that was not present', function () {
+		it('does nothing if removing attribution that was not present', function () {
 			control.addAttribution('foo');
 			control.addAttribution('baz');
 			control.removeAttribution('bar');
@@ -52,14 +52,14 @@ describe("Control.Attribution", function () {
 	});
 
 	describe('#setPrefix', function () {
-		it('should change prefix', function () {
+		it('changes prefix', function () {
 			control.setPrefix('bla');
 			expect(container.innerHTML).toEqual('bla');
 		});
 	});
 
 	describe('control.attribution factory', function () {
-		it('should create Control.Attribution instance', function () {
+		it('creates Control.Attribution instance', function () {
 			var options = {prefix: 'prefix'};
 			expect(L.control.attribution(options)).toEqual(new L.Control.Attribution(options));
 		});

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -19,7 +19,7 @@ describe("Class", function() {
 			});
 		});
 
-		it("should create a class with the given constructor & properties", function() {
+		it("creates a class with the given constructor & properties", function() {
 			var a = new Klass();
 
 			expect(constructor).toHaveBeenCalled();
@@ -30,7 +30,7 @@ describe("Class", function() {
 			expect(method).toHaveBeenCalled();
 		});
 
-		it("should inherit parent classes' constructor & properties", function() {
+		it("inherits parent classes' constructor & properties", function() {
 			var Klass2 = Klass.extend({baz: 2});
 
 			var b = new Klass2();
@@ -46,28 +46,28 @@ describe("Class", function() {
 			expect(method).toHaveBeenCalled();
 		});
 
-		it("should support static properties", function() {
+		it("supports static properties", function() {
 			expect(Klass.bla).toEqual(1);
 		});
 
-		it("should inherit parent static properties", function() {
+		it("inherits parent static properties", function() {
 			var Klass2 = Klass.extend({});
 
 			expect(Klass2.bla).toEqual(1);
 		});
 
-		it("should override parent static properties", function() {
+		it("overrides parent static properties", function() {
 			var Klass2 = Klass.extend({statics: {bla: 2}});
 
 			expect(Klass2.bla).toEqual(2);
 		});
 
-		it("should include the given mixin", function() {
+		it("includes the given mixin", function() {
 			var a = new Klass();
 			expect(a.mixin).toBeTruthy();
 		});
 
-		it("should be able to include multiple mixins", function() {
+		it("includes multiple mixins", function() {
 			var Klass2 = L.Class.extend({
 				includes: [{mixin: true}, {mixin2: true}]
 			});
@@ -77,14 +77,14 @@ describe("Class", function() {
 			expect(a.mixin2).toBeTruthy();
 		});
 
-		it("should grant the ability to include the given mixin", function() {
+		it("grants the ability to include the given mixin", function() {
 			Klass.include({mixin2: true});
 
 			var a = new Klass();
 			expect(a.mixin2).toBeTruthy();
 		});
 
-		it("should merge options instead of replacing them", function() {
+		it("merges options instead of replacing them", function() {
 			var KlassWithOptions1 = L.Class.extend({
 				options: {
 					foo1: 1,
@@ -107,7 +107,7 @@ describe("Class", function() {
 			});
 		});
 
-		it("should add constructor hooks correctly", function () {
+		it("adds constructor hooks correctly", function () {
 			var spy1 = jasmine.createSpy("init hook 1");
 
 			Klass.addInitHook(spy1);
@@ -119,7 +119,7 @@ describe("Class", function() {
 			expect(method).toHaveBeenCalledWith(1, 2, 3);
 		});
 
-		it("should inherit constructor hooks", function () {
+		it("inherits constructor hooks", function () {
 			var spy1 = jasmine.createSpy("init hook 1"),
 				spy2 = jasmine.createSpy("init hook 2");
 
@@ -134,7 +134,7 @@ describe("Class", function() {
 			expect(spy2).toHaveBeenCalled();
 		});
 
-		it("should not call child constructor hooks", function () {
+		it("does not call child constructor hooks", function () {
 			var spy1 = jasmine.createSpy("init hook 1"),
 				spy2 = jasmine.createSpy("init hook 2");
 

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -9,7 +9,7 @@ describe('Events', function() {
 
 	describe('#fireEvent', function() {
 
-		it('should fire all listeners added through #addEventListener', function() {
+		it('fires all listeners added through #addEventListener', function() {
 			var obj = new Klass(),
 				spy = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
@@ -42,7 +42,7 @@ describe('Events', function() {
 			expect(spy6.calls.length).toEqual(1);
 		});
 
-		it('should provide event object to listeners and execute them in the right context', function() {
+		it('provides event object to listeners and executes them in the right context', function() {
 			var obj = new Klass(),
 				obj2 = new Klass(),
 				obj3 = new Klass(),
@@ -88,7 +88,7 @@ describe('Events', function() {
 			obj4.fireEvent('test', {baz: 4});
 		});
 
-		it('should not call listeners removed through #removeEventListener', function() {
+		it('calls no listeners removed through #removeEventListener', function() {
 			var obj = new Klass(),
 				spy = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
@@ -127,7 +127,7 @@ describe('Events', function() {
 		});
 
 		// added due to context-sensitive removeListener optimization
-		it('should fire multiple listeners with the same context with id properly', function () {
+		it('fires multiple listeners with the same context with id', function () {
 			var obj = new Klass(),
 				spy = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
@@ -144,7 +144,7 @@ describe('Events', function() {
 			expect(spy2).toHaveBeenCalled();
 		});
 
-		it('should remove listeners with stamped contexts properly', function () {
+		it('removes listeners with stamped contexts', function () {
 			var obj = new Klass(),
 				spy = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
@@ -166,7 +166,7 @@ describe('Events', function() {
 
 	describe('#on, #off & #fire', function() {
 
-		it('should work like #addEventListener && #removeEventListener', function() {
+		it('works like #addEventListener && #removeEventListener', function() {
 			var obj = new Klass(),
 				spy = jasmine.createSpy();
 
@@ -181,7 +181,7 @@ describe('Events', function() {
 			expect(spy.callCount).toBeLessThan(2);
 		});
 
-		it('should not override existing methods with the same name', function() {
+		it('does not override existing methods with the same name', function() {
 			var spy1 = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
 				spy3 = jasmine.createSpy();

--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -10,7 +10,7 @@ describe('Util', function() {
 			};
 		});
 
-		it('should extend the first argument with the properties of the second', function() {
+		it('extends the first argument with the properties of the second', function() {
 			L.Util.extend(a, {
 				bar: 7,
 				baz: 3
@@ -23,7 +23,7 @@ describe('Util', function() {
 			});
 		});
 
-		it('should work with more than 2 arguments', function() {
+		it('accepts more than 2 arguments', function() {
 			L.Util.extend(a, {bar: 7}, {baz: 3});
 
 			expect(a).toEqual({
@@ -35,7 +35,7 @@ describe('Util', function() {
 	});
 
 	describe('#bind', function() {
-		it('should return the given function with the given context', function() {
+		it('returns the given function with the given context', function() {
 			var fn = function() {
 				return this;
 			};
@@ -45,7 +45,7 @@ describe('Util', function() {
 			expect(fn2()).toEqual(5);
 		});
 
-		it('should pass additional arguments to the bound function', function () {
+		it('passes additional arguments to the bound function', function () {
 			var fn = jasmine.createSpy(),
 				foo = {},
 				a = {},
@@ -60,7 +60,7 @@ describe('Util', function() {
 	});
 
 	describe('#stamp', function() {
-		it('should set a unique id on the given object and return it', function() {
+		it('sets a unique id on the given object and returns it', function() {
 			var a = {},
 				id = L.Util.stamp(a);
 
@@ -75,13 +75,13 @@ describe('Util', function() {
 	});
 
 	describe('#falseFn', function () {
-		it('should just return false', function () {
+		it('returns false', function () {
 			expect(L.Util.falseFn()).toBe(false);
 		});
 	});
 
 	describe('#formatNum', function () {
-		it('should format numbers with a given precision', function () {
+		it('formats numbers with a given precision', function () {
 			expect(L.Util.formatNum(13.12325555, 3)).toEqual(13.123);
 			expect(L.Util.formatNum(13.12325555)).toEqual(13.12326);
 		});
@@ -89,7 +89,7 @@ describe('Util', function() {
 
 
 	describe('#getParamString', function() {
-		it('should create a valid query string for appending depending on url input', function() {
+		it('creates a valid query string for appending depending on url input', function() {
 			var a = {
 				url: "http://example.com/get",
 				obj: {bar: 7, baz: 3},
@@ -117,7 +117,7 @@ describe('Util', function() {
 	});
 
 	describe('#requestAnimFrame', function () {
-		it('should call a function on next frame, unless canceled', function () {
+		it('calles a function on next frame, unless canceled', function () {
 			var spy = jasmine.createSpy(),
 				spy2 = jasmine.createSpy(),
 				called = false,
@@ -147,7 +147,7 @@ describe('Util', function() {
 	});
 
 	describe('#limitExecByInterval', function() {
-		it('should limit execution to not more often than specified time interval', function () {
+		it('limits execution to not more often than specified time interval', function () {
 			var spy = jasmine.createSpy(),
 				check = false;
 
@@ -176,7 +176,7 @@ describe('Util', function() {
 	});
 
 	describe('#splitWords', function () {
-		it('should split words into an array', function () {
+		it('splits words into an array', function () {
 			expect(L.Util.splitWords('foo bar baz')).toEqual(['foo', 'bar', 'baz']);
 		});
 	});
@@ -184,7 +184,7 @@ describe('Util', function() {
 	// TODO setOptions
 
 	describe('#template', function () {
-		it('should evaluate templates with a given data object', function () {
+		it('evaluates templates with a given data object', function () {
 			var tpl = 'Hello {foo} and {bar}!';
 
 			var str = L.Util.template(tpl, {

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -24,7 +24,7 @@ describe('DomEvent', function() {
 	});
 	
 	describe('#addListener', function() {
-		it('should add a listener and call it on event', function() {
+		it('adds a listener and calls it on event', function() {
 			var listener1 = jasmine.createSpy('listener1'), 
 				listener2 = jasmine.createSpy('listener2');
 		
@@ -37,7 +37,7 @@ describe('DomEvent', function() {
 			expect(listener2).toHaveBeenCalled();
 		});
 		
-		it('should have "this" keyword point to the given context', function() {
+		it('binds "this" to the given context', function() {
 			var obj = {foo: 'bar'},
 				result;
 			
@@ -50,7 +50,7 @@ describe('DomEvent', function() {
 			expect(result).toEqual(obj);
 		});
 		
-		it('should pass an event object to the listener', function() {
+		it('passes an event object to the listener', function() {
 			var type;
 			
 			L.DomEvent.addListener(el, 'click', function(e) {
@@ -63,7 +63,7 @@ describe('DomEvent', function() {
 	});
 	
 	describe('#removeListener', function() {
-		it('should remove previously added listener', function() {
+		it('removes a previously added listener', function() {
 			var listener = jasmine.createSpy('listener');
 			
 			L.DomEvent.addListener(el, 'click', listener);
@@ -76,7 +76,7 @@ describe('DomEvent', function() {
 	});
 	
 	describe('#stopPropagation', function() {
-		it('should stop propagation of the given event', function() {
+		it('stops propagation of the given event', function() {
 			var child = document.createElement('div'),
 				listener = jasmine.createSpy('listener');
 			
@@ -93,7 +93,7 @@ describe('DomEvent', function() {
 		});
 	});
 	describe('#preventDefault', function() {
-		it('should prevent the default action of event', function() {
+		it('prevents the default action of event', function() {
 			L.DomEvent.addListener(el, 'click', L.DomEvent.preventDefault);
 
 			expect(simulateClick(el)).toBe(false);

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -13,18 +13,18 @@ describe('DomUtil', function() {
 	});
 
 	describe('#get', function() {
-		it('should get element by id if the given argument is string', function() {
+		it('gets element by id if the given argument is string', function() {
 			el.id = 'testId';
 			expect(L.DomUtil.get(el.id)).toBe(el);
 		});
 
-		it('should return the element if it is given as an argument', function() {
+		it('returns the element if it is given as an argument', function() {
 			expect(L.DomUtil.get(el)).toBe(el);
 		});
 	});
 
 	describe('#addClass, #removeClass, #hasClass', function() {
-		it('should has defined class for test element', function() {
+		it('has defined class for test element', function() {
 			el.className = 'bar foo baz ';
 			expect(L.DomUtil.hasClass(el, 'foo')).toBeTruthy();
 			expect(L.DomUtil.hasClass(el, 'bar')).toBeTruthy();
@@ -32,7 +32,7 @@ describe('DomUtil', function() {
 			expect(L.DomUtil.hasClass(el, 'boo')).toBeFalsy();
 		});
 
-		it('should properly addClass and removeClass for element', function() {
+		it('adds or removes the class', function() {
 			el.className = '';
 			L.DomUtil.addClass(el, 'foo');
 
@@ -54,14 +54,14 @@ describe('DomUtil', function() {
 	});
 
 	describe('#documentIsLtr', function () {
-		it('should return true if doc direction is ltr', function () {
+		it('returns true if doc direction is ltr', function () {
 			expect(L.DomUtil.documentIsLtr()).toBe(true);
 			expect(L.DomUtil.documentIsLtr()).toBe(true); // cached
 		});
 	});
 
 	describe('#getViewportOffset', function () {
-		it('should calculate and return viewport offset of an element', function () {
+		it('calculates the viewport offset of an element', function () {
 			var div = document.createElement('div');
 			div.style.position = 'absolute';
 			div.style.top = '100px';

--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -9,7 +9,7 @@ describe('LatLngBounds', function() {
 	});
 
 	describe('constructor', function () {
-		it('should instantiate properly either passing two latlngs or an array of latlngs', function () {
+		it('instantiates either passing two latlngs or an array of latlngs', function () {
 			var b = new L.LatLngBounds([
 				new L.LatLng(14, 12),
 				new L.LatLng(30, 40)
@@ -20,12 +20,12 @@ describe('LatLngBounds', function() {
 	});
 
 	describe('#extend', function () {
-		it('should extend the bounds by a given point', function () {
+		it('extends the bounds by a given point', function () {
 			a.extend(new L.LatLng(20, 50));
 			expect(a.getNorthEast()).toEqual(new L.LatLng(30, 50));
 		});
 
-		it('should extend the bounds by given bounds', function () {
+		it('extends the bounds by given bounds', function () {
 			a.extend([[20, 50], [8, 40]]);
 
 			expect(a.getSouthEast()).toEqual(new L.LatLng(8, 50));
@@ -33,13 +33,13 @@ describe('LatLngBounds', function() {
 	});
 
 	describe('#getCenter', function () {
-		it('should return the bounds center', function () {
+		it('returns the bounds center', function () {
 			expect(a.getCenter()).toEqual(new L.LatLng(22, 26));
 		});
 	});
 
 	describe('#pad', function () {
-		it('should pad the bounds by a given ratio', function () {
+		it('pads the bounds by a given ratio', function () {
 			var b = a.pad(0.5);
 
 			expect(b).toEqual(L.latLngBounds([[6, -2], [38, 54]]));
@@ -47,7 +47,7 @@ describe('LatLngBounds', function() {
 	});
 
 	describe('#equals', function () {
-		it('should return true if bounds equal', function () {
+		it('returns true if bounds equal', function () {
 			expect(a.equals([[14, 12], [30, 40]])).toBe(true);
 			expect(a.equals([[14, 13], [30, 40]])).toBe(false);
 			expect(a.equals(null)).toBe(false);
@@ -55,79 +55,79 @@ describe('LatLngBounds', function() {
 	});
 
 	describe('#isValid', function() {
-		it('should return true if properly set up', function() {
+		it('returns true if properly set up', function() {
 			expect(a.isValid()).toBeTruthy();
 		});
-		it('should return false if is invalid', function() {
+		it('returns false if is invalid', function() {
 			expect(c.isValid()).toBeFalsy();
 		});
-		it('should be valid if extended', function() {
+		it('returns true if extended', function() {
 			c.extend([0, 0]);
 			expect(c.isValid()).toBeTruthy();
 		});
 	});
 
 	describe('#getWest', function () {
-		it('should return a proper bbox west value', function() {
+		it('returns a proper bbox west value', function() {
 			expect(a.getWest()).toEqual(12);
 		});
 	});
 
 	describe('#getSouth', function () {
-		it('should return a proper bbox south value', function() {
+		it('returns a proper bbox south value', function() {
 			expect(a.getSouth()).toEqual(14);
 		});
 
 	});
 
 	describe('#getEast', function () {
-		it('should return a proper bbox east value', function() {
+		it('returns a proper bbox east value', function() {
 			expect(a.getEast()).toEqual(40);
 		});
 
 	});
 
 	describe('#getNorth', function () {
-		it('should return a proper bbox north value', function() {
+		it('returns a proper bbox north value', function() {
 			expect(a.getNorth()).toEqual(30);
 		});
 
 	});
 
 	describe('#toBBoxString', function () {
-		it('should return a proper left,bottom,right,top bbox', function() {
+		it('returns a proper left,bottom,right,top bbox', function() {
 			expect(a.toBBoxString()).toEqual("12,14,40,30");
 		});
 
 	});
 
 	describe('#getNorthWest', function () {
-		it('should return a proper north-west LatLng', function() {
+		it('returns a proper north-west LatLng', function() {
 			expect(a.getNorthWest()).toEqual(new L.LatLng(a.getNorth(), a.getWest()));
 		});
 
 	});
 
 	describe('#getSouthEast', function () {
-		it('should return a proper south-east LatLng', function() {
+		it('returns a proper south-east LatLng', function() {
 			expect(a.getSouthEast()).toEqual(new L.LatLng(a.getSouth(), a.getEast()));
 		});
 	});
 
 	describe('#contains', function () {
-		it('should return true if contains latlng point', function () {
+		it('returns true if contains latlng point', function () {
 			expect(a.contains([16, 20])).toBe(true);
 			expect(L.latLngBounds(a).contains([5, 20])).toBe(false);
 		});
 
-		it('should accept bounds', function () {
+		it('returns true if contains bounds', function () {
 			expect(a.contains([[16, 20], [20, 40]])).toBe(true);
 			expect(a.contains([[16, 50], [8, 40]])).toBe(false);
 		});
 	});
 
 	describe('#intersects', function () {
-		it('should return true if intersects the given bounds', function () {
+		it('returns true if intersects the given bounds', function () {
 			expect(a.intersects([[16, 20], [50, 60]])).toBe(true);
 			expect(a.contains([[40, 50], [50, 60]])).toBe(false);
 		});

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -1,6 +1,6 @@
 describe('LatLng', function() {
 	describe('constructor', function() {
-		it("should set lat and lng", function() {
+		it("sets lat and lng", function() {
 			var a = new L.LatLng(25, 74);
 			expect(a.lat).toEqual(25);
 			expect(a.lng).toEqual(74);
@@ -10,7 +10,7 @@ describe('LatLng', function() {
 			expect(b.lng).toEqual(-74);
 		});
 
-		it('should throw error if invalid lat or lng', function () {
+		it('throws an error if invalid lat or lng', function () {
 			expect(function () {
 				var a = new L.LatLng(NaN, NaN);
 			}).toThrow();
@@ -18,26 +18,26 @@ describe('LatLng', function() {
 	});
 
 	describe('#equals', function() {
-		it("should return true if compared objects are equal within a certain margin", function() {
+		it("returns true if compared objects are equal within a certain margin", function() {
 			var a = new L.LatLng(10, 20);
 			var b = new L.LatLng(10 + 1.0E-10, 20 - 1.0E-10);
 			expect(a.equals(b)).toBe(true);
 		});
 
-		it("should return false if compared objects are not equal within a certain margin", function() {
+		it("returns false if compared objects are not equal within a certain margin", function() {
 			var a = new L.LatLng(10, 20);
 			var b = new L.LatLng(10, 23.3);
 			expect(a.equals(b)).toBe(false);
 		});
 
-		it('should return false if passed non-valid object', function () {
+		it('returns false if passed non-valid object', function () {
 			var a = new L.LatLng(10, 20);
 			expect(a.equals(null)).toBe(false);
 		});
 	});
 
 	describe('#wrap', function () {
-		it("#wrap should wrap longitude to lie between -180 and 180 by default", function() {
+		it("wraps longitude to lie between -180 and 180 by default", function() {
 			var a = new L.LatLng(0, 190).wrap().lng;
 			expect(a).toEqual(-170);
 
@@ -63,7 +63,7 @@ describe('LatLng', function() {
 			expect(h).toEqual(180);
 		});
 
-		it("#wrap should wrap longitude within the given range", function() {
+		it("wraps longitude within the given range", function() {
 			var a = new L.LatLng(0, 190).wrap(-100, 100).lng;
 			expect(a).toEqual(-10);
 		});
@@ -71,14 +71,14 @@ describe('LatLng', function() {
 	});
 
 	describe('#toString', function () {
-		it('should format to string', function () {
+		it('formats a string', function () {
 			var a = new L.LatLng(10.333333333, 20.2222222);
 			expect(a.toString(3)).toEqual('LatLng(10.333, 20.222)');
 		});
 	});
 
 	describe('#distanceTo', function () {
-		it('should calculate distance in meters', function () {
+		it('calculates distance in meters', function () {
 			var a = new L.LatLng(50.5, 30.5);
 			var b = new L.LatLng(50, 1);
 
@@ -87,30 +87,30 @@ describe('LatLng', function() {
 	});
 
 	describe('L.latLng factory', function () {
-		it('should return LatLng instance as is', function () {
+		it('returns LatLng instance as is', function () {
 			var a = new L.LatLng(50, 30);
 
 			expect(L.latLng(a)).toBe(a);
 		});
 
-		it('should accept an array of coordinates', function () {
+		it('accepts an array of coordinates', function () {
 			expect(L.latLng([50, 30])).toEqual(new L.LatLng(50, 30));
 		});
 
-		it('should pass null or undefined as is', function () {
+		it('passes null or undefined as is', function () {
 			expect(L.latLng(undefined)).toBe(undefined);
 			expect(L.latLng(null)).toBe(null);
 		});
 
-		it('should create a LatLng object from two coordinates', function () {
+		it('creates a LatLng object from two coordinates', function () {
 			expect(L.latLng(50, 30)).toEqual(new L.LatLng(50, 30));
 		});
 
-		it('should accept an object with lat/lng', function () {
+		it('accepts an object with lat/lng', function () {
 			expect(L.latLng({lat: 50, lng: 30})).toEqual(new L.LatLng(50, 30));
 		});
 
-		it('should accept an object with lat/lon', function () {
+		it('accepts an object with lat/lon', function () {
 			expect(L.latLng({lat: 50, lon: 30})).toEqual(new L.LatLng(50, 30));
 		});
 	});

--- a/spec/suites/geo/ProjectionSpec.js
+++ b/spec/suites/geo/ProjectionSpec.js
@@ -16,7 +16,7 @@ xdescribe("Projection.Mercator", function() {
 
 
 	describe("#project", function() {
-		it("should do projection properly", function() {
+		it("projects", function() {
 			//edge cases
 			expect(p.project(new L.LatLng(0, 0))).toAlmostEqual(new L.Point(0, 0));
 			expect(p.project(new L.LatLng(90, 180))).toAlmostEqual(new L.Point(-Math.PI, Math.PI));
@@ -27,7 +27,7 @@ xdescribe("Projection.Mercator", function() {
 	});
 
 	describe("#unproject", function() {
-		it("should do unprojection properly", function() {
+		it("unprojects", function() {
 			function pr(point) {
 				return p.project(p.unproject(point));
 			}

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -14,18 +14,18 @@ describe('Bounds', function() {
 	});
 
 	describe('constructor', function() {
-		it('should create bounds with proper min & max on (Point, Point)', function() {
+		it('creates bounds with proper min & max on (Point, Point)', function() {
 			expect(a.min).toEqual(new L.Point(14, 12));
 			expect(a.max).toEqual(new L.Point(30, 40));
 		});
-		it('should create bounds with proper min & max on (Point[])', function() {
+		it('creates bounds with proper min & max on (Point[])', function() {
 			expect(b.min).toEqual(new L.Point(14, 12));
 			expect(b.max).toEqual(new L.Point(30, 40));
 		});
 	});
 
 	describe('#extend', function() {
-		it('should extend the bounds to contain the given point', function() {
+		it('extends the bounds to contain the given point', function() {
 			a.extend(new L.Point(50, 20));
 			expect(a.min).toEqual(new L.Point(14, 12));
 			expect(a.max).toEqual(new L.Point(50, 40));
@@ -37,13 +37,13 @@ describe('Bounds', function() {
 	});
 
 	describe('#getCenter', function() {
-		it('should return the center point', function() {
+		it('returns the center point', function() {
 			expect(a.getCenter()).toEqual(new L.Point(22, 26));
 		});
 	});
 
 	describe('#contains', function() {
-		it('should contains other bounds or point', function() {
+		it('contains other bounds or point', function() {
 			a.extend(new L.Point(50, 10));
 			expect(a.contains(b)).toBeTruthy();
 			expect(b.contains(a)).toBeFalsy();
@@ -53,33 +53,33 @@ describe('Bounds', function() {
 	});
 
 	describe('#isValid', function() {
-		it('should return true if properly set up', function() {
+		it('returns true if properly set up', function() {
 			expect(a.isValid()).toBeTruthy();
 		});
-		it('should return false if is invalid', function() {
+		it('returns false if is invalid', function() {
 			expect(c.isValid()).toBeFalsy();
 		});
-		it('should be valid if extended', function() {
+		it('returns true if extended', function() {
 			c.extend([0, 0]);
 			expect(c.isValid()).toBeTruthy();
 		});
 	});
 
 	describe('#getSize', function () {
-		it('should return the size of the bounds as point', function () {
+		it('returns the size of the bounds as point', function () {
 			expect(a.getSize()).toEqual(new L.Point(16, 28));
 		});
 	});
 
 	describe('#intersects', function () {
-		it('should return true if bounds intersect', function () {
+		it('returns true if bounds intersect', function () {
 			expect(a.intersects(b)).toBe(true);
 			expect(a.intersects(new L.Bounds(new L.Point(100, 100), new L.Point(120, 120)))).toEqual(false);
 		});
 	});
 
 	describe('L.bounds factory', function () {
-		it('should create bounds from array of number arrays', function () {
+		it('creates bounds from array of number arrays', function () {
 			var bounds = L.bounds([[14, 12], [30, 40]]);
 			expect(bounds).toEqual(a);
 		});

--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -8,7 +8,7 @@ describe('LineUtil', function () {
 			bounds = L.bounds([5, 0], [15, 10]);
 		});
 
-		it('should clip segment by bounds correctly', function () {
+		it('clips a segment by bounds', function () {
 			var a = new L.Point(0, 0);
 			var b = new L.Point(15, 15);
 
@@ -26,7 +26,7 @@ describe('LineUtil', function () {
 			expect(segment2[1]).toEqual(new L.Point(15, 5));
 		});
 
-		it('should use last bit code and reject segments out of bounds', function () {
+		it('uses last bit code and reject segments out of bounds', function () {
 			var a = new L.Point(15, 15);
 			var b = new L.Point(25, 20);
 			var segment = L.LineUtil.clipSegment(a, b, bounds, true);
@@ -41,17 +41,17 @@ describe('LineUtil', function () {
 		var p2 = new L.Point(10, 0);
 		var p = new L.Point(0, 0);
 
-		it('should calculate distance from point to segment', function () {
+		it('calculates distance from point to segment', function () {
 			expect(L.LineUtil.pointToSegmentDistance(p, p1, p2)).toEqual(Math.sqrt(200) / 2);
 		});
 
-		it('should get point closest to segment', function () {
+		it('calculates point closest to segment', function () {
 			expect(L.LineUtil.closestPointOnSegment(p, p1, p2)).toEqual(new L.Point(5, 5));
 		});
 	});
 
 	describe('#simplify', function () {
-		it('should simplify polylines according to tolerance', function () {
+		it('simplifies polylines according to tolerance', function () {
 			var points = [
 				new L.Point(0, 0),
 				new L.Point(0.01, 0),

--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -2,13 +2,13 @@ describe("Point", function() {
 
 	describe('constructor', function() {
 
-		it("should create a point with the given x and y", function() {
+		it("creates a point with the given x and y", function() {
 			var p = new L.Point(1.5, 2.5);
 			expect(p.x).toEqual(1.5);
 			expect(p.y).toEqual(2.5);
 		});
 
-		it("should round the given x and y if the third argument is true", function() {
+		it("rounds the given x and y if the third argument is true", function() {
 			var p = new L.Point(1.3, 2.7, true);
 			expect(p.x).toEqual(1);
 			expect(p.y).toEqual(3);
@@ -16,7 +16,7 @@ describe("Point", function() {
 	});
 
 	describe('#subtract', function() {
-		it('should subtract the given point from this one', function() {
+		it('subtracts the given point from this one', function() {
 			var a = new L.Point(50, 30),
 				b = new L.Point(20, 10);
 			expect(a.subtract(b)).toEqual(new L.Point(30, 20));
@@ -24,31 +24,31 @@ describe("Point", function() {
 	});
 
 	describe('#add', function() {
-		it('should add the given point to this one', function() {
+		it('adds given point to this one', function() {
 			expect(new L.Point(50, 30).add(new L.Point(20, 10))).toEqual(new L.Point(70, 40));
 		});
 	});
 
 	describe('#divideBy', function() {
-		it('should divide this point by the given amount', function() {
+		it('divides this point by the given amount', function() {
 			expect(new L.Point(50, 30).divideBy(5)).toEqual(new L.Point(10, 6));
 		});
 	});
 
 	describe('#multiplyBy', function() {
-		it('should multiply this point by the given amount', function() {
+		it('multiplies this point by the given amount', function() {
 			expect(new L.Point(50, 30).multiplyBy(2)).toEqual(new L.Point(100, 60));
 		});
 	});
 
 	describe('#floor', function () {
-		it('should return a new point with floored coordinates', function () {
+		it('returns a new point with floored coordinates', function () {
 			expect(new L.Point(50.56, 30.123).floor()).toEqual(new L.Point(50, 30));
 		});
 	});
 
 	describe('#distanceTo', function () {
-		it('should calculate distance between two points', function () {
+		it('calculates distance between two points', function () {
 			var p1 = new L.Point(0, 30);
 			var p2 = new L.Point(40, 0);
 			expect(p1.distanceTo(p2)).toEqual(50.0);
@@ -56,7 +56,7 @@ describe("Point", function() {
 	});
 
 	describe('#equals', function () {
-		it('should return true if points are equal', function () {
+		it('returns true if points are equal', function () {
 			var p1 = new L.Point(20.4, 50.12);
 			var p2 = new L.Point(20.4, 50.12);
 			var p3 = new L.Point(20.5, 50.13);
@@ -67,23 +67,23 @@ describe("Point", function() {
 	});
 
 	describe('#toString', function () {
-		it('should format a string out of point coordinates', function () {
+		it('formats a string out of point coordinates', function () {
 			expect(new L.Point(50, 30) + '').toEqual('Point(50, 30)');
 		});
 	});
 
 	describe('L.point factory', function () {
-		it('should leave L.Point instances as is', function () {
+		it('leaves L.Point instances as is', function () {
 			var p = new L.Point(50, 30);
 			expect(L.point(p)).toBe(p);
 		});
-		it('should create a point out of three arguments', function () {
+		it('creates a point out of three arguments', function () {
 			expect(L.point(50.1, 30.1, true)).toEqual(new L.Point(50, 30));
 		});
-		it('should create a point from an array of coordinates', function () {
+		it('creates a point from an array of coordinates', function () {
 			expect(L.point([50, 30])).toEqual(new L.Point(50, 30));
 		});
-		it('should not fail on invalid arguments', function () {
+		it('does not fail on invalid arguments', function () {
 			expect(L.point(undefined)).toBe(undefined);
 			expect(L.point(null)).toBe(null);
 		});

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -1,7 +1,7 @@
 describe('PolyUtil', function () {
 
 	describe('#clipPolygon', function () {
-		it('should clip polygon by bounds correctly', function () {
+		it('clips polygon by bounds', function () {
 			var bounds = L.bounds([0, 0], [10, 10]);
 
 			var points = [

--- a/spec/suites/geometry/TransformationSpec.js
+++ b/spec/suites/geometry/TransformationSpec.js
@@ -7,23 +7,23 @@ describe("Transformation", function() {
 	});
 
 	describe('#transform', function () {
-		it("should perform a transformation", function() {
+		it("performs a transformation", function() {
 			var p2 = t.transform(p, 2);
 			expect(p2).toEqual(new L.Point(24, 128));
 		});
-		it('should assume scale of 1 if not specified', function () {
+		it('assumes a scale of 1 if not specified', function () {
 			var p2 = t.transform(p);
 			expect(p2).toEqual(new L.Point(12, 64));
 		});
 	});
 
 	describe('#untransform', function () {
-		it("should perform a reverse transformation", function() {
+		it("performs a reverse transformation", function() {
 			var p2 = t.transform(p, 2);
 			var p3 = t.untransform(p2, 2);
 			expect(p3).toEqual(p);
 		});
-		it('should assume scale of 1 if not specified', function () {
+		it('assumes a scale of 1 if not specified', function () {
 			var p2 = t.transform(p);
 			expect(t.untransform(new L.Point(12, 64))).toEqual(new L.Point(10, 20));
 		});

--- a/spec/suites/layer/TileLayerSpec.js
+++ b/spec/suites/layer/TileLayerSpec.js
@@ -6,7 +6,7 @@ describe('TileLayer', function () {
 			map = L.map(document.createElement('div'));
 		});
 		describe("when a tilelayer is added to a map with no other layers", function () {
-			it("should have the same zoomlevels as the tilelayer", function () {
+			it("has the same zoomlevels as the tilelayer", function () {
 				var maxZoom = 10,
 					minZoom = 5;
 					map.setView([0, 0], 1);
@@ -20,7 +20,7 @@ describe('TileLayer', function () {
 			});
 		});
 		describe("when a tilelayer is added to a map that already has a tilelayer", function () {
-			it("should have its zoomlevels updated to fit the new layer", function () {
+			it("has its zoomlevels updated to fit the new layer", function () {
 				map.setView([0, 0], 1);
 
 				L.tileLayer("{z}{x}{y}", { minZoom:10, maxZoom: 15 }).addTo(map);
@@ -43,7 +43,7 @@ describe('TileLayer', function () {
 			});
 		});
 		describe("when a tilelayer is removed from a map", function () {
-			it("it should have its zoomlevels updated to only fit the layers it currently has", function () {
+			it("has its zoomlevels updated to only fit the layers it currently has", function () {
 				var tiles = [  L.tileLayer("{z}{x}{y}", { minZoom:10, maxZoom: 15 }).addTo(map),
 							   L.tileLayer("{z}{x}{y}", { minZoom:5, maxZoom: 10 }).addTo(map),
 							   L.tileLayer("{z}{x}{y}", { minZoom:10, maxZoom: 20 }).addTo(map),

--- a/spec/suites/layer/vector/CircleMarkerSpec.js
+++ b/spec/suites/layer/vector/CircleMarkerSpec.js
@@ -7,7 +7,7 @@
 		});
 		describe("when a CircleMarker is added to the map ", function() {
 			describe("with a radius set as an option", function() {
-				it("should take that radius", function() {
+				it("takes that radius", function() {
 					var marker = L.circleMarker([0, 0], { radius: 20 }).addTo(map);
 
 					expect(marker._radius).toBe(20);
@@ -15,7 +15,7 @@
 			});
 
 			describe("and radius is set before adding it", function () {
-				it("should take that radius", function () {
+				it("takes that radius", function () {
 					var marker = L.circleMarker([0, 0], { radius: 20 });
 					marker.setRadius(15);
 					marker.addTo(map);
@@ -24,7 +24,7 @@
 			});
 
 			describe("and radius is set after adding it", function () {
-				it("should take that radius", function () {
+				it("takes that radius", function () {
 					var marker = L.circleMarker([0, 0], { radius: 20 });
 					marker.addTo(map);
 					marker.setRadius(15);
@@ -33,7 +33,7 @@
 			});
 
 			describe("and setStyle is used to change the radius after adding", function () {
-				it("should take the given radius", function() {
+				it("takes the given radius", function() {
 					var marker = L.circleMarker([0, 0], { radius: 20 });
 					marker.addTo(map);
 					marker.setStyle({ radius: 15 });
@@ -41,7 +41,7 @@
 				});
 			});
 			describe("and setStyle is used to change the radius before adding", function () {
-				it("should take the given radius", function () {
+				it("takes the given radius", function () {
 					var marker = L.circleMarker([0, 0], { radius: 20 });
 					marker.setStyle({ radius: 15 });
 					marker.addTo(map);

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -7,7 +7,7 @@ describe('Circle', function () {
 			circle = L.circle([50, 30], 200);
 		});
 
-		it('should return correct bounds', function () {
+		it('returns bounds', function () {
 			var bounds = circle.getBounds();
 
 			expect(bounds.getSouthWest().equals([49.998203369, 29.997204939])).toBeTruthy();

--- a/spec/suites/layer/vector/PolylineGeometrySpec.js
+++ b/spec/suites/layer/vector/PolylineGeometrySpec.js
@@ -7,7 +7,7 @@ describe('PolylineGeometry', function() {
 	map.setView(new L.LatLng(55.8, 37.6), 6);
 	
 	describe("#distanceTo", function() {
-		it("should calculate correct distances to points", function() {
+		it("calculates distances to points", function() {
 			var p1 = map.latLngToLayerPoint(new L.LatLng(55.8, 37.6));
 			var p2 = map.latLngToLayerPoint(new L.LatLng(57.123076977278, 44.861962891635));
 			var latlngs = [[56.485503424111, 35.545556640339], [55.972522915346, 36.116845702918], [55.502459116923, 34.930322265253], [55.31534617509, 38.973291015816]]

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -7,7 +7,7 @@ describe("Map", function () {
 	});
 
 	describe('#getCenter', function () {
-		it ('should throw if not set before', function () {
+		it ('throws if not set before', function () {
 			expect(function () {
 				map.getCenter();
 			}).toThrow();
@@ -69,7 +69,7 @@ describe("Map", function () {
 
 	describe("#addLayer", function () {
 		describe("When the first layer is added to a map", function () {
-			it("should fire a zoomlevelschange event", function () {
+			it("fires a zoomlevelschange event", function () {
 				map.on("zoomlevelschange", spy);
 				expect(spy).not.toHaveBeenCalled();
 				L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 }).addTo(map);
@@ -77,7 +77,7 @@ describe("Map", function () {
 			});
 		});
 		describe("when a new layer with greater zoomlevel coverage than the current layer is added to a map", function () {
-			it("Should fire a zoomlevelschange event ",
+			it("fires a zoomlevelschange event ",
 			   function () {
 				   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 }).addTo(map);
 				   map.on("zoomlevelschange", spy);
@@ -87,7 +87,7 @@ describe("Map", function () {
 			   });
 		});
 		describe("when a new layer with the same or lower zoomlevel coverage as the current layer is added to a map", function () {
-			it("Shouldn't fire a zoomlevelschange event ",
+			it("fires no a zoomlevelschange event ",
 			   function () {
 				   L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 }).addTo(map);
 				   map.on("zoomlevelschange", spy);
@@ -103,7 +103,7 @@ describe("Map", function () {
 	});
 	describe("#removeLayer", function () {
 		describe("when the last tile layer on a map is removed", function () {
-			it("should fire a zoomlevelschange event ", function () {
+			it("fires a zoomlevelschange event ", function () {
 				   map.whenReady(function(){
 					   var tl = L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 })
 							   .addTo(map);
@@ -116,7 +116,7 @@ describe("Map", function () {
 			   });
 		});
 		describe("when a tile layer is removed from a map and it had greater zoom level coverage than the remainding layer", function () {
-			it("should fire a zoomlevelschange event ", function () {
+			it("fires a zoomlevelschange event ", function () {
 				   map.whenReady(function(){
 					   var tl = L.tileLayer("{z}{x}{y}", { minZoom:0, maxZoom: 10 })
 							   .addTo(map),


### PR DESCRIPTION
The rationale is this: the spec string describes the expected behavior
unconditionally. The code examples, on the other hand, set up an expectation
that is tested with the call to the expect method. The code examples can
violate the expectation, but the spec string does not. The value of the spec
string is as clearly as possible describing the behavior. Including “should”
in that description adds no value. (From http://rubyspec.org/style_guide/)
