### PR TITLE
prevents origin point goes infinite by dividing center by 0

### DIFF
--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -78,8 +78,11 @@ L.Map.include(!zoomAnimated ? {} : {
 			L.DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 		}
 
-		var scale = this.getZoomScale(zoom),
-			origin = this._getCenterLayerPoint().add(this._getCenterOffset(center)._divideBy(1 - 1 / scale));
+		var scale = this.getZoomScale(zoom);
+		if (scale === 1) {
+			scale += 0.001;
+		}
+		var origin = this._getCenterLayerPoint().add(this._getCenterOffset(center)._divideBy(1 - 1 / scale));
 
 		this.fire('zoomanim', {
 			center: center,


### PR DESCRIPTION
fix to the issue https://github.com/Leaflet/Leaflet/issues/2519. I don't expect it to be a permanent fix but hope it gives some idea.

<!---
@huboard:{"milestone_order":2236.5}
-->
