### PR TITLE
Implement fast zoom on minus/plus keydown with shiftKey

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -141,7 +141,7 @@ L.Map.Keyboard = L.Handler.extend({
 			}
 
 		} else if (key in this._zoomKeys) {
-			map.setZoom(map.getZoom() + (e.shiftKey ? this._zoomKeys[key] * 3 : this._zoomKeys[key]));
+			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key]);
 
 		} else if (key === 27) {
 			map.closePopup();


### PR DESCRIPTION
Goal is to make it consistent with the zoomControl shift+click.

If you think it's a good suggestion, I'm still not sure:
- if we should also factorize the `shiftZoomFactor` with zoomControl
- if not, then if we need a `shiftZoomFactor` option at all

Thanks for reviewing :)
