### PR TITLE
Fix grammar related to the word "milliseconds"

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -350,7 +350,7 @@ var map = L.map('map', {
 		<td><code><b>inertiaThreshold</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>depends</code></td>
-		<td>Amount of milliseconds that should pass between stopping the movement and releasing the mouse or touch to prevent inertial movement. <code><span class="number">32</span></code> for touch devices and <code><span class="number">14</span></code> for the rest by default.</td>
+		<td>Number of milliseconds that should pass between stopping the movement and releasing the mouse or touch to prevent inertial movement. <code><span class="number">32</span></code> for touch devices and <code><span class="number">14</span></code> for the rest by default.</td>
 	</tr>
 </table>
 
@@ -1020,7 +1020,7 @@ var map = L.map('map', {
 		<td><code><b>timeout</b></code></td>
 		<td><code>Number</code></td>
 		<td><code><span class="number">10000</span></code></td>
-		<td>Number of millisecond to wait for a response from geolocation before firing a <code>locationerror</code> event.</td>
+		<td>Number of milliseconds to wait for a response from geolocation before firing a <code>locationerror</code> event.</td>
 	</tr>
 	<tr>
 		<td><code><b>maximumAge</b></code></td>


### PR DESCRIPTION
This pull request is parallel to #2175. Not sure if it's necessary but sending it anyway in case it is.
