### PR TITLE
Fix for #2606: Cannot read property x of undefined

### DIFF
--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -32,8 +32,11 @@ L.PosAnimation = L.Evented.extend({
 		// if we just removed the transition property, the element would jump to its final position,
 		// so we need to make it stay at the current position
 
+                // Only setPosition if _getPos actually returns a valid position.
 		this._newPos = this._getPos();
-		L.DomUtil.setPosition(this._el, this._newPos);
+		if (this._newPos) {
+		    L.DomUtil.setPosition(this._el, this._newPos);
+		}
 
 		this._onTransitionEnd();
 		L.Util.falseFn(this._el.offsetWidth); // force reflow in case we are about to start a new animation


### PR DESCRIPTION
Only setPosition if _getPos actually returns a valid position to this._newPos
