### PR TITLE
Add alt to tiles for accessibility reasons

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -58,7 +58,7 @@ L.TileLayer = L.GridLayer.extend({
 
 		/*
 		 Alt tag is set to empty string to keep screen readers from reading URL and for compliance reasons
-		 http://warc.calpoly.edu/accessibility/508indepth/alternate.html
+		 http://www.w3.org/TR/WCAG20-TECHS/H67
 		*/
 		tile.alt = '';
 


### PR DESCRIPTION
This adds alt tags to image tiles as they are created.  This prevents screen readers from reading the URLs for said tiles, creating confusion for users. 

As map tiles are not able to provide meaning to screen readers, their alt should default to null, so that this behavior is not experienced by users.

I've had multiple accessibility teams request this be done on pages containing map data, and figured I'd see if everyone would be interested in having the change so that I can stop supporting it separately!

Reason: http://www.w3.org/TR/WCAG20-TECHS/H67
