### PR TITLE
implemented getRadius() in CircleMarker.  Fixed bug where getRadius() of...

### DIFF
--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -32,7 +32,11 @@ L.CircleMarker = L.Circle.extend({
 	setRadius: function (radius) {
 		this.options.radius = this._radius = radius;
 		return this.redraw();
-	}
+	},
+
+    getRadius: function () {
+        return this._radius;
+    }
 });
 
 L.circleMarker = function (latlng, options) {


### PR DESCRIPTION
... CircleMarker always returned undefined.

fix for issue #2016
