### PR TITLE
Remove margin override for .leaflet-control-zoom

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -260,10 +260,6 @@
 
 /* zoom control */
 
-.leaflet-container .leaflet-control-zoom {
-	margin-left: 13px;
-	margin-top: 12px;
-	}
 .leaflet-control-zoom-in {
 	font: bold 18px 'Lucida Console', Monaco, monospace;
 	}


### PR DESCRIPTION
It should have the same margins as other .leaflet-controls (10px).
