### PR TITLE
Hide single base layer in the Layers control

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -7,7 +7,7 @@ L.Control.Layers = L.Control.extend({
 		collapsed: true,
 		position: 'topright',
 		autoZIndex: true,
-		hideSingleBase: true
+		hideSingleBase: false
 	},
 
 	initialize: function (baseLayers, overlays, options) {


### PR DESCRIPTION
When only a single base layer is present on the map, i.e. listed in the Layers control, do not display it since there's nothing to choose from.

Customizable via the `hideSingleBase` option, defaults to `true`.

Example:

```
L.control.layers({
    'Base Map': L.tileLayer(...).addTo(map)
},{
    'Smile': L.tileLayer(...)
},{
    collapsed: false,
    hideSingleBase: false
});
```

![image](https://cloud.githubusercontent.com/assets/3540490/5488166/42cf8e2e-86ba-11e4-98c4-e00fbd9cea78.png)
