### PR TITLE
Use DOM event delegation for all layers

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -1,16 +1,25 @@
 describe("Marker", function () {
 	var map,
 		spy,
+		div,
 		icon1,
 		icon2;
 
 	beforeEach(function () {
-		map = L.map(document.createElement('div')).setView([0, 0], 0);
+		div = document.createElement('div');
+		div.style.height = '100px';
+		document.body.appendChild(div);
+
+		map = L.map(div).setView([0, 0], 0);
 		icon1 = new L.Icon.Default();
 		icon2 = new L.Icon.Default({
 			iconUrl: icon1._getIconUrl('icon') + '?2',
 			shadowUrl: icon1._getIconUrl('shadow') + '?2'
 		});
+	});
+
+	afterEach(function () {
+		document.body.removeChild(div);
 	});
 
 	describe("#setIcon", function () {
@@ -143,6 +152,19 @@ describe("Marker", function () {
 			expect(eventArgs.oldLatLng).to.be(beforeLatLng);
 			expect(eventArgs.latlng).to.be(afterLatLng);
 			expect(marker.getLatLng()).to.be(afterLatLng);
+		});
+	});
+
+	describe('events', function () {
+		it('fires click event when clicked', function () {
+			var spy = sinon.spy();
+
+			var marker = L.marker([0, 0]).addTo(map);
+
+			marker.on('click', spy);
+			happen.click(marker._icon);
+
+			expect(spy.called).to.be.ok();
 		});
 	});
 });

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -219,4 +219,19 @@ L.DomUtil = {
 	L.DomUtil.enableImageDrag = function () {
 		L.DomEvent.off(window, 'dragstart', L.DomEvent.preventDefault);
 	};
+
+	L.DomUtil.preventOutline = function (element) {
+		L.DomUtil.restoreOutline();
+		this._outlineElement = element;
+		this._outlineStyle = element.style.outline;
+		element.style.outline = 'none';
+		L.DomEvent.on(window, 'keydown', L.DomUtil.restoreOutline, this);
+	};
+	L.DomUtil.restoreOutline = function () {
+		if (!this._outlineElement) { return; }
+		this._outlineElement.style.outline = this._outlineStyle;
+		delete this._outlineElement;
+		delete this._outlineStyle;
+		L.DomEvent.off(window, 'keydown', L.DomUtil.restoreOutline, this);
+	};
 })();

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -20,9 +20,10 @@ L.Draggable = L.Evented.extend({
 		}
 	},
 
