### PR TITLE
Leaflet.ActiveLayers plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -521,6 +521,15 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 			<a href="https://github.com/leplatrem">Mathieu Leplatre</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/vogdb/Leaflet.ActiveLayers">Leaflet.ActiveLayers</a>
+		</td><td>
+			Adds new L.Control.ActiveLayers with functionality to get currently active layers on the map.
+		</td><td>
+			<a href="https://github.com/vogdb">vogdb</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
This plugin adds new `L.Control.ActiveLayers` with functionality to get currently active layers on the map. I hope that this plugin will be useful as a solution to [get-active-baselayer problem](http://leaflet.uservoice.com/forums/150880-ideas-and-suggestions-for-leaflet/suggestions/3777550-get-active-baselayer)

<!---
@huboard:{"order":14.0}
-->
