### PR TITLE
handle any existing tilelayers when adding attribution control

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -18,6 +18,12 @@ L.Control.Attribution = L.Control.extend({
 		this._container = L.DomUtil.create('div', 'leaflet-control-attribution');
 		L.DomEvent.disableClickPropagation(this._container);
 
+		for (var i in map._layers) {
+			if (map._layers[i].getAttribution) {
+				this.addAttribution(map._layers[i].getAttribution());
+			}
+		}
+		
 		map
 		    .on('layeradd', this._onLayerAdd, this)
 		    .on('layerremove', this._onLayerRemove, this);


### PR DESCRIPTION
Handling the case of existing layers being included in attribution control when not at map init.

Fixes #2177
