### PR TITLE
Popup close button fix

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -124,6 +124,7 @@ L.Popup = L.Class.extend({
 			        L.DomUtil.create('a', prefix + '-close-button', container);
 			closeButton.href = '#close';
 			closeButton.innerHTML = '&#215;';
+			L.DomEvent.disableClickPropagation(closeButton);
 
 			L.DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this);
 		}


### PR DESCRIPTION
We need to remove draggable mixin from popup close button, because we have yellow border on this button after closing popup.

![lf](https://f.cloud.github.com/assets/1333916/280939/1870932c-916a-11e2-8f42-e36bb95c92fb.PNG)
