### PR TITLE
Focus should be set back to the marker upon closing the popup

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -298,7 +298,9 @@ L.Popup = L.Class.extend({
 
 	_onCloseButtonClick: function (e) {
 		this._close();
-		this._source._icon.focus();
+		if (this._source._icon) {
+			this._source._icon.focus();
+		}
 		L.DomEvent.stop(e);
 	}
 });


### PR DESCRIPTION
So keyboard users can continue tabbing through the markers. Without this, they must tab through everything all over again if they decide to close the popup. Extension of Issue #2199
