### PR TITLE
Fixed an Issue when shift-clicking

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -130,6 +130,7 @@ L.Draggable = L.Class.extend({
 			L.Util.cancelAnimFrame(this._animRequest);
 
 			this.fire('dragend');
+			this._moved = false;
 		}
 
 		this._moving = false;


### PR DESCRIPTION
when you **shift click** on the map directly after dragging no click event get fired. (boxZoom: false)

to construct the bug:
1. click on map => clickEvent fired
2. shift click on map => clickEvent fired
3. drag map around 
4. shift click on map => **no click Event**
5. click on map => clickEvent fired
6. shift click on map => clickEvent fired

the buggy workflow:
- at 3 L.Draggable this._moved is set to true.
- at 4 L.Draggable line 49 _onDown returns directly because shift is pressed. and this._moved is not set back to false in line 67. So this._moved is still true.
- at 4 L.Map line 679 returns because this.dragging.moved() returns true. And no event get fired.

lg

fastrde
