### PR TITLE
fix enable/disable of marker dragging

### DIFF
--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -10,19 +10,21 @@ L.Handler.MarkerDrag = L.Handler.extend({
 	addHooks: function () {
 		var icon = this._marker._icon;
 		if (!this._draggable) {
-			this._draggable = new L.Draggable(icon, icon)
-			    .on('dragstart', this._onDragStart, this)
-			    .on('drag', this._onDrag, this)
-			    .on('dragend', this._onDragEnd, this);
+			this._draggable = new L.Draggable(icon, icon);
 		}
+
+		this._draggable
+			.on('dragstart', this._onDragStart, this)
+			.on('drag', this._onDrag, this)
+			.on('dragend', this._onDragEnd, this);
 		this._draggable.enable();
 	},
 
 	removeHooks: function () {
 		this._draggable
-		    .off('dragstart', this._onDragStart)
-		    .off('drag', this._onDrag)
-		    .off('dragend', this._onDragEnd);
+			.off('dragstart', this._onDragStart)
+			.off('drag', this._onDrag)
+			.off('dragend', this._onDragEnd);
 
 		this._draggable.disable();
 	},


### PR DESCRIPTION
Events needs to be readded if they were removed by .disable(); Otherwise the position of marker is not updated!
