### PR TITLE
Adds Popup autoPanPadding(TopLeft & BottomRight) options. Fixes #1588

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -17,6 +17,8 @@ L.Popup = L.Class.extend({
 		closeButton: true,
 		offset: [0, 7],
 		autoPanPadding: [5, 5],
+		autoPanPaddingTopLeft: null,
+		autoPanPaddingBottomRight: null,
 		keepInView: false,
 		className: '',
 		zoomAnimation: true
@@ -257,21 +259,23 @@ L.Popup = L.Class.extend({
 
 		var containerPos = map.layerPointToContainerPoint(layerPos),
 		    padding = L.point(this.options.autoPanPadding),
+		    paddingTL = L.point(this.options.autoPanPaddingTopLeft || padding),
+		    paddingBR = L.point(this.options.autoPanPaddingBottomRight || padding),
 		    size = map.getSize(),
 		    dx = 0,
 		    dy = 0;
 
-		if (containerPos.x + containerWidth > size.x) { // right
-			dx = containerPos.x + containerWidth - size.x + padding.x;
+		if (containerPos.x + containerWidth + paddingBR.x > size.x) { // right
+			dx = containerPos.x + containerWidth - size.x + paddingBR.x;
 		}
-		if (containerPos.x - dx < 0) { // left
-			dx = containerPos.x - padding.x;
+		if (containerPos.x - dx - paddingTL.x < 0) { // left
+			dx = containerPos.x - paddingTL.x;
 		}
-		if (containerPos.y + containerHeight > size.y) { // bottom
-			dy = containerPos.y + containerHeight - size.y + padding.y;
+		if (containerPos.y + containerHeight + paddingBR.y > size.y) { // bottom
+			dy = containerPos.y + containerHeight - size.y + paddingBR.y;
 		}
-		if (containerPos.y - dy < 0) { // top
-			dy = containerPos.y - padding.y;
+		if (containerPos.y - dy - paddingTL.y < 0) { // top
+			dy = containerPos.y - paddingTL.y;
 		}
 
 		if (dx || dy) {


### PR DESCRIPTION
Fixes Issue described in #1588.

By analogy with options `paddingTopLeft/paddingBottomRight` of `fitBounds()` method, the Popup options `autoPanPaddingTopLeft/autoPanPaddingBottomRight` was added. Usage autoPanPadding options as a Bounds type is impossible. Also, autoPanPadding  influence for calculating dX/dY was fixed, even when popup fully visible in viewport.
