### PR TITLE
don't capture keydowns if modifier key is active

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -125,6 +125,8 @@ L.Map.Keyboard = L.Handler.extend({
 	},
 
 	_onKeyDown: function (e) {
+		if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) { return; }
+
 		var key = e.keyCode,
 		    map = this._map;
 


### PR DESCRIPTION
If a modifier key is active while a keyboard event is about to get captured...bypass it.

References #2368
