### PR TITLE
Add setLayers() to LayerGroup

### DIFF
--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -54,6 +54,44 @@
 		});
 	});
 
+	describe("#setLayers", function () {
+		it('adds layers', function () {
+			var initialMarkers = [
+				L.marker([0, 0])
+			];
+
+			var lg = L.layerGroup(initialMarkers);
+
+			var newMarkers = [
+				L.marker([0, 1]),
+				L.marker([1, 1])
+			];
+
+			var allMarkers = initialMarkers.concat( newMarkers );
+
+			lg.setLayers(allMarkers);
+
+			expect(lg.getLayers()).to.eql(allMarkers);
+		});
+
+		it('removes layers', function () {
+			var initialMarkers = [
+				L.marker([0, 0]),
+				L.marker([0, 1]),
+				L.marker([1, 1]),
+				L.marker([1, 2])
+			];
+
+			var lg = L.layerGroup(initialMarkers);
+
+			var newMarkers = initialMarkers.splice(1,1);
+
+			lg.setLayers( newMarkers );
+
+			expect(lg.getLayers()).to.eql(newMarkers);
+		});
+	});
+
 	describe("#eachLayer", function () {
 		it('iterates over all layers', function () {
 			var lg = L.layerGroup(),

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -99,6 +99,34 @@ L.LayerGroup = L.Layer.extend({
 		return layers;
 	},
 
+	setLayers: function (layers) {
+		// What exists in new layers, but not current layers?
+		for (var newLayerIndex in layers) {
+			if (!this.hasLayer(layers[newLayerIndex])) {
+				this.addLayer(layers[newLayerIndex]);
+			}
+		}
+
+		// What exists in current layers, but not new layers?
+		for (var existingLayerIndex in this._layers) {
+			var found = false;
+
+			for (var newLayerIndex2 in layers) {
+				if (this._layers[existingLayerIndex] === layers[newLayerIndex2]) {
+					found = true;
+
+					break;
+				}
+			}
+
+			if (!found) {
+				this.removeLayer(this._layers[existingLayerIndex]);
+			}
+		}
+
+		return this;
+	},
+
 	setZIndex: function (zIndex) {
 		return this.invoke('setZIndex', zIndex);
 	},


### PR DESCRIPTION
Adds ability to set all layers in a LayerGroup en mass.

This is useful when needing to sync up the layers with
those stored in a separate location, for example.

Also provides parity with the existing getLayers() method

Fixes #2991
