### PR TITLE
Fix marker.bringToFront not being call on featuregroup.bringToFront

### DIFF
--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -83,4 +83,15 @@
 			expect(fg.hasLayer(marker)).to.be(false);
 		});
 	});
+	describe('bringToFront', function () {
+		it('brings to front included markers', function () {
+			var fg = L.featureGroup().addTo(map),
+			    marker1 = L.marker([0, 0]).addTo(fg),
+				marker2 = L.marker([0, 0]).addTo(map);
+
+			expect(marker1._icon.style.zIndex).not.to.be.greaterThan(marker2._icon.style.zIndex);
+			fg.bringToFront();
+			expect(marker1._icon.style.zIndex).to.be.greaterThan(marker2._icon.style.zIndex);
+		});
+	});
 });

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -257,6 +257,10 @@ L.Marker = L.Layer.extend({
 		this._updateZIndex(this.options.riseOffset);
 	},
 
+	bringToFront: function () {
+		this._bringToFront();
+	},
+
 	_resetZIndex: function () {
 		this._updateZIndex(0);
 	}


### PR DESCRIPTION
Not sure though about your plans here.
Also, marker doesn't have any `_bringToBack` method, so it isn't symmetric.

But without this change, calling `bringToFront` on a `FeatureLayer` doesn't do nothing on markers, which is disconcerting.

@mourner thoughts?
