### PR TITLE
Fix second click popup issue (#1925)

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -101,6 +101,8 @@ L.DomEvent = {
 		} else {
 			e.cancelBubble = true;
 		}
+		L.DomEvent._skipped(e);
+
 		return this;
 	},
 
@@ -127,7 +129,9 @@ L.DomEvent = {
 	},
 
 	stop: function (e) {
-		return L.DomEvent.preventDefault(e).stopPropagation(e);
+		return L.DomEvent
+			.preventDefault(e)
+			.stopPropagation(e);
 	},
 
 	getMousePosition: function (e, container) {


### PR DESCRIPTION
Deleted one line from L.Popup to fix the issue described in Issue #1925
The click events doesn't propagate to the map when you click the close button so the _fakeStop called in disableClickPropagation disable the first real mapClick.

I tested propagation in Firefox 22 and Chrome 28.0.1500.95 and it seems to work.

lg

fastrde
