### PR TITLE
L.Class usage example Said L.Class where it should've said MyClass

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -5069,7 +5069,7 @@ a.greet('Jason'); // alerts "Yo, bro Jason!"</code></pre>
 	}
 });
 
-var MyChildClass = L.Class.extend({
+var MyChildClass = MyClass.extend({
 	options: {
 		myOption1: 'baz',
 		myOption3: 5


### PR DESCRIPTION
Usage example for L.Class options mechanism should refer to MyChildClass inheriting from MyClass instead of MyChildClass inheriting from L.Class directly.
