### PR TITLE
proper svg pointer-events value

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -110,7 +110,7 @@ L.SVG = L.Renderer.extend({
 			path.setAttribute('fill', 'none');
 		}
 
-		path.setAttribute('pointer-events', options.pointerEvents || (options.clickable ? 'auto' : 'none'));
+		path.setAttribute('pointer-events', options.pointerEvents || (options.clickable ? 'visiblePainted' : 'none'));
 	},
 
 	_updatePoly: function (layer, closed) {


### PR DESCRIPTION
Attribute `pointer-events: auto` as a child of node with `pointer-events: none` uncrossbrowser solution (strange behavior in IE9/Opera 12.x). Its better to use `visiblePainted`. According to [mdn](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) :

> **auto** - The element behaves as it would if the pointer-events property was not specified. In SVG content, _this value and the value visiblePainted have the same effect._
> 
> **visiblePainted** - SVG only. The element can only be the target of a mouse event when the visibility property is set to visible and when the mouse cursor is over the interior (i.e., 'fill') of the element and the fill property is set to a value other than none, or when the mouse cursor is over the perimeter (i.e., 'stroke') of the element and the stroke property is set to a value other than none.
