### PR TITLE
Prevent memory leak in removal of canvas layers

### DIFF
--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -38,6 +38,7 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 
 		if (this.options.clickable) {
 			this._map.off('click', this._onClick, this);
+			this._map.off('mousemove', this._onMouseMove, this);
 		}
 
 		this._requestUpdate();


### PR DESCRIPTION
The mousemove handler for cursor handling was not being removed upon destruction of canvas paths.

thanks @jfgirard!

Mentioned in https://github.com/Leaflet/Leaflet/pull/1403#issuecomment-18697146
