### PR TITLE
Call layer's _update like SVG renderer does, fixes #2476

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -64,6 +64,7 @@ L.Canvas = L.Renderer.extend({
 		this._redrawBounds = layer._pxBounds;
 		this._draw(true);
 		layer._project();
+		layer._update();
 		this._draw();
 		this._redrawBounds = null;
 	},


### PR DESCRIPTION
The SVG renderer calls the layer's `_update` method in `_updatePath`, but then canvas renderer does not. This causes, among other things, `L.Polyline.addLatLng` to not have any visible effect until a call to `_updatePath` is forced for some other reason.
