### PR TITLE
Fix IE Touch pointer events passing through to the map

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -53,13 +53,12 @@ L.DomEvent = {
 		var originalHandler = handler;
 
 		if (L.Browser.pointer && type.indexOf('touch') === 0) {
-			return this.addPointerListener(obj, type, handler, id);
-		}
-		if (L.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
+			this.addPointerListener(obj, type, handler, id);
+		
+		} else if (L.Browser.touch && (type === 'dblclick') && this.addDoubleTapListener) {
 			this.addDoubleTapListener(obj, handler, id);
-		}
 
-		if ('addEventListener' in obj) {
+		} else if ('addEventListener' in obj) {
 
 			if (type === 'mousewheel') {
 				obj.addEventListener('DOMMouseScroll', handler, false);


### PR DESCRIPTION
Pointer events in IE Touch would trigger on the map even when not started on the map. For example, if you had a dialog box on top of the map and dragged inside the map, the map would move. I believe this is because the handler never gets added to the obj[eventsKey] map. I noticed in the corresponding _off function below that the logic reaches there because of the multiple if/else statements. So I modified the _on even to match and it seems to fix the problem.

This would only seem to be a problem in IE Touch via the Metro interface. You can reproduce the bug by starting that and either using your finger or a mouse to drag on an element above the map to see the issue. 
