### PR TITLE
Use this._popupHandlersAdded to manage Marker popup event

### DIFF
--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -41,11 +41,12 @@ L.Marker.include({
 
 		options = L.extend({offset: anchor}, options);
 
-		if (!this._popup) {
+		if (!this._popupHandlersAdded) {
 			this
 			    .on('click', this.togglePopup, this)
 			    .on('remove', this.closePopup, this)
 			    .on('move', this._movePopup, this);
+			this._popupHandlersAdded = true;
 		}
 
 		if (content instanceof L.Popup) {
@@ -70,9 +71,10 @@ L.Marker.include({
 		if (this._popup) {
 			this._popup = null;
 			this
-			    .off('click', this.togglePopup)
-			    .off('remove', this.closePopup)
-			    .off('move', this._movePopup);
+			    .off('click', this.togglePopup, this)
+			    .off('remove', this.closePopup, this)
+			    .off('move', this._movePopup, this);
+			this._popupHandlersAdded = false;
 		}
 		return this;
 	},


### PR DESCRIPTION
This make the internal API more consistent with Path.

My use case is to disable event management in bindPopup (because I manage them myself).

Also, I've added `this` argument to `this.off` calls, otherwise the signature of the event would not be the same as the one added with `this.on`. I've thought it was a really minimal change to commit it, but if you prefer a separate PR or separate commit at least, it's fair, just ask :)

Thanks!
