### PR TITLE
Throw an exception if a map div is not found and test for initialization exceptions

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -24,6 +24,28 @@ describe("Map", function () {
 			expect(spy.called).not.to.be.ok();
 		});
 
+		describe("corner case checking", function () {
+			it("throws an exception upon reinitialization", function () {
+				var container = document.createElement('div'),
+					map = new L.Map(container);
+				expect(function () {
+					new L.Map(container);
+				}).to.throwException(function(e) {
+					expect(e.message).to.eql("Map container is already initialized.");
+				});
+				map.remove();
+			});
+
+			it("throws an exception if a container is not found", function () {
+				expect(function () {
+					new L.Map('nonexistentdivelement');
+				}).to.throwException(function(e) {
+					expect(e.message).to.eql("Map container not found.");
+				});
+				map.remove();
+			});
+		});
+
 		it("undefines container._leaflet", function () {
 			var container = document.createElement('div'),
 			    map = new L.Map(container);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -435,7 +435,9 @@ L.Map = L.Class.extend({
 	_initContainer: function (id) {
 		var container = this._container = L.DomUtil.get(id);
 
-		if (container._leaflet) {
+		if (!container) {
+			throw new Error("Map container not found.");
+		} else if (container._leaflet) {
 			throw new Error("Map container is already initialized.");
 		}
 


### PR DESCRIPTION
Simply adds another exception-throwing check to Leaflet where otherwise it would produce a confusing error, and uses `throwsException` to check that Leaflet throws the proper exceptions.
