### PR TITLE
Update setOpacity() in Marker.js

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -283,6 +283,8 @@ L.Marker = L.Class.extend({
 		if (this._map) {
 			this._updateOpacity();
 		}
+		
+		return this;
 	},
 
 	_updateOpacity: function () {


### PR DESCRIPTION
According to the Leaflet documentation, setOpacity must return "this".
http://leafletjs.com/reference.html#marker-setopacity
