### PR TITLE
Make container optional in L.DomUtil.getMousePosition(). Addresses #1926

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -137,8 +137,13 @@ L.DomEvent = {
 		    docEl = document.documentElement,
 		    x = e.pageX ? e.pageX - body.scrollLeft - docEl.scrollLeft: e.clientX,
 		    y = e.pageY ? e.pageY - body.scrollTop - docEl.scrollTop: e.clientY,
-		    pos = new L.Point(x, y),
-		    rect = container.getBoundingClientRect(),
+		    pos = new L.Point(x, y);
+
+		if (!container) {
+			return pos;
+		}
+
+		var rect = container.getBoundingClientRect(),
 		    left = rect.left - container.clientLeft,
 		    top = rect.top - container.clientTop;
 


### PR DESCRIPTION
Makes the container argument in L.DomUtil.getMousePosition() optional, addressing #1926. Tested against Leaflet.zoomslider as well as the use cases that #1826 was intended to fix.
