### PR TITLE
pass through coordsToLatLng when processing GeometryCollection

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -116,7 +116,7 @@ L.extend(L.GeoJSON, {
 					geometry: geometry.geometries[i],
 					type: 'Feature',
 					properties: geojson.properties
-				}, pointToLayer);
+				}, pointToLayer, coordsToLatLng);
 
 				layers.push(layer);
 			}


### PR DESCRIPTION
I'm using a custom coordsToLatLng with L.GeoJSON (see Kartena/proj4leaflet#32) and noticed that the geometries created as part of GeometryCollection were not using it.  This PR ensures the custom function is passed through to the recursive call.
