### PR TITLE
Allow for ids to be set on DivIcons

### DIFF
--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -11,6 +11,7 @@ L.DivIcon = L.Icon.extend({
 		popupAnchor: (Point)
 		html: (String)
 		bgPos: (Point)
+		idName: (String)
 		*/
 		className: 'leaflet-div-icon',
 		html: false
@@ -32,6 +33,11 @@ L.DivIcon = L.Icon.extend({
 		}
 
 		this._setIconStyles(div, 'icon');
+
+		if (options.idName) {
+			div.id = options.idName;
+		}
+
 		return div;
 	},
 


### PR DESCRIPTION
Simply allow for ids as well as classnames to be set when DivIcons are created

References #1862

<!---
@huboard:{"order":32.375}
-->
