### PR TITLE
fixed GridLayer not showing up after removing and adding the same instance

### DIFF
--- a/debug/map/layer_remove_add.html
+++ b/debug/map/layer_remove_add.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+    <button id="removeAdd">Remove and Add Layer</button>
+
+	<script type="text/javascript">
+        map = L.map('map', { center: [0, 0], zoom: 3, maxZoom: 4 });
+
+        L.Icon.Default.imagePath = 'http://cdn.leafletjs.com/leaflet-0.7.3/images';
+
+
+        var tileLayer = L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+            attribution: "Map: Tiles Courtesy of MapQuest (OpenStreetMap, CC-BY-SA)",
+            subdomains: ["otile1", "otile2", "otile3", "otile4"],
+            maxZoom: 12,
+            minZoom: 2
+        });
+        tileLayer.addTo(map);
+
+        L.DomUtil.get('removeAdd').onclick = function() {
+            map.removeLayer(tileLayer);
+
+            setTimeout(function() {
+                map.addLayer(tileLayer);
+            }, 1000);
+
+
+        };
+	</script>
+</body>
+</html>

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -55,6 +55,7 @@ L.GridLayer = L.Layer.extend({
 		L.DomUtil.remove(this._container);
 		map._removeZoomLimit(this);
 		this._container = null;
+		this._tileZoom = null;
 	},
 
 	bringToFront: function () {


### PR DESCRIPTION
Commit e09397929798298983e73d5e148bb2ceed0a5fba introduced a bug causing a GridLayer (in this example TileLayer) not showing up anymore after removing and adding the same instance.

So basically the following will cause a TileLayer to be hidden (and only show itself again after e.g., zooming)

``` javascript
map.removeLayer(tileLayer);
map.addLayer(tileLayer);
```

I've fixed the bug by just resetting the `this._tileZoom` after removing the layer from the map.

The included debug page will show the fix (clicking the button will remove the layer and one second after that add it again).
