### PR TITLE
Allow classes to be constructed without `new`

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -2,31 +2,40 @@ describe("Class", function() {
 
 	describe("#extend", function() {
 		var Klass,
-			constructor,
+			initializer,
 			method;
 
 		beforeEach(function() {
-			constructor = jasmine.createSpy("Klass constructor");
+			initializer = jasmine.createSpy("Klass initializer");
 			method = jasmine.createSpy("Klass#bar method");
 
 			Klass = L.Class.extend({
 				statics: {bla: 1},
 				includes: {mixin: true},
 
-				initialize: constructor,
+				initialize: initializer,
 				foo: 5,
 				bar: method
 			});
 		});
 
-		it("creates a class with the given constructor & properties", function() {
-			var a = new Klass();
+		it("returns a constructor that calls initialize", function() {
+			var a = new Klass(1, 2, 3);
+			expect(initializer).toHaveBeenCalledWith(1, 2, 3);
+			expect(a instanceof Klass).toBe(true);
+		});
 
-			expect(constructor).toHaveBeenCalled();
+		it("returns a constructor that can be called without new", function() {
+			var a = Klass(1, 2, 3);
+			expect(initializer).toHaveBeenCalledWith(1, 2, 3);
+			expect(a instanceof Klass).toBe(true);
+		});
+
+		it("sets property values", function() {
+			var a = new Klass();
 			expect(a.foo).toEqual(5);
 
 			a.bar();
-
 			expect(method).toHaveBeenCalled();
 		});
 
@@ -38,7 +47,7 @@ describe("Class", function() {
 			expect(b instanceof Klass).toBeTruthy();
 			expect(b instanceof Klass2).toBeTruthy();
 
-			expect(constructor).toHaveBeenCalled();
+			expect(initializer).toHaveBeenCalled();
 			expect(b.baz).toEqual(2);
 
 			b.bar();

--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -8,7 +8,7 @@ describe('LatLngBounds', function() {
 		c = new L.LatLngBounds();
 	});
 
-	function testConstructor(fn) {
+	function testConstructor(fn, factory) {
 		return function () {
 			it('constructs a LatLngBounds instance from the given LatLngs', function () {
 				var sw = new L.LatLng(14, 12),
@@ -38,16 +38,18 @@ describe('LatLngBounds', function() {
 				expect(fn(a)).toBe(a);
 			});
 
-			it('returns null or undefined as is', function () {
-				expect(fn(undefined)).toBe(undefined);
-				expect(fn(null)).toBe(null);
-			});
+			if (factory) {
+				it('returns null or undefined as is', function () {
+					expect(fn(undefined)).toBe(undefined);
+					expect(fn(null)).toBe(null);
+				});
+			}
 		}
 	}
 
 	describe('constructed via new L.LatLngBounds', testConstructor(function(a, b) { return new L.LatLngBounds(a, b); }));
-	describe('constructed via L.LatLngBounds', testConstructor(function(a, b) { return L.LatLngBounds(a, b); }));
-	describe('constructed via L.latLngBounds', testConstructor(function(a, b) { return L.latLngBounds(a, b); }));
+	describe('constructed via L.LatLngBounds', testConstructor(function(a, b) { return L.LatLngBounds(a, b); }, true));
+	describe('constructed via L.latLngBounds', testConstructor(function(a, b) { return L.latLngBounds(a, b); }, true));
 
 	describe('#extend', function () {
 		it('extends the bounds by a given point', function () {

--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -8,16 +8,46 @@ describe('LatLngBounds', function() {
 		c = new L.LatLngBounds();
 	});
 
-	describe('constructor', function () {
-		it('instantiates either passing two latlngs or an array of latlngs', function () {
-			var b = new L.LatLngBounds([
-				new L.LatLng(14, 12),
-				new L.LatLng(30, 40)
-			]);
-			expect(b).toEqual(a);
-			expect(b.getNorthWest()).toEqual(new L.LatLng(30, 12));
-		});
-	});
+	function testConstructor(fn) {
+		return function () {
+			it('constructs a LatLngBounds instance from the given LatLngs', function () {
+				var sw = new L.LatLng(14, 12),
+				    ne = new L.LatLng(30, 40),
+				    b = fn(sw, ne);
+				expect(b.getSouthWest()).toEqual(sw);
+				expect(b.getNorthEast()).toEqual(ne);
+			});
+
+			it('constructs a LatLngBounds instance from the given array of LatLngs', function () {
+				var sw = new L.LatLng(14, 12),
+				    ne = new L.LatLng(30, 40),
+				    b = fn([sw, ne]);
+				expect(b.getSouthWest()).toEqual(sw);
+				expect(b.getNorthEast()).toEqual(ne);
+			});
+
+			it('constructs a LatLngBounds instance from the given array of coordinates', function () {
+				var sw = [14, 12],
+				    ne = [30, 40],
+				    b = fn([sw, ne]);
+				expect(b.getSouthWest()).toEqual(new L.LatLng(sw));
+				expect(b.getNorthEast()).toEqual(new L.LatLng(ne));
+			});
+
+			it('returns LatLngBounds instance as is', function () {
+				expect(fn(a)).toBe(a);
+			});
+
+			it('returns null or undefined as is', function () {
+				expect(fn(undefined)).toBe(undefined);
+				expect(fn(null)).toBe(null);
+			});
+		}
+	}
+
+	describe('constructed via new L.LatLngBounds', testConstructor(function(a, b) { return new L.LatLngBounds(a, b); }));
+	describe('constructed via L.LatLngBounds', testConstructor(function(a, b) { return L.LatLngBounds(a, b); }));
+	describe('constructed via L.latLngBounds', testConstructor(function(a, b) { return L.latLngBounds(a, b); }));
 
 	describe('#extend', function () {
 		it('extends the bounds by a given point', function () {

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -1,21 +1,53 @@
 describe('LatLng', function() {
-	describe('constructor', function() {
-		it("sets lat and lng", function() {
-			var a = new L.LatLng(25, 74);
-			expect(a.lat).toEqual(25);
-			expect(a.lng).toEqual(74);
+	function testConstructor(fn) {
+		return function () {
+			it("constructs the origin", function () {
+				var a = fn(0, 0);
+				expect(a.lat).toEqual(0);
+				expect(a.lng).toEqual(0);
+			});
 
-			var b = new L.LatLng(-25, -74);
-			expect(b.lat).toEqual(-25);
-			expect(b.lng).toEqual(-74);
-		});
+			it("constructs a LatLng with the given lat and lng", function () {
+				var a = fn(25, 74);
+				expect(a.lat).toEqual(25);
+				expect(a.lng).toEqual(74);
+			});
 
-		it('throws an error if invalid lat or lng', function () {
-			expect(function () {
-				var a = new L.LatLng(NaN, NaN);
-			}).toThrow();
-		});
-	});
+			it('constructs a LatLng from array of coordinates', function () {
+				var a = fn([50, 30]);
+				expect(a.lat).toEqual(50);
+				expect(a.lng).toEqual(30);
+			});
+
+			it('throws an error if invalid lat or lng', function () {
+				expect(function () {
+					fn(NaN, NaN);
+				}).toThrow();
+			});
+
+			it('returns LatLng instances as is', function () {
+				var a = fn(50, 30);
+				expect(fn(a)).toBe(a);
+			});
+
+			it('returns null or undefined as is', function () {
+				expect(fn(undefined)).toBe(undefined);
+				expect(fn(null)).toBe(null);
+			});
+
+			it('accepts an object with lat/lng', function () {
+				expect(fn({lat: 50, lng: 30})).toEqual(fn(50, 30));
+			});
+
+			it('accepts an object with lat/lon', function () {
+				expect(fn({lat: 50, lon: 30})).toEqual(fn(50, 30));
+			});
+		}
+	}
+
+	describe('constructed via new L.LatLng', testConstructor(function(a, b) { return new L.LatLng(a, b); }));
+	describe('constructed via L.LatLng', testConstructor(function(a, b) { return L.LatLng(a, b); }));
+	describe('constructed via L.latLng', testConstructor(function(a, b) { return L.latLng(a, b); }));
 
 	describe('#equals', function() {
 		it("returns true if compared objects are equal within a certain margin", function() {
@@ -85,34 +117,4 @@ describe('LatLng', function() {
 			expect(Math.abs(Math.round(a.distanceTo(b) / 1000) - 2084) < 5).toBe(true);
 		});
 	});
-
-	describe('L.latLng factory', function () {
-		it('returns LatLng instance as is', function () {
-			var a = new L.LatLng(50, 30);
-
-			expect(L.latLng(a)).toBe(a);
-		});
-
-		it('accepts an array of coordinates', function () {
-			expect(L.latLng([50, 30])).toEqual(new L.LatLng(50, 30));
-		});
-
-		it('passes null or undefined as is', function () {
-			expect(L.latLng(undefined)).toBe(undefined);
-			expect(L.latLng(null)).toBe(null);
-		});
-
-		it('creates a LatLng object from two coordinates', function () {
-			expect(L.latLng(50, 30)).toEqual(new L.LatLng(50, 30));
-		});
-
-		it('accepts an object with lat/lng', function () {
-			expect(L.latLng({lat: 50, lng: 30})).toEqual(new L.LatLng(50, 30));
-		});
-
-		it('accepts an object with lat/lon', function () {
-			expect(L.latLng({lat: 50, lon: 30})).toEqual(new L.LatLng(50, 30));
-		});
-	});
 });
-

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -1,5 +1,5 @@
 describe('LatLng', function() {
-	function testConstructor(fn) {
+	function testConstructor(fn, factory) {
 		return function () {
 			it("constructs the origin", function () {
 				var a = fn(0, 0);
@@ -30,10 +30,12 @@ describe('LatLng', function() {
 				expect(fn(a)).toBe(a);
 			});
 
-			it('returns null or undefined as is', function () {
-				expect(fn(undefined)).toBe(undefined);
-				expect(fn(null)).toBe(null);
-			});
+			if (factory) {
+				it('returns null or undefined as is', function () {
+					expect(fn(undefined)).toBe(undefined);
+					expect(fn(null)).toBe(null);
+				});
+			}
 
 			it('accepts an object with lat/lng', function () {
 				expect(fn({lat: 50, lng: 30})).toEqual(fn(50, 30));
@@ -46,8 +48,8 @@ describe('LatLng', function() {
 	}
 
 	describe('constructed via new L.LatLng', testConstructor(function(a, b) { return new L.LatLng(a, b); }));
-	describe('constructed via L.LatLng', testConstructor(function(a, b) { return L.LatLng(a, b); }));
-	describe('constructed via L.latLng', testConstructor(function(a, b) { return L.latLng(a, b); }));
+	describe('constructed via L.LatLng', testConstructor(function(a, b) { return L.LatLng(a, b); }, true));
+	describe('constructed via L.latLng', testConstructor(function(a, b) { return L.latLng(a, b); }, true));
 
 	describe('#equals', function() {
 		it("returns true if compared objects are equal within a certain margin", function() {

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -13,7 +13,7 @@ describe('Bounds', function() {
 		c = new L.Bounds();
 	});
 
-	function testConstructor(fn) {
+	function testConstructor(fn, factory) {
 		return function () {
 			it('constructs a Bounds instance from the given Points', function () {
 				var min = new L.Point(14, 12),
@@ -43,16 +43,18 @@ describe('Bounds', function() {
 				expect(fn(a)).toBe(a);
 			});
 
-			it('returns null or undefined as is', function () {
-				expect(fn(undefined)).toBe(undefined);
-				expect(fn(null)).toBe(null);
-			});
+			if (factory) {
+				it('returns null or undefined as is', function () {
+					expect(fn(undefined)).toBe(undefined);
+					expect(fn(null)).toBe(null);
+				});
+			}
 		}
 	}
 
 	describe('constructed via new L.Bounds', testConstructor(function(a, b) { return new L.Bounds(a, b); }));
-	describe('constructed via L.Bounds', testConstructor(function(a, b) { return L.Bounds(a, b); }));
-	describe('constructed via L.bounds', testConstructor(function(a, b) { return L.bounds(a, b); }));
+	describe('constructed via L.Bounds', testConstructor(function(a, b) { return L.Bounds(a, b); }, true));
+	describe('constructed via L.bounds', testConstructor(function(a, b) { return L.bounds(a, b); }, true));
 
 	describe('#extend', function() {
 		it('extends the bounds to contain the given point', function() {

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -13,16 +13,46 @@ describe('Bounds', function() {
 		c = new L.Bounds();
 	});
 
-	describe('constructor', function() {
-		it('creates bounds with proper min & max on (Point, Point)', function() {
-			expect(a.min).toEqual(new L.Point(14, 12));
-			expect(a.max).toEqual(new L.Point(30, 40));
-		});
-		it('creates bounds with proper min & max on (Point[])', function() {
-			expect(b.min).toEqual(new L.Point(14, 12));
-			expect(b.max).toEqual(new L.Point(30, 40));
-		});
-	});
+	function testConstructor(fn) {
+		return function () {
+			it('constructs a Bounds instance from the given Points', function () {
+				var min = new L.Point(14, 12),
+				    max = new L.Point(30, 40),
+				    b = fn(min, max);
+				expect(b.min).toEqual(min);
+				expect(b.max).toEqual(max);
+			});
+
+			it('constructs a Bounds instance from the given array of Points', function () {
+				var min = new L.Point(14, 12),
+				    max = new L.Point(30, 40),
+				    b = fn([min, max]);
+				expect(b.min).toEqual(min);
+				expect(b.max).toEqual(max);
+			});
+
+			it('constructs a Bounds instance from the given array of coordinates', function () {
+				var min = [14, 12],
+				    max = [30, 40],
+				    b = fn([min, max]);
+				expect(b.min).toEqual(new L.Point(min));
+				expect(b.max).toEqual(new L.Point(max));
+			});
+
+			it('returns Bounds instance as is', function () {
+				expect(fn(a)).toBe(a);
+			});
+
+			it('returns null or undefined as is', function () {
+				expect(fn(undefined)).toBe(undefined);
+				expect(fn(null)).toBe(null);
+			});
+		}
+	}
+
+	describe('constructed via new L.Bounds', testConstructor(function(a, b) { return new L.Bounds(a, b); }));
+	describe('constructed via L.Bounds', testConstructor(function(a, b) { return L.Bounds(a, b); }));
+	describe('constructed via L.bounds', testConstructor(function(a, b) { return L.bounds(a, b); }));
 
 	describe('#extend', function() {
 		it('extends the bounds to contain the given point', function() {
@@ -75,13 +105,6 @@ describe('Bounds', function() {
 		it('returns true if bounds intersect', function () {
 			expect(a.intersects(b)).toBe(true);
 			expect(a.intersects(new L.Bounds(new L.Point(100, 100), new L.Point(120, 120)))).toEqual(false);
-		});
-	});
-
-	describe('L.bounds factory', function () {
-		it('creates bounds from array of number arrays', function () {
-			var bounds = L.bounds([[14, 12], [30, 40]]);
-			expect(bounds).toEqual(a);
 		});
 	});
 });

--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -1,19 +1,45 @@
 describe("Point", function() {
+	function testConstructor(fn) {
+		return function () {
+			it("constructs the origin", function () {
+				var a = fn(0, 0);
+				expect(a.x).toEqual(0);
+				expect(a.x).toEqual(0);
+			});
 
-	describe('constructor', function() {
+			it("constructs a Point with the given x and y", function () {
+				var p = fn(1.5, 2.5);
+				expect(p.x).toEqual(1.5);
+				expect(p.y).toEqual(2.5);
+			});
 
-		it("creates a point with the given x and y", function() {
-			var p = new L.Point(1.5, 2.5);
-			expect(p.x).toEqual(1.5);
-			expect(p.y).toEqual(2.5);
-		});
+			it("rounds the given x and y if the third argument is true", function () {
+				var p = fn(1.3, 2.7, true);
+				expect(p.x).toEqual(1);
+				expect(p.y).toEqual(3);
+			});
 
-		it("rounds the given x and y if the third argument is true", function() {
-			var p = new L.Point(1.3, 2.7, true);
-			expect(p.x).toEqual(1);
-			expect(p.y).toEqual(3);
-		});
-	});
+			it('constructs a Point from an array of coordinates', function () {
+				var p = fn([50, 30]);
+				expect(p.x).toEqual(50);
+				expect(p.y).toEqual(30);
+			});
+
+			it('returns Point instances as is', function () {
+				var p = fn(50, 30);
+				expect(fn(p)).toBe(p);
+			});
+
+			it('returns null or undefined as is', function () {
+				expect(fn(undefined)).toBe(undefined);
+				expect(fn(null)).toBe(null);
+			});
+		}
+	}
+
+	describe('constructed via new L.Point', testConstructor(function(a, b, c) { return new L.Point(a, b, c); }));
+	describe('constructed via L.Point', testConstructor(function(a, b, c) { return L.Point(a, b, c); }));
+	describe('constructed via L.point', testConstructor(function(a, b, c) { return L.point(a, b, c); }));
 
 	describe('#subtract', function() {
 		it('subtracts the given point from this one', function() {
@@ -82,23 +108,6 @@ describe("Point", function() {
 	describe('#toString', function () {
 		it('formats a string out of point coordinates', function () {
 			expect(new L.Point(50, 30) + '').toEqual('Point(50, 30)');
-		});
-	});
-
-	describe('L.point factory', function () {
-		it('leaves L.Point instances as is', function () {
-			var p = new L.Point(50, 30);
-			expect(L.point(p)).toBe(p);
-		});
-		it('creates a point out of three arguments', function () {
-			expect(L.point(50.1, 30.1, true)).toEqual(new L.Point(50, 30));
-		});
-		it('creates a point from an array of coordinates', function () {
-			expect(L.point([50, 30])).toEqual(new L.Point(50, 30));
-		});
-		it('does not fail on invalid arguments', function () {
-			expect(L.point(undefined)).toBe(undefined);
-			expect(L.point(null)).toBe(null);
 		});
 	});
 });

--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -1,5 +1,5 @@
 describe("Point", function() {
-	function testConstructor(fn) {
+	function testConstructor(fn, factory) {
 		return function () {
 			it("constructs the origin", function () {
 				var a = fn(0, 0);
@@ -30,16 +30,18 @@ describe("Point", function() {
 				expect(fn(p)).toBe(p);
 			});
 
-			it('returns null or undefined as is', function () {
-				expect(fn(undefined)).toBe(undefined);
-				expect(fn(null)).toBe(null);
-			});
+			if (factory) {
+				it('returns null or undefined as is', function () {
+					expect(fn(undefined)).toBe(undefined);
+					expect(fn(null)).toBe(null);
+				});
+			}
 		}
 	}
 
 	describe('constructed via new L.Point', testConstructor(function(a, b, c) { return new L.Point(a, b, c); }));
-	describe('constructed via L.Point', testConstructor(function(a, b, c) { return L.Point(a, b, c); }));
-	describe('constructed via L.point', testConstructor(function(a, b, c) { return L.point(a, b, c); }));
+	describe('constructed via L.Point', testConstructor(function(a, b, c) { return L.Point(a, b, c); }, true));
+	describe('constructed via L.point', testConstructor(function(a, b, c) { return L.point(a, b, c); }, true));
 
 	describe('#subtract', function() {
 		it('subtracts the given point from this one', function() {

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -2,7 +2,7 @@
  * L.Control.Attribution is used for displaying attribution on the map (added by default).
  */
 
-L.Control.Attribution = L.Control.extend({
+L.Control.Attribution = L.control.attribution = L.Control.extend({
 	options: {
 		position: 'bottomright',
 		prefix: '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>'
@@ -109,7 +109,3 @@ L.Map.addInitHook(function () {
 		this.attributionControl = (new L.Control.Attribution()).addTo(this);
 	}
 });
-
-L.control.attribution = function (options) {
-	return new L.Control.Attribution(options);
-};

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -2,7 +2,7 @@
  * L.Control.Layers is a control to allow users to switch between different layers on the map.
  */
 
-L.Control.Layers = L.Control.extend({
+L.Control.Layers = L.control.layers = L.Control.extend({
 	options: {
 		collapsed: true,
 		position: 'topright',
@@ -242,7 +242,3 @@ L.Control.Layers = L.Control.extend({
 		this._container.className = this._container.className.replace(' leaflet-control-layers-expanded', '');
 	}
 });
-
-L.control.layers = function (baseLayers, overlays, options) {
-	return new L.Control.Layers(baseLayers, overlays, options);
-};

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -2,7 +2,7 @@
  * L.Control.Scale is used for displaying metric/imperial scale on the map.
  */
 
-L.Control.Scale = L.Control.extend({
+L.Control.Scale = L.control.scale = L.Control.extend({
 	options: {
 		position: 'bottomleft',
 		maxWidth: 100,
@@ -106,7 +106,3 @@ L.Control.Scale = L.Control.extend({
 		return pow10 * d;
 	}
 });
-
-L.control.scale = function (options) {
-	return new L.Control.Scale(options);
-};

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -2,7 +2,7 @@
  * L.Control.Zoom is used for the default zoom buttons on the map.
  */
 
-L.Control.Zoom = L.Control.extend({
+L.Control.Zoom = L.control.zoom = L.Control.extend({
 	options: {
 		position: 'topleft'
 	},
@@ -79,8 +79,3 @@ L.Map.addInitHook(function () {
 		this.addControl(this.zoomControl);
 	}
 });
-
-L.control.zoom = function (options) {
-	return new L.Control.Zoom(options);
-};
-

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -3,7 +3,7 @@
  * All other controls extend from this class.
  */
 
-L.Control = L.Class.extend({
+L.Control = L.control = L.Class.extend({
 	options: {
 		position: 'topright'
 	},
@@ -68,7 +68,3 @@ L.Control = L.Class.extend({
 		return this;
 	}
 });
-
-L.control = function (options) {
-	return new L.Control(options);
-};

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -6,18 +6,34 @@
 L.Class = function () {};
 
 L.Class.extend = function (props) {
+	var noInitialize = {};
 
 	// extended class with the new prototype
-	var NewClass = function () {
+	var NewClass = function (_) {
+		if (!(this instanceof NewClass)) {
+			var instance = new NewClass(noInitialize);
 
-		// call the constructor
-		if (this.initialize) {
-			this.initialize.apply(this, arguments);
-		}
+			// call the constructor
+			if (instance.initialize) {
+				instance.initialize.apply(instance, arguments);
+			}
 
-		// call all constructor hooks
-		if (this._initHooks) {
-			this.callInitHooks();
+			// call all constructor hooks
+			if (instance._initHooks) {
+				instance.callInitHooks();
+			}
+
+			return instance;
+		} else if (_ !== noInitialize) {
+			// call the constructor
+			if (this.initialize) {
+				this.initialize.apply(this, arguments);
+			}
+
+			// call all constructor hooks
+			if (this._initHooks) {
+				this.callInitHooks();
+			}
 		}
 	};
 

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -2,12 +2,28 @@
  * L.LatLng represents a geographical point with latitude and longitude coordinates.
  */
 
-L.LatLng = function (rawLat, rawLng) { // (Number, Number)
-	var lat = parseFloat(rawLat),
-	    lng = parseFloat(rawLng);
+L.LatLng = L.latLng = function (a, b) { // (LatLng) or ([Number, Number]) or (Number, Number)
+	if (a instanceof L.LatLng) {
+		return a;
+	}
+	if (L.Util.isArray(a)) {
+		return new L.LatLng(a[0], a[1]);
+	}
+	if (a === undefined || a === null) {
+		return a;
+	}
+	if (typeof a === 'object' && 'lat' in a) {
+		return new L.LatLng(a.lat, 'lng' in a ? a.lng : a.lon);
+	}
+	if (!(this instanceof L.LatLng)) {
+		return new L.LatLng(a, b);
+	}
+
+	var lat = parseFloat(a),
+	    lng = parseFloat(b);
 
 	if (isNaN(lat) || isNaN(lng)) {
-		throw new Error('Invalid LatLng object: (' + rawLat + ', ' + rawLng + ')');
+		throw new Error('Invalid LatLng object: (' + a + ', ' + b + ')');
 	}
 
 	this.lat = lat;
@@ -69,20 +85,3 @@ L.LatLng.prototype = {
 		return new L.LatLng(this.lat, lng);
 	}
 };
-
-L.latLng = function (a, b) { // (LatLng) or ([Number, Number]) or (Number, Number)
-	if (a instanceof L.LatLng) {
-		return a;
-	}
-	if (L.Util.isArray(a)) {
-		return new L.LatLng(a[0], a[1]);
-	}
-	if (a === undefined || a === null) {
-		return a;
-	}
-	if (typeof a === 'object' && 'lat' in a) {
-		return new L.LatLng(a.lat, 'lng' in a ? a.lng : a.lon);
-	}
-	return new L.LatLng(a, b);
-};
-

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -2,10 +2,15 @@
  * L.LatLngBounds represents a rectangular area on the map in geographical coordinates.
  */
 
-L.LatLngBounds = function (southWest, northEast) { // (LatLng, LatLng) or (LatLng[])
-	if (!southWest) { return; }
+L.LatLngBounds = L.latLngBounds = function (a, b) { // (LatLngBounds) or (LatLng, LatLng) or (LatLng[])
+	if (!a || a instanceof L.LatLngBounds) {
+		return a;
+	}
+	if (!(this instanceof L.LatLngBounds)) {
+		return new L.LatLngBounds(a, b);
+	}
 
-	var latlngs = northEast ? [southWest, northEast] : southWest;
+	var latlngs = b ? [a, b] : a;
 
 	for (var i = 0, len = latlngs.length; i < len; i++) {
 		this.extend(latlngs[i]);
@@ -144,10 +149,3 @@ L.LatLngBounds.prototype = {
 };
 
 //TODO International date line?
-
-L.latLngBounds = function (a, b) { // (LatLngBounds) or (LatLng, LatLng)
-	if (!a || a instanceof L.LatLngBounds) {
-		return a;
-	}
-	return new L.LatLngBounds(a, b);
-};

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -2,8 +2,13 @@
  * L.Bounds represents a rectangular area on the screen in pixel coordinates.
  */
 
-L.Bounds = function (a, b) { //(Point, Point) or Point[]
-	if (!a) { return; }
+L.Bounds = L.bounds = function (a, b) { // (Bounds) or (Point, Point) or Point[]
+	if (!a || a instanceof L.Bounds) {
+		return a;
+	}
+	if (!(this instanceof L.Bounds)) {
+		return new L.Bounds(a, b);
+	}
 
 	var points = b ? [a, b] : a;
 
@@ -85,11 +90,4 @@ L.Bounds.prototype = {
 	isValid: function () {
 		return !!(this.min && this.max);
 	}
-};
-
-L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])
-	if (!a || a instanceof L.Bounds) {
-		return a;
-	}
-	return new L.Bounds(a, b);
 };

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -2,7 +2,20 @@
  * L.Point represents a point with x and y coordinates.
  */
 
-L.Point = function (/*Number*/ x, /*Number*/ y, /*Boolean*/ round) {
+L.Point = L.point = function (/*Number*/ x, /*Number*/ y, /*Boolean*/ round) {
+	if (x instanceof L.Point) {
+		return x;
+	}
+	if (L.Util.isArray(x)) {
+		return new L.Point(x[0], x[1]);
+	}
+	if (x === undefined || x === null) {
+		return x;
+	}
+	if (!(this instanceof L.Point)) {
+		return new L.Point(x, y, round);
+	}
+
 	this.x = (round ? Math.round(x) : x);
 	this.y = (round ? Math.round(y) : y);
 };
@@ -99,17 +112,4 @@ L.Point.prototype = {
 		        L.Util.formatNum(this.x) + ', ' +
 		        L.Util.formatNum(this.y) + ')';
 	}
-};
-
-L.point = function (x, y, round) {
-	if (x instanceof L.Point) {
-		return x;
-	}
-	if (L.Util.isArray(x)) {
-		return new L.Point(x[0], x[1]);
-	}
-	if (x === undefined || x === null) {
-		return x;
-	}
-	return new L.Point(x, y, round);
 };

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -3,7 +3,7 @@
  * shared between a group of interactive layers (like vectors or markers).
  */
 
-L.FeatureGroup = L.LayerGroup.extend({
+L.FeatureGroup = L.featureGroup = L.LayerGroup.extend({
 	includes: L.Mixin.Events,
 
 	statics: {
@@ -76,7 +76,3 @@ L.FeatureGroup = L.LayerGroup.extend({
 		this.fire(e.type, e);
 	}
 });
-
-L.featureGroup = function (layers) {
-	return new L.FeatureGroup(layers);
-};

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -2,7 +2,7 @@
  * L.GeoJSON turns any GeoJSON data into a Leaflet layer.
  */
 
-L.GeoJSON = L.FeatureGroup.extend({
+L.GeoJSON = L.geoJson = L.FeatureGroup.extend({
 
 	initialize: function (geojson, options) {
 		L.setOptions(this, options);
@@ -146,7 +146,3 @@ L.extend(L.GeoJSON, {
 		return latlngs;
 	}
 });
-
-L.geoJson = function (geojson, options) {
-	return new L.GeoJSON(geojson, options);
-};

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -2,7 +2,7 @@
  * L.ImageOverlay is used to overlay images over the map (to specific geographical bounds).
  */
 
-L.ImageOverlay = L.Class.extend({
+L.ImageOverlay = L.imageOverlay = L.Class.extend({
 	includes: L.Mixin.Events,
 
 	options: {
@@ -126,7 +126,3 @@ L.ImageOverlay = L.Class.extend({
 		L.DomUtil.setOpacity(this._image, this.options.opacity);
 	}
 });
-
-L.imageOverlay = function (url, bounds, options) {
-	return new L.ImageOverlay(url, bounds, options);
-};

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -3,7 +3,7 @@
  * you can manipulate the group (e.g. add/remove it) as one layer.
  */
 
-L.LayerGroup = L.Class.extend({
+L.LayerGroup = L.layerGroup = L.Class.extend({
 	initialize: function (layers) {
 		this._layers = {};
 
@@ -97,7 +97,3 @@ L.LayerGroup = L.Class.extend({
 		return this.invoke('setZIndex', zIndex);
 	}
 });
-
-L.layerGroup = function (layers) {
-	return new L.LayerGroup(layers);
-};

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -6,7 +6,7 @@ L.Map.mergeOptions({
 	closePopupOnClick: true
 });
 
-L.Popup = L.Class.extend({
+L.Popup = L.popup = L.Class.extend({
 	includes: L.Mixin.Events,
 
 	options: {
@@ -264,7 +264,3 @@ L.Popup = L.Class.extend({
 		L.DomEvent.stop(e);
 	}
 });
-
-L.popup = function (options, source) {
-	return new L.Popup(options, source);
-};

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -3,7 +3,7 @@
  * to use with L.Marker.
  */
 
-L.DivIcon = L.Icon.extend({
+L.DivIcon = L.divIcon = L.Icon.extend({
 	options: {
 		iconSize: new L.Point(12, 12), // also can be set through CSS
 		/*
@@ -36,7 +36,3 @@ L.DivIcon = L.Icon.extend({
 		return null;
 	}
 });
-
-L.divIcon = function (options) {
-	return new L.DivIcon(options);
-};

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -2,7 +2,7 @@
  * L.Icon is an image-based icon class that you can use with L.Marker for custom markers.
  */
 
-L.Icon = L.Class.extend({
+L.Icon = L.icon = L.Class.extend({
 	options: {
 		/*
 		iconUrl: (String) (required)
@@ -95,7 +95,3 @@ L.Icon = L.Class.extend({
 		return this.options[name + 'Url'];
 	}
 });
-
-L.icon = function (options) {
-	return new L.Icon(options);
-};

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -2,7 +2,7 @@
  * L.Marker is used to display clickable/draggable icons on the map.
  */
 
-L.Marker = L.Class.extend({
+L.Marker = L.marker = L.Class.extend({
 
 	includes: L.Mixin.Events,
 
@@ -263,7 +263,3 @@ L.Marker = L.Class.extend({
 		this._updateZIndex(0);
 	}
 });
-
-L.marker = function (latlng, options) {
-	return new L.Marker(latlng, options);
-};

--- a/src/layer/tile/TileLayer.Canvas.js
+++ b/src/layer/tile/TileLayer.Canvas.js
@@ -3,7 +3,7 @@
  * dynamically drawn Canvas-based tile layers.
  */
 
-L.TileLayer.Canvas = L.TileLayer.extend({
+L.TileLayer.Canvas = L.tileLayer.canvas = L.TileLayer.extend({
 	options: {
 		async: false
 	},
@@ -57,8 +57,3 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 		this._tileOnLoad.call(tile);
 	}
 });
-
-
-L.tileLayer.canvas = function (options) {
-	return new L.TileLayer.Canvas(options);
-};

--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -2,7 +2,7 @@
  * L.TileLayer.WMS is used for putting WMS tile layers on the map.
  */
 
-L.TileLayer.WMS = L.TileLayer.extend({
+L.TileLayer.WMS = L.tileLayer.wms = L.TileLayer.extend({
 
 	defaultWmsParams: {
 		service: 'WMS',
@@ -77,7 +77,3 @@ L.TileLayer.WMS = L.TileLayer.extend({
 		return this;
 	}
 });
-
-L.tileLayer.wms = function (url, options) {
-	return new L.TileLayer.WMS(url, options);
-};

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -2,7 +2,7 @@
  * L.TileLayer is used for standard xyz-numbered tile layers.
  */
 
-L.TileLayer = L.Class.extend({
+L.TileLayer = L.tileLayer = L.Class.extend({
 	includes: L.Mixin.Events,
 
 	options: {
@@ -582,7 +582,3 @@ L.TileLayer = L.Class.extend({
 		layer._tileLoaded();
 	}
 });
-
-L.tileLayer = function (url, options) {
-	return new L.TileLayer(url, options);
-};

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -2,7 +2,7 @@
  * L.Circle is a circle overlay (with a certain radius in meters).
  */
 
-L.Circle = L.Path.extend({
+L.Circle = L.circle = L.Path.extend({
 	initialize: function (latlng, radius, options) {
 		L.Path.prototype.initialize.call(this, options);
 
@@ -92,7 +92,3 @@ L.Circle = L.Path.extend({
 		       p.x + r < vp.min.x || p.y + r < vp.min.y;
 	}
 });
-
-L.circle = function (latlng, radius, options) {
-	return new L.Circle(latlng, radius, options);
-};

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -2,7 +2,7 @@
  * L.CircleMarker is a circle overlay with a permanent pixel radius.
  */
 
-L.CircleMarker = L.Circle.extend({
+L.CircleMarker = L.circleMarker = L.Circle.extend({
 	options: {
 		radius: 10,
 		weight: 2
@@ -27,7 +27,3 @@ L.CircleMarker = L.Circle.extend({
 		return this.redraw();
 	}
 });
-
-L.circleMarker = function (latlng, options) {
-	return new L.CircleMarker(latlng, options);
-};

--- a/src/layer/vector/MultiPoly.js
+++ b/src/layer/vector/MultiPoly.js
@@ -34,14 +34,6 @@
 		});
 	}
 
-	L.MultiPolyline = createMulti(L.Polyline);
-	L.MultiPolygon = createMulti(L.Polygon);
-
-	L.multiPolyline = function (latlngs, options) {
-		return new L.MultiPolyline(latlngs, options);
-	};
-
-	L.multiPolygon = function (latlngs, options) {
-		return new L.MultiPolygon(latlngs, options);
-	};
+	L.MultiPolyline = L.multiPolyline = createMulti(L.Polyline);
+	L.MultiPolygon = L.multiPolygon = createMulti(L.Polygon);
 }());

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -2,7 +2,7 @@
  * L.Polygon is used to display polygons on a map.
  */
 
-L.Polygon = L.Polyline.extend({
+L.Polygon = L.polygon = L.Polyline.extend({
 	options: {
 		fill: true
 	},
@@ -66,7 +66,3 @@ L.Polygon = L.Polyline.extend({
 		return str + (L.Browser.svg ? 'z' : 'x');
 	}
 });
-
-L.polygon = function (latlngs, options) {
-	return new L.Polygon(latlngs, options);
-};

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -2,7 +2,7 @@
  * L.Polyline is used to display polylines on a map.
  */
 
-L.Polyline = L.Path.extend({
+L.Polyline = L.polyline = L.Path.extend({
 	initialize: function (latlngs, options) {
 		L.Path.prototype.initialize.call(this, options);
 
@@ -166,7 +166,3 @@ L.Polyline = L.Path.extend({
 		L.Path.prototype._updatePath.call(this);
 	}
 });
-
-L.polyline = function (latlngs, options) {
-	return new L.Polyline(latlngs, options);
-};

--- a/src/layer/vector/Rectangle.js
+++ b/src/layer/vector/Rectangle.js
@@ -2,7 +2,7 @@
  * L.Rectangle extends Polygon and creates a rectangle when passed a LatLngBounds object.
  */
 
-L.Rectangle = L.Polygon.extend({
+L.Rectangle = L.rectangle = L.Polygon.extend({
 	initialize: function (latLngBounds, options) {
 		L.Polygon.prototype.initialize.call(this, this._boundsToLatLngs(latLngBounds), options);
 	},
@@ -21,7 +21,3 @@ L.Rectangle = L.Polygon.extend({
 		];
 	}
 });
-
-L.rectangle = function (latLngBounds, options) {
-	return new L.Rectangle(latLngBounds, options);
-};

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -2,7 +2,7 @@
  * L.Map is the central class of the API - it is used to create a map.
  */
 
-L.Map = L.Class.extend({
+L.Map = L.map = L.Class.extend({
 
 	includes: L.Mixin.Events,
 
@@ -708,7 +708,3 @@ L.Map = L.Class.extend({
 		return Math.max(min, Math.min(max, zoom));
 	}
 });
-
-L.map = function (id, options) {
-	return new L.Map(id, options);
-};


### PR DESCRIPTION
This uses the "instanceof trick" from [John Resig](http://ejohn.org/blog/simple-class-instantiation/) to ensure that
`new Foo(…)` and `Foo(…)` both return a newly constructed instance.

This eliminates the need for separate camel-case functions that wrap the
constructor (e.g. `L.map`). The subtleties of that approach are a source
of confusion and frustration for new users.

I suggest that the documentation be changed to exclusively reference a
`new L.Map()`/`L.Map()` style. Obviously we'll have to keep the camel-case
variants around for backward compatibility at least until a major version
release.

This is not quite ready to merge: several specs are failing. The issue
is that there's no way to make e.g. `new L.LatLng(undefined)` behave like
`L.latLng(undefined)` (returning undefined). Is this an important behavior?
For example, what's the rationale for 84d537b8046fd6ee397d20d8f5154d9812b63502?