### PR TITLE
Tilelayer 'loading' event tests

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -4,6 +4,7 @@
 	<meta charset="utf-8">
 	<title>Leaflet Spec Runner</title>
 	<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css">
+	<link rel="stylesheet" type="text/css" href="../dist/leaflet.css">
 </head>
 <body>
 	<div id="mocha"></div>

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -110,14 +110,6 @@ describe('TileLayer', function () {
 		var tileUrl1 = 'http://{s}.tile.osm.org/{z}/{x}/{y}.png',
 			tileUrl2 = 'http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png';
 
-		// Inject Leaflet css
-		var head = document.getElementsByTagName("head")[0],
-			link = document.createElement("link");
-		link.href = "../dist/leaflet.css";
-		link.type = "text/css";
-		link.rel = "stylesheet";
-		head.appendChild(link);
-
 		// Add map div to DOM. The map panning tests do not work reliably unless
 		// the Leaflet map is properly styled and part of the DOM
 		var mapDiv = document.createElement('div');


### PR DESCRIPTION
Tests for #2802.

Having to inject the Leaflet css and add the map div to the DOM feels weird, but the panning tests don't fail unless the map is properly styled and a part of the DOM.