-	initialize: function (element, dragStartTarget) {
+	initialize: function (element, dragStartTarget, preventOutline) {
 		this._element = element;
 		this._dragStartTarget = dragStartTarget || element;
+		this._preventOutline = preventOutline;
 	},
 
 	enable: function () {
@@ -48,6 +49,10 @@ L.Draggable = L.Evented.extend({
 		if (e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 
 		L.DomEvent.stopPropagation(e);
+
+		if (this._preventOutline) {
+			L.DomEvent.preventDefault(e);
+		}
 
 		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -51,7 +51,7 @@ L.Draggable = L.Evented.extend({
 		L.DomEvent.stopPropagation(e);
 
 		if (this._preventOutline) {
-			L.DomEvent.preventDefault(e);
+			L.DomUtil.preventOutline(this._element);
 		}
 
 		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -26,13 +26,20 @@ L.ImageOverlay = L.Layer.extend({
 			}
 		}
 
+		if (this.options.interactive) {
+			L.DomUtil.addClass(this._image, 'leaflet-interactive');
+			this.addInteractiveTarget(this._image);
+		}
+
 		this.getPane().appendChild(this._image);
-		this._initInteraction();
 		this._reset();
 	},
 
 	onRemove: function () {
 		L.DomUtil.remove(this._image);
+		if (this.options.interactive) {
+			this.removeInteractiveTarget(this._image);
+		}
 	},
 
 	setOpacity: function (opacity) {
@@ -63,19 +70,6 @@ L.ImageOverlay = L.Layer.extend({
 			L.DomUtil.toBack(this._image);
 		}
 		return this;
-	},
-
-	_initInteraction: function () {
-		if (!this.options.interactive) { return; }
-		L.DomUtil.addClass(this._image, 'leaflet-interactive');
-		L.DomEvent.on(this._image, 'click dblclick mousedown mouseup mouseover mousemove mouseout contextmenu',
-				this._fireMouseEvent, this);
-	},
-
-	_fireMouseEvent: function (e, type) {
-		if (this._map) {
-			this._map._fireMouseEvent(this, e, type, true);
-		}
 	},
 
 	setUrl: function (url) {

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -25,6 +25,16 @@ L.Layer = L.Evented.extend({
 		return this._map.getPane(name ? (this.options[name] || name) : this.options.pane);
 	},
 
+	addInteractiveTarget: function (targetEl) {
+		this._map._targets[L.stamp(targetEl)] = this;
+		return this;
+	},
+
+	removeInteractiveTarget: function (targetEl) {
+		delete this._map._targets[L.stamp(targetEl)];
+		return this;
+	},
+
 	_layerAdd: function (e) {
 		var map = e.target;
 

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -11,7 +11,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		var icon = this._marker._icon;
 
 		if (!this._draggable) {
-			this._draggable = new L.Draggable(icon, icon);
+			this._draggable = new L.Draggable(icon, icon, true);
 		}
 
 		this._draggable.on({

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -123,11 +123,11 @@ L.Marker = L.Layer.extend({
 		this._icon = icon;
 		this._initInteraction();
 
-		if (L.DomEvent && options.riseOnHover) {
-			L.DomEvent.on(icon, {
+		if (options.riseOnHover) {
+			this.on({
 				mouseover: this._bringToFront,
 				mouseout: this._resetZIndex
-			}, this);
+			});
 		}
 
 		var newShadow = options.icon.createShadow(this._shadow),
@@ -158,14 +158,15 @@ L.Marker = L.Layer.extend({
 	},
 
 	_removeIcon: function () {
-		if (L.DomEvent && this.options.riseOnHover) {
-			L.DomEvent.off(this._icon, {
+		if (this.options.riseOnHover) {
+			this.off({
 				mouseover: this._bringToFront,
 			    mouseout: this._resetZIndex
-			}, this);
+			});
 		}
 
 		L.DomUtil.remove(this._icon);
+		this.removeInteractiveTarget(this._icon);
 
 		this._icon = null;
 	},
@@ -205,11 +206,7 @@ L.Marker = L.Layer.extend({
 
 		L.DomUtil.addClass(this._icon, 'leaflet-interactive');
 
-		if (L.DomEvent) {
-			L.DomEvent.on(this._icon,
-				'click dblclick mousedown mouseup mouseover mousemove mouseout contextmenu keypress',
-				this._fireMouseEvent, this);
-		}
+		this.addInteractiveTarget(this._icon);
 
 		if (L.Handler.MarkerDrag) {
 			var draggable = this.options.draggable;
@@ -223,21 +220,6 @@ L.Marker = L.Layer.extend({
 			if (draggable) {
 				this.dragging.enable();
 			}
-		}
-	},
-
-	_fireMouseEvent: function (e, type) {
-		// to prevent outline when clicking on keyboard-focusable marker
-		if (e.type === 'mousedown') {
-			L.DomEvent.preventDefault(e);
-		}
-
-		if (e.type === 'keypress' && e.keyCode === 13) {
-			type = 'click';
-		}
-
-		if (this._map) {
-			this._map._fireMouseEvent(this, e, type, true, this._latlng);
 		}
 	},
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -190,7 +190,8 @@ L.Canvas = L.Renderer.extend({
 
 		for (var id in this._layers) {
 			if (this._layers[id]._containsPoint(point)) {
-				this._layers[id]._fireMouseEvent(e);
+				L.DomEvent._fakeStop(e);
+				this._fireEvent(this._layers[id], e);
 			}
 		}
 	},
@@ -213,18 +214,22 @@ L.Canvas = L.Renderer.extend({
 			// if we just got inside the layer, fire mouseover
 			if (!layer._mouseInside) {
 				L.DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
-				layer._fireMouseEvent(e, 'mouseover');
+				this._fireEvent(layer, e, 'mouseover');
 				layer._mouseInside = true;
 			}
 			// fire mousemove
-			layer._fireMouseEvent(e);
+			this._fireEvent(layer, e);
 
 		} else if (layer._mouseInside) {
 			// if we're leaving the layer, fire mouseout
 			L.DomUtil.removeClass(this._container, 'leaflet-interactive');
-			layer._fireMouseEvent(e, 'mouseout');
+			this._fireEvent(layer, e, 'mouseout');
 			layer._mouseInside = false;
 		}
+	},
+
+	_fireEvent: function (layer, e, type) {
+		this._map._fireDOMEvent(layer, e, type || e.type);
 	},
 
 	// TODO _bringToFront & _bringToBack, pretty tricky

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -74,10 +74,6 @@ L.Path = L.Layer.extend({
 		return this;
 	},
 
-	_fireMouseEvent: function (e, type) {
-		this._map._fireMouseEvent(this, e, type, true);
-	},
-
 	_clickTolerance: function () {
 		// used when doing hit detection for Canvas layers
 		return (this.options.stroke ? this.options.weight / 2 : 0) + (L.Browser.touch ? 10 : 0);

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -7,9 +7,6 @@ L.SVG = L.Renderer.extend({
 	_initContainer: function () {
 		this._container = L.SVG.create('svg');
 
-		this._paths = {};
-		this._initEvents();
-
 		// makes it possible to click through svg root; we'll reset it back in individual paths
 		this._container.setAttribute('pointer-events', 'none');
 	},
@@ -54,15 +51,13 @@ L.SVG = L.Renderer.extend({
 	},
 
 	_addPath: function (layer) {
-		var path = layer._path;
-		this._container.appendChild(path);
-		this._paths[L.stamp(path)] = layer;
+		this._container.appendChild(layer._path);
+		layer.addInteractiveTarget(layer._path);
 	},
 
 	_removePath: function (layer) {
-		var path = layer._path;
-		L.DomUtil.remove(path);
-		delete this._paths[L.stamp(path)];
+		L.DomUtil.remove(layer._path);
+		layer.removeInteractiveTarget(layer._path);
 	},
 
 	_updatePath: function (layer) {
@@ -139,19 +134,6 @@ L.SVG = L.Renderer.extend({
 
 	_bringToBack: function (layer) {
 		L.DomUtil.toBack(layer._path);
-	},
-
-	// TODO remove duplication with L.Map
-	_initEvents: function () {
-		L.DomEvent.on(this._container, 'click dblclick mousedown mouseup mouseover mouseout mousemove contextmenu',
-				this._fireMouseEvent, this);
-	},
-
-	_fireMouseEvent: function (e) {
-		var path = this._paths[L.stamp(e.target || e.srcElement)];
-		if (path) {
-			path._fireMouseEvent(e);
-		}
 	}
 });
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -581,7 +581,7 @@ L.Map = L.Evented.extend({
 				!L.DomEvent._checkMouse(this._container, e)) { return; }
 
 		// prevents outline when clicking on keyboard-focusable element
-		if (type === 'mousedown') {
+		if (target && type === 'mousedown') {
 			L.DomEvent.preventDefault(e);
 		}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -581,8 +581,8 @@ L.Map = L.Evented.extend({
 				!L.DomEvent._checkMouse(this._container, e)) { return; }
 
 		// prevents outline when clicking on keyboard-focusable element
-		if (target && type === 'mousedown') {
-			L.DomEvent.preventDefault(e);
+		if (type === 'mousedown') {
+			L.DomUtil.preventOutline(e.target || e.srcElement);
 		}
 
 		this._fireDOMEvent(target || this, e, type);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -585,8 +585,10 @@ L.Map = L.Evented.extend({
 			L.DomEvent.preventDefault(e);
 		}
 
-		target = target || this;
+		this._fireDOMEvent(target || this, e, type);
+	},
 
+	_fireDOMEvent: function (target, e, type) {
 		if (!target.listens(type, true) && (type !== 'click' || !target.listens('preclick', true))) { return; }
 
 		if (type === 'contextmenu') {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -557,6 +557,8 @@ L.Map = L.Evented.extend({
 			'click dblclick mousedown mouseup mouseenter mouseleave mousemove contextmenu',
 			this._handleMouseEvent, this);
 
+		this._targets = {};
+
 		if (this.options.trackResize) {
 			L.DomEvent[onOff](window, 'resize', this._onResize, this);
 		}
@@ -571,9 +573,11 @@ L.Map = L.Evented.extend({
 	_handleMouseEvent: function (e) {
 		if (!this._loaded) { return; }
 
-		this._fireMouseEvent(this, e,
+		var target = this._targets[L.stamp(e.target || e.srcElement)];
+
+		this._fireMouseEvent(target || this, e,
 				e.type === 'mouseenter' ? 'mouseover' :
-				e.type === 'mouseleave' ? 'mouseout' : e.type);
+				e.type === 'mouseleave' ? 'mouseout' : e.type, true);
 	},
 
 	_fireMouseEvent: function (obj, e, type, propagate, latlng) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -602,8 +602,8 @@ L.Map = L.Evented.extend({
 			originalEvent: e
 		};
 		if (e.type !== 'keypress') {
-			// TODO latlng isn't used, wrong latlng for markers
-			data.containerPoint = this.mouseEventToContainerPoint(e);
+			data.containerPoint = target instanceof L.Marker ?
+					this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
 			data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);
 			data.latlng = this.layerPointToLatLng(data.layerPoint);
 		}


### PR DESCRIPTION
Adds `Layer` `addInteractiveTarget` and `removeInteractiveTarget` that implements event magic for all layers using delegate events (propagated to map container and handled there in one place). No more mouse event code duplication, and it speeds up adding lots of markers significantly (no need to add tons of listeners on each individual element). Closes #46 

To Do:
- [x] test extensively to make sure nothing is broken
- [x] figure out how to pass marker latlng instead of mouse position in marker event data
- [x] add some tests