### PR TITLE
TileLayer.Canvas resetOnRedraw option

### DIFF
--- a/src/layer/tile/TileLayer.Canvas.js
+++ b/src/layer/tile/TileLayer.Canvas.js
@@ -5,7 +5,8 @@
 
 L.TileLayer.Canvas = L.TileLayer.extend({
 	options: {
-		async: false
+		async: false,
+		resetOnRedraw: true
 	},
 
 	initialize: function (options) {
@@ -13,7 +14,7 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 	},
 
 	redraw: function () {
-		if (this._map) {
+		if (this._map && this.options.resetOnRedraw) {
 			this._reset({hard: true});
 			this._update();
 		}


### PR DESCRIPTION
#1817 introduced a problem by recreating canvas elements on every redraw, which can cause flicker and slow downs in some scenarios. This adds the option to control this behaviour.

It defaults to true, which is the same as before. By setting it to false, TileLayer.Canvas will behave like in 0.5.
