### PR TITLE
Default Attribution prefix opens via target="_blank"

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -5,7 +5,7 @@
 L.Control.Attribution = L.Control.extend({
 	options: {
 		position: 'bottomright',
-		prefix: '<a href="http://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>'
+		prefix: '<a href="http://leafletjs.com" title="A JS library for interactive maps" target="_blank">Leaflet</a>'
 	},
 
 	initialize: function (options) {


### PR DESCRIPTION
to prevent the user from accidentally closing the app because they didn't know the link opened in the same tab. Also prevents from opening in iframe if the app is in an iframe. 

This default is more sane then having to add a new attribution control just to change the prefix anchor target.
