### PR TITLE
Stop transition if element is outside fo the DOM

### DIFF
--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -39,6 +39,10 @@ L.PosAnimation = L.Class.extend({
 	},
 
 	_onStep: function () {
+		if (!document.documentElement.contains(this._el)) {
+			this._onTransitionEnd();
+			return;
+		}
 		// jshint camelcase: false
 		// make L.DomUtil.getPosition return intermediate position value during animation
 		this._el._leaflet_pos = this._getPos();


### PR DESCRIPTION
I have a backbone application, where map is rendered once and then stored globally. And sometimes when users open another page before animation is complete, it gives me a bunch of errors.

```
Uncaught TypeError: Cannot read property '1' of null leaflet.js:8210
L.PosAnimation.L.Class.extend._getPos leaflet.js:8210
L.PosAnimation.L.Class.extend._onStep leaflet.js:8193
(anonymous function)
```

on that line.

``` javascript
_getPos: function () {
        var left, top, matches,
            el = this._el,
            style = window.getComputedStyle(el);

        if (L.Browser.any3d) {
            matches = style[L.DomUtil.TRANSFORM].match(this._transformRe);
            left = parseFloat(matches[1]);
--------------   Uncaught TypeError: Cannot read property '1' of null
            top  = parseFloat(matches[2]);
        } else {
            left = parseFloat(style.left);
            top  = parseFloat(style.top);
        }

        return new L.Point(left, top, true);
    },
```
