### PR TITLE
fix memory leak generated by setIcon

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -209,6 +209,10 @@ L.Marker = L.Layer.extend({
 				this._fireMouseEvent, this);
 
 		if (L.Handler.MarkerDrag) {
+			if (this.dragging) {
+				this.dragging.disable();
+			}
+			
 			this.dragging = new L.Handler.MarkerDrag(this);
 
 			if (this.options.draggable) {


### PR DESCRIPTION
when setIcon is called this.dragging is replaced without be disabled before, so hooks remains active.

Also avoid trigger a click event on the map after dragging a marker that has called setIcon, check this jsfliddle http://jsfiddle.net/nMS9u/
