### PR TITLE
hasLayer and removeLayer by id.

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -29,10 +29,10 @@ L.LayerGroup = L.Class.extend({
 	},
 
 	removeLayer: function (layer) {
-		var id = this.getLayerId(layer);
+		var id = layer in this._layers ? layer : this.getLayerId(layer);
 
 		if (this._map && this._layers[id]) {
-			this._map.removeLayer(layer);
+			this._map.removeLayer(this._layers[id]);
 		}
 
 		delete this._layers[id];
@@ -43,7 +43,7 @@ L.LayerGroup = L.Class.extend({
 	hasLayer: function (layer) {
 		if (!layer) { return false; }
 
-		return (this.getLayerId(layer) in this._layers);
+		return (layer in this._layers || this.getLayerId(layer) in this._layers);
 	},
 
 	clearLayers: function () {


### PR DESCRIPTION
Now that we can override Layer stamping with 786fadd I think it makes sense to access them with their id.

In my use case I'm using custom indexes (Backbone.Model.cid) to identify polygons, and this would be a convenient way to keep things in sync. For example, if a model is deleted I can remove the polygon from the map with `removeLayer(model.cid)`. 

If not, I can still use `LayerGroup._layers[model.cid]`
