### PR TITLE
change unload order

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -205,9 +205,6 @@ L.Map = L.Evented.extend({
 	},
 
 	remove: function () {
-		if (this._loaded) {
-			this.fire('unload');
-		}
 
 		this._initEvents('off');
 
@@ -225,6 +222,10 @@ L.Map = L.Evented.extend({
 		}
 
 		this._clearHandlers();
+		
+		if (this._loaded) {
+			this.fire('unload');
+		}
 
 		return this;
 	},


### PR DESCRIPTION
After calling _map.remove()_ I tried to initialise a new map on the same DOM element  , after _map.on('unload')_, and came up against **''Uncaught Error: Map container is already initialized."**

I found that by firing 'unload' at the end of _remove()_ I can achieve this.
