### PR TITLE
Allow access to L.TileLayer imagedata

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -58,7 +58,7 @@ L.TileLayer = L.GridLayer.extend({
 		tile.onerror = L.bind(this._tileOnError, this, done, tile);
 		
 		if (this.options.crossOrigin) {
-			tile.crossOrigin = '';	
+			tile.crossOrigin = '';
 		}
 		
 		/*


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/HTML/CORS_Enabled_Image. Seemed like such a small change it could maybe go in core instead of writing an entire plugin for it, but I also doubt it's a common use case. I use this to pull in data that's stored in tiles (e.g. elevation data, soil composition).
