### PR TITLE
Choose zoom window based on device. 

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -19,7 +19,6 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 	},
 
 	_onWheelScroll: function (e) {
-		console.log("SCROLL");
 		var delta = L.DomEvent.getWheelDelta(e);
 
 		this._delta += delta;


### PR DESCRIPTION
Tested on Chrome, Firefox, Safari and IE 10. Seems to be a nice balance between responsiveness and smooth zooming.
