### PR TITLE
performance: don’t update svgViewBox in the middle of an animation. Make...

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -16,6 +16,7 @@ L.SVG = L.Renderer.extend({
 
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
+		if (this._map._panAnim && this._map._panAnim._inProgress) { return; }
 
 		L.Renderer.prototype._update.call(this);
 


### PR DESCRIPTION
...s map with 3000 features much zippier on iOS/mobile, when dragging out-of-bounds for example, but changes the way the overlay is displayed a bit, because it's not updated before being animated.
