### PR TITLE
L.LatLngBounds.extend optimization

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -38,6 +38,10 @@ describe('LatLngBounds', function () {
 			a.extend({lat: 20, lng: 50});
 			expect(a.getNorthEast()).to.eql(new L.LatLng(30, 50));
 		});
+
+		it('extend the bounds by an empty bounds object', function () {
+			expect(a.extend(new L.LatLngBounds())).to.eql(a);
+		});
 	});
 
 	describe('#getCenter', function () {

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -25,6 +25,10 @@ L.LatLngBounds.prototype = {
 		} else if (obj instanceof L.LatLngBounds) {
 			newSouthWest = obj._southWest;
 			newNorthEast = obj._northEast;
+
+			if (!newSouthWest || !newNorthEast) {
+				return this;
+			}
 		} else if (obj) {
 			var latLng = L.latLng(obj);
 			if (latLng !== null) {


### PR DESCRIPTION
Hello

I'm working on a KD-Tree MarkerCluster and the analysis of performances showed that L.LatLngBounds.extend 
was the second most costly operation. So I optimized it, and… the code is less beautiful :(

Anyway, you have this pull-request.

And this is the result, the pull request contains the orange version : (Other is Internet Explorer 11)
![2014-01-15 11_21_07-test latlngbounds jsperf](https://f.cloud.github.com/assets/45740/1919285/4fb36090-7dd1-11e3-838f-75800847e019.png) [JSPerfs](http://jsperf.com/test-latlngbounds)
