### PR TITLE
Bugfix for #2704

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -324,7 +324,7 @@ L.GridLayer = L.Layer.extend({
 	_tileCoordsToBounds: function (coords) {
 
 		var map = this._map,
-		    tileSize = this.options.tileSize,
+		    tileSize = this._getTileSize(),
 
 		    nwPoint = coords.multiplyBy(tileSize),
 		    sePoint = nwPoint.add([tileSize, tileSize]),


### PR DESCRIPTION
This fixes the problem that the tiles disappear if `maxNativeZoom` in combination with `bounds` is set. This bugfix is associated with #2704.
