### PR TITLE
Add an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[**.{json}]
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[**.{js,css,html,md}]
+indent_size = 4
+indent_style = tab
+insert_final_newline = true


### PR DESCRIPTION
From http://editorconfig.org/:
"EditorConfig helps developers define and maintain consistent coding
styles between different editors and IDEs. The EditorConfig project
consists of a file format for defining coding styles and a collection of
text editor plugins that enable editors to read the file format and
adhere to defined styles."

I tried my best to derive the specific settings from the Leaflet source
code.
I'm a bit unsure whether Leaflet uses lf or crlf though, there seems to
be a bit of both. :)
