### PR TITLE
Don't bounce near zoom limits on touch zoom

### DIFF
--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -58,7 +58,8 @@ L.Map.TouchZoom = L.Handler.extend({
 		if (this._scale === 1) { return; }
 
 		if (!map.options.bounceAtZoomLimits) {
-			if ((map.getZoom() === map.getMinZoom() && this._scale < 1) || (map.getZoom() === map.getMaxZoom() && this._scale > 1)) { return; }
+			if ((map.getZoom() === map.getMinZoom() && this._scale < 1) ||
+			    (map.getZoom() === map.getMaxZoom() && this._scale > 1)) { return; }
 		}
 
 		if (!this._moved) {


### PR DESCRIPTION
Fixes #1864 by disabling scaling below minZoom and above maxZoom for touch zoom actions.
