### PR TITLE
always expose window.L for plugins

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -23,6 +23,6 @@ if (typeof module === 'object' && typeof module.exports === 'object') {
 	define(L);
 
 // define Leaflet as a global L variable, saving the original L to restore later if needed
-} else {
-	expose();
 }
+
+expose();


### PR DESCRIPTION
As it currently stands at the next version Leaflet will only expose a global `L` variable when neither a AMD or CommonJS loader is being used. This presents a problem for plugin authors who are used to relying on the global `window.L` variable always being present. It looks like this was decided in https://github.com/Leaflet/Leaflet/issues/2364 but no one implemented the change.

This is especially important because without this change module authors would have to wrap their code in a UMD style block like Leaflet which would significantly raise the barrier to writing a plugin. With this change if a plugin isn't wrapped in a UMD block developers will still be able to do this...

```
var L = require('leaflet');

// create map, use L, ect...
var map  = new L.Map('map').setView(latlng, 12);

// Leaflet.heat doesn't have a UMD block but we can still access it
var layer = new window.L.HeatLayer(latlngs).addTo(map);
```

This isn't ideal (since it defeats the point of the module system) but it works and plugins would continue to function and authors could add UMD blocks and users requested them.

I am also planning on updating the Plugin guide with info from https://github.com/Leaflet/Leaflet/issues/2783 in a separate PR so we can have best practices around UMD wrappers.
