### PR TITLE
Support center-oriented scroll/double-click zoom

### DIFF
--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -8,15 +8,22 @@ L.Map.mergeOptions({
 
 L.Map.DoubleClickZoom = L.Handler.extend({
 	addHooks: function () {
-		this._map.on('dblclick', this._onDoubleClick);
+		this._map.on('dblclick', this._onDoubleClick, this);
 	},
 
 	removeHooks: function () {
-		this._map.off('dblclick', this._onDoubleClick);
+		this._map.off('dblclick', this._onDoubleClick, this);
 	},
 
 	_onDoubleClick: function (e) {
-		this.setZoomAround(e.containerPoint, this._zoom + 1);
+		var map = this._map,
+		    zoom = map.getZoom() + 1;
+
+		if (map.options.doubleClickZoom === 'center') {
+			map.setZoom(zoom);
+		} else {
+			map.setZoomAround(e.containerPoint, zoom);
+		}
 	}
 });
 

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -51,7 +51,11 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		if (!delta) { return; }
 
-		map.setZoomAround(this._lastMousePos, zoom + delta);
+		if (map.options.scrollWheelZoom === 'center') {
+			map.setZoom(zoom + delta);
+		} else {
+			map.setZoomAround(this._lastMousePos, zoom + delta);
+		}
 	}
 });
 


### PR DESCRIPTION
This is needed for [new share features](https://github.com/openstreetmap/openstreetmap-website/pull/351) on openstreetmap.org -- when the "Include marker" option is checked, the marker needs to be kept centered within the map, so zooming should temporarily be relative to the center, not to the current cursor location.

Some users have requested restoring the 0.5.x behavior for double-click zoom full-time. We don't have plans to do that, but this gives other Leaflet users that option.

I chose overloading a single configuration option rather than creating a new one because I anticipate we might want another mutually exclusive variant in the future -- zoom relative to an arbitrary LatLng. For example, Google Maps classic does this when you've clicked a POI.
