### PR TITLE
Fix FF zoom animations and tile mispositioning.

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -142,6 +142,10 @@
 	visibility: hidden;
 	}
 
+/* This invisible border fixes zoom animation and tile mispositioning (minor gaps between tiles) in FF. */
+.leaflet-tile {
+	border-bottom: 0.01px solid transparent;
+	}
 
 /* cursors */
 


### PR DESCRIPTION
Edit: see comments about tile mispositioning.

Fix FF zoom animations by adding an invisible border at the bottom of all tiles.

Without this patch the top tile row is misplaced while performing a zoom animation in FF.
Could be reproduced on http://osm.org, http://leafletjs.com/, with Leaflet v0.5.1, and with Leaflet v0.6-dev (current master) in Firefox 21.0. I observe that bug every time, but if you do not know what I'm talking about, I'm attaching a screenshot:
![85](https://f.cloud.github.com/assets/291301/553977/d79508fe-c398-11e2-9f3e-21713ab64f92.png).
http://oserv.org/bugs/leaflet-ff/recording.mkv — here is a (slowed down via css) video.

I'm not sure how or why this hack works, but it solves the problem for me (with Firefox 21.0) in both v0.5.1 and v0.6-dev. No other effect should be done. The border-bottom is overlapped by the corresponding image on the next row.
It's transparent, so it's not visible even if the corresponding image on the next row is not yet loaded.

Probably this should be tested on earlier FF versions.

By the way, this bug is not observable at all (even without the patch) if ALL controls are disabled (including zoomControl and attributionControl).

If would be great if someone would write a testcase for FF from this bug, or pointed me to already existing bugreport.

<!---
@huboard:{"order":168.0}
-->
