### PR TITLE
Allow options to be passed to Map.setMaxBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Leaflet Changelog
 
 An in-progress version being developed on the master branch.
 
+* Added ability to pass animation `options` to `setMaxBounds` to allow configuration of view changes when max bounds have changed (by [@davidjb](http://git.io/djb)). [#1834](https://github.com/Leaflet/Leaflet/pull/1834)
+
 * Added `TileLayer` `maxNativeZoom` option that allows displaying tile layers on zoom levels above their maximum by upscaling tiles. [#1802](https://github.com/Leaflet/Leaflet/issues/1802) [#1798](https://github.com/Leaflet/Leaflet/issues/1798)
 
 ## 0.6.2 (June 28, 2013)

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -114,7 +114,7 @@ L.Map = L.Class.extend({
 		return this.fire('moveend');
 	},
 
-	setMaxBounds: function (bounds) {
+	setMaxBounds: function (bounds, options) {
 		bounds = L.latLngBounds(bounds);
 
 		this.options.maxBounds = bounds;
@@ -131,7 +131,7 @@ L.Map = L.Class.extend({
 
 		if (this._loaded) {
 			if (this._zoom < minZoom) {
-				this.setView(bounds.getCenter(), minZoom);
+				this.setView(bounds.getCenter(), minZoom, options);
 			} else {
 				this.panInsideBounds(bounds);
 			}


### PR DESCRIPTION
Allow options to be passed to Map.setMaxBounds such that they can passed through to setView.  Without this, animation (zooming/panning) can't be customised.  In my specific use case, I do this:

```
map.setMaxBounds([[-86, -250], [86, 250]], {animate:false})
```

to just force the map to go to those bounds without panning or zooming.

This is my first pull request -- so when I'm updating documentation regarding this, I'll need to have another pull request for that.  Should I do that now or wait for this to accepted?
