### PR TITLE
Make L.DivIcon accept HTML Elements in options.html

### DIFF
--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -21,7 +21,11 @@ L.DivIcon = L.Icon.extend({
 		    options = this.options;
 
 		if (options.html !== false) {
-			div.innerHTML = options.html;
+			if (options.html instanceof Element) {
+				div.appendChild(options.html);
+			} else {
+				div.innerHTML = options.html;
+			}
 		} else {
 			div.innerHTML = '';
 		}


### PR DESCRIPTION
While writing plugin code, I would like to do transformations on the content of a `L.DivIcon`. This can be done through CSS, but for I simple plugin, I don't like the need of including an additional file.

This PR changes `L.DivIcon` to accept `Element`s created with `L.DomUtil.create(...)` besides the normal html string.
