### PR TITLE
Allow value of 0 in L.DivIcon's html parameter

### DIFF
--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -12,14 +12,15 @@ L.DivIcon = L.Icon.extend({
 		html: (String)
 		bgPos: (Point)
 		*/
-		className: 'leaflet-div-icon'
+		className: 'leaflet-div-icon',
+		html: false
 	},
 
 	createIcon: function () {
 		var div = document.createElement('div'),
 		    options = this.options;
 
-		if (options.html) {
+		if (options.html !== false) {
 			div.innerHTML = options.html;
 		}
 


### PR DESCRIPTION
Replacement pull request for https://github.com/Leaflet/Leaflet/pull/1627.
- Fixed white space
- Own branch
- jake test passes

Not sure how to verify that it will pass in Travis, but the "whitespace after :" issue is fixed.  Sorry about the bad pull request before. 

This pull request allows
new L.DivIcon({className:'numbericon',html:0});
to create an icon with a '0' in the label.

Icons created with an html value of 0 ended up with an empty string for html instead of a 0 since options.html evaluated to false.

This sets a default value of false, and checks if options.html !== false.
