### PR TITLE
Remove v2 from CDN src

### DIFF
--- a/download.md
+++ b/download.md
@@ -35,7 +35,7 @@ The latest stable Leaflet release is hosted on a CDN &mdash; to start using
 it straight away, place this in the `head` of your HTML code:
 
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js?2"></script>
+    <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
 
 ### Leaflet Source Code
 


### PR DESCRIPTION
I think this is an unnecessary leftover from issues with 0.7.1 required a rebuild on the CDN.
