### PR TITLE
Simplify converting a GeoJSON GeometryCollection to a vector layer

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -111,13 +111,7 @@ L.extend(L.GeoJSON, {
 
 		case 'GeometryCollection':
 			for (i = 0, len = geometry.geometries.length; i < len; i++) {
-
-				layer = this.geometryToLayer({
-					geometry: geometry.geometries[i],
-					type: 'Feature',
-					properties: geojson.properties
-				}, pointToLayer);
-
+				layer = this.geometryToLayer(geometry.geometries[i], pointToLayer);
 				layers.push(layer);
 			}
 			return new L.FeatureGroup(layers);


### PR DESCRIPTION
A GeometryCollection is simply a list of geometries (features are not allowed)
which can be directly converted without first turning them into features.
