### PR TITLE
Add GeometryCollection's id to the layer data.

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -107,7 +107,8 @@ L.extend(L.GeoJSON, {
 				layers.push(this.geometryToLayer({
 					geometry: geometry.geometries[i],
 					type: 'Feature',
-					properties: geojson.properties
+					properties: geojson.properties,
+					id: geojson.id
 				}, options));
 			}
 			return new L.FeatureGroup(layers);


### PR DESCRIPTION
When creating a layer from a GeometryCollection using pointToLayer the id of the
collection should be added to the layer data. This may make it easier to inspect
the feature to see what source it originally came from.

Fixes #2971 