### PR TITLE
CSS reset for svg max-width declarations

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -40,12 +40,10 @@
 .leaflet-marker-shadow {
 	display: block;
 	}
-/* map is broken in FF if you have max-width: 100% on tiles */
+/* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
+/* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
+.leaflet-container svg,
 .leaflet-container img {
-	max-width: none !important;
-	}
-/* reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
-.leaflet-container svg {
 	max-width: none !important;
 	}
 /* stupid Android 2 doesn't understand "max-width: none" properly */


### PR DESCRIPTION
This PR is a fix for the issue described in #2881 

I think it makes sense to add it because the faulty CSS declaration that I mention there is by default included in every Joomla (popular opensource CMS) 3.x site and therefore effects millions of sites. It can't be fixed in the current Joomla version because of backwards compatibility considerations.
