### PR TITLE
Somewhat "safer" _getSubdomain method - now it works even when (tilePoint.x + tilePoint.y) is negative.

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -496,7 +496,7 @@ L.TileLayer = L.Class.extend({
 	},
 
 	_getSubdomain: function (tilePoint) {
-		var index = (tilePoint.x + tilePoint.y) % this.options.subdomains.length;
+		var index = Math.abs(tilePoint.x + tilePoint.y) % this.options.subdomains.length;
 		return this.options.subdomains[index];
 	},
 


### PR DESCRIPTION
Note that (tilePoint.x + tilePoint.y) might be negative in some cases (custom CRS with tiled WMS).
I discovered that tilePoint.y is often negative when using custom CRS (epsg:2393), tiled WMS layer and proj4leaflet together. 
This small fix prevents possible negative subdomain index generation. 
