### PR TITLE
Add getBounds() method to ImageOverlay

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -81,6 +81,10 @@ L.ImageOverlay = L.Layer.extend({
 
 		return events;
 	},
+	
+	getBounds: function() {
+		return this._bounds;
+	},
 
 	_initImage: function () {
 		var img = this._image = L.DomUtil.create('img',


### PR DESCRIPTION
Bugfix : ImageOverlay can be added to FeatueGroup, but calling getBounds on FeatureGroup throw an error cause ImageOverlay misses this method.
