### PR TITLE
CircleMarker radius redrawing fixed

### DIFF
--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -35,8 +35,10 @@ L.CircleMarker = L.Path.extend({
 	},
 
 	setStyle : function (options) {
-		this._radius = options && options.radius || this._radius;
+		var radius = options && options.radius || this._radius;
 		L.Path.prototype.setStyle.call(this, options);
+		this.setRadius(radius);
+		return this;
 	},
 
 	_project: function () {


### PR DESCRIPTION
Code:

```
var circle = L.circleMarker([51.7314, 36.1938], {
    color: '#0da5d5',
    opacity: 1,
    fillColor: '#0da5d5',
    fillOpacity: 1,
    weight: 1,
    radius: 20
}).addTo(map);

map.on('click', function(e) {
    circle.setStyle({
        color: '#ff0000',
        opacity: 1,
        fillColor: '#ff0000',
        fillOpacity: 1,
        weight: 1,
        radius: 10
    });
});
```

How to reproduce bug: click on map.
Expected result: radius of the circle should be 10 px.
Actual result: radius has not changed after click
