### PR TITLE
adds a method that only redraw the tiles

### DIFF
--- a/src/layer/tile/TileLayer.Canvas.js
+++ b/src/layer/tile/TileLayer.Canvas.js
@@ -10,6 +10,7 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 
 	initialize: function (options) {
 		L.setOptions(this, options);
+		this._animRequest = null;
 	},
 
 	redraw: function () {
@@ -17,11 +18,21 @@ L.TileLayer.Canvas = L.TileLayer.extend({
 			this._reset({hard: true});
 			this._update();
 		}
-		
+
+		this.redrawTiles();
+
+		return this;
+	},
+
+	redrawTiles: function () {
+		L.Util.cancelAnimFrame(this._animRequest);
+		this._animRequest = L.Util.requestAnimFrame(this._redrawTiles, this);
+	},
+
+	_redrawTiles: function () {
 		for (var i in this._tiles) {
 			this._redrawTile(this._tiles[i]);
 		}
-		return this;
 	},
 
 	_redrawTile: function (tile) {


### PR DESCRIPTION
this commit [1] is backwards incompatible since the previous version didn't reload the tiles on redraw. 

I think with this layer there is a naming issue, redraw using canvas sounds like "redraw the tiles in the canvas" but in a tiled layer redraw means reload the tiles.

My proposal here is to add a new method called redrawTiles that updates the content on the screen without loading the tiles. This also uses requestAnimationFrame to render the canvas tiles.

I don't know it drawTiles is the best name since it can be confused with the redraw method

[1] https://github.com/Leaflet/Leaflet/commit/724f9aa3d8071a9c409987aa0f1dd059d2ec47bc
