### PR TITLE
L.Ellipse

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -128,9 +128,15 @@ var deps = {
 		desc: ['Rectangle overlays.']
 	},
 
+	Ellipse: {
+		src: ['layer/vector/Ellipse.js'],
+		deps: ['Path'],
+		desc: 'Ellipse overlays (with x and y radius in meters).'
+	},
+
 	Circle: {
 		src: ['layer/vector/Circle.js'],
-		deps: ['Path'],
+		deps: ['Ellipse'],
 		desc: 'Circle overlays (with radius in meters).'
 	},
 

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -2,94 +2,19 @@
  * L.Circle is a circle overlay (with a certain radius in meters).
  */
 
-L.Circle = L.Path.extend({
+L.Circle = L.Ellipse.extend({
 	initialize: function (latlng, radius, options) {
-		L.Path.prototype.initialize.call(this, options);
-
-		this._latlng = L.latLng(latlng);
-		this._mRadius = radius;
-	},
-
-	options: {
-		fill: true
-	},
-
-	setLatLng: function (latlng) {
-		this._latlng = L.latLng(latlng);
-		return this.redraw();
+		L.Ellipse.prototype.initialize.apply(this, [latlng, L.point(radius, radius), options]);
 	},
 
 	setRadius: function (radius) {
-		this._mRadius = radius;
+		this._mRadiusX = radius;
+		this._mRadiusY = radius;
 		return this.redraw();
 	},
 
-	projectLatlngs: function () {
-		var lngRadius = this._getLngRadius(),
-		    latlng = this._latlng,
-		    pointLeft = this._map.latLngToLayerPoint([latlng.lat, latlng.lng - lngRadius]);
-
-		this._point = this._map.latLngToLayerPoint(latlng);
-		this._radius = Math.max(this._point.x - pointLeft.x, 1);
-	},
-
-	getBounds: function () {
-		var lngRadius = this._getLngRadius(),
-		    latRadius = (this._mRadius / 40075017) * 360,
-		    latlng = this._latlng;
-
-		return new L.LatLngBounds(
-		        [latlng.lat - latRadius, latlng.lng - lngRadius],
-		        [latlng.lat + latRadius, latlng.lng + lngRadius]);
-	},
-
-	getLatLng: function () {
-		return this._latlng;
-	},
-
-	getPathString: function () {
-		var p = this._point,
-		    r = this._radius;
-
-		if (this._checkIfEmpty()) {
-			return '';
-		}
-
-		if (L.Browser.svg) {
-			return 'M' + p.x + ',' + (p.y - r) +
-			       'A' + r + ',' + r + ',0,1,1,' +
-			       (p.x - 0.1) + ',' + (p.y - r) + ' z';
-		} else {
-			p._round();
-			r = Math.round(r);
-			return 'AL ' + p.x + ',' + p.y + ' ' + r + ',' + r + ' 0,' + (65535 * 360);
-		}
-	},
-
 	getRadius: function () {
-		return this._mRadius;
-	},
-
-	// TODO Earth hardcoded, move into projection code!
-
-	_getLatRadius: function () {
-		return (this._mRadius / 40075017) * 360;
-	},
-
-	_getLngRadius: function () {
-		return this._getLatRadius() / Math.cos(L.LatLng.DEG_TO_RAD * this._latlng.lat);
-	},
-
-	_checkIfEmpty: function () {
-		if (!this._map) {
-			return false;
-		}
-		var vp = this._map._pathViewport,
-		    r = this._radius,
-		    p = this._point;
-
-		return p.x - r > vp.max.x || p.y - r > vp.max.y ||
-		       p.x + r < vp.min.x || p.y + r < vp.min.y;
+		return this._mRadiusX;
 	}
 });
 

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -10,7 +10,8 @@ L.CircleMarker = L.Circle.extend({
 
 	initialize: function (latlng, options) {
 		L.Circle.prototype.initialize.call(this, latlng, null, options);
-		this._radius = this.options.radius;
+		this._radiusX = this.options.radius;
+		this._radiusY = this.options.radius;
 	},
 
 	projectLatlngs: function () {
@@ -30,9 +31,15 @@ L.CircleMarker = L.Circle.extend({
 	},
 
 	setRadius: function (radius) {
-		this.options.radius = this._radius = radius;
+		this._radius = this.options.radius = radius;
+		this._radiusX = this._radius;
+		this._radiusY = this._radius;
 		return this.redraw();
-	}
+	},
+
+	getRadius: function () {
+			return this.options.radius;
+		}
 });
 
 L.circleMarker = function (latlng, options) {

--- a/src/layer/vector/Ellipse.js
+++ b/src/layer/vector/Ellipse.js
@@ -1,0 +1,108 @@
+/*
+ * L.Ellipse is an ellipse overlay (with a certain radius in meters).
+ */
+
+L.Ellipse = L.Path.extend({
+    initialize: function (latlng, radii, options) {
+        L.Path.prototype.initialize.call(this, options);
+
+        this._latlng = L.latLng(latlng);
+
+        if (radii) {
+            this._mRadiusX = radii.x;
+            this._mRadiusY = radii.y;
+        }
+    },
+
+    options: {
+        fill: true
+    },
+
+    setLatLng: function (latlng) {
+        this._latlng = L.latLng(latlng);
+        return this.redraw();
+    },
+
+    setRadius: function (radii) {
+        this._mRadiusX = radii.x;
+        this._mRadiusY = radii.y;
+        return this.redraw();
+    },
+
+    projectLatlngs: function () {
+        var lngRadius = this._getLngRadius(),
+            latRadius = this._getLatRadius(),
+            latlng = this._latlng,
+            pointLeft = this._map.latLngToLayerPoint([latlng.lat, latlng.lng - lngRadius]),
+            pointBelow = this._map.latLngToLayerPoint([latlng.lat - latRadius, latlng.lng]);
+
+        this._point = this._map.latLngToLayerPoint(latlng);
+        this._radiusX = Math.max(this._point.x - pointLeft.x, 1);
+        this._radiusY = Math.max(pointBelow.y - this._point.y, 1);
+    },
+
+    getBounds: function () {
+        var lngRadius = this._getLngRadius(),
+            latRadius = this._getLatRadius(),
+            latlng = this._latlng;
+
+        return new L.LatLngBounds(
+                [latlng.lat - latRadius, latlng.lng - lngRadius],
+                [latlng.lat + latRadius, latlng.lng + lngRadius]);
+    },
+
+    getLatLng: function () {
+        return this._latlng;
+    },
+
+    getPathString: function () {
+        var p = this._point,
+            rx = this._radiusX,
+            ry = this._radiusY;
+
+        if (this._checkIfEmpty()) {
+            return '';
+        }
+
+        if (L.Browser.svg) {
+            return 'M' + p.x + ',' + (p.y - ry) +
+                   'A' + rx + ',' + ry + ',0,1,1,' +
+                   (p.x - 0.1) + ',' + (p.y - ry) + ' z';
+        } else {
+            p._round();
+            rx = Math.round(rx);
+            ry = Math.round(ry);
+            return 'AL ' + p.x + ',' + p.y + ' ' + rx + ',' + ry + ' 0,' + (65535 * 360);
+        }
+    },
+
+    getRadius: function () {
+        return new L.point(this._mRadiusX, this._mRadiusY);
+    },
+
+    // TODO Earth hardcoded, move into projection code!
+
+    _getLatRadius: function () {
+        return (this._mRadiusY / 40075017) * 360;
+    },
+
+    _getLngRadius: function () {
+        return ((this._mRadiusX / 40075017) * 360) / Math.cos(L.LatLng.DEG_TO_RAD * this._latlng.lat);
+    },
+
+    _checkIfEmpty: function () {
+        if (!this._map) {
+            return false;
+        }
+        var vp = this._map._pathViewport,
+            r = this._radiusX,
+            p = this._point;
+
+        return p.x - r > vp.max.x || p.y - r > vp.max.y ||
+               p.x + r < vp.min.x || p.y + r < vp.min.y;
+    }
+});
+
+L.ellipse = function (latlng, radii, options) {
+    return new L.Ellipse(latlng, radii, options);
+};


### PR DESCRIPTION
I've been working with Yuriy Dybskiy (@dybskiy) for the last few days to add Ellipses to Leaflet. He had a client that really needed to be able to draw ellipses (via Leaflet.draw) but since there is no native support for ellipses in Leaflet we needed to add it.

I have also been wondering why there is no support for ellipses which seems like a natural base class for `L.Circle` and `L.CircleMarker`.

This PR adds a new `L.Ellipse` class with a signature of `L.Ellipse(latlng, [radiusX, radiusY], options)`.

I wanted to throw this up and see if its a good candidate for inclusion in the Leaflet core or would be better as a plugin.
