### PR TITLE
mousemove event for marker

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -205,7 +205,7 @@ L.Marker = L.Layer.extend({
 
 		L.DomUtil.addClass(this._icon, 'leaflet-clickable');
 
-		L.DomEvent.on(this._icon, 'click dblclick mousedown mouseup mouseover mouseout contextmenu keypress',
+		L.DomEvent.on(this._icon, 'click dblclick mousedown mouseup mouseover mousemove mouseout contextmenu keypress',
 				this._fireMouseEvent, this);
 
 		if (L.Handler.MarkerDrag) {


### PR DESCRIPTION
Sometimes you just need to handle mousemove event on marker.
I ran into it while making draggable waypoints (intermediate points) like in maps.yandex.ru or in maps.google.com
