### PR TITLE
Fix worldCopyJump if you start zoomed all the way out. Fixes #1831

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -31,6 +31,8 @@ L.Map.Drag = L.Handler.extend({
 			if (map.options.worldCopyJump) {
 				this._draggable.on('predrag', this._onPreDrag, this);
 				map.on('viewreset', this._onViewReset, this);
+
+				this._onViewReset();
 			}
 		}
 		this._draggable.enable();


### PR DESCRIPTION
Fix worldCopyJump if you start zoomed all the way out. Fixes #1831

Without this Map.Drag.js _onPreDrag calculates newX as NaN.
