### PR TITLE
Initialize _sizeChanged to true to prevent async map initialization issues

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -44,6 +44,7 @@ L.Map = L.Evented.extend({
 		this._handlers = [];
 		this._layers = {};
 		this._zoomBoundLayers = {};
+		this._sizeChanged = true;
 
 		this.callInitHooks();
 


### PR DESCRIPTION
When asynchronously initializing a map, the series of events can
create a scenario where _size is incorrectly initialized, and
therefore calls to getSize will not cause a new value to be generated.

This fix sets _sizeChanged to true upon map initialization, which
allows the following first call to getSize to work properly.

Closes #3031
