### PR TITLE
added bounds option to TileLayer

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1923,6 +1923,12 @@ var map = L.map('map', {
 		<td><code><span class="literal">false</span></code></td>
 		<td>If <code><span class="literal">true</span></code>, all the tiles that are not visible after panning are placed in a reuse queue from which they will be fetched when new tiles become visible (as opposed to dynamically creating new ones). This will in theory keep memory usage low and eliminate the need for reserving new memory whenever a new tile is needed.</td>
 	</tr>
+	<tr>
+		<td><code><b>bounds</b></code></td>
+		<td><code><a href="#latlngbounds">LatLngBounds</a></code></td>
+		<td><code><span class="literal">null</span></code></td>
+		<td>When this option is set, the TileLayer only loads tiles that are in the given geographical bounds.</td>
+	</tr>
 </table>
 
 <h3>Events</h3>


### PR DESCRIPTION
The bounds option of the TileLayer class (or rather the GridLayer class) was not part of the documentation.
