### PR TITLE
Events#Once

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -295,5 +295,17 @@ describe('Events', function() {
 
 		    expect(spy.called).to.be(false);
 		});
+
+		it('works if called from a context that doesnt implement #Events', function() {
+			var obj = new Klass(),
+				spy = new sinon.spy(),
+				foo = {};
+
+			obj.once('test', spy, foo);
+
+			obj.fire('test');
+
+			expect(spy.called).to.be(true);
+		});
 	});
 });

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -148,13 +148,13 @@ L.Mixin.Events = {
 	},
 
 	once: function (types, fn, context) {
-	    var handlerFor = function (fn, type, context) {
-	        var handler = function () {
+	    var handlerFor = L.bind(function (fn, type, context) {
+	        var handler = L.bind(function () {
 	            this.removeEventListener(type, fn, context);
 	            this.removeEventListener(type, handler, context);
-	        };
+	        }, this);
 	        return handler;
-	    };
+	    }, this);
 
 	    if (typeof types === 'object') {
 	        for (var type in types) {


### PR DESCRIPTION
Hello! This PR implements Events#once, a handy bit of syntactic sugar for self-disposing event bindings that will only run one time, along the lines of [jQuery.one()](http://api.jquery.com/one/) and [Backbone.once()](http://backbonejs.org/#Events-once). Useful when you want to say "when this event fires, do this thing one time".
