### PR TITLE
If svg has been given a min-width, it must be reset to none.

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -13,6 +13,7 @@
 	position: absolute;
 	left: 0;
 	top: 0;
+	min-width: none;
 	}
 .leaflet-container {
 	overflow: hidden;


### PR DESCRIPTION
Other objects there are likely also reliant on 'min-width: none'.  If that's not the case, the scope of this can be minimized, but "reset"-type css like this that is required needs to be clearly declared or else it will be overridden by external stylesheets.
