### PR TITLE
proper transitionend detection

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -174,8 +174,8 @@ L.DomUtil = {
 			['webkitTransition', 'transition', 'OTransition', 'MozTransition', 'msTransition']);
 
 	L.DomUtil.TRANSITION_END =
-			transition ?
-			((transition === 'webkitTransition' || transition === 'OTransition') ? transition + 'End' : 'transitionend') :
+		transition ?
+			(transition === 'webkitTransition' || transition === 'OTransition' ? transition + 'End' : 'transitionend') :
 			false;
 
 


### PR DESCRIPTION
It's better L.DomUtil.TRANSITION_END return false, in case browser doesn't support css transitions.
