### PR TITLE
Fixed 'bounceAtZoomLimits' when you don't start pinching from max\min level

### DIFF
--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -54,9 +54,11 @@ L.Map.TouchZoom = L.Handler.extend({
 		this._scale = p1.distanceTo(p2) / this._startDist;
 		this._delta = p1._add(p2)._divideBy(2)._subtract(this._startCenter);
 
-		if (!map.options.bounceAtZoomLimits &&
-		    ((map.getZoom() === map.getMinZoom() && this._scale < 1) ||
-		     (map.getZoom() === map.getMaxZoom() && this._scale > 1))) { return; }
+		if (!map.options.bounceAtZoomLimits) {
+			var currentZoom = map.getScaleZoom(this._scale);
+			if ((currentZoom <= map.getMinZoom() && this._scale < 1) ||
+		     (currentZoom >= map.getMaxZoom() && this._scale > 1)) { return; }
+		}
 
 		if (!this._moved) {
 			map


### PR DESCRIPTION
When you set `bounceAtZoomLimits` to false, it works correctly only if you start pinching from the maximum or minimum level (affected all Leaflet versions that support such feature)

To reproduce the bug:
1- Set `bounceAtZoomLimits` to false, set `minZoom` of the map to 10, and `maxZoom` to 15
2- Go to to level 11, and now pinch out how far you can (or go to level 14 and pinch in how far you can)
3- Observe how you are able to pinch out far beyond the minimum level (or pinch in far over the  maximum level).
However when you release the touch, the map level zoom is correctly set to the right minimum\maximum level.

The fix consists on calculating the proper current zoom level, without using `map.getZoom()` that is updated only when user actually completes the pinch gesture (i.e. when user releases touches).
