### PR TITLE
Fix array of array of LatLngs toGeoJSON edge case

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -120,7 +120,7 @@ describe("L.Polyline (multi) #toGeoJSON", function () {
 });
 
 describe("L.Polygon#toGeoJSON", function () {
-	it("returns a 2D Polygon object (no holes)", function () {
+	it("returns a 2D Polygon object (no holes) from a flat LatLngs array", function () {
 		var polygon = new L.Polygon([[1, 2], [3, 4], [5, 6]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
@@ -128,11 +128,31 @@ describe("L.Polygon#toGeoJSON", function () {
 		});
 	});
 
-	it("returns a 3D Polygon object (no holes)", function () {
+	it("returns a 3D Polygon object (no holes) from a flat LatLngs array", function () {
 		var polygon = new L.Polygon([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [[[2, 1, 3], [5, 4, 6], [8, 7, 9], [2, 1, 3]]]
+		});
+	});
+
+	it("returns a 2D Polygon object from a simple GeoJSON like input", function () {
+		var multiPolygon = new L.Polygon([[[1, 2], [3, 4], [5, 6]]]);
+		expect(multiPolygon.toGeoJSON().geometry).to.eql({
+			type: 'Polygon',
+			coordinates: [
+				[[2, 1], [4, 3], [6, 5], [2, 1]]
+			]
+		});
+	});
+
+	it("returns a 3D MultiPolygon object from a simple GeoJSON like input", function () {
+		var multiPolygon = new L.Polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
+		expect(multiPolygon.toGeoJSON().geometry).to.eql({
+			type: 'Polygon',
+			coordinates: [
+				[[2, 1, 3], [5, 4, 6], [8, 7, 9], [2, 1, 3]]
+			]
 		});
 	});
 
@@ -157,11 +177,12 @@ describe("L.Polygon#toGeoJSON", function () {
 			]
 		});
 	});
+
 });
 
 describe("L.Polygon (multi) #toGeoJSON", function () {
 	it("returns a 2D MultiPolygon object", function () {
-		var multiPolygon = new L.Polygon([[[1, 2], [3, 4], [5, 6]]]);
+		var multiPolygon = new L.Polygon([[[[1, 2], [3, 4], [5, 6]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -171,7 +192,7 @@ describe("L.Polygon (multi) #toGeoJSON", function () {
 	});
 
 	it("returns a 3D MultiPolygon object", function () {
-		var multiPolygon = new L.Polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
+		var multiPolygon = new L.Polygon([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -179,6 +200,28 @@ describe("L.Polygon (multi) #toGeoJSON", function () {
 			]
 		});
 	});
+
+	it("returns a 2D MultiPolygon object with two polygons", function () {
+		var multiPolygon = new L.Polygon([[[[1, 2], [3, 4], [5, 6]]], [[[7, 8], [9, 10], [11, 12]]]]);
+		expect(multiPolygon.toGeoJSON().geometry).to.eql({
+			type: 'MultiPolygon',
+			coordinates: [
+				[[[2, 1], [4, 3], [6, 5], [2, 1]]],
+				[[[8, 7], [10, 9], [12, 11], [8, 7]]]
+			]
+		});
+	});
+
+	it("returns a 2D MultiPolygon object with polygon having a hole", function () {
+		var multiPolygon = new L.Polygon([[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]]);
+		expect(multiPolygon.toGeoJSON().geometry).to.eql({
+			type: 'MultiPolygon',
+			coordinates: [
+				[[[2, 1], [4, 3], [6, 5], [2, 1]], [[8, 7], [10, 9], [12, 11], [8, 7]]]
+			]
+		});
+	});
+
 });
 
 describe("L.LayerGroup#toGeoJSON", function () {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -206,10 +206,6 @@ L.Polygon.prototype.toGeoJSON = function () {
 
 	var coords = L.GeoJSON.latLngsToCoords(this._latlngs, multi ? 2 : holes ? 1 : 0, true);
 
-	if (holes && this._latlngs.length === 1) {
-		multi = true;
-		coords = [coords];
-	}
 	if (!holes) {
 		coords = [coords];
 	}


### PR DESCRIPTION
In master branch, MultiPolygon and Polygon are both managed by the Polygon class, and in the process of exporting to GeoJSON we now have a "guess" step, to know if we need to export to a Polygon or a MultiPolygon.

Here is in summary the [GeoJSON specs](http://geojson.org/geojson-spec.html#polygon):
- a Polygon is an _array of LinearRing coordinate arrays_, so something like `[[…], […]]`; the first of those arrays being the exterior ring of the Polygon, and the optional others being the holes
- a MultiPolygon is an _array of Polygon coordinate arrays_, which is an array of one or more Polygon as just defined, so something like `[[[…], […]], [[…], […]]]`

So, sadly, we don't have an exact one to one match between GeoJSON specs and Leaflet internal. There is an edge case: Leaflet allows to create a simple polygon with an array of LatLngs, while this would be, strictly speaking, an invalid GeoJSON coordinates value; instead, the minimal form of a Polygon according to GeoJSON specs would be _an array with an array of LatLngs_.

Corollary, this very simple GeoJSON Polygon (i.e. not multi, no hole, but strict GeoJSON structure, with an array of arrays of LatLngs) was wrongly output as a MultiPolygon. This PR fixes that.

Before:

``` javascript
> JSON.stringify(L.polygon([[[1,2], [2,2], [2,1]]]).toGeoJSON())
'{"type":"Feature","properties":{},"geometry":{"type":"MultiPolygon","coordinates":[[[[2,1],[2,2],[1,2],[2,1]]]]}}'
```

After:

``` javascript
> JSON.stringify(L.polygon([[[1,2], [2,2], [2,1]]]).toGeoJSON())
'{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[2,1],[2,2],[1,2],[2,1]]]}}'
```

I've also added more test cases, to be sure I'm not breaking other edge cases.

Thanks for reviewing :)
