### PR TITLE
update AMD recommendation in plugin guide

### DIFF
--- a/PLUGIN-GUIDE.md
+++ b/PLUGIN-GUIDE.md
@@ -163,9 +163,7 @@ You can add support for AMD/CommonJS loaders to your Leaflet plugin by following
 
     // define an AMD module that relies on 'leaflet'
     if (typeof define === 'function' && define.amd) {
-        define(['leaflet'], function (L) {
-            return (exports = factory(L));
-        });
+        define(['leaflet'], factory);
     
     // define a Common JS module that relies on 'leaflet'
     } else if (typeof exports === 'object') {


### PR DESCRIPTION
The factory function is already in the format of an AMD callback, so it doesn't need to be wrapped.  Also, there isn't a need to set `exports =` since the AMD loader handles that (and the definition as it stands will create exports as a global).

Also, note the CommonJS module definition is really a Node.js module definition since `module` is not a part of the original CommonJS syntax.  I don't use CommonJS/Node modules myself so I'll leave it up to someone who does to update the recommendation if it seems important.

This PR also adds a newline to the end of the file, the editor did that automatically.
