### PR TITLE
#2662 - setStyle now takes className

### DIFF
--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -103,6 +103,15 @@ L.SVG.include(!L.Browser.vml ? {} : {
 			container.removeChild(fill);
 			layer._fill = null;
 		}
+
+		if (options.className) {
+			var eClasses = L.Util.splitWords(L.DomUtil.getClass(container))
+			.filter(function(e){
+				return e.indexOf('leaflet-') === 0;
+			})
+			.join(' ');
+			L.DomUtil.setClass(container,eClasses + ' ' + options.className);
+		}
 	},
 
 	_updateCircle: function (layer) {

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -117,6 +117,15 @@ L.SVG = L.Renderer.extend({
 		}
 
 		path.setAttribute('pointer-events', options.pointerEvents || (options.interactive ? 'visiblePainted' : 'none'));
+
+		if (options.className) {
+			var eClasses = L.Util.splitWords(L.DomUtil.getClass(path))
+			.filter(function(e){
+				return e.indexOf('leaflet-') === 0;
+			})
+			.join(' ');
+			L.DomUtil.setClass(path,eClasses + ' ' + options.className);
+		}
 	},
 
 	_updatePoly: function (layer, closed) {


### PR DESCRIPTION
http://leafletjs.com/reference.html#path-setstyle says that it accepts a  <Path options> object which includes a className parameter, however className is ignored. 

This pull request adds className support to setStyle and if accepted would resolve #2662 

If className is set in the <Path options> object, setStyle will set the object's class to the string provided. 

Notes: 
- Class names starting with 'leaflet-' are ignored when finding class names to remove so as not to break internal leaflet assumptions. This results in the case where a user could set a class name (eg. leaflet-customclass) which they can't remove. 
- I do not have a version of IE to test SVG.VML.js on. 
- [jmaxxz suggested](https://github.com/Leaflet/Leaflet/issues/2662#issuecomment-42316958) that addClass and removeClass methods would make more sense. I think those would be useful additions too, but I think there's also value in className working like the rest of setStyle. If there's interest in addClass/removeClass I'd be happy to implement those. 

Here's a simple demo: http://stuporglue.org/downloads/leaflet-2662/

The geojson features have an on('click') handler that sets a new className. CSS changes the style from blue to red.
