### PR TITLE
add {r} format to url, which returns @2x when retina detected and enabled

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -63,7 +63,7 @@ L.TileLayer = L.GridLayer.extend({
 
 	getTileUrl: function (coords) {
 		return L.Util.template(this._url, L.extend({
-			r: this.options.detectRetina && L.Browser.retina && this.options.maxZoom > 0 ? '' : '@2x',
+			r: this.options.detectRetina && L.Browser.retina && this.options.maxZoom > 0 ? '@2x' : '',
 			s: this._getSubdomain(coords),
 			x: coords.x,
 			y: this.options.tms ? this._tileNumBounds.max.y - coords.y : coords.y,


### PR DESCRIPTION
you can use {r} in tileLayer url, to serve different tiles (2x ones) for retina screens, cause the current detectRetina implementation makes the labels in tiles too small
