### PR TITLE
Fixed zoom out on Windows 8 with Firefox

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -40,7 +40,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 		    delta = this._delta,
 		    zoom = map.getZoom();
 
-		delta = delta > 0 ? Math.ceil(delta) : Math.round(delta);
+		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
 		delta = Math.max(Math.min(delta, 4), -4);
 		delta = map._limitZoom(zoom + delta) - zoom;
 


### PR DESCRIPTION
Firefox receives wheel delta of 0.33 on zoom in and -0.33 on zoom out, which turns into Math.ceil(0.33) == 1 and Math.round(-0.33) == 0. After this fix it returns correctly -1 for zooming out.
Worked fine before and after this fix in Chrome and Internet Explorer.
