### PR TITLE
Add coordinates to all tile events of L.GridLayer

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -67,4 +67,38 @@ describe('GridLayer', function () {
 			'656:300': [0, 1]
 		});
 	});
+
+	it('fires tile events', function (done) {
+		var map = L.map(div).setView([0, 0], 10),
+		    grid = L.gridLayer(),
+		    loadingSpy = sinon.spy(),
+		    loadSpy = sinon.spy(),
+		    unloadSpy = sinon.spy();
+
+		grid.on({
+		    tileloadstart: loadingSpy,
+		    tileload: loadSpy,
+		    tileunload: unloadSpy
+		});
+
+		grid.createTile = function (coords) {
+			return document.createElement('div');
+		};
+
+		map.addLayer(grid);
+
+		setTimeout(function () {
+			expect(loadingSpy.callCount).to.be.equal(16);
+			expect(loadSpy.callCount).to.be.equal(16);
+			expect(loadSpy.lastCall.args[0].coords.z).to.be.equal(10);
+
+			map.setZoom(9);
+			setTimeout(function () {
+				expect(unloadSpy.callCount).to.be.equal(16);
+				expect(unloadSpy.lastCall.args[0].coords.z).to.be.equal(10);
+				done();
+			});
+		}, 0);
+		
+	});
 });


### PR DESCRIPTION
Add parameter `coords` to the following events of `L.GridLayer`: `tileloadstart`, `tileload`, `tileunload`.

It was disscussed in #2247 and #1526.

I've changed format of `L.GridLayer._tiles` key form `x:y` to `x:y:z`. I hope it doesn't break any plugins...

BTW, layer event is called `loading`, but corresponding tile event - `tileloadstart` (not `tileloading`).
