### PR TITLE
Removed 1 unnecessary array-creation

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -3,6 +3,13 @@
  */
 
 L.Util = {
+	// utility function for fail-fast behaviour
+	assert: function(condition) {
+		if (!condition) {
+			throw new Error(Array.prototype.slice.call(arguments, 1).join(' '));
+		}
+	},
+	
 	// extend an object with properties of one or more other objects
 	extend: function (dest) {
 		var i, j, len, src;
@@ -189,6 +196,7 @@ L.Util = {
 })();
 
 // shortcuts for most used utility functions
+L.assert = L.Util.assert;
 L.extend = L.Util.extend;
 L.bind = L.Util.bind;
 L.stamp = L.Util.stamp;


### PR DESCRIPTION
The last couple of weeks I investigated leaflet's performance on mobile. Found a couple of hotspots, and some are just the gc kicking in cause L creates an enormous mount of objects.

This patch removes 1 unnecessary array-creations, not much of a gain, but a check for me for how to do pull-requests.
