### PR TITLE
Include accuracy property in 'locationfound' events.

### DIFF
--- a/src/map/ext/Map.Geolocation.js
+++ b/src/map/ext/Map.Geolocation.js
@@ -63,11 +63,12 @@ L.Map.include({
 	},
 
 	_handleGeolocationResponse: function (pos) {
-		var lat = pos.coords.latitude,
+		var accuracy = parseFloat(pos.coords.accuracy),
+		    lat = pos.coords.latitude,
 		    lng = pos.coords.longitude,
 		    latlng = new L.LatLng(lat, lng),
 
-		    latAccuracy = 180 * pos.coords.accuracy / 40075017,
+		    latAccuracy = 180 * accuracy / 40075017,
 		    lngAccuracy = latAccuracy / Math.cos(L.LatLng.DEG_TO_RAD * lat),
 
 		    bounds = L.latLngBounds(
@@ -83,7 +84,8 @@ L.Map.include({
 
 		var data = {
 			latlng: latlng,
-			bounds: bounds
+			bounds: bounds,
+			accuracy: accuracy
 		};
 
 		for (var i in pos.coords) {


### PR DESCRIPTION
I am submitting a patch adding back the `accuracy` property to `locationfound` events originating from `Map.Geolocation`. I believe it is desirable that a plugin bolstering Leaflet's geolocation wrapper, such as the otherwise currently broken [domoritz/leaflet-locatecontrol](https://github.com/domoritz/leaflet-locatecontrol), would have access to this property in some way.
