### PR TITLE
Fix empty popup content

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -25,7 +25,7 @@ L.Popup = L.Class.extend({
 	initialize: function (options, source) {
 		L.setOptions(this, options);
 
-		this._source = source;
+		this._content = source;
 		this._animated = L.Browser.any3d && this.options.zoomAnimation;
 	},
 


### PR DESCRIPTION
If popup is created with 

``` javascript
    new L.Popup(options, source)
```

content of popup has appeared empty
