### PR TITLE
Fix inertia animation with worldCopyJump enabled

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -67,7 +67,7 @@ L.Map.Drag = L.Handler.extend({
 	_onDrag: function () {
 		if (this._map.options.inertia) {
 			var time = this._lastTime = +new Date(),
-			    pos = this._lastPos = this._draggable._newPos;
+			    pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
 
 			this._positions.push(pos);
 			this._times.push(time);
@@ -101,6 +101,7 @@ L.Map.Drag = L.Handler.extend({
 		    newX2 = (x + halfWidth + dx) % worldWidth - halfWidth - dx,
 		    newX = Math.abs(newX1 + dx) < Math.abs(newX2 + dx) ? newX1 : newX2;
 
+		this._draggable._absPos = this._draggable._newPos.clone();
 		this._draggable._newPos.x = newX;
 	},
 


### PR DESCRIPTION
Hello,

This patch fixes an issue where inertia animation fails when dragging over 180/-180° with the 'worldCopyJump' option enabled

See https://github.com/Leaflet/Leaflet/issues/2624 for more details

Hope this commit will be useful
