### PR TITLE
Add holes support to L.Polygon.setLatLngs(). Fixes #1518

### DIFF
--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -24,6 +24,21 @@ describe('Polygon', function() {
 			var polygon = new L.Polygon([]);
 			expect(polygon.getLatLngs()).to.eql([]);
 		});
+        
+		it("can be initialized with holes", function () {
+			var originalLatLngs = [
+				[ //external rink
+					[0, 10], [10, 10], [10, 0]
+				], [ //hole
+					[2, 3], [2, 4], [3, 4]
+				]
+			];
+
+			var polygon = new L.Polygon(originalLatLngs);
+
+			//getLatLngs() returns only external ring
+			expect(polygon.getLatLngs()).to.eql([L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])]);
+		})
 	});
 
 	describe("#setLatLngs", function () {
@@ -40,6 +55,22 @@ describe('Polygon', function() {
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
 		});
+		
+		it("can be set external ring and holes", function() {
+			var latLngs = [
+				[ //external rink
+					[0, 10], [10, 10], [10, 0]
+				], [ //hole
+					[2, 3], [2, 4], [3, 4]
+				]
+			];
+
+			var polygon = new L.Polygon([]);
+			polygon.setLatLngs(latLngs);
+
+			//getLatLngs() returns only external ring
+			expect(polygon.getLatLngs()).to.eql([L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])]);
+		})
 	});
 
 	describe("#spliceLatLngs", function () {

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -8,10 +8,12 @@ L.Polygon = L.Polyline.extend({
 	},
 
 	initialize: function (latlngs, options) {
-		var i, len, hole;
-
 		L.Polyline.prototype.initialize.call(this, latlngs, options);
+		this._initWithHoles(latlngs);
+	},
 
+	_initWithHoles: function (latlngs) {
+		var i, len, hole;
 		if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
 			this._latlngs = this._convertLatLngs(latlngs[0]);
 			this._holes = latlngs.slice(1);
@@ -49,6 +51,15 @@ L.Polygon = L.Polyline.extend({
 			for (j = 0, len2 = this._holes[i].length; j < len2; j++) {
 				this._holePoints[i][j] = this._map.latLngToLayerPoint(this._holes[i][j]);
 			}
+		}
+	},
+
+	setLatLngs: function (latlngs) {
+		if (latlngs && L.Util.isArray(latlngs[0]) && (typeof latlngs[0][0] !== 'number')) {
+			this._initWithHoles(latlngs);
+			return this.redraw();
+		} else {
+			return L.Polyline.prototype.setLatLngs.call(this, latlngs);
 		}
 	},
 


### PR DESCRIPTION
I've added support of holes to `L.Polygon.setLalLngs()`.

But there are several more problems with holes in polygons:
- no public method to get holes (`getLatLngs()` returns only external ring)
- no functions to modify holes similar to `addLatLng()`, `spliceLatLngs()`, etc.
- no information about restrictions on holes: should they be strictly inside external ring, can they intersect, include each other, etc.
