### PR TITLE
Fix icon.js documentation

### DIFF
--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -10,7 +10,7 @@ L.Icon = L.Class.extend({
 		iconSize: (Point) (can be set through CSS)
 		iconAnchor: (Point) (centered by default, can be set in CSS with negative margins)
 		popupAnchor: (Point) (if not specified, popup opens in the anchor point)
-		shadowUrl: (Point) (no shadow by default)
+		shadowUrl: (String) (no shadow by default)
 		shadowRetinaUrl: (String) (optional, used for retina devices if detected)
 		shadowSize: (Point)
 		shadowAnchor: (Point)


### PR DESCRIPTION
ShadowUrl was being referred to as a point.
