### PR TITLE
Map#eachLayer?

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -180,4 +180,29 @@ describe("Map", function () {
 			});
 		});
 	});
+
+	describe("#eachLayer", function () {
+		it("returns self", function () {
+			expect(map.eachLayer(function () {})).toBe(map);
+		});
+
+		it("calls the provided function for each layer", function () {
+			var t1 = L.tileLayer("{z}{x}{y}").addTo(map),
+			    t2 = L.tileLayer("{z}{x}{y}").addTo(map);
+
+			map.eachLayer(spy);
+
+			expect(spy.calls.length).toEqual(2);
+			expect(spy.calls[0].args).toEqual([t1]);
+			expect(spy.calls[1].args).toEqual([t2]);
+		});
+
+		it("calls the provided function with the provided context", function () {
+			var t1 = L.tileLayer("{z}{x}{y}").addTo(map);
+
+			map.eachLayer(spy, map);
+
+			expect(spy.calls[0].object).toEqual(map);
+		});
+	});
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -198,6 +198,15 @@ L.Map = L.Class.extend({
 		return this._layers.hasOwnProperty(id);
 	},
 
+	eachLayer: function (method, context) {
+		for (var i in this._layers) {
+			if (this._layers.hasOwnProperty(i)) {
+				method.call(context, this._layers[i]);
+			}
+		}
+		return this;
+	},
+
 	invalidateSize: function (animate) {
 		var oldSize = this.getSize();
 


### PR DESCRIPTION
There doesn't seem to be any public API for getting the current layers of a map. The only way is to listen to layeradd, but then you miss any layers that are already added. `Map#eachLayer`, following `LayerGroup#eachLayer`, would be the minimal API.
