### PR TITLE
New link for providers plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -210,7 +210,7 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/seelmann/leaflet-providers">leaflet-providers</a>
+			<a href="https://github.com/leaflet-extras/leaflet-providers">leaflet-providers</a>
 		</td><td>
 			Contains configurations for various free tile providers &mdash; OSM, OpenCycleMap, MapQuest, Mapbox Streets, Stamen, Esri, etc.
 		</td><td>


### PR DESCRIPTION
@seelmann switched this plugin to be under an organization [discussion of it is here](https://github.com/leaflet-extras/leaflet-providers/issues/17)
