### PR TITLE
latLng capitalization compatibility layer

### DIFF
--- a/debug/tests/rtl.html
+++ b/debug/tests/rtl.html
@@ -35,7 +35,7 @@
 				.addLayer(cloudmade);
 
 		map.on('click', function(e) {
-			L.popup().setLatLng(e.latlng).setContent('Hello').openOn(map);
+			L.popup().setLatLng(e.latLng).setContent('Hello').openOn(map);
 		});
 	</script>
 </body>

--- a/debug/tests/rtl2.html
+++ b/debug/tests/rtl2.html
@@ -19,7 +19,7 @@
   var map = L.map('map').setView([51.505, -0.09], 13);
   L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 map.on('click', function(e) {
-    L.popup().setLatLng(e.latlng).setContent('Hello').openOn(map);
+    L.popup().setLatLng(e.latLng).setContent('Hello').openOn(map);
 });
 
 </script>

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -58,7 +58,10 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		marker._latlng = latlng;
 
 		marker
-		    .fire('move', {latlng: latlng})
+		    .fire('move', {
+			    latLng: latlng,
+			    latlng: latlng
+		    })
 		    .fire('drag');
 	},
 

--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -84,6 +84,6 @@ L.Marker.include({
 	},
 
 	_movePopup: function (e) {
-		this._popup.setLatLng(e.latlng);
+		this._popup.setLatLng(e.latLng);
 	}
 });

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -59,7 +59,10 @@ L.Marker = L.Layer.extend({
 
 		this.update();
 
-		return this.fire('move', {latlng: this._latlng});
+		return this.fire('move', {
+			latLng: this._latlng,
+			latlng: this._latlng
+		});
 	},
 
 	setZIndexOffset: function (offset) {
@@ -239,6 +242,7 @@ L.Marker = L.Layer.extend({
 
 		this.fire(e.type, {
 			originalEvent: e,
+			latLng: this._latlng,
 			latlng: this._latlng
 		});
 	},
@@ -247,6 +251,7 @@ L.Marker = L.Layer.extend({
 		if (e.keyCode === 13) {
 			this.fire('click', {
 				originalEvent: e,
+				latLng: this._latlng,
 				latlng: this._latlng
 			});
 		}
@@ -256,6 +261,7 @@ L.Marker = L.Layer.extend({
 
 		this.fire(e.type, {
 			originalEvent: e,
+			latLng: this._latlng,
 			latlng: this._latlng
 		});
 

--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -148,6 +148,7 @@ L.Path = L.Path.extend({
 		    latlng = map.layerPointToLatLng(layerPoint);
 
 		this.fire(e.type, {
+			latLng: latlng,
 			latlng: latlng,
 			layerPoint: layerPoint,
 			containerPoint: containerPoint,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -577,6 +577,7 @@ L.Map = L.Class.extend({
 		    latlng = this.layerPointToLatLng(layerPoint);
 
 		this.fire(type, {
+			latLng: latlng,
 			latlng: latlng,
 			layerPoint: layerPoint,
 			containerPoint: containerPoint,

--- a/src/map/ext/Map.Geolocation.js
+++ b/src/map/ext/Map.Geolocation.js
@@ -82,6 +82,7 @@ L.Map.include({
 		}
 
 		var data = {
+			latLng: latlng,
 			latlng: latlng,
 			bounds: bounds,
 			timestamp: pos.timestamp


### PR DESCRIPTION
One possible solution for issue #1423

Removal of `latlng` can be done at a later time I guess, as breaking changes (1.0?)

<!---
@huboard:{"order":4.375}
-->
