### PR TITLE
A transitionEnd event only finishes a zoom animation if it is for a transform

### DIFF
--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -24,8 +24,8 @@ if (L.DomUtil.TRANSITION) {
 
 L.Map.include(!L.DomUtil.TRANSITION ? {} : {
 
-	_catchTransitionEnd: function () {
-		if (this._animatingZoom) {
+	_catchTransitionEnd: function (e) {
+		if (this._animatingZoom && e.propertyName.indexOf('transform') >= 0) {
 			this._onZoomTransitionEnd();
 		}
 	},


### PR DESCRIPTION
We get opacity transitionEnd events for fading tiles in, these can prematurely end a zoom animation which will then leave us at a non-integer zoom. Fixes #2255

Using indexOf as it can be 'transform' or '-webkit-transform' (and probably more)
