### PR TITLE
Fix build script on windows.

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -17,7 +17,7 @@ var build = require('./build/build.js');
 function hint(msg, paths) {
 	return function () {
 		console.log(msg);
-		jake.exec('./node_modules/jshint/bin/jshint -c ' + paths,
+		jake.exec('node node_modules/jshint/bin/jshint -c ' + paths,
 				{printStdout: true}, function () {
 			console.log('\tCheck passed.\n');
 			complete();


### PR DESCRIPTION
The build and trace output is useless, but here it is anyway:

```
>jake --trace
Checking for JS errors...
jake aborted.
Error: '.' is not recognized as an internal or external command,
operable program or batch file.
    at api.fail (C:\Users\dave\AppData\Roaming\npm\node_modules\jake\lib\api.js:326:18)
    at null.<anonymous> (C:\Users\dave\AppData\Roaming\npm\node_modules\jake\lib\utils\index.js:134:9)
    at EventEmitter.emit (events.js:98:17)
    at ChildProcess.<anonymous> (C:\Users\dave\AppData\Roaming\npm\node_modules\jake\lib\utils\index.js:210:20)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:789:12)
```
