### PR TITLE
Issue #1631: Fixed a bug on removeEventListener

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -128,7 +128,10 @@ describe('Events', function() {
 
 		it('can handle calls to #removeEventListener on objects with no registered event listeners', function () {
 			var obj = new Klass();
-			obj.removeEventListener('test');
+			var removeNonExistentListener = function () {
+				obj.removeEventListener('test');
+			};
+			expect(removeNonExistentListener).to.not.throwException();
 		});
 
 		// added due to context-sensitive removeListener optimization

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -66,7 +66,7 @@ L.Mixin.Events = {
 		if (!this[eventsKey]) {
 			return this;
 		}
-		
+
 		if (!types) {
 			return this.clearAllEventListeners();
 		}


### PR DESCRIPTION
Bugfix for issue #1631 where removeEventListener would throw when no event listeners are registered on the object.
