### PR TITLE
fix regression from #2250 (map.getSize)

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -73,7 +73,7 @@ L.Map = L.Class.extend({
 
 	setZoomAround: function (latlng, zoom, options) {
 		var scale = this.getZoomScale(zoom),
-		    viewHalf = this.getSize().divideBy(2),
+		    viewHalf = this.getSize(true).divideBy(2),
 		    containerPoint = latlng instanceof L.Point ? latlng : this.latLngToContainerPoint(latlng),
 
 		    centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
@@ -154,10 +154,9 @@ L.Map = L.Class.extend({
 		}, options === true ? {animate: true} : options);
 
 		var oldSize = this.getSize();
-		this._sizeChanged = true;
 		this._initialCenter = null;
 
-		var newSize = this.getSize(),
+		var newSize = this.getSize(true),
 		    oldCenter = oldSize.divideBy(2).round(),
 		    newCenter = newSize.divideBy(2).round(),
 		    offset = oldCenter.subtract(newCenter);
@@ -267,7 +266,7 @@ L.Map = L.Class.extend({
 
 		var zoom = this.getMinZoom() - (inside ? 1 : 0),
 		    maxZoom = this.getMaxZoom(),
-		    size = this.getSize(),
+		    size = this.getSize(true),
 
 		    nw = bounds.getNorthWest(),
 		    se = bounds.getSouthEast(),
@@ -291,13 +290,11 @@ L.Map = L.Class.extend({
 		return inside ? zoom : zoom - 1;
 	},
 
-	getSize: function () {
-		if (!this._size || this._sizeChanged) {
+	getSize: function (refresh) {
+		if (!this._size || refresh) {
 			this._size = new L.Point(
 				this._container.clientWidth,
 				this._container.clientHeight);
-
-			this._sizeChanged = false;
 		}
 		return this._size.clone();
 	},


### PR DESCRIPTION
With #2250 I have unknowingly broken a chain of `invalidateSize(); fitBounds()` calls when map is not loaded, but the container was resized in meantime. It is a complex use-case, involving `getSize()` calls when map is not yet loaded, and using `fitBounds()` for initialization, instead of `setView()`. See [this jsfiddle](http://jsfiddle.net/uA7Pe/1/) (by uncommenting ).

This PR removes `map._sizeChanged` property, since it is basically a parameter to `getSize()` method, and adds `refresh` parameter to `setSize()`. Methods that can call `setView()` (including `fitBounds()`) now call `getSize(true)`, so they always use current values for container size.

I hope this can be merged in *stable* for 0.7.2 release. 

<!---
@huboard:{"order":1.75}
-->
