### PR TITLE
L.map._onMouseClick custom handler recognition

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -678,7 +678,7 @@ L.Map = L.Class.extend({
 	_onMouseClick: function (e) {
 		if (!this._loaded || (!e._simulated &&
 					this._checkHandlerMoved() ||
-		            L.DomEvent._skipped(e))) { return; }
+					L.DomEvent._skipped(e))) { return; }
 
 		this.fire('preclick');
 		this._fireMouseEvent(e);


### PR DESCRIPTION
Hello Again,

i added a function to L.Map to check if a handler has 'moved()' (we should rename this function to stopClickPropagation or somthing like that).
The benefit is that custom handler now can stop 'mapClicking' like drag and boxZoom.

lg

fastrde

<!---
@huboard:{"order":26.25}
-->
