### PR TITLE
Typo fix in reference.html

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -4557,7 +4557,7 @@ L.map('map');</code></pre>
 	<tr>
 		<td><code><b>ie7</b></code></td>
 		<td><code>Boolean</code></td>
-		<td><code><span class="literal">true</span></code> for Internet Explorer 6.</td>
+		<td><code><span class="literal">true</span></code> for Internet Explorer 7.</td>
 	</tr>
 	<tr>
 		<td><code><b>webkit</b></code></td>


### PR DESCRIPTION
ie7 property's description in Browser section was "true for Internet Explorer 6." instead of "true for Internet Explorer 7."
