### PR TITLE
Allow for cancelling a boxzoom being drawn pressing Escape key

### DIFF
--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -38,6 +38,7 @@ L.Map.BoxZoom = L.Handler.extend({
 		L.DomEvent
 		    .on(document, 'mousemove', this._onMouseMove, this)
 		    .on(document, 'mouseup', this._onMouseUp, this)
+		    .on(document, 'keydown', this._onKeyDown, this)
 		    .preventDefault(e);
 
 		this._map.fire("boxzoomstart");
@@ -61,7 +62,7 @@ L.Map.BoxZoom = L.Handler.extend({
 		box.style.height = (Math.max(0, Math.abs(offset.y) - 4)) + 'px';
 	},
 
-	_onMouseUp: function (e) {
+	_finish: function () {
 		this._pane.removeChild(this._box);
 		this._container.style.cursor = '';
 
@@ -69,7 +70,13 @@ L.Map.BoxZoom = L.Handler.extend({
 
 		L.DomEvent
 		    .off(document, 'mousemove', this._onMouseMove)
-		    .off(document, 'mouseup', this._onMouseUp);
+		    .off(document, 'mouseup', this._onMouseUp)
+		    .off(document, 'keydown', this._onKeyDown);
+	},
+
+	_onMouseUp: function (e) {
+
+		this._finish();
 
 		var map = this._map,
 		    layerPoint = map.mouseEventToLayerPoint(e);
@@ -85,6 +92,12 @@ L.Map.BoxZoom = L.Handler.extend({
 		map.fire("boxzoomend", {
 			boxZoomBounds: bounds
 		});
+	},
+
+	_onKeyDown: function (e) {
+		if (e.keyCode === 27) {
+			this._finish();
+		}
 	}
 });
 


### PR DESCRIPTION
I think we need a way to escape a drawn boxzoom.
And I think pressing escape is the natural way to handle the cancel of this kind of action.
Another way could be to cancel boxzoom if one stop pressing shift before mouseup event, but this is not my preferred way.
What do you think?

Thanks!

Yohan
