### PR TITLE
Updated maxBounds behaviour docs.

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -204,8 +204,8 @@ var map = L.map('map', {
 		<td><code><b>maxBounds</b></code></td>
 		<td><code><a href="#latlngbounds">LatLngBounds</a></code></td>
 		<td><code><span class="literal">null</span></code></td>
-		<td>When this option is set, the map restricts the view to the given geographical bounds, bouncing the user back when he tries to pan outside the view, and also not allowing to zoom out to a view that's larger than the given bounds (depending on the map size). To set the restriction dynamically, use <a href="#map-setmaxbounds">setMaxBounds</a> method</td>
-	</tr>
+		<td>When this option is set, the map restricts the view to the given geographical bounds, bouncing the user back when he tries to pan outside the view. To set the restriction dynamically, use <a href="#map-setmaxbounds">setMaxBounds</a> method</td>
+    </tr>
 	<tr>
 		<td><code><b>crs</b></code></td>
 		<td><code><a href="#icrs">CRS</a></code></td>


### PR DESCRIPTION
I think the reference docs for maxBounds behaviour are outdated. MinZoom behaviour was removed in 0.7.x
