### PR TITLE
performance: don’t set drag-class on touch-browsers. avoids a reflow/rep...

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -89,10 +89,12 @@ L.Draggable = L.Evented.extend({
 			this._moved = true;
 			this._startPos = L.DomUtil.getPosition(this._element).subtract(offset);
 
-			L.DomUtil.addClass(document.body, 'leaflet-dragging');
+			if (!L.Browser.touch) {
+				L.DomUtil.addClass(document.body, 'leaflet-dragging');
 
-			this._lastTarget = e.target || e.srcElement;
-			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
+				this._lastTarget = e.target || e.srcElement;
+				L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
+			}
 		}
 
 		this._newPos = this._startPos.add(offset);
@@ -109,11 +111,13 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onUp: function () {
-		L.DomUtil.removeClass(document.body, 'leaflet-dragging');
+		if (!L.Browser.touch) {
+			L.DomUtil.removeClass(document.body, 'leaflet-dragging');
 
-		if (this._lastTarget) {
-			L.DomUtil.removeClass(this._lastTarget, 'leaflet-drag-target');
-			this._lastTarget = null;
+			if (this._lastTarget) {
+				L.DomUtil.removeClass(this._lastTarget, 'leaflet-drag-target');
+				this._lastTarget = null;
+			}
 		}
 
 		for (var i in L.Draggable.MOVE) {


### PR DESCRIPTION
...aint, saves almost a second in my case.
