### PR TITLE
Fixed typo in bounds retrieval.

### DIFF
--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -38,7 +38,7 @@ L.CRS = {
 	getProjectedBounds: function (zoom) {
 		if (this.infinite) { return null; }
 
-		var b = this.projection.bounds,
+		var b = this.options.bounds,
 		    s = this.scale(zoom),
 		    min = this.transformation.transform(b.min, s),
 		    max = this.transformation.transform(b.max, s);


### PR DESCRIPTION
Wrong bounds retrieval ends up with `Uncaught TypeError: Cannot read property 'min' of undefined`.
