### PR TITLE
make AMD declaration anonymous

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -10,7 +10,7 @@ if (typeof module === 'object' && typeof module.exports === 'object') {
 
 // define Leaflet as an AMD module
 } else if (typeof define === 'function' && define.amd) {
-	define('leaflet', [], function () { return L; });
+	define(L);
 }
 
 // define Leaflet as a global L variable, saving the original L to restore later if needed


### PR DESCRIPTION
Thanks for adding AMD support to Leaflet!  At some point, I'd like to follow up on the discussion in #1364 about using AMD for Leaflet's internal modules as well - but for now I have a simple request: can you change the module declaration to be anonymous?  Explicitly declaring the module name leads to inflexibility, as I'll explain.

Per the [RequireJS docs](http://requirejs.org/docs/api.html#modulename), modules should generally be declared anonymously in order to support full portability between projects.  For example, if I want to put leaflet in a `lib/` [subfolder in my JS directory](https://github.com/wq/wq.app/tree/master/js/), the resolved module name might be `lib/leaflet` (or `wq/lib/leaflet`), not `leaflet`.  By defining the module anonymously, projects can integrate Leaflet wherever they wish without needing to define a RequireJS "paths" configuration pointing any dependencies on `leaflet` to their project's location of the file.

One of the only libraries that declares its AMD module explicitly is jquery, and this is largely for historical reasons - with the idea that this special case for jquery will be removed over time.

You'll notice that in this PR I've also removed the function that returns L - this is not needed since [define() can be used directly with simple objects](http://requirejs.org/docs/api.html#defsimple), in which case it will just return the object.

**Edit 2013-11-18**: Note that AMD best practice is to put third party libs at the AMD `baseUrl` so that they can be referenced by their common names.  As above, the purpose of this is to avoid needing a complicated paths config for RequireJS or a similar loader.  This is especially important when integrating a plugin such as [Proj4leaflet](https://github.com/kartena/proj4leaflet), which AMD-depends on both 'proj4' and 'leaflet'.  In general, Leaflet will likely be referenced from other AMD modules as 'leaflet' (and not './leaflet' or 'lib/leaflet').  So, my initial motivation for making Leaflet's AMD definition anonymous was not fully correct (and I am [updating my library](https://github.com/wq/wq.app/pull/12) accordingly).  Nevertheless, it is still recommended to use anonymous module definitions in nearly all cases.
