### PR TITLE
it fixes marker's setIcon method

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -76,7 +76,7 @@ L.Marker = L.Layer.extend({
 		}
 
 		if (this._popup) {
-			this.bindPopup(this._popup);
+			this.bindPopup(this._popup, this._popup.options);
 		}
 
 		return this;


### PR DESCRIPTION
It fixes marker's setIcon method, that flushes popup's options, which leads to breaking popup's custom offset.
The issue is: during `marker.setIcon()` leaflet updates `marker._popup.offset` with value from icon's setting `popupAnchor`.
And that could happen: [ http://jsbin.com/wipupo/1/edit?js,output](http://jsbin.com/wipupo/1/edit?js,output).
First click on marker - popup is positioned ok.
Then click on a link below and then click on a marker again - it's repositioned.
I think while setting new icon we have to account popup's settings that were made with options explicitly.
