### PR TITLE
Throw invalid GeoJSON error on Polygon with an empty interior

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -99,6 +99,9 @@ L.extend(L.GeoJSON, {
 			return new L.Polyline(latlngs);
 
 		case 'Polygon':
+			if (coords.length === 2 && !coords[1].length) {
+				throw new Error('Invalid GeoJSON object.');
+			}
 			latlngs = this.coordsToLatLngs(coords, 1, coordsToLatLng);
 			return new L.Polygon(latlngs);
 


### PR DESCRIPTION
Check to see if second array is present, and empty, for GeoJSON polygon parsing.

Fixes #1917
