### PR TITLE
Permit layer stamping to be overridden

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -11,7 +11,7 @@ L.FeatureGroup = L.LayerGroup.extend({
 	},
 
 	addLayer: function (layer) {
-		if (this._layers[L.stamp(layer)]) {
+		if (this.hasLayer(layer)) {
 			return this;
 		}
 
@@ -30,7 +30,6 @@ L.FeatureGroup = L.LayerGroup.extend({
 		layer.off(L.FeatureGroup.EVENTS, this._propagateEvent, this);
 
 		L.LayerGroup.prototype.removeLayer.call(this, layer);
-
 
 		if (this._popupContent) {
 			this.invoke('unbindPopup');

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -17,7 +17,7 @@ L.LayerGroup = L.Class.extend({
 	},
 
 	addLayer: function (layer) {
-		var id = L.stamp(layer);
+		var id = this.getLayerId(layer);
 
 		this._layers[id] = layer;
 
@@ -29,7 +29,7 @@ L.LayerGroup = L.Class.extend({
 	},
 
 	removeLayer: function (layer) {
-		var id = L.stamp(layer);
+		var id = this.getLayerId(layer);
 
 		delete this._layers[id];
 
@@ -43,7 +43,7 @@ L.LayerGroup = L.Class.extend({
 	hasLayer: function (layer) {
 		if (!layer) { return false; }
 
-		var id = L.stamp(layer);
+		var id = this.getLayerId(layer);
 		return this._layers.hasOwnProperty(id);
 	},
 
@@ -105,6 +105,10 @@ L.LayerGroup = L.Class.extend({
 
 	setZIndex: function (zIndex) {
 		return this.invoke('setZIndex', zIndex);
+	},
+
+	getLayerId: function (layer) {
+		return L.stamp(layer);
 	}
 });
 


### PR DESCRIPTION
Extracts the detail of how layers are stamped to a single method which can be overridden. mapbox.js would use this in [markerLayer](https://github.com/mapbox/mapbox.js/blob/v1/src/marker_layer.js) to implement a [key](http://mapbox.com/mapbox.js/api/v0.6.7/#markers.key) function.

I suspect it will also be useful towards #1416 -- in general, it's useful to be able to set up a GeoJSON layer group that associates features and layers based on the feature's `id` property rather than an arbitrary monotonic stamp.
