### PR TITLE
tile layers added after initial load don't show up until zoomed

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -240,7 +240,11 @@ L.TileLayer = L.Class.extend({
 				var className = 'leaflet-tile-container leaflet-zoom-animated';
 
 				this._bgBuffer = L.DomUtil.create('div', className, this._container);
+				this._bgBuffer.style.zIndex = 1;
+
 				this._tileContainer = L.DomUtil.create('div', className, this._container);
+				this._tileContainer.style.zIndex = 2;
+
 			} else {
 				this._tileContainer = this._container;
 			}


### PR DESCRIPTION
http://bl.ocks.org/jfirebaugh/abe9676ef9ce9165bfba

Zoom in, and the other two tile layers are shown.

In the initial state, the base layer has z-index 2 and the other layers have no explicit z-index, so they are below the base layer.
