### PR TITLE
Add Leaflet Layer-Config plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1486,6 +1486,17 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 			<a href="https://github.com/moklick">Moritz Klack</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Norkart/Leaflet-LayerConfig">Leaflet LayerConfig</a>
+		</td>
+		<td>
+			Provide a json file or service response with a configuration of layers and markers to automatically set up a Leaflet client.
+		</td>
+		<td>
+			<a href="https://github.com/alexanno">Alexander Nossum</a>
+		</td>
+	</tr>
 </table>
 
 To submit your own Leaflet plugin to this list, just send a pull request with the addition to Leaflet repo's [gh-pages branch](https://github.com/Leaflet/Leaflet/tree/gh-pages) (`plugins.md` file).


### PR DESCRIPTION
This adds a reference in plugins.md to our new plugin for configuring layers via json.
