### PR TITLE
Allow options to be passed to Map.panInsideBounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Leaflet Changelog
 An in-progress version being developed on the `master` branch. Includes all fixes from the `stable` branch.
 
 * Added `TileLayer` `maxNativeZoom` option that allows displaying tile layers on zoom levels above their maximum by **upscaling tiles**. [#1802](https://github.com/Leaflet/Leaflet/issues/1802) [#1798](https://github.com/Leaflet/Leaflet/issues/1798)
+* Added ability to pass zoom/pan animation options to `panInsideBounds`, ensuring `setMaxBounds` passes options through. (by [@davidjb](http://git.io/djb)). [#1879](https://github.com/Leaflet/Leaflet/pull/1879)
 
 ## 0.6.3 (July 17, 2013)
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -133,7 +133,7 @@ L.Map = L.Class.extend({
 			if (this._zoom < minZoom) {
 				this.setView(bounds.getCenter(), minZoom, options);
 			} else {
-				this.panInsideBounds(bounds);
+				this.panInsideBounds(bounds, options);
 			}
 		}
 
@@ -142,7 +142,7 @@ L.Map = L.Class.extend({
 		return this;
 	},
 
-	panInsideBounds: function (bounds) {
+	panInsideBounds: function (bounds, options) {
 		bounds = L.latLngBounds(bounds);
 
 		var viewBounds = this.getPixelBounds(),
@@ -167,7 +167,7 @@ L.Map = L.Class.extend({
 		}
 
 		if (dx || dy) {
-			return this.panBy([dx, dy]);
+			return this.panBy([dx, dy], options);
 		}
 
 		return this;


### PR DESCRIPTION
Pass the options from `Map.setMaxBounds` through to the call to  `panInsideBounds`.  This ensures consistent behaviour -- in allowing for controlling animation -- with calling `setMaxBounds` when the zoom level needs to change and when it doesn't.
