### PR TITLE
Add Leaflet.StyledLayerControl Plugin in the plugins.md list 

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -975,7 +975,7 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 		<td>
 			<a href="https://github.com/davicustodio/Leaflet.StyledLayerControl">Leaflet.StyledLayerControl</a>
 		</td><td>
-			A Leaflet plugin that implements the management and control of layers by organization into categories or groups. The StyledLayerControl class extends the original L.control.layers control. The plugin uses HTML5 and CSS3 to style the presentation in a modern way.
+			A Leaflet plugin that implements the management and control of layers by organization into categories or groups. 
 		</td><td>
 			<a href="https://github.com/davicustodio">Davi Custodio</a>
 		</td>


### PR DESCRIPTION
A Leaflet plugin that implements the management and control of layers by organization into categories or groups. The StyledLayerControl class extends the original L.control.layers control. The plugin uses HTML5 and CSS3 to style the presentation in a modern way. The initial ideas were based in the plugin: Leaflet.Groupedlayercontrol
