### PR TITLE
In Draggable, set _moved back to false on mouseup

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -134,6 +134,7 @@ L.Draggable = L.Evented.extend({
 			});
 		}
 
+		this._moved = false;
 		this._moving = false;
 	}
 });


### PR DESCRIPTION
I have an issue (instructions to reproduce below) where a marker's click handler won't accept clicks because they are ignored by this logic in `Map._fireMouseEvent`:

```
if (!e._simulated && ((this.dragging && this.dragging.moved()) ||
                                  (this.boxZoom && this.boxZoom.moved()))) return;
```

Here, `this.dragging` is a `Map.Drag` object with a `Draggable` that for some reason has `_moved` set to true. This checking seems a bit weird to me, and it feels like there ought to be a cleaner way. At any rate, `_moved` is apparently set when the map is dragged, but it is never reset to `false` for some reason on mouseup.

Changing `Draggable` to set `_moved` to `false` works, but I don't know if this would have implications beyond my test case.

**To reproduce**: Go to our live production site [here](http://rapidcityjournal.homes.com/search). Click on "draw" above the map. Draw 5-6 polygon points clickly enough with the mouse that you cause an accidental map drag. Then try to complete the polygon (by clicking on the first point you created). You will notice that the marker does not accept clicks. (This is using our own drawing code, by the way, not leaflet.draw, as we need touch support.)
