### PR TITLE
Add parameter to invalidateSize for changing the center.

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -257,13 +257,14 @@ L.Map = L.Class.extend({
 			} else {
 				if (!changeCenter) {
 					this._rawPanBy(offset);
+				}
 
 				this.fire('move');
-				}
 
 				clearTimeout(this._sizeTimer);
 				this._sizeTimer = setTimeout(L.bind(this.fire, this, 'moveend'), 200);
 			}
+
 			this.fire('resize', {
 				oldSize: oldSize,
 				newSize: newSize


### PR DESCRIPTION
In certain situations you don't want the map to pan when you invalidate the size (usually after the maps container is resized).

Take Google maps as an example. The sidebar can be contracted and expanded. When this happens the map does not maintain the center (by panning).

I wasn't quire sure on the naming of the variable. It needed to be falsey by default to not break the API.

Let me know if you are happy with this change and I will update the docs as well.
