### PR TITLE
Fix a typo in the plugins page

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -871,7 +871,7 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/bbecquet/Leaflet.MagnifyingGlass">leaflet-zoom-min</a>
+			<a href="https://github.com/bbecquet/Leaflet.MagnifyingGlass">Leaflet.MagnifyingGlass</a>
 		</td><td>
 			Allows you to display a small portion of the map at another zoom level, either at a fixed position or linked to the mouse movement, for a magnifying glass effect.
 		</td><td>


### PR DESCRIPTION
When Leaflet.MagnifyingGlass was added, the previous line was copy-pasted but the title wasn't changed. Fixed it to show the correct name on the new link.
