### PR TITLE
Add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"uglify-js": "~2.2.3",
 		"jake": "latest"
 	},
+	"main": "dist/leaflet.js",
 	"scripts": {
 		"test": "node ./node_modules/jake/bin/cli test"
 	},


### PR DESCRIPTION
In order to require() and use Leaflet via browserify requires
that the package define a main entry point for the module.
