### PR TITLE
Don't delay moveend event on invalidateSize

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -288,7 +288,14 @@ L.Map = L.Class.extend({
 				this._rawPanBy(offset);
 			}
 
-			this.fire('move').fire('moveend');
+			this.fire('move');
+
+			if (options.debounceMoveend) {
+				clearTimeout(this._sizeTimer);
+				this._sizeTimer = setTimeout(L.bind(this.fire, this, 'moveend'), 200);
+			} else {
+				this.fire('moveend');
+			}
 		}
 
 		return this.fire('resize', {
@@ -685,7 +692,7 @@ L.Map = L.Class.extend({
 	_onResize: function () {
 		L.Util.cancelAnimFrame(this._resizeRequest);
 		this._resizeRequest = L.Util.requestAnimFrame(
-		        this.invalidateSize, this, false, this._container);
+		        function () { this.invalidateSize({debounceMoveend: true}); }, this, false, this._container);
 	},
 
 	_onMouseClick: function (e) {


### PR DESCRIPTION
This causes unnecessary nondeterminism in the sequence of events emitted. Instead, the caller should be responsible for throttling, as e.g. Map#_onResize does.

@mourner Does this make sense? The setTimeout is causing a problem for OSM.org -- sometimes the moveend triggers stuff 200ms later that should have happened synchronously with invalidateSize.
