### PR TITLE
Retina support for TileLayer.WMS

### DIFF
--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -29,6 +29,10 @@ L.TileLayer.WMS = L.TileLayer.extend({
 
 		options = L.setOptions(this, options);
 
+		if (options.detectRetina) {
+			this._initRetina();
+		}
+
 		wmsParams.width = wmsParams.height =
 				options.tileSize * (options.detectRetina && L.Browser.retina ? 2 : 1);
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -26,14 +26,8 @@ L.TileLayer = L.GridLayer.extend({
 
 		options = L.setOptions(this, options);
 
-		// detecting retina displays, adjusting tileSize and zoom levels
-		if (options.detectRetina && L.Browser.retina && options.maxZoom > 0) {
-
-			options.tileSize = Math.floor(options.tileSize / 2);
-			options.zoomOffset++;
-
-			options.minZoom = Math.max(0, options.minZoom);
-			options.maxZoom--;
+		if (options.detectRetina) {
+			this._initRetina();
 		}
 
 		if (typeof options.subdomains === 'string') {
@@ -75,6 +69,20 @@ L.TileLayer = L.GridLayer.extend({
 			y: this.options.tms ? this._tileNumBounds.max.y - coords.y : coords.y,
 			z: this._getZoomForUrl()
 		}, this.options));
+	},
+
+	_initRetina: function() {
+		var options = this.options;
+
+		// detecting retina displays, adjusting tileSize and zoom levels
+		if (L.Browser.retina && options.maxZoom > 0) {
+
+			options.tileSize = Math.floor(options.tileSize / 2);
+			options.zoomOffset++;
+
+			options.minZoom = Math.max(0, options.minZoom);
+			options.maxZoom--;
+		}
 	},
 
 	_tileOnLoad: function (done, tile) {


### PR DESCRIPTION
Hello

I added the retina support to TileLayer.WMS and I tried to factorize a bit the code.

It should also be ok with these layers for example : https://github.com/shramov/leaflet-plugins/tree/master/layer/tile
