### PR TITLE
Localization Support for Zoom Control

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -6,9 +6,9 @@ L.Control.Zoom = L.Control.extend({
 	options: {
 		position: 'topleft',
 		zoomInText: '+',
-		zoomInTooltip: 'Zoom in',
+		zoomInTitle: 'Zoom in',
 		zoomOutText: '-',
-		zoomOutTooltip: 'Zoom out'
+		zoomOutTitle: 'Zoom out'
 	},
 
 	onAdd: function (map) {
@@ -18,10 +18,10 @@ L.Control.Zoom = L.Control.extend({
 		this._map = map;
 
 		this._zoomInButton  = this._createButton(
-		        this.options.zoomInText, this.options.zoomInTooltip,
+		        this.options.zoomInText, this.options.zoomInTitle,
 		        zoomName + '-in',  container, this._zoomIn,  this);
 		this._zoomOutButton = this._createButton(
-		        this.options.zoomOutText, this.options.zoomOutTooltip,
+		        this.options.zoomOutText, this.options.zoomOutTitle,
 		        zoomName + '-out', container, this._zoomOut, this);
 
 		map.on('zoomend zoomlevelschange', this._updateDisabled, this);


### PR DESCRIPTION
I added localization support for the zoom control. There was a pull request for this before: https://github.com/Leaflet/Leaflet/pull/1643 But the implementation was quite strange with language overriding. 

This implementation uses the control options to localize the strings. I also thought of another solution with: 

```
options: {
    buttons: {
        zoomIn: {
            title: 'Zoom in',
            text: '+'
        },
        zoomOut: {
            title: 'Zoom out',
            text: '-'
        }
    }
}
```

Let me know what you'd prefer and I will implement it. 
