### PR TITLE
[FIXED] bug on IE10: "Unable to get property of '0' of undefined or null...

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -108,7 +108,7 @@ L.Map.Drag = L.Handler.extend({
 		    options = map.options,
 		    delay = +new Date() - this._lastTime,
 
-		    noInertia = !options.inertia || delay > options.inertiaThreshold || !this._positions[0];
+		    noInertia = !options.inertia || delay > options.inertiaThreshold || !this._positions || !this._positions[0];
 
 		map.fire('dragend', e);
 


### PR DESCRIPTION
... reference
I notice that on a Windows 8.0 Pro tablet, using IE10 I get a javascript error while trying to access this._position[0]
The error is caused by the fact that the _position attribute does not exist.
