### PR TITLE
Address issue #1905, Error when zoom out of max/minZoom

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -241,7 +241,10 @@ L.GridLayer = L.Layer.extend({
 		    tileSize = this._getTileSize();
 
 		if (zoom > this.options.maxZoom ||
-		    zoom < this.options.minZoom) { return; }
+		    zoom < this.options.minZoom) { 
+			this._clearBgBuffer();
+			return; 
+		}
 
 		// tile coordinates range for the current view
 		var tileBounds = L.bounds(


### PR DESCRIPTION
see issue #1905, invoke `_clearBgBuffer()` function to reset layer div container when zoom out of max or minZoom.
