### PR TITLE
Issue where the tile layer is not reset and updated when redraw is calle...

### DIFF
--- a/src/layer/tile/TileLayer.Canvas.js
+++ b/src/layer/tile/TileLayer.Canvas.js
@@ -13,6 +13,11 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 	},
 
 	redraw: function () {
+		if (this._map) {
+			this._reset({hard: true});
+			this._update();
+		}
+		
 		for (var i in this._tiles) {
 			this._redrawTile(this._tiles[i]);
 		}


### PR DESCRIPTION
I was able to replicate this issue: https://github.com/Leaflet/Leaflet/issues/1797. The problem is that redraw does not call update and reset on the TileLayer, therefore causing the above issue. I am proposing simply doing it before calling drawTile. I built and tested it against the issue.
