### PR TITLE
Fire an unload event on removal

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -7,6 +7,22 @@ describe("Map", function () {
 	});
 
 	describe("#remove", function () {
+		it("fires an unload event if loaded", function () {
+			var container = document.createElement('div'),
+			    map = new L.Map(container).setView([0, 0], 0);
+			map.on('unload', spy);
+			map.remove();
+			expect(spy).toHaveBeenCalled();
+		});
+
+		it("fires no unload event if not loaded", function () {
+			var container = document.createElement('div'),
+			    map = new L.Map(container);
+			map.on('unload', spy);
+			map.remove();
+			expect(spy).not.toHaveBeenCalled();
+		});
+
 		it("undefines container._leaflet", function () {
 			var container = document.createElement('div'),
 			    map = new L.Map(container);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -240,6 +240,9 @@ L.Map = L.Class.extend({
 	},
 
 	remove: function () {
+		if (this._loaded) {
+			this.fire('unload');
+		}
 		this._initEvents('off');
 		delete this._container._leaflet;
 		return this;


### PR DESCRIPTION
Plugins that need to bind events to `window` or `document` can attach a
listener for this event and unbind their event handlers.

However, for symmetry, unload is fired only if load has been fired.

See https://github.com/mapbox/Leaflet.fullscreen/commit/145938baad28aa1179c60df8da8454d3dc4235d4 for an example of use.
