### PR TITLE
Add comment to removeEventListener in docs

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -4645,7 +4645,7 @@ map.off('click', onClick);</code></pre>
 		</code></td>
 
 		<td><code><span class="keyword">this</span></code></td>
-		<td>Removes a previously added listener function. If no function is specified, it will remove all the listeners of that particular event from the object.</td>
+		<td>Removes a previously added listener function. If no function is specified, it will remove all the listeners of that particular event from the object.  Note that if you passed a custom context to <code>addEventListener</code>, you must pass the same context to <code>removeEventListener</code> in order to remove the listener.</td>
 	</tr>
 	<tr>
 		<td><code><b>removeEventListener</b>(


### PR DESCRIPTION
I added the following sentence to the docs for `removeEventListener`: 

> Note that if you passed a custom context to <code>addEventListener</code>, you must pass the same context to <code>removeEventListener</code> in order to remove the listener.

I think this will help - it wasn't at all clear to me that this was the case before I looked in the [source code](https://github.com/Leaflet/Leaflet/blob/master/src/core/Events.js).
#### Background

It's natural to think that:

```
map.on('zoom', this.myFunction, this);
```

would be removed by:

```
map.off('zoom', this.myFunction).
```

After all, you need to know the context when you're executing the callback, but if you're going to _not_ execute the callback, it seems that there's no need for the context.

Turns out, this is _not_ the case b/c listeners with custom contexts are stored in a separate hash.  It took me a while to figure this out - I was looking at my code and saying: no, that can't be firing because I've already removed those event listeners.

Hope this helps other folks out there.
