### PR TITLE
.fillable() predicate on vector paths

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -24,6 +24,10 @@ L.Circle = L.Path.extend({
 		return this.redraw();
 	},
 
+	fillable: function () {
+		return true;
+	},
+
 	projectLatlngs: function () {
 		var lngRadius = this._getLngRadius(),
 		    latlng2 = new L.LatLng(this._latlng.lat, this._latlng.lng - lngRadius),

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -79,6 +79,10 @@ L.Path = L.Class.extend({
 		}, this);
 	},
 
+	fillable: function () {
+		return false;
+	},
+
 	projectLatlngs: function () {
 		// do all projection stuff here
 	},

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -32,6 +32,10 @@ L.Polygon = L.Polyline.extend({
 		}
 	},
 
+	fillable: function () {
+		return true;
+	},
+
 	projectLatlngs: function () {
 		L.Polyline.prototype.projectLatlngs.call(this);
 

--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -85,8 +85,7 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 
 				this._ctx[drawMethod](point.x, point.y);
 			}
-			// TODO refactor ugly hack
-			if (this instanceof L.Polygon) {
+			if (this.fillable()) {
 				this._ctx.closePath();
 			}
 		}


### PR DESCRIPTION
This deals with a minor hack in the Leaflet source by providing a trivial `{path,circle,rect,etc}.fillable()` predicate.

Moreover, it will also make it possible to clean up a certain hack in Leaflet.draw: https://github.com/Leaflet/Leaflet.draw/blob/master/src/edit/handler/EditToolbar.Edit.js#L188

Which in turn means that plugins that introduce new editing modes (I'm working on one) won't have to copy-paste and propagate that hack around. Would be much appreciated!
