### PR TITLE
Optional addOverlay "toggle"

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -52,9 +52,9 @@ L.Control.Layers = L.Control.extend({
 		return this;
 	},
 
-	addOverlay: function (layer, name, toggle) {
-		var toggle = toggle || false;
-		if(toggle){
+	addOverlay: function (layer, name, checkToggle) {
+		var checkToggle = checkToggle || false;
+		if (toggle) {
 			this._map.addLayer(layer);
 		}
 		this._addLayer(layer, name, true);


### PR DESCRIPTION
Optional argument for adding a toggled overlay to a layers control.

The method `.addOverlay(layer, "Name", true)` would add the layer with text "Name" to the layers control box, and also toggle the checkbox and display the layer on the map.
