### PR TITLE
Popup-specific closeOnClick option

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -1,13 +1,49 @@
 describe('Popup', function() {
 
-	var map;
+	var c, map;
 
 	beforeEach(function () {
-		var c = document.createElement('div');
+		c = document.createElement('div');
 		c.style.width = '400px';
 		c.style.height = '400px';
 		map = new L.Map(c);
 		map.setView(new L.LatLng(55.8, 37.6), 6);
+	});
+
+	it("closes on map click when map has closePopupOnClick option", function() {
+		map.options.closePopupOnClick = true;
+
+		var popup = new L.Popup()
+			.setLatLng(new L.LatLng(55.8, 37.6))
+			.openOn(map);
+
+		happen.click(c);
+
+		expect(map.hasLayer(popup)).to.be(false);
+	});
+
+	it("closes on map click when popup has closeOnClick option", function() {
+		map.options.closePopupOnClick = false;
+
+		var popup = new L.Popup({closeOnClick: true})
+			.setLatLng(new L.LatLng(55.8, 37.6))
+			.openOn(map);
+
+		happen.click(c);
+
+		expect(map.hasLayer(popup)).to.be(false);
+	});
+
+	it("does not close on map click when popup has closeOnClick: false option", function() {
+		map.options.closePopupOnClick = true;
+
+		var popup = new L.Popup({closeOnClick: false})
+			.setLatLng(new L.LatLng(55.8, 37.6))
+			.openOn(map);
+
+		happen.click(c);
+
+		expect(map.hasLayer(popup)).to.be(true);
 	});
 
 	it("should trigger popupopen on marker when popup opens", function() {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -113,7 +113,7 @@ L.Popup = L.Class.extend({
 		if (this._animated) {
 			events.zoomanim = this._zoomAnimation;
 		}
-		if (this._map.options.closePopupOnClick) {
+		if ('closeOnClick' in this.options ? this.options.closeOnClick : this._map.options.closePopupOnClick) {
 			events.preclick = this._close;
 		}
 		if (this.options.keepInView) {


### PR DESCRIPTION
This is needed for fixing mapbox/mapbox.js#382 -- it needs to
disable this option for a specific popup.

This feels like it should have been a per-popup option from the
start, so I would support removing the map-wide closePopupOnClick
option, if you think that's ok.
