### PR TITLE
Added unproject to CRS, along with a custom implementation for CRS.EPSG3...

### DIFF
--- a/src/geo/crs/CRS.EPSG3857.js
+++ b/src/geo/crs/CRS.EPSG3857.js
@@ -13,6 +13,13 @@ L.CRS.EPSG3857 = L.extend({}, L.CRS, {
 		var projectedPoint = this.projection.project(latlng),
 		    earthRadius = 6378137;
 		return projectedPoint.multiplyBy(earthRadius);
+	},
+
+	unproject: function (point) { // (Point) -> LatLng
+	    var earthRadius = 6378137,
+	    newPoint = point.divideBy(earthRadius);
+
+	    return this.projection.unproject(newPoint);
 	}
 });
 

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -21,6 +21,10 @@ L.CRS = {
 		return this.projection.project(latlng);
 	},
 
+	unproject: function (point) {
+		return this.projection.unproject(point);
+	},
+
 	scale: function (zoom) {
 		return 256 * Math.pow(2, zoom);
 	}


### PR DESCRIPTION
There's no unproject method for CRSs.  This means, for instance with EPGS 3857, you must do some manual adjustments before being able to unproject coordinates.  For instance:

```
L.Projection.SphericalMercator.unproject(new L.Point(-7963446.5, 5343756.0).divideBy(6378137))
```

Obviously this is only a minor annoyance, but it's a really simple change to L.CRS and L.CRS.EPSG3857.
