### PR TITLE
Prevent infinite loop in adding of canvas CircleMarkers

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -143,9 +143,10 @@ var deps = {
 	VectorsCanvas: {
 		src: ['layer/vector/canvas/Polyline.Canvas.js',
 		      'layer/vector/canvas/Polygon.Canvas.js',
-		      'layer/vector/canvas/Circle.Canvas.js'],
-		deps: ['PathCanvas', 'Polyline', 'Polygon', 'Circle'],
-		desc: 'Canvas fallback for vector layers (polygons, polylines, circles)'
+		      'layer/vector/canvas/Circle.Canvas.js',
+		      'layer/vector/canvas/CircleMarker.Canvas.js'],
+		deps: ['PathCanvas', 'Polyline', 'Polygon', 'Circle', 'CircleMarker'],
+		desc: 'Canvas fallback for vector layers (polygons, polylines, circles, circlemarkers)'
 	},
 
 	GeoJSON: {

--- a/debug/tests/canvasloop.html
+++ b/debug/tests/canvasloop.html
@@ -1,0 +1,48 @@
+<html>
+    <head>
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+    <!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+    <script>
+        L_PREFER_CANVAS = true;
+    </script>
+    <link rel="stylesheet" href="../css/screen.css" />
+
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+
+    </head>
+    <body>
+
+        <div id="map"></div>
+
+
+        <script>
+
+        $(document).ready(function() {
+            //Init a map, and attempt a locate.
+            var map = L.map('map', {
+                center: [39.84, -96.591],
+                zoom: 4
+            }).locate();
+
+            L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+            }).addTo(map);
+
+            var vanillaLayer = new L.LayerGroup();
+            map.addLayer(vanillaLayer);
+
+            map.on('moveend',function(e) {
+                console.log('moveend fired.')
+            });
+
+            //For experiments using setRadius
+            window.marker = L.circleMarker(map.getCenter(),{radius:30}).addTo(vanillaLayer);
+        });
+
+        </script>
+        <script type="text/javascript" src="../../build/deps.js"></script>
+
+        <script src="../leaflet-include.js"></script>
+
+    </body>
+</html>

--- a/src/layer/vector/canvas/CircleMarker.Canvas.js
+++ b/src/layer/vector/canvas/CircleMarker.Canvas.js
@@ -1,0 +1,9 @@
+/*
+ * CircleMarker canvas specific drawing parts.
+ */
+
+L.CircleMarker.include(!L.Path.CANVAS ? {} : {
+	_updateStyle: function () {
+		L.Path.prototype._updateStyle.call(this);
+	}
+});


### PR DESCRIPTION
This is a hotfix for #1712.

However, it doesn't eliminate the issue of one 'moveend' being fired off use of setRadius, but I feel that getting an infinite loop out of the question is a good thing for a start.
