### PR TITLE
IE8 fixes.

### DIFF
--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -23,6 +23,9 @@ L.SVG.include(!L.Browser.vml ? {} : {
 
 	_initContainer: function () {
 		this._container = L.DomUtil.create('div', 'leaflet-vml-container');
+
+		this._paths = {};
+		this._initEvents();
 	},
 
 	_update: function () {
@@ -40,19 +43,19 @@ L.SVG.include(!L.Browser.vml ? {} : {
 		layer._path = L.SVG.create('path');
 		container.appendChild(layer._path);
 
-		if (layer.options.clickable) {
-			this._initEvents(layer, container);
-		}
-
 		this._updateStyle(layer);
 	},
 
 	_addPath: function (layer) {
-		this._container.appendChild(layer._container);
+		var container = layer._container;
+		this._container.appendChild(container);
+		this._paths[L.stamp(container)] = layer;
 	},
 
 	_removePath: function (layer) {
-		L.DomUtil.remove(layer._container);
+		var container = layer._container;
+		L.DomUtil.remove(container);
+		delete this._paths[L.stamp(container)];
 	},
 
 	_updateStyle: function (layer) {

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -147,7 +147,7 @@ L.SVG = L.Renderer.extend({
 	},
 
 	_fireMouseEvent: function (e) {
-		this._paths[L.stamp(e.target)]._fireMouseEvent(e);
+		this._paths[L.stamp(e.target || e.srcElement)]._fireMouseEvent(e);
 	}
 });
 


### PR DESCRIPTION
Events on VML elements actually work :)

The code is a bit copy/paste from SVG.js, but I wasn't sure the best way to do this.
If we renamed _path to _container and the existing _container to something else we could reuse the addPath/removePath functions from SVG, it'd be a bit weird inside the VML class however.

(Broken by the vector refactor)
