### PR TITLE
Fixed setPopupContent 2nd argument

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1561,8 +1561,7 @@ var map = L.map('map', {
 	</tr>
 	<tr id="marker-bindpopup">
 		<td><code><b>setPopupContent</b>(
-			<nobr>&lt;String&gt; <i>html</i> |</nobr> <nobr>&lt;HTMLElement&gt; <i>el</i>,</nobr>
-			<nobr>&lt;<a href="#popup-options">Popup options</a>&gt; <i>options?</i> )</nobr>
+			<nobr>&lt;String&gt; <i>html</i> |</nobr> <nobr>&lt;HTMLElement&gt; <i>el</i> )</nobr>
 		</code></td>
 
 		<td><code><span class="keyword">this</span></code></td>


### PR DESCRIPTION
There is no 'options' argument in Marker.setPopupContent.
