### PR TITLE
Include "addAndListen" function on Layer

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -10,6 +10,12 @@ L.Layer = L.Evented.extend({
 		return this;
 	},
 
+	addAndListen: function (map, event, callback) {
+		map.addLayer(this);
+		this.on(event, callback);
+		return this;
+	},
+
 	remove: function () {
 		return this.removeFrom(this._map || this._mapToAdd);
 	},


### PR DESCRIPTION
This allows the immediate passing of an event listener when adding a new layer to the map. Accepts map (the map to which the layer is added), event (the event being listened for), and callback (the callback fired after the event occurs).

This is a concise addition to the codebase that seems too trivial for a plug-in. I've found myself frequently adding event listeners immediately after adding layers, so this would simplify the process of adding and listening all at once.
-   addAndListen: function (map, event, callback) {
  -      map.addLayer(this);
  -      this.on(event, callback);
  -      return this;
  -  },
