### PR TITLE
Avoid re-using CRS.scale in CRS.getSize, since scale might be overridden

### DIFF
--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -26,7 +26,7 @@ L.CRS = {
 	},
 
 	getSize: function (zoom) {
-		var s = this.scale(zoom);
+		var s = 256 * Math.pow(2, zoom);
 		return L.point(s, s);
 	}
 };


### PR DESCRIPTION
In the general case, the relation between scale and size is not as simple as for spherical Mercator. This makes it unfortunate to reuse the `scale` the calculate the value for `getSize`. CRS implementations created for older versions of Leaflet might override `scale`, unintentionally making `getSize` return undesirable values. This might cause regressions in a few cases, like #2231.

This PR copies the calculation from scale to getSize, and avoids trying to be smart by reusing the formula, and more closely replicating the behaviour of Leaflet before 0.7. This should fix problems where a custom CRS has been implemented and combined with using a TileLayer with the tms option enabled.
