### PR TITLE
Use event.target as a default for event.layer

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -85,10 +85,10 @@ L.FeatureGroup = L.LayerGroup.extend({
 	},
 
 	_propagateEvent: function (e) {
-		e = L.extend({}, e, {
+		e = L.extend({
 			layer: e.target,
 			target: this
-		});
+		}, e);
 		this.fire(e.type, e);
 	}
 });


### PR DESCRIPTION
In 2464d13, event.layer is overwritten to equal event.target. This commit uses event.target as a default for event.layer. Closes #2252
