### PR TITLE
#1871, initial zoom and center fixed

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -33,9 +33,10 @@ L.Map = L.Evented.extend({
 			this.setMaxBounds(options.maxBounds);
 		}
 
-		if (options.center && options.zoom !== undefined) {
-			this.setView(L.latLng(options.center), options.zoom, {reset: true});
-		}
+		var initialZoom = options.zoom || 0;
+		var initialCenter = options.center || L.latLng(0, 0);
+
+		this.setView(initialCenter, initialZoom, {reset: true});
 
 		this._handlers = [];
 		this._layers = {};


### PR DESCRIPTION
We need call setView ever, because this method calls _resetView and initializes this._zoom property. Otherwise this._zoom will be undefined after map initialization, but it should be necessary for other methods.

This pull request fixes this case: https://github.com/Leaflet/Leaflet/issues/1871#issuecomment-43033782.
