### PR TITLE
Fix for touch-sensitive browsers detecting drag on tap

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -79,7 +79,7 @@ L.Draggable = L.Evented.extend({
 		    offset = newPoint.subtract(this._startPoint);
 
 		if (!offset.x && !offset.y) { return; }
-		if(L.Browser.touch && Math.abs(offset.x) + Math.abs(offset.y) < 3) { return; }
+		if (L.Browser.touch && Math.abs(offset.x) + Math.abs(offset.y) < 3) { return; }
 
 		L.DomEvent.preventDefault(e);
 


### PR DESCRIPTION
Chrome 33 on Android seems to very commonly detect a 1 pixel drag movement during a standard touch tap, when no drag was intended, making it extremely difficult to tap on markers. This fix prevents a drag from beginning until the X and Y drag offset is at least 3 pixels in total.
