### PR TITLE
Add FeatureCollection to GeoJSON parse

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -122,7 +122,20 @@ L.extend(L.GeoJSON, {
 				}, pointToLayer, coordsToLatLng, vectorOptions));
 			}
 			return new L.FeatureGroup(layers);
+		
+		case 'FeatureCollection':
+			for (i = 0, len = geometry.features.length; i < len; i++) {
 
+				layer = this.geometryToLayer({
+					geometry: geometry.features[i].geometry,
+					type: 'Feature',
+					properties: geometry.features[i].properties
+				}, pointToLayer, coordsToLatLng);
+
+				layers.push(layer);
+			}
+			return new L.FeatureGroup(layers);
+			
 		default:
 			throw new Error('Invalid GeoJSON object.');
 		}


### PR DESCRIPTION
FeatureCollections are a valid part of the spec http://www.geojson.org/geojson-spec.html#examples

This parses them correctly into layers
