### PR TITLE
Now draggable marker does not fire click event to map after dragging

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -223,7 +223,10 @@ L.Marker = L.Layer.extend({
 			L.DomEvent.preventDefault(e);
 		}
 
-		if (e.type === 'click' && this.dragging && this.dragging.moved()) { return; }
+		if (e.type === 'click' && this.dragging && this.dragging.moved()) {
+			L.DomEvent.stopPropagation(e);
+			return;
+		}
 
 		if (e.type === 'keypress' && e.keyCode === 13) {
 			type = 'click';


### PR DESCRIPTION
Code:

```
var marker = L.marker([50.5, 30.51], {draggable: true});
marker.addTo(map);
map.on('click', function (e) {
    console.log(e);
});
```

How to reproduce bug:
1) drag marker
2) see console
Map click event printed to console. But user does not click the map, he drags marker.
