### PR TITLE
Properly calculate the y position of the element when parent is positioned relatively

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -53,12 +53,15 @@ L.DomUtil = {
 
 			if (pos === 'relative' && !el.offsetLeft) {
 				var width = L.DomUtil.getStyle(el, 'width'),
-				    maxWidth = L.DomUtil.getStyle(el, 'max-width');
+				    maxWidth = L.DomUtil.getStyle(el, 'max-width'),
+				    r = el.getBoundingClientRect();
 
 				if (width !== 'none' || maxWidth !== 'none') {
-					var r = el.getBoundingClientRect();
 					left += r.left + el.clientLeft;
 				}
+
+				//calculate full y offset since we're breaking out of the loop
+				top += r.top + (docBody.scrollTop  || docEl.scrollTop  || 0);
 
 				break;
 			}


### PR DESCRIPTION
An attempt to deal with https://github.com/Leaflet/Leaflet/issues/1744 - this adds in calculation for the top offset when the item is positioned relative.  This fixes an issue with mouse events not getting the correct lat/lng when a parent of the map had a vertical offset.

<!---
@huboard:{"order":538.5}
-->
