### PR TITLE
Update src/dom/DomEvent.js

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -67,7 +67,7 @@ L.DomEvent = {
 		    key = '_leaflet_' + type + id,
 		    handler = obj[key];
 
-		if (!handler) { return; }
+		if (!handler) { return this; }
 
 		if (L.Browser.msTouch && type.indexOf('touch') === 0) {
 			this.removeMsTouchListener(obj, type, id);


### PR DESCRIPTION
return this from removeListener when there is no handler so that chained calls still work in other places in the code such as removeHooks() inside the keyboard handler. If you call removeHooks() twice on the keyboard handler, you will get a javascript error in the second chained .off() call. 
