### PR TITLE
Add prepublish script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 	},
 	"main": "dist/leaflet.js",
 	"scripts": {
-		"test": "node ./node_modules/jake/bin/cli test"
+		"test": "jake test",
+		"prepublish": "jake"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Also, npm scripts are run in an environment with node_module binaries in the
path, so just "jake test" and "jake" are sufficient.

https://npmjs.org/doc/scripts.html
