### PR TITLE
bugfix: set boxZoom._moved to false when finished, otherwise mouse event...

### DIFF
--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -96,6 +96,8 @@ L.Map.BoxZoom = L.Handler.extend({
 		this._map
 			.fitBounds(bounds)
 			.fire('boxzoomend', {boxZoomBounds: bounds});
+			
+		this._moved = false;
 	},
 
 	_onKeyDown: function (e) {


### PR DESCRIPTION
...s don’t work anymore, because the variable is used in Map._fireMouseEvent
