### PR TITLE
Use _getTileSize() instead of using options.tileSize directly

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -473,7 +473,7 @@ L.TileLayer = L.Class.extend({
 	_getWrapTileNum: function () {
 		var crs = this._map.options.crs,
 		    size = crs.getSize(this._map.getZoom());
-		return size.divideBy(this.options.tileSize);
+		return size.divideBy(this._getTileSize());
 	},
 
 	_adjustTilePoint: function (tilePoint) {


### PR DESCRIPTION
Should fix #2314.
