### PR TITLE
Unbind moveend event when maxBounds removed

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -117,6 +117,7 @@ L.Map = L.Class.extend({
 
 		if (!bounds) {
 			this._boundsMinZoom = null;
+			this.off('moveend', this._panInsideMaxBounds, this);
 			return this;
 		}
 


### PR DESCRIPTION
An attempt to resolve https://github.com/Leaflet/Leaflet/issues/1749

See issue for fiddle showing the issue.

This pull request simply unbinds the event (which is bound when the maxBounds are set) when the maxBounds are removed
