### PR TITLE
Add fractional zoom support to fitBounds and getBoundsZoom

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -292,8 +292,8 @@ L.Map = L.Evented.extend({
 		padding = L.point(padding || [0, 0]);
 		step = step || 1;
 
-		var minZoom = this.getMinZoom(),
-		    maxZoom = Math.min(this.getMaxZoom(), 18) + step,
+		var minZoom = this.getMinZoom() - (inside ? step : 0),
+		    maxZoom = Math.min(this.getMaxZoom(), 18) + (inside ? 0 : step),
 		    size = this.getSize(),
 
 		    nw = bounds.getNorthWest(),
@@ -309,15 +309,25 @@ L.Map = L.Evented.extend({
 
 			boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)).add(padding).floor();
 
-			if (!inside ? size.contains(boundsSize) : boundsSize.x < size.x || boundsSize.y < size.y) {
-				minZoom = zoom;
-				zoomNotFound = false;
+			if (!inside) {
+				if (size.contains(boundsSize)) {
+					minZoom = zoom;
+					zoomNotFound = false;
+				} else {
+					maxZoom = zoom;
+					zoom = minZoom;
+				}
 			} else {
-				maxZoom = zoom;
-				zoom = minZoom;
+				 if (boundsSize.contains(size)) {
+					maxZoom = zoom;
+					zoomNotFound = false;
+				} else {
+					minZoom = zoom;
+					zoom = maxZoom;
+				}
 			}
 
-		} while (Math.round((maxZoom - minZoom) / step) > 1 || (zoomNotFound && minZoom !== maxZoom));
+		} while (Math.round((maxZoom - minZoom) / step) > 1);
 
 		if (zoomNotFound && inside) {
 			return null;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -293,7 +293,7 @@ L.Map = L.Evented.extend({
 		step = step || 1;
 
 		var minZoom = this.getMinZoom() - (inside ? step : 0),
-		    maxZoom = Math.min(this.getMaxZoom(), 18) + (inside ? 0 : step),
+		    maxZoom = (isFinite(this.getMaxZoom()) ? this.getMaxZoom() : 18) + (inside ? 0 : step),
 		    size = this.getSize(),
 
 		    nw = bounds.getNorthWest(),


### PR DESCRIPTION
Adds a 'step' option to fitBounds (and equivalent 'step' parameter to getBoundsZoom), defaulting to 1, enabling these functions to use fractional zoom levels (#2382). For example, set 'step' to 0.25 for nearest quarter zoom level, i.e. 10, 10.25, 10.5, 10.75, and so on.

Optimizes getBoundsZoom with a binary search; previous implementation counted up from minZoom using whole numbers.

<!---
@huboard:{"milestone_order":3019.5}
-->
