### PR TITLE
Added Keycode 171 to support zoomIn Firefox 22 & 23

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -15,7 +15,7 @@ L.Map.Keyboard = L.Handler.extend({
 		right:   [39],
 		down:    [40],
 		up:      [38],
-		zoomIn:  [187, 107, 61],
+		zoomIn:  [187, 107, 61, 171],
 		zoomOut: [189, 109, 173]
 	},
 


### PR DESCRIPTION
Hello,

I added keycode 171 (FF22 and FF23 +-keycode) to the zoomIn Array to fix Issue #1943.

lg

fastrde
