### PR TITLE
Fix click events when touch zooming on ie 10

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -78,7 +78,10 @@ L.Draggable = L.Class.extend({
 	},
 
 	_onMove: function (e) {
-		if (e.touches && e.touches.length > 1) { return; }
+		if (e.touches && e.touches.length > 1) {
+			this._moved = true;
+			return;
+		}
 
 		var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
 		    newPoint = new L.Point(first.clientX, first.clientY),


### PR DESCRIPTION
The drag click avoid hack is needed for touch zooms on ie10 also, when releasing your fingers after a touch zoom click events are generated. Fixes #2094

Not sure if this is the best solution, but it works.
