### PR TITLE
Fix circle bounds (#1463)

### DIFF
--- a/debug/tests/circle_bounds.html
+++ b/debug/tests/circle_bounds.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+	
+	<link rel="stylesheet" href="../css/screen.css" />
+	
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map" style="width: 600px; height: 600px; border: 1px solid #ccc"></div>
+
+	<script type="text/javascript">
+
+		var center = [80, 30];
+
+		var map = L.map('map').setView(center, 3);
+		var circle = L.circle(center, 500000).addTo(map);
+		L.rectangle(circle.getBounds()).addTo(map);
+
+		L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png').addTo(map);
+		
+	</script>
+</body>
+</html>

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -1,17 +1,20 @@
 describe('Circle', function () {
 	describe('#getBounds', function () {
 
-		var circle;
+		var circle, map;
 
 		beforeEach(function () {
-			circle = L.circle([50, 30], 200);
+			map = L.map(document.createElement('div'));
+			map.setView([80, 30], 3);
+
+			circle = L.circle([80, 30], 500000).addTo(map);
 		});
 
 		it('returns bounds', function () {
 			var bounds = circle.getBounds();
 
-			expect(bounds.getSouthWest().equals([49.998203369, 29.997204939])).toBeTruthy();
-			expect(bounds.getNorthEast().equals([50.001796631, 30.002795061])).toBeTruthy();
+			expect(bounds.getSouthWest().equals([74.35482803013984, 4.21875])).toBeTruthy();
+			expect(bounds.getNorthEast().equals([83.61859796759485, 55.8984375])).toBeTruthy();
 		});
 	});
 });

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -34,11 +34,10 @@ L.Circle = L.Path.extend({
 	},
 
 	getBounds: function () {
-		var lngRadius = this._getLngRadius(),
-		    latRadius = (this._mRadius / 40075017) * 360,
-		    latlng = this._latlng,
-		    sw = new L.LatLng(latlng.lat - latRadius, latlng.lng - lngRadius),
-		    ne = new L.LatLng(latlng.lat + latRadius, latlng.lng + lngRadius);
+		var p = this._point,
+		    r = this._radius,
+		    sw = this._map.layerPointToLatLng([p.x - r, p.y - r]),
+		    ne = this._map.layerPointToLatLng([p.x + r, p.y + r]);
 
 		return new L.LatLngBounds(sw, ne);
 	},


### PR DESCRIPTION
Fix difference between visible circle bounds and result of `getBounds()` (see #1463).

Now circle bounds depend on map projection. As a result, circle should be added to map to calculate bounds.

It is strange that bounds now slightly depends on current zoom. Looks like reprojection arithmetic errors. Probably, it can be fixed by using map projection directly, without CRS.
