### PR TITLE
Indicate primary CSS file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "karma-coverage": "~0.1.5"
   },
   "main": "dist/leaflet-src.js",
+  "style": "dist/leaflet.css",
   "scripts": {
     "test": "jake test",
     "prepublish": "jake build"


### PR DESCRIPTION
Many modules in npm are starting to expose their css entry files in their package.json files. This allows tools like `npm-css`, `rework-npm`, and `npm-less` to import a module's styles from the node_modules directory. Bootstrap is [in the process](https://github.com/twbs/bootstrap/pull/12441) of adopting this standard as well.
