### PR TITLE
fix multiple containers for one control

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -37,6 +37,10 @@ L.Control = L.Class.extend({
 	},
 
 	addTo: function (map) {
+        if (this._isAdd) {
+            return this;
+        }
+
 		this._map = map;
 
 		var container = this._container = this.onAdd(map),
@@ -51,6 +55,8 @@ L.Control = L.Class.extend({
 			corner.appendChild(container);
 		}
 
+        this._isAdd = true;
+
 		return this;
 	},
 
@@ -61,6 +67,7 @@ L.Control = L.Class.extend({
 			this.onRemove(this._map);
 		}
 
+        this._isAdd = false;
 		this._map = null;
 
 		return this;


### PR DESCRIPTION
We can add more than 1 html container for one control.
If we'll add more than one container control will be work correct only in last container.

Fix disables adding control on map if it has already been added.
