### PR TITLE
Give L.CircleMarker.setLatLng a return statement.

### DIFF
--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -27,6 +27,7 @@ L.CircleMarker = L.Circle.extend({
 		if (this._popup && this._popup._isOpen) {
 			this._popup.setLatLng(latlng);
 		}
+		return this;
 	},
 
 	setRadius: function (radius) {


### PR DESCRIPTION
Ever since e5bf57c4f78e4843c7268c2585104a88e52ac700, `L.CircleMarker.setLatLng` has not had a return statement. The API says it's supposed to return `this`. This branch resolves this issue.

This should be backpatched to v0.7 as a hotfix if possible. The issue does not exist in any release prior to v0.7.
