### PR TITLE
Work around iOS7 memory trouble

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -192,20 +192,25 @@ describe('Events', function() {
 
 		it('removes listeners with context == this and a stamp originally added without one', function () {
 			var obj = new Klass(),
+				obj2 = new Klass(),
 				spy1 = sinon.spy(),
-				spy2 = sinon.spy();
+				spy2 = sinon.spy(),
+				spy3 = sinon.spy();
 
 			obj.addEventListener('test', spy1, obj);
 			L.Util.stamp(obj);
 			obj.addEventListener('test', spy2, obj);
+			obj.addEventListener('test', spy3, obj2); // So that there is a contextId based listener, otherwise removeEventListener will do correct behaviour anyway
 
 			obj.removeEventListener('test', spy1, obj);
 			obj.removeEventListener('test', spy2, obj);
+			obj.removeEventListener('test', spy3, obj2);
 
 			obj.fireEvent('test');
 
 			expect(spy1.called).to.be(false);
 			expect(spy2.called).to.be(false);
+			expect(spy3.called).to.be(false);
 		});
 
 		it('doesnt lose track of listeners when removing non existent ones', function () {

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -74,7 +74,7 @@ L.Mixin.Events = {
 		if (L.Util.invokeEach(types, this.removeEventListener, this, fn, context)) { return this; }
 
 		var events = this[eventsKey],
-		    contextId = context && L.stamp(context),
+		    contextId = context && context !== this && L.stamp(context),
 		    i, len, type, listeners, j, indexKey, indexLenKey, typeIndex, removed;
 
 		types = L.Util.splitWords(types);
@@ -93,7 +93,7 @@ L.Mixin.Events = {
 				delete events[indexLenKey];
 
 			} else {
-				listeners = context && typeIndex ? typeIndex[contextId] : events[type];
+				listeners = contextId && typeIndex ? typeIndex[contextId] : events[type];
 
 				if (listeners) {
 					for (j = listeners.length - 1; j >= 0; j--) {


### PR DESCRIPTION
Don't apply the contextId performance optimization when context==this. The optimization does nothing in this case anyway AFAIK.
Most of our event adders appear to have context==this according to testing.

Fixes #2122
