### PR TITLE
Enforce maxZoom before applying paddingOffset in Map.fitBounds, fixes #2489

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -93,7 +93,7 @@ L.Map = L.Evented.extend({
 
 		    zoom = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR));
 
-		zoom = (options.maxZoom) ? Math.min(options.maxZoom, zoom) : zoom;
+		zoom = options.maxZoom ? Math.min(options.maxZoom, zoom) : zoom;
 
 		var paddingOffset = paddingBR.subtract(paddingTL).divideBy(2),
 


### PR DESCRIPTION
I have been having the same problem. It seems like it was happening because the center point is being calculated before enforcing the maxZoom. It breaks in cases where the calculated zoom for the bounds is larger than maxZoom. This fixed it for me.
