### PR TITLE
Use proper minus sign (U+2212)

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -7,7 +7,7 @@ L.Control.Zoom = L.Control.extend({
 		position: 'topleft',
 		zoomInText: '+',
 		zoomInTitle: 'Zoom in',
-		zoomOutText: '-',
+		zoomOutText: '−',
 		zoomOutTitle: 'Zoom out'
 	},
 


### PR DESCRIPTION
Using minus instead of a dash is better because it's usually of the same size as plus, so the buttons look symmetric.
