### PR TITLE
Include view information on view changed events

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -531,7 +531,12 @@ L.Map = L.Class.extend({
 			this.fire('movestart');
 
 			if (zoomChanged) {
-				this.fire('zoomstart');
+				// _resetView is called on initialization; getCenter throws if the map isn't initalized,
+				// hence the _loaded check here.  This should probably be done differently.
+				this.fire('zoomstart',
+						{ from: !this._loaded ? {} : { center: this.getCenter(), zoom: this._zoom},
+						  to:   { center: center, zoom: zoom }
+						});
 			}
 		}
 

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -38,7 +38,9 @@ L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 
 		this
 		    .fire('movestart')
-		    .fire('zoomstart');
+		    .fire('zoomstart', { from: { center: this.getCenter(), zoom: this._zoom},
+		                         to:   { center: center, zoom: zoom }
+		                       });
 
 		this._animateZoom(center, zoom, origin, scale);
 


### PR DESCRIPTION
*NB This PR is to initiate discussion and is not intended to be merged in its present state.*

Events like `move*` and `zoom*` could tell their handlers a bit more about what is changing.  I propose changing their documented type from Event to ViewEvent. The additional data would look something like this:

``` js
{ from:
    { center: {lat: 45.5081, lng: -73.555} // a LatLng object
    , zoom: 13
    }
, to:
    { center: {lat: 45.5081, lng: -73.555} // a LatLng object
    , zoom: 14
    }
}
```

Then the handlers can refer to `event.from.zoom` or `event.to.center` and so on instead of having to poke at `event.target`, where some of this information is only available through undocumented internal properties.

This would solve #1509, possibly among others.

You can see a start on this for the `zoomstart` event in this PR.  This is the only event I need for what I'm trying to achieve, but I'd like to see this implemented.  I'm hoping for some feedback before proceeding any further.

Questions:
* Which events need this information? I list `move*`, `zoom*`, `viewreset`, maybe `load`. Others?
* What information should be included? I've added lat/lng and zoom, but the pixel offsets might be of interest too.
* Is the naming / data layout right?
* Are there any reasons not to do this?

<!---
@huboard:{"order":28.0}
-->
