### PR TITLE
Removed documented url property of TileEvent

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -4895,11 +4895,6 @@ map.off('click', onClick);</code></pre>
 		<td><code>HTMLElement</code></td>
 		<td>The tile element (image).</td>
 	</tr>
-	<tr>
-		<td><code><b>url</b></code></td>
-		<td><code>String</code></td>
-		<td>The source URL of the tile.</td>
-	</tr>
 </table>
 
 <h3 id="resize-event">ResizeEvent</h3>


### PR DESCRIPTION
To reflect fourth bullet point [here](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#tilelayer-related-changes).
