### PR TITLE
Ipad tagname fix

### DIFF
--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -36,7 +36,7 @@ L.Map.Tap = L.Handler.extend({
 		this._startPos = this._newPos = new L.Point(first.clientX, first.clientY);
 
 		// if touching a link, highlight it
-		if (el.tagName.toLowerCase() === 'a') {
+		if (el.tagName && el.tagName.toLowerCase() === 'a') {
 			L.DomUtil.addClass(el, 'leaflet-active');
 		}
 


### PR DESCRIPTION
el.tagName sometimes undefined on some iPads using Leaflet.label plugin.

This complements the previous commit regarding same issue: d78fb499435530f2d8178931084b716218adba42
