### PR TITLE
map.addControl support multiple controls

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -83,11 +83,14 @@ L.control = function (options) {
 // adds control-related methods to L.Map
 
 L.Map.include({
-	addControl: function (control) {
-		control.addTo(this);
+	addControl: function (controls) {
+		controls = controls ? (L.Util.isArray(controls) ? controls : [controls]) : [];
+
+		for (var i = 0, len = controls.length; i < len; i++) {
+			controls[i].addTo(this);
+		}
 		return this;
 	},
-
 	removeControl: function (control) {
 		control.removeFrom(this);
 		return this;


### PR DESCRIPTION
these simple patch allows you to add an array of controls(like as map.addLayer) in a single line of code. 
It 'a very useful when working on big webmapping applications with many controls!

_current solution:_

```
map.addControl(panels.profile);
map.addControl(panels.friends);
map.addControl(panels.place);
map.addControl(panels.user);
map.addControl(controls.search);
map.addControl(controls.gps);
map.addControl(controls.zoom);
map.addControl(controls.attrib);
map.addControl(controls.alerts);
map.addControl(buttons.status);
map.addControl(buttons.profile);
map.addControl(buttons.friend);
```

_3dparty solution(underscorejs):_

```
_.invoke([
    panels.profile,
    panels.friends,
    panels.place,               
    panels.user,
    controls.search,
    controls.gps,
    controls.zoom,              
    controls.attrib,
    controls.alerts,    
    buttons.status,
    buttons.profile,
    buttons.friends
],'addTo', map);
```

**patch solution:**

```
map.addControl([
    panels.profile, panels.friends, panels.place, panels.user,
    controls.search, controls.gps, controls.zoom, controls.attrib, controls.alerts,
    buttons.status, buttons.profile, buttons.friends
]);
```
