### PR TITLE
All layers added callback add to GEOJSON layers

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -25,6 +25,9 @@ L.GeoJSON = L.FeatureGroup.extend({
 				if (feature.geometries || feature.geometry || feature.features || feature.coordinates) {
 					this.addData(features[i]);
 				}
+				
+				if (i === len - 1 && typeof this.options.onComplete === 'function') this.options.onComplete(this._layers);
+				
 			}
 			return this;
 		}


### PR DESCRIPTION
Fires a callback once all the geojson has been added to the map and returns the layers. Is useful for manipulating the layers on load such as fading them in.

example:

var demo = new L.GeoJSON.AJAX(url, {
    pointToLayer: function(feature, latlng) {},
    onEachFeature: function(feature, layer) {},
    onComplete: function(layers){}
}).addTo(map);
