### PR TITLE
dblclicking now zooms around mouse, not centre

### DIFF
--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -16,7 +16,12 @@ L.Map.DoubleClickZoom = L.Handler.extend({
 	},
 
 	_onDoubleClick: function (e) {
-		this.setView(e.latlng, this._zoom + 1);
+		var map = this,
+		scale = map.getZoomScale(map._zoom + 1),
+		viewHalf = map.getSize()._divideBy(2),
+		centerOffset = e.containerPoint._subtract(viewHalf)._multiplyBy(1 - 1 / scale),
+		newCenterPoint = map._getTopLeftPoint()._add(viewHalf)._add(centerOffset);
+		map.setView(map.unproject(newCenterPoint), map._zoom + 1);
 	}
 });
 


### PR DESCRIPTION
Just like with scrollzooming, it is expected that that the map will zoom around the clicked point, not the center.

Maybe this should be added as map.setZoomAbout(zoom, point) or something, since the functionality is shared with the scroll handler, but wasn't sure if it was preferrable.
