### PR TITLE
Move _containsPoint method to CircleMarker for canvas renderer

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -287,6 +287,6 @@ L.Polygon.prototype._containsPoint = function (p) {
 	return inside || L.Polyline.prototype._containsPoint.call(this, p, true);
 };
 
-L.Circle.prototype._containsPoint = function (p) {
+L.CircleMarker.prototype._containsPoint = function (p) {
 	return p.distanceTo(this._point) <= this._radius + this._clickTolerance();
 };


### PR DESCRIPTION
CircleMarker is the parent of Circle as of 508a75f7a836a0a5bd1e9472cb09434183046860 and should have _containsPoint instead.
Fixes no method '_containsPoint' error when hovering on a map with a CircleMarker.
