### PR TITLE
Add oldLatlng parameter to Marker move event

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -91,4 +91,27 @@ describe("Marker", function () {
 			expect(marker._shadow.parentNode).to.be(map._panes.shadowPane);
 		});
 	});
+
+	describe("#setLatLng", function () {
+		it("fires a move event", function () {
+
+			var marker = new L.Marker([0, 0], { icon: icon1 });
+			map.addLayer(marker);
+
+			var beforeLatLng = marker._latlng;
+			var afterLatLng = new L.LatLng(1, 2);
+
+			var eventArgs = null;
+			marker.on('move', function (e) {
+				eventArgs = e;
+			});
+
+			marker.setLatLng(afterLatLng);
+
+			expect(eventArgs).to.not.be(null);
+			expect(eventArgs.oldLatlng).to.be(beforeLatLng);
+			expect(eventArgs.latlng).to.be(afterLatLng);
+			expect(marker.getLatLng()).to.be(afterLatLng);
+		});
+	});
 });

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -55,9 +55,10 @@ L.Marker = L.Layer.extend({
 	},
 
 	setLatLng: function (latlng) {
+		var oldLatlng = this._latlng;
 		this._latlng = L.latLng(latlng);
 		this.update();
-		return this.fire('move', {latlng: this._latlng});
+		return this.fire('move', { oldLatlng: oldLatlng, latlng: this._latlng });
 	},
 
 	setZIndexOffset: function (offset) {


### PR DESCRIPTION
Will allow MarkerCluster to support moving markers.

Refs Leaflet/Leaflet.markercluster#57

Not sure about the capitalization. We have a 'latlng' parameter, so I matched that.
