### PR TITLE
update a circlemarker's popup positioning when using setLatLng.

### DIFF
--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -22,6 +22,13 @@ L.CircleMarker = L.Circle.extend({
 		this.setRadius(this.options.radius);
 	},
 
+	setLatLng: function (latlng) {
+		L.Circle.prototype.setLatLng.call(this, latlng);
+		if (this._popup && this._popup._isOpen) {
+			this._popup.setLatLng(latlng);
+		}
+	},
+
 	setRadius: function (radius) {
 		this.options.radius = this._radius = radius;
 		return this.redraw();


### PR DESCRIPTION
Keep the popups of circlemarkers in sync when using setLatLng. Here we just default to the new latLng of the marker..if we wanted to we could figure out the old offset & use that instead.

References #1921
