### PR TITLE
Add  Leaflet.GameController in the plugins list

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1172,6 +1172,15 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 			<a href="https://github.com/zimmicz">Michal Zimmermann</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/SINTEF-9012/Leaflet.GameController">Leaflet GameController</a>
+		</td><td>
+			Interaction handler providing support for gamepads.
+		</td><td>
+			<a href="https://github.com/yellowiscool">Antoine Pultier</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Hello.

I added a small plugin for moving the map with a gamepad. I only have a 3D mouse as gamepad but I think it can be adapted for other gamepads.

Otherwise, the draft gamepad API is unstable, the values are weird in Firefox and I have to restart chrome canary instead of reloading the page.
