### PR TITLE
Fix for #2010 (don't recreate DOM elements when updating popup content)

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -180,38 +180,37 @@ L.Popup = L.Class.extend({
 
 		if (typeof this._content === 'string') {
 			this._contentNode.innerHTML = this._content;
-			this._content = this._contentNode.childNodes;
 		} else {
+			var mustSaveContent = true;
 			if (this._contentNode.hasChildNodes()) {
-                if (this._content.length && this._content.length === this._contentNode.childNodes.length) {
-                    var isEqual = true;
-                    for (var i = 0; i < this._content.length; ++i) {
-                        if (this._content[i] !== this._contentNode.childNodes[i]) {
-                            isEqual = false;
-                            break;
-                        }
-                    }
-                    if (!isEqual) {
-                        while (this._contentNode.hasChildNodes()) {
-                            this._contentNode.removeChild(this._contentNode.firstChild);
-                        }
-                    }
-                }
-            }
-
-            if (this._content.length) {
-                if (!this._contentNode.hasChildNodes()) {
-                    while (this._content.length) {
-                        this._contentNode.appendChild(this._content[0]);
-                    }
-                }
-            } else {
-                while (this._contentNode.hasChildNodes()) {
-                    this._contentNode.removeChild(this._contentNode.firstChild);
-                }
-                this._contentNode.appendChild(this._content);
-            }
+				if ('length' in this._content && this._content.length === this._contentNode.childNodes.length) {
+					for (var i = 0; i < this._content.length; ++i) {
+						if (this._content[i] !== this._contentNode.childNodes[i]) {
+							mustSaveContent = false;
+							break;
+						}
+					}
+				} else {
+					mustSaveContent = false;
+				}
+			}
+			
+			if (!mustSaveContent) {
+				while (this._contentNode.hasChildNodes()) {
+					this._contentNode.removeChild(this._contentNode.firstChild);
+				}
+				
+				if ('length' in this._content) {
+					while (this._content.length) {
+						this._contentNode.appendChild(this._content[0]);
+					}
+				} else {
+					this._contentNode.appendChild(this._content);
+				}
+			}
 		}
+
+		this._content = this._contentNode.childNodes;
 		this.fire('contentupdate');
 	},
 


### PR DESCRIPTION
Fixed bug: Added support for templates with multiple roots at _updateContent method.
#2010
