### PR TITLE
Fix wrong word (Number instead of Point) in closestPointonSegment docs

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -4882,7 +4882,7 @@ L.map('map');</code></pre>
 			<nobr>&lt;<a href="#point">Point</a>&gt; <i>p2</i> )</nobr>
 		</code></td>
 
-		<td><code>Number</code></td>
+		<td><code><a href="#point">Point</a></code></td>
 
 		<td>Returns the closest point from a point <code>p</code> on a segment <code>p1</code> to <code>p2</code>.</td>
 	</tr>


### PR DESCRIPTION
References #1720
