### PR TITLE
Disable 3D CSS transforms on PhantomJS

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -13,6 +13,7 @@
 	    ua = navigator.userAgent.toLowerCase(),
 	    webkit = ua.indexOf('webkit') !== -1,
 	    chrome = ua.indexOf('chrome') !== -1,
+	    phantomjs = ua.indexOf('phantom') !== -1,
 	    android = ua.indexOf('android') !== -1,
 	    android23 = ua.search('android [23]') !== -1,
 
@@ -28,7 +29,7 @@
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()),
 	    gecko3d = 'MozPerspective' in doc.style,
 	    opera3d = 'OTransition' in doc.style,
-	    any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d);
+	    any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs;
 
 
 	var touch = !window.L_NO_TOUCH && (function () {


### PR DESCRIPTION
PhantomJS does not support 3D CSS transform even though it's a Webkit product. This patch detects PhantomJS in the user agent and disables 3D transforms.

Details on PhantomJS support are here: https://groups.google.com/forum/#!msg/phantomjs/h7-4-CWsy1g/KX1tlf5gT5IJ
