### PR TITLE
Prevent contextmenu events on popups from falling thru to map

### DIFF
--- a/debug/tests/popupcontextmenuclicks.html
+++ b/debug/tests/popupcontextmenuclicks.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<!--[if lte IE 8]><link rel="stylesheet" href="../../dist/leaflet.ie.css" /><![endif]-->
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+	<button id="populate">Populate with 10 markers</button>
+
+	<script type="text/javascript">
+
+var map = L.map('map').setView([36.9, -95.4], 5);
+map.on('contextmenu', function (e) {
+    alert('The map has been right-clicked');
+});
+L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+    attribution: 'Map data &copy; 2011 OpenStreetMap contributors, Imagery &copy; 2011 CloudMade',
+    key: 'BC9A493B41014CAABB98F0471D759707'
+}).addTo(map);
+
+
+
+var exampleGeoJSON = {
+    type: 'Polygon',
+    coordinates: [
+        [
+            [-90.0, 35.0],
+            [-90.0, 45.0],
+            [-100.0, 45.0],
+            [-100.0, 35.0]
+        ]
+    ]
+};
+
+var geoJsonLayer = L.geoJson(exampleGeoJSON, {
+    onEachFeature: function (feature, layer) {
+        layer.on('contextmenu', function (e) {
+            alert('The GeoJSON layer has been clicked');
+        });
+    }
+}).addTo(map);
+
+var marker = L.marker([36, -95]).addTo(map);
+marker.bindPopup('Right-click me <br> to test contextmenu <br> event capture').openPopup();
+
+
+	</script>
+</body>
+</html>

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -152,7 +152,7 @@ L.Popup = L.Class.extend({
 
 		this._contentNode = L.DomUtil.create('div', prefix + '-content', wrapper);
 		L.DomEvent.on(this._contentNode, 'mousewheel', L.DomEvent.stopPropagation);
-
+		L.DomEvent.on(wrapper, 'contextmenu', L.DomEvent.stopPropagation);
 		this._tipContainer = L.DomUtil.create('div', prefix + '-tip-container', container);
 		this._tip = L.DomUtil.create('div', prefix + '-tip', this._tipContainer);
 	},


### PR DESCRIPTION
Prevents context menu clicks on a popup from propagating to the map.

Debug test formed from @taylorhutchison example.

References #1730
