### PR TITLE
Add new maxBoundsResistance option

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -130,6 +130,12 @@ L.Map = L.Class.extend({
 		bounds = L.latLngBounds(bounds);
 
 		this.options.maxBounds = bounds;
+		if (this.options.maxBoundsResistance > 1.0) {
+			this.options.maxBoundsResistance = 1.0;
+		}
+		if (this.options.maxBoundsResistance < 0.0) {
+			this.options.maxBoundsResistance = 0.0;
+		}
 
 		if (!bounds) {
 			return this.off('moveend', this._panInsideMaxBounds, this);


### PR DESCRIPTION
Obey maxBounds during dragging a map.

New option "maxBoundsResistance" (0.0 - 1.0) controls its behavior;
0.0: Classic (No effect during dragging)
0.8: Modern reaction
1.0: Strictly forbid to beyond the maxBounds

<!---
@huboard:{"order":3.5}
-->
