### PR TITLE
Add missing capital L to coordsToLatLng(s)

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -3402,7 +3402,7 @@ map.fitBounds(bounds);</code></pre>
 		<td>Creates a layer from a given GeoJSON feature.</td>
 	</tr>
 	<tr>
-		<td><code><b>coordsToLatlng</b>(
+		<td><code><b>coordsToLatLng</b>(
 			<nobr>&lt;Array&gt; <i>coords</i></nobr>,
 			<nobr>&lt;Boolean&gt; <i>reverse?</i> )</nobr>
 		</code></td>
@@ -3411,7 +3411,7 @@ map.fitBounds(bounds);</code></pre>
 		<td>Creates a LatLng object from an array of 2 numbers (latitude, longitude) used in GeoJSON for points. If <code>reverse</code> is set to <code><span class="literal">true</span></code>, the numbers will be interpreted as (longitude, latitude).</td>
 	</tr>
 	<tr>
-		<td><code><b>coordsToLatlngs</b>(
+		<td><code><b>coordsToLatLngs</b>(
 			<nobr>&lt;Array&gt; <i>coords</i></nobr>,
 			<nobr>&lt;Number&gt; <i>levelsDeep?</i></nobr>,
 			<nobr>&lt;Boolean&gt; <i>reverse?</i> )</nobr>


### PR DESCRIPTION
Add the missing capital L for following functions documentation:
- L.GeoJSON.coordsToLatLng()
- L.GeoJSON.coordsToLatLngs()
