### PR TITLE
Modify L.DivIcon so that the html option can be either a string OR a HTML Node

### DIFF
--- a/spec/suites/layer/marker/DivIconSpec.js
+++ b/spec/suites/layer/marker/DivIconSpec.js
@@ -1,0 +1,14 @@
+describe("DivIcon", function() {
+	var map;
+
+	beforeEach(function () {
+		map = L.map(document.createElement('div')).setView([0, 0], 0);
+	});
+
+	describe("#createIcon", function() {
+		it ("Accepts an HTMl node", function() {
+			var div = document.createElement('div'),
+				icon = new L.DivIcon({ html: div });
+		});
+	});
+});

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -17,17 +17,30 @@ L.DivIcon = L.Icon.extend({
 	},
 
 	createIcon: function (oldIcon) {
-		var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
-		    options = this.options;
+		var options = this.options;
 
-		div.innerHTML = options.html !== false ? options.html : '';
+		this._container = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div');
+		this._innerHTML = (options.html !== false) ? options.html : '';
+
+		this._updateHTMLContent();
 
 		if (options.bgPos) {
-			div.style.backgroundPosition = (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
+			this._container.style.backgroundPosition = (-options.bgPos.x) + 'px ' + (-options.bgPos.y) + 'px';
 		}
-		this._setIconStyles(div, 'icon');
+		this._setIconStyles(this._container, 'icon');
 
-		return div;
+		return this._container;
+	},
+
+	_updateHTMLContent: function() {
+		if (typeof this._innerHTML === 'string') {
+			this._container.innerHTML = this._innerHTML;
+		} else {
+			while (this._container.hasChildNodes()) {
+				this._container.removeChild(this._container.firstChild);
+			}
+			this._container.appendChild(this._innerHTML);
+		}
 	},
 
 	createShadow: function () {


### PR DESCRIPTION
I modified L.DivIcon so that the `html` parameter passed in the `options` object can be either a string or an HTML object.  This is purely for the convenience of application + plugin developers.  For example:

``` javascript
var icon, marker;
....
this._textarea = L.DomUtil.create('textarea', 'sample-application-textarea'),
icon = new L.DivIcon({ html: textarea });
marker = new L.Marker(L.latLng(10, 10), { icon: icon });
...
```

This will make it more convenient for plugin developers to store a reference to the DOM node that is being set as the icon.  This pull request also sets a `_container` property on the `DivIcon`, making it easier for plugin developers to access the `<div>` container holding the icon's HTML.

I modeled this on [`L.Popup#_updateContent`](https://github.com/Leaflet/Leaflet/blob/master/src/layer/Popup.js#L171), since popups already exhibit similar overloading (they accept either a string or an HTML element).

I also added a test in `/spec/suites/layer/marker/DivIconSpec.js`.

<!---
@huboard:{"milestone_order":2325.5}
-->
