### PR TITLE
Only trigger mousemove when mouse has really moved

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -242,6 +242,18 @@ L.DomEvent = {
 		L.DomEvent._lastClick = timeStamp;
 
 		return handler(e);
+	},
+	
+	// workaround for some browsers that continually fire mousemove
+	_hasMouseMoved: function (previous) {
+		this._hasMouseMoved = function (current) {
+			if (previous.clientX === current.clientX && previous.clientY === current.clientY) {
+				return false;
+			}
+			previous = current;
+			return true;
+		};
+		return true;
 	}
 };
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -581,6 +581,9 @@ L.Map = L.Evented.extend({
 		if (type === 'click' || type === 'dblclick' || type === 'contextmenu') {
 			L.DomEvent.stopPropagation(e);
 		}
+		if (type === 'mousemove' && !L.DomEvent._hasMouseMoved(e)) {
+			return;
+		}
 
 		var data = {
 			originalEvent: e,


### PR DESCRIPTION
Some browsers can sometimes keep triggering mousemove even when the mouse is not moving. This is a simple filter that only triggers mousemove on Leaflet objects when the mouse position has changed.
