### PR TITLE
Remove global variable that disables dragging for all maps during zoom

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -49,7 +49,7 @@ L.Draggable = L.Evented.extend({
 
 		L.DomEvent.stopPropagation(e);
 
-		if (L.Draggable._disabled) { return; }
+		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 
 		L.DomUtil.disableImageDrag();
 		L.DomUtil.disableTextSelection();

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -89,11 +89,6 @@ L.Map.include(!zoomAnimated ? {} : {
 			this._animateToCenter = center;
 			this._animateToZoom = zoom;
 
-			// disable any dragging during animation
-			if (L.Draggable) {
-				L.Draggable._disabled = true;
-			}
-
 			L.DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 		}
 
@@ -113,9 +108,5 @@ L.Map.include(!zoomAnimated ? {} : {
 		L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 
 		this._resetView(this._animateToCenter, this._animateToZoom, true, true);
-
-		if (L.Draggable) {
-			L.Draggable._disabled = false;
-		}
 	}
 });


### PR DESCRIPTION
Starting a zoom animation will disable dragging for all maps on the
page. Only the map that is being zoomed should have dragging disabled.

This fix removes a global static variable which is redundant since
the map pane already has a css class assigned to it for the duration of
the zoom animation.

Fixes #2539
