### PR TITLE
Image placeholder appears on map if tile load error

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -422,9 +422,8 @@ L.GridLayer = L.Layer.extend({
 			});
 		} else {
 			L.DomUtil.addClass(tile, 'leaflet-tile-loaded');
+			this.fire('tileload', {tile: tile});
 		}
-
-		this.fire('tileload', {tile: tile});
 
 		this._tilesToLoad--;
 


### PR DESCRIPTION
'leaflet-tile-loaded' class was being applied even if a tile failed to load (404 error).  This would cause an image placeholder to appear on the map.

Here is an example:
![image](https://f.cloud.github.com/assets/2304500/1842716/6df771f4-74c1-11e3-830c-68a0e03f876c.png)

I fixed this by only adding the class if no error.
