### PR TITLE
Fix for L_PREFER_CANVAS/CircleMarker bug

### DIFF
--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -19,12 +19,12 @@ L.CircleMarker = L.Circle.extend({
 
 	_updateStyle : function () {
 		L.Circle.prototype._updateStyle.call(this);
-		this.setRadius(this.options.radius);
+		this.setRadius(this.options.radius, true);
 	},
 
-	setRadius: function (radius) {
+	setRadius: function (radius, noRedraw) {
 		this.options.radius = this._radius = radius;
-		return this.redraw();
+		return noRedraw ? this : this.redraw();
 	}
 });
 


### PR DESCRIPTION
There is a problem with CircleMarkers when L_PREFER_CANVAS is truthy. If a CircleMarker is added to the map, redraw requests are continually made. It seems that the moveend handler calls _updatePath which calls _updateStyle which calls CircleMarker.setRadius which calls redraw which results in a moveend event, repeating the process.

Here's a JSFiddle that demonstrates the problem:
http://jsfiddle.net/cartant/NSJWa/
It'll write "moveend" to the console again and again and again.

The simplest solution seemed to be the addition of a noRedraw parameter. (I noticed there are functions elsewhere in Leaflet that use a similar parameter.)
