### PR TITLE
add imageOverlay events binding support by declaring clickable true.

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -5,7 +5,8 @@
 L.ImageOverlay = L.Layer.extend({
 
 	options: {
-		opacity: 1
+		opacity: 1,
+		clickable: true
 	},
 
 	initialize: function (url, bounds, options) { // (String, LatLngBounds, Object)
@@ -89,6 +90,9 @@ L.ImageOverlay = L.Layer.extend({
 		img.onmousemove = L.Util.falseFn;
 
 		img.onload = L.bind(this.fire, this, 'load');
+
+		this._initInteraction();
+
 		img.src = this._url;
 	},
 
@@ -115,6 +119,30 @@ L.ImageOverlay = L.Layer.extend({
 
 	_updateOpacity: function () {
 		L.DomUtil.setOpacity(this._image, this.options.opacity);
+	},
+
+	_initInteraction: function () {
+		if (!this.options.clickable) { return; }
+
+		L.DomUtil.addClass(this._image, 'leaflet-clickable');
+
+		L.DomEvent.on(this._image, 'click dblclick mousedown mouseup mouseover mouseout contextmenu keypress',
+				this._fireMouseEvent, this);
+	},
+
+	_fireMouseEvent: function (e, type) {
+		// to prevent outline when clicking on keyboard-focusable marker
+		if (e.type === 'mousedown') {
+			L.DomEvent.preventDefault(e);
+		}
+
+		if (e.type === 'keypress' && e.keyCode === 13) {
+			type = 'click';
+		}
+
+		if (this._map) {
+			this._map._fireMouseEvent(this, e, type, true, this._latlng);
+		}
 	}
 });
 


### PR DESCRIPTION
see issue #2564, as @urban-1 points out, add the support to bind DOM events to imageOverlay. Although I did this in `_initImage()` function, the same as marker. A simple test fiddle can be seen at http://jsfiddle.net/francischan/qna75/3/ , I want to add some tests, could you please tell me where to put the test file? Or are there any existing, relevant tests I can build on ? (under debug/tests/ I think).
