### PR TITLE
GridLayer and pane docs + misc layer docs

### DIFF
--- a/reference-tpl.html
+++ b/reference-tpl.html
@@ -45,7 +45,7 @@
 		<th>Description</th>
 	</tr>
 	<tr>
-		<td><code><b>[method]</b>( <nobr>argument</nobr>, <nobr>argument )</nobr></code></td>
+		<td><code><b>[method]</b>(<nobr>&lt;type&gt;</nobr> <i>argument</i>, <nobr>&lt;type&gt; <i>argument</i>)</nobr></code></td>
 		<td><code>[return-type]</code></td>
 		<td>[description]</td>
 	</tr>

--- a/reference.html
+++ b/reference.html
@@ -37,7 +37,6 @@ bodyclass: api-page
 		<ul>
 			<li><a href="#tilelayer">TileLayer</a></li>
 			<li><a href="#tilelayer-wms">TileLayer.WMS</a></li>
-			<li><a href="#tilelayer-canvas">TileLayer.Canvas</a></li>
 			<li><a href="#imageoverlay">ImageOverlay</a></li>
 		</ul>
 		<h4>Vector Layers</h4>
@@ -56,6 +55,7 @@ bodyclass: api-page
 			<li><a href="#layergroup">LayerGroup</a></li>
 			<li><a href="#featuregroup">FeatureGroup</a></li>
 			<li><a href="#geojson">GeoJSON</a></li>
+			<li><a href="#gridlayer">GridLayer</a></li>
 		</ul>
 		<h4>Basic Types</h4>
 		<ul>
@@ -75,10 +75,11 @@ bodyclass: api-page
 		</ul>
 	</div>
 	<div class="span-3">
-		<h4>Events</h4>
+		<h4>Shared Methods</h4>
 		<ul>
-			<li><a href="#events">Event methods</a></li>
-			<li><a href="#event-objects">Event objects</a></li>
+			<li><a href="#events">Event</a></li>
+            <li><a href="#layers">Layer</a></li>
+			<li><a href="#popups">Popup</a></li>
 		</ul>
 		<h4>Utility</h4>
 		<ul>
@@ -111,6 +112,7 @@ bodyclass: api-page
 
 		<h4>Misc</h4>
 		<ul>
+			<li><a href="#event-objects">Event objects</a></li>
 			<li><a href="#global">global switches</a></li>
 			<li><a href="#noconflict">noConflict</a></li>
 			<li><a href="#version">version</a></li>
@@ -996,6 +998,20 @@ var map = L.map('map', {
 		<td>Returns the container element of the map.</td>
 	</tr>
 	<tr>
+		<td><code><b>createPane</b>(
+			<nobr>&lt;String&gt; <i>name</i>, </nobr> <nobr>&lt;HTMLElement&gt; <i>contianer?</i>
+		)</code></td>
+		<td><a href="#map-panes"><code>MapPane</code></td>
+		<td>Creates a pane with the given name. Created panes will be given a generated class based on the name like <code class="css"><span class="selector">.leaflet-pane-name</span></code>"</td>
+	</tr>
+	<tr>
+		<td><code><b>getPane</b>(
+			<nobr>&lt;String&gt; <i>name</i>
+		)</code></td>
+		<td><a href="#map-panes"><code>MapPane</code></td>
+		<td>Returns the HTML element representing the named map pane.</td>
+	</tr>
+	<tr>
 		<td><code><b>getPanes</b>()</code></td>
 		<td><code><a href="#map-panes">MapPanes</a></code></td>
 		<td>Returns an object with different map panes (to render overlays in).</td>
@@ -1248,47 +1264,51 @@ var map = L.map('map', {
 
 <h3 id="map-panes">Map Panes</h3>
 
-<p>An object literal (returned by <a href="#map-getpanes">map.getPanes</a></code>) that contains different map panes that you can use to put your custom overlays in. The difference is mostly in zIndex order that such overlays get.</p>
+<p>Panes are DOM elements used to control the ordering of layers on the map. You can access panes with <a href="#map-getpane">map.getPane</a> or <a href="#map-getpanes">map.getPanes</a>methods. New panes can be created with the <a href="#map-getpane">map.createPane</a> method.<p>
+
+<p>Every map has the following panes that differ only in zIndex.</p>
 
 <table data-id='map'>
 	<tr>
-		<th class="width100">Property</th>
+		<th class="width100">Pane</th>
 		<th class="width100">Type</th>
+		<th class="width100">Z Index</th>
 		<th>Description</th>
 	</tr>
 	<tr>
 		<td><code><b>mapPane</b></code></td>
 		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="string">'auto'</span></code></td>
 		<td>Pane that contains all other map panes.</td>
 	</tr>
 	<tr>
 		<td><code><b>tilePane</b></code></td>
 		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="number">2</span></code></td>
 		<td>Pane for tile layers.</td>
-	</tr>
-	<tr>
-		<td><code><b>objectsPane</b></code></td>
-		<td><code>HTMLElement</code></td>
-		<td>Pane that contains all the panes except tile pane.</td>
-	</tr>
-	<tr>
-		<td><code><b>shadowPane</b></code></td>
-		<td><code>HTMLElement</code></td>
-		<td>Pane for overlay shadows (e.g. marker shadows).</td>
 	</tr>
 	<tr>
 		<td><code><b>overlayPane</b></code></td>
 		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="number">4</span></code></td>
 		<td>Pane for overlays like polylines and polygons.</td>
+	</tr>
+	<tr>
+		<td><code><b>shadowPane</b></code></td>
+		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="number">5</span></code></td>
+		<td>Pane for overlay shadows (e.g. marker shadows).</td>
 	</tr>
 	<tr>
 		<td><code><b>markerPane</b></code></td>
 		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="number">6</span></code></td>
 		<td>Pane for marker icons.</td>
 	</tr>
 	<tr>
 		<td><code><b>popupPane</b></code></td>
 		<td><code>HTMLElement</code></td>
+		<td><code class="javascript"><span class="number">7</span></code></td>
 		<td>Pane for popups.</td>
 	</tr>
 </table>
@@ -1296,7 +1316,7 @@ var map = L.map('map', {
 
 <h2 id="marker">Marker</h2>
 
-<p>Used to put markers on the map.</p>
+<p>Used to put markers on the map. Extends <a href="#layer">Layer</a>.</p>
 
 <pre><code class="javascript">L.marker([50.5, 30.5]).addTo(map);</code></pre>
 
@@ -1387,6 +1407,18 @@ var map = L.map('map', {
 		<td><code><span class="number">250</span></code></td>
 		<td>The z-index offset used for the <code>riseOnHover</code> feature.</td>
 	</tr>
+	<tr>
+		<td><code><b>pane</b></code></td>
+		<td><code>String</code></td>
+		<td><code><span class="string">'markerPane'</span></code></td>
+		<td><a href="#map-panes">Map pane</a> where the markers icon will be added.</td>
+	</tr>
+	<tr>
+		<td><code><b>shadowPane</b></code></td>
+		<td><code>String</code></td>
+		<td><code><span class="string">'shadowPane'</span></code></td>
+		<td><a href="#map-panes">Map pane</a> where the markers shadow will be added.</td>
+	</tr>
 </table>
 
 <h3>Events</h3>
@@ -1473,19 +1505,13 @@ var map = L.map('map', {
 
 <h3>Methods</h3>
 
+<p>In addition to <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
+
 <table data-id='marker'>
 	<tr>
 		<th>Method</th>
 		<th>Returns</th>
 		<th>Description</th>
-	</tr>
-	<tr>
-		<td><code><b>addTo</b>(
-			<nobr>&lt;<a href="#map">Map</a>&gt; <i>map</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Adds the marker to the map.</td>
 	</tr>
 	<tr>
 		<td><code><b>getLatLng</b>()</code></td>
@@ -1721,21 +1747,35 @@ var map = L.map('map', {
 	</tr>
 </table>
 
+<h3>Events</h3>
+
+<table data-id='popup'>
+	<tr>
+		<th>Event</th>
+		<th>Data</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td><code><b>added</b></code></td>
+		<td><code><a href="#popup-event">PopupEvent</a></code></td>
+		<td>Fired when the popup is added to the map.</td>
+	</tr>
+	<tr>
+		<td><code><b>removed</b></code></td>
+		<td><code><a href="#popup-event">PopupEvent</a></code></td>
+		<td>Fired when the popup is removed from the map.</td>
+	</tr>
+</table>
+
 <h3>Methods</h3>
+
+<p>In addition to <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> you can also use the following methods:</p>
 
 <table data-id='popup'>
 	<tr>
 		<th class="width250">Method</th>
 		<th class="minwidth">Returns</th>
 		<th>Description</th>
-	</tr>
-	<tr>
-		<td><code><b>addTo</b>(
-			<nobr>&lt;<a href="#map">Map</a>&gt; <i>map</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Adds the popup to the map.</td>
 	</tr>
 	<tr>
 		<td><code><b>openOn</b>(
@@ -1815,9 +1855,9 @@ var map = L.map('map', {
 
 <p>A string of the following form:</p>
 
-<pre><code class="javascript">'http://{s}.somedomain.com/blabla/{z}/{x}/{y}.png'</code></pre>
+<pre><code class="javascript">'http://{s}.somedomain.com/blabla/{z}/{x}/{y}{r}.png'</code></pre>
 
-<p><code>{s}</code> means one of the available subdomains (used sequentially to help with browser parallel requests per domain limitation; subdomain values are specified in options; <code>a</code>, <code>b</code> or <code>c</code> by default, can be omitted), <code>{z}</code> &mdash; zoom level, <code>{x}</code> and <code>{y}</code> &mdash; tile coordinates.</p>
+<p><code>{s}</code> means one of the available subdomains (used sequentially to help with browser parallel requests per domain limitation; subdomain values are specified in options; <code>a</code>, <code>b</code> or <code>c</code> by default, can be omitted), <code>{z}</code> &mdash; zoom level, <code>{x}</code> and <code>{y}</code> &mdash; tile coordinates. <code>{r}</code> can be used to add <code>@2x</code> to the URL to load retina tiles.</p>
 
 <p>You can use custom keys in the template, which will be <a href="#util-template">evaluated</a> from TileLayer options, like this:</p>
 
@@ -1917,6 +1957,12 @@ var map = L.map('map', {
 		<td>The explicit zIndex of the tile layer. Not set by default.</td>
 	</tr>
 	<tr>
+		<td><code><b>updateInterval</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="number">200</span></code></td>
+		<td>Tiles will not update more then once every <code>updateInterval</code>.</td>
+	</tr>
+	<tr>
 		<td><code><b>unloadInvisibleTiles</b></code></td>
 		<td><code>Boolean</code></td>
 		<td>depends</td>
@@ -1982,6 +2028,11 @@ var map = L.map('map', {
 		<td><code><b>tileunload</b></code></td>
 		<td><code><a href="#tile-event">TileEvent</a></code></td>
 		<td>Fired when a tile is removed (e.g. when you have <code>unloadInvisibleTiles</code> on).</td>
+	</tr>
+	<tr>
+		<td><code><b>tileerror</b></code></td>
+		<td><code><a href="#tileerror-event">TileEvent</a></code></td>
+		<td>Fired when there is an error loading a tile.</td>
 	</tr>
 </table>
 
@@ -2154,77 +2205,6 @@ var map = L.map('map', {
 </table>
 
 
-<h2 id="tilelayer-canvas">TileLayer.Canvas</h2>
-
-<p>Used to create Canvas-based tile layers where tiles get drawn on the browser side. Extends <a href="#tilelayer">TileLayer</a>.</p>
-
-<h3>Usage example</h3>
-
-<pre><code class="javascript">var canvasTiles = L.tileLayer.canvas();
-
-canvasTiles.drawTile = function(canvas, tilePoint, zoom) {
-	var ctx = canvas.getContext('2d');
-	// draw something on the tile canvas
-}</code></pre>
-
-<h3>Creation</h3>
-
-<table data-id='tilelayer-canvas'>
-	<tr>
-		<th class="width200">Factory</th>
-
-		<th>Description</th>
-	</tr>
-	<tr>
-		<td><code><b>L.tileLayer.canvas</b>(
-			<nobr>&lt;<a href="#tilelayer-options">TileLayer options</a>&gt; <i>options?</i> )</nobr>
-		</code></td>
-
-		<td>Instantiates a Canvas tile layer object given an options object (optionally).</td>
-	</tr>
-</table>
-
-<h3>Options</h3>
-<table data-id='tilelayer-canvas'>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	<tr>
-		<td><code><b>async</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code><span class="literal">false</span></code></td>
-		<td>Indicates that tiles will be drawn asynchronously. <a href="#tilelayer-canvas-tiledrawn">tileDrawn</a> method should be called for each tile after drawing completion.</td>
-	</tr>
-</table>
-
-<h3>Methods</h3>
-
-<table data-id='tilelayer-canvas'>
-	<tr>
-		<th class="width200">Method</th>
-		<th>Returns</th>
-		<th>Description</th>
-	</tr>
-	<tr id = "tilelayer-canvas-drawtile">
-		<td><code><b>drawTile</b>(
-			<nobr>&lt;HTMLCanvasElement&gt; <i>canvas</i></nobr>,
-			<nobr>&lt;<a href="#point">Point</a>&gt; <i>tilePoint</i></nobr>,
-			<nobr>&lt;Number&gt; <i>zoom</i> )</nobr>
-		</code></td>
-		<td><code><span class="keyword">this</span></code></td>
-		<td>You need to define this method after creating the instance to draw tiles; <code>canvas</code> is the actual canvas tile on which you can draw, <code>tilePoint</code> represents the tile numbers, and <code>zoom</code> is the current zoom.</td>
-	</tr>
-	<tr id="tilelayer-canvas-tiledrawn">
-		<td><code><b>tileDrawn</b>( <nobr>&lt;HTMLCanvasElement&gt; <i>canvas</i></nobr> )</code></td>
-		<td>-</td>
-		<td>If <code>async</code> option is defined, this function should be called for each tile after drawing completion. <code>canvas</code> is the same canvas element, that was passed to <a href="#tilelayer-canvas-drawtile">drawTile</a>.</td>
-	</tr>
-</table>
-
-
 <h2 id="imageoverlay">ImageOverlay</h2>
 
 <p>Used to load and display a single image over specific bounds of the map. Extends <a href="#layer">Layer</a>.</p>
@@ -2323,7 +2303,7 @@ L.imageOverlay(imageUrl, imageBounds).addTo(map);</code></pre>
 
 
 <h2 id="path">Path</h2>
-<p>An abstract class that contains options and constants shared between vector overlays (Polygon, Polyline, Circle). Do not use it directly.
+<p>An abstract class that contains options and constants shared between vector overlays (Polygon, Polyline, Circle). Do not use it directly. Extends <a href="#layer">Layer</a>.
 
 <h3 id="path-options">Options</h3>
 <table data-id='path'>
@@ -2482,56 +2462,14 @@ L.imageOverlay(imageUrl, imageBounds).addTo(map);</code></pre>
 </table>
 
 <h3 id="path-methods">Methods</h3>
+
+<p>In addition to <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
+
 <table data-id='path'>
 	<tr>
 		<th class="width250">Method</th>
 		<th>Returns</th>
 		<th>Description</th>
-	</tr>
-	<tr>
-		<td><code><b>addTo</b>(
-			<nobr>&lt;<a href="#map">Map</a>&gt; <i>map</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Adds the layer to the map.</td>
-	</tr>
-	<tr id="path-bindpopup">
-		<td><code><b>bindPopup</b>(
-			<nobr>&lt;String&gt; <i>html</i> |</nobr> <nobr>&lt;HTMLElement&gt; <i>el</i> |</nobr> <nobr>&lt;<a href="#popup">Popup</a>&gt; <i>popup</i>,</nobr>
-			<nobr>&lt;<a href="#popup-options">Popup options</a>&gt; <i>options?</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Binds a popup with a particular HTML content to a click on this path.</td>
-	</tr>
-	<tr>
-		<td><code><b>bindPopup</b>(
-			<nobr>&lt;<a href="#popup">Popup</a>&gt; <i>popup</i></nobr>,
-			<nobr>&lt;<a href="#popup-options">Popup options</a>&gt; <i>options?</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Binds a given popup object to the path.</td>
-	</tr>
-	<tr id="path-unbindpopup">
-		<td><code><b>unbindPopup</b>()</code></td>
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Unbinds the popup previously bound to the path with <code>bindPopup</code>.</td>
-	</tr>
-	<tr id="path-openpopup">
-		<td><code><b>openPopup</b>(
-			<nobr>&lt;<a href="#latlng">LatLng</a>&gt; <i>latlng?</i> )</nobr>
-		</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Opens the popup previously bound by the <a href="#path-bindpopup">bindPopup</a> method in the given point, or in one of the path's points if not specified.</td>
-	</tr>
-	<tr id="path-closepopup">
-		<td><code><b>closePopup</b>()</code></td>
-
-		<td><code><span class="keyword">this</span></code></td>
-		<td>Closes the path's bound popup if it is opened.</td>
 	</tr>
 	<tr id="path-setstyle">
 		<td><code><b>setStyle</b>(
@@ -2673,7 +2611,7 @@ var latlngs = [
 
 <h3>Methods</h3>
 
-<p>You can use <a href="#path-methods">Path methods</a> and additionally the following methods:</p>
+<p>In addition to <a href="#path-methods">Path methods</a> like <code>redraw()</code> and <code>bringToFront()</code>, <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
 
 <table data-id='polyline'>
 	<tr>
@@ -2788,7 +2726,7 @@ var latlngs = [
 
 <h3>Methods</h3>
 
-<p>Polygon has the same options and methods as Polyline, with the following differences:</p>
+<p>In addition to <a href="#path-methods">Path methods</a> like <code>redraw()</code> and <code>bringToFront()</code>, <a href="#polyline-methods">Polyline mehtods</a> like <code>setLatLngs()</code> and <code>getLatLngs()</code>, <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
 
 <table data-id='polygon'>
 	<tr>
@@ -2840,7 +2778,7 @@ map.fitBounds(bounds);</code></pre>
 
 <h3>Methods</h3>
 
-<p>You can use <a href="#path-methods">Path methods</a> and additionally the following methods:</p>
+<p>In addition to <a href="#path-methods">Path methods</a> like <code>redraw()</code> and <code>bringToFront()</code>, <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
 
 <table data-id='rectangle'>
 	<tr>
@@ -2886,6 +2824,8 @@ map.fitBounds(bounds);</code></pre>
 </table>
 
 <h3>Methods</h3>
+
+<p>In addition to <a href="#path-methods">Path methods</a> like <code>redraw()</code> and <code>bringToFront()</code>, <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
 
 <table data-id='circle'>
 	<tr>
@@ -2952,6 +2892,8 @@ map.fitBounds(bounds);</code></pre>
 </table>
 
 <h3>Methods</h3>
+
+<p>In addition to <a href="#path-methods">Path methods</a> like <code>redraw()</code> and <code>bringToFront()</code>, <a href="#layers">shared layer methods</a> like <code>addTo()</code> and <code>remove()</code> and <a href="#popups">popup methods</a> like <code>bindPopup()</code> you can also use the following methods:</p>
 
 <table data-id='circlemarker'>
 	<tr>
@@ -3125,8 +3067,6 @@ map.fitBounds(bounds);</code></pre>
 </table>
 
 <h3>Methods</h3>
-
-<p>Has all <a href="#layergroup">layerGroup</a> methods and additionally:</p>
 
 <table data-id='featuregroup'>
 	<tr>
@@ -3373,8 +3313,216 @@ map.fitBounds(bounds);</code></pre>
 	</tr>
 </table>
 
+<h2 id="gridlayer">GridLayer</h2>
 
+<p>Generic class for handling a tiled grid of HTML elements. This is the base class for all tile layers and replaces <code>TileLayer.Canvas</code>.</p>
 
+<p>GridLayer can be extended to create a tiled grid of HTML Elements like <code>&lt;canvas&gt;</code>, <code>&lt;img&gt;</code> or <code>&lt;div&gt;</code>.GridLayer will handle creating and animating these DOM elements for you.</p>
+
+<h3>Synchronous usage example</h3>
+
+<p>To create a custom layer, extend GridLayer and impliment the <code>createTile()</code> method, which will be passed a <a href="#point">Point</a> object with the <code>x</code>, <code>y</code>, and <code>z</code> (zoom level) coordinates to draw your tile.</p>
+
+<pre><code class="javascript">var CanvasLayer = L.GridLayer.extend({
+	createTile: function(coords){
+		// create a &lt;canvas&gt; element for drawing
+		var tile = L.DomUtil.create('canvas', 'leaflet-tile');
+
+		// setup tile width and height according to the options
+		tile.width = tile.height = this.options.tileSize;
+
+		// get a canvas context and draw something on it using coords.x, coords.y and coords.z
+		var ctx = canvas.getContext('2d');
+
+		// return the tile so it can be rendered on screen
+		return tile;
+	}
+});</code></pre>
+
+<h3>Asyncronous usage example</h3>
+
+<p>Tile creation can also be asyncronous, this is useful when using a third-party drawing library. Once the tile is finsihed drawing it can be passed to the <code>done()</code> callback.</p>
+
+<pre><code class="javascript">var CanvasLayer = L.GridLayer.extend({
+	createTile: function(coords, done){
+		var error;
+
+		// create a &lt;canvas&gt; element for drawing
+		var tile = L.DomUtil.create('canvas', 'leaflet-tile');
+
+		// setup tile width and height according to the options
+		tile.width = tile.height = this.options.tileSize;
+
+		// draw something and pass the tile to the done() callback
+		done(error, tile);
+	}
+});</code></pre>
+
+<h3>Constructor</h3>
+
+<table>
+	<tr>
+		<th>Factory</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td><code>L.gridLayer(&lt;<a href="#gridlayer-options">GridLayer options</a>&gt; <i>options</i>?)</code></td>
+		<td>Creates a new instance of GridLayer with the supplied options.</td>
+	</tr>
+</table>
+
+<h3 id="gridlayer-options">Options</h3>
+
+<table>
+	<tr>
+		<th>Option</th>
+		<th>Type</th>
+		<th>Default value</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td><code><b>maxZoom</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="string">'tilePane'</span></code></td>
+		<td>The <a href="#map-panes">map pane</a> the layer will be added to.</td>
+	</tr>
+	<tr>
+		<td><code><b>tileSize</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="number">256</span></code></td>
+		<td>Width and height of tiles in the grid. Can be used in the <code>createTile()</code> function.</td>
+	</tr>
+	<tr>
+		<td><code><b>opacity</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="number">1</span></code></td>
+		<td>Opacity of the tiles. Can be used in the <code>createTile()</code> function.</td>
+	</tr>
+	<tr>
+		<td><code><b>unloadInvisibleTiles</b></code></td>
+		<td><code>Boolean</code></td>
+		<td>depends</td>
+		<td>If <code><span class="literal">true</span></code>, all the tiles that are not visible after panning are removed (for better performance). <code><span class="literal">true</span></code> by default on mobile WebKit, otherwise <code><span class="literal">false</span></code>.</td>
+	</tr>
+	<tr>
+		<td><code><b>updateWhenIdle</b></code></td>
+		<td><code>Boolean</code></td>
+		<td>depends</td>
+		<td>If <code><span class="literal">false</span></code>, new tiles are loaded during panning, otherwise only after it (for better performance). <code><span class="literal">true</span></code> by default on mobile WebKit, otherwise <code><span class="literal">false</span></code>.</td>
+	</tr>
+	<tr>
+		<td><code><b>updateInterval</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="number">200</span></code></td>
+		<td>Tiles will not update more then once every <code>updateInterval</code>.</td>
+	</tr>
+	<tr>
+		<td><code><b>zIndex</b></code></td>
+		<td><code>Number</code></td>
+		<td><code><span class="literal">null</span></code></td>
+		<td>The explicit zIndex of the tile layer. Not set by default.</td>
+	</tr>
+	<tr>
+		<td><code><b>bounds</b></code></td>
+		<td><code><a href="latlngbounds">LatLngBounds</a></code></td>
+		<td><code><span class="literal">null</span></code></td>
+		<td>If set tiles will only be loaded inside inside the set <a href="latlngbounds">LatLngBounds</a>.</td>
+	</tr>
+	<tr>
+		<td><code><b>bounds</b></code></td>
+		<td><code><a href="latlngbounds">LatLngBounds</a></code></td>
+		<td><code><span class="literal">null</span></code></td>
+		<td>If set tiles will only be loaded inside inside the set <a href="latlngbounds">LatLngBounds</a>.</td>
+	</tr>
+	<tr>
+		<td><code><b>minZoom</b></code></td>
+		<td><code>Number</code></td>
+		<td><code class="javascript"><span class="number">0</span></code></td>
+		<td>The minimum zoom level that tiles will be loaded at. By default the entire map.</td>
+	</tr>
+</table>
+
+<h3>Methods</h3>
+
+<table>
+	<tr>
+		<td><code><b>bringToFront</b>()</code></td>
+		<td><code><span class="keyword">this</span></code></td>
+		<td>Brings the tile layer to the top of all tile layers.</td>
+	</tr>
+	<tr>
+		<td><code><b>bringToBack</b>()</code></td>
+		<td><code><span class="keyword">this</span></code></td>
+		<td>Brings the tile layer to the bottom of all tile layers.</td>
+	</tr>
+	<tr>
+		<td><code><b>setOpacity</b>(
+			<nobr>&lt;Number&gt; <i>opacity</i> )</nobr>
+		</code></td>
+
+		<td><code><span class="keyword">this</span></code></td>
+		<td>Changes the opacity of the tile layer.</td>
+	</tr>
+	<tr>
+		<td><code><b>setZIndex</b>(
+			<nobr>&lt;Number&gt; <i>zIndex</i> )</nobr>
+		</code></td>
+
+		<td><code><span class="keyword">this</span></code></td>
+		<td>Sets the zIndex of the tile layer.</td>
+	</tr>
+	<tr>
+		<td><code><b>redraw</b>()</code></td>
+		<td><code><span class="keyword">this</span></code></td>
+		<td>Causes the layer to clear all the tiles and request them again.</td>
+	</tr>
+	<tr>
+		<td><code><b>getContainer</b>()</nobr>
+		</code></td>
+		<td><code>HTMLElement</code></td>
+		<td>Returns the HTML element that contains the tiles for this layer.</td>
+	</tr>
+</table>
+
+<h3>Events</h3>
+
+<table data-id='tilelayer'>
+	<tr>
+		<th class="width100">Event</th>
+		<th class="width100">Data</th>
+		<th>Description</th>
+	</tr>
+	<tr>
+		<td><code><b>loading</b></code></td>
+		<td><code><a href="#event">Event</a></code></td>
+		<td>Fired when the tile layer starts loading tiles.</td>
+	</tr>
+	<tr>
+		<td><code><b>load</b></code></td>
+		<td><code><a href="#event">Event</a></code></td>
+		<td>Fired when the tile layer loaded all visible tiles.</td>
+	</tr>
+    <tr>
+		<td><code><b>tileloadstart</b></code></td>
+		<td><code><a href="#tile-event">TileEvent</a></code></td>
+		<td>Fired when a tile is requested and starts loading.</td>
+	</tr>
+	<tr>
+		<td><code><b>tileload</b></code></td>
+		<td><code><a href="#tile-event">TileEvent</a></code></td>
+		<td>Fired when a tile loads.</td>
+	</tr>
+	<tr>
+		<td><code><b>tileunload</b></code></td>
+		<td><code><a href="#tile-event">TileEvent</a></code></td>
+		<td>Fired when a tile is removed (e.g. when you have <code>unloadInvisibleTiles</code> on).</td>
+	</tr>
+	<tr>
+		<td><code><b>tileerror</b></code></td>
+		<td><code><a href="#tileerror-event">TileEvent</a></code></td>
+		<td>Fired when there is an error loading a tile.</td>
+	</tr>
+</table>
 
 <h2 id="latlng">LatLng</h2>
 
@@ -4416,10 +4564,9 @@ L.control.layers(baseLayers, overlays).addTo(map);</code></pre>
 </table>
 
 
-
 <h2 id="events">Events methods</h2>
 
-<p>A set of methods shared between event-powered classes (like Map). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map <code><span class="string">'fire'</span></code> event).</p>
+<p>A set of methods shared between event-powered classes (like Map and Marker). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map <code><span class="string">'fire'</span></code> event).</p>
 
 <h3>Example</h3>
 
@@ -4541,268 +4688,98 @@ map.off('click', onClick);</code></pre>
 </table>
 
 
-<h2 id="event-objects">Event objects</h2>
+<h2 id="layers">Layer methods</h2>
 
-<p>Event object is an object that you recieve as an argument in a listener function when some event is fired, containing useful information about that event. For example:</p>
+A set of methods inherited from the <a href="#layer">Layer</a> base class that all Leaflet layers use.
 
-<pre><code class="javascript">map.on('click', function(e) {
-	alert(e.latlng); // e is an event object (MouseEvent in this case)
-});</code></pre>
+<pre><code class="javascript">var layer = L.Marker(latlng).addTo(map);
+layer.addTo(map);
+layer.remove();</code></pre>
 
-<h3 id="event">Event</h3>
+<h3>Methods</h3>
 
-<p>The base event object. All other event objects contain these properties too.</p>
-
-<table data-id='events'>
+<table data-id="layer">
 	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
+		<th>Method</th>
+		<th>Returns</th>
+		<th>Description</th>
 	</tr>
 	<tr>
-		<td><code><b>type</b></code></td>
-		<td><code>String</code></td>
-		<td>The event type (e.g. <code><span class="string">'click'</span></code>).</td>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href="#map-class">Map</a>&gt; <i>map</i>)</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Adds the layer to the given map.</td>
 	</tr>
 	<tr>
-		<td><code><b>target</b></code></td>
-		<td><code>Object</code></td>
-		<td>The object that fired the event.</td>
-	</tr>
-</table>
-
-<h3 id="mouse-event">MouseEvent</h3>
-
-<table data-id='events'>
-	<tr>
-		<th class="width100">property</th>
-		<th>type</th>
-		<th>description</th>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href="#map-class">Map</a>&gt; <i>map</i>)</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Removes the layer to the given map.</td>
 	</tr>
 	<tr>
-		<td><code><b>latlng</b></code></td>
-		<td><code><a href="#latlng">LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td><code><b>remove</b>()</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Removes the layer from the map it is currently active on.</td>
 	</tr>
 	<tr>
-		<td><code><b>layerPoint</b></code></td>
-		<td><code><a href="#point">Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
-	</tr>
-	<tr>
-		<td><code><b>containerPoint</b></code></td>
-		<td><code><a href="#point">Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
-	</tr>
-	<tr>
-		<td><code><b>originalEvent</b></code></td>
-		<td><code>DOMMouseEvent</code></td>
-		<td>The original DOM mouse event fired by the browser.</td>
-	</tr>
-</table>
-
-<h3 id="location-event">LocationEvent</h3>
-
-<table data-id='events'>
-	<tr>
-		<th class="width100">property</th>
-		<th>type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>latlng</b></code></td>
-		<td><code><a href="#latlng">LatLng</a></code></td>
-		<td>Detected geographical location of the user.</td>
-	</tr>
-	<tr>
-		<td><code><b>bounds</b></code></td>
-		<td><code><a href="#latlngbounds">LatLngBounds</a></code></td>
-		<td>Geographical bounds of the area user is located in (with respect to the accuracy of location).</td>
-	</tr>
-	<tr>
-		<td><code><b>accuracy</b></code></td>
-		<td><code>Number</code></td>
-		<td>Accuracy of location in meters.</td>
-	</tr>
-	<tr>
-		<td><code><b>altitude</b></code></td>
-		<td><code>Number</code></td>
-		<td>Height of the position above the WGS84 ellipsoid in meters.</td>
-	</tr>
-	<tr>
-		<td><code><b>altitudeAccuracy</b></code></td>
-		<td><code>Number</code></td>
-		<td>Accuracy of altitude in meters.</td>
-	</tr>
-	<tr>
-		<td><code><b>heading</b></code></td>
-		<td><code>Number</code></td>
-		<td>The direction of travel in degrees counting clockwise from true North.</td>
-	</tr>
-	<tr>
-		<td><code><b>speed</b></code></td>
-		<td><code>Number</code></td>
-		<td>Current velocity in meters per second.</td>
-	</tr>
-	<tr>
-		<td><code><b>timestamp</b></code></td>
-		<td><code>Number</code></td>
-		<td>The time when the position was acquired.</td>
-	</tr>
-</table>
-
-<h3 id="error-event">ErrorEvent</h3>
-
-<table data-id='error-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>message</b></code></td>
-		<td><code>String</code></td>
-		<td>Error message.</td>
-	</tr>
-	<tr>
-		<td><code><b>code</b></code></td>
-		<td><code>Number</code></td>
-		<td>Error code (if applicable).</td>
-	</tr>
-</table>
-
-<h3 id="layer-event">LayerEvent</h3>
-
-<table data-id='layer-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>layer</b></code></td>
-		<td><code><a href="#layer">ILayer</a></code></td>
-		<td>The layer that was added or removed.</td>
-	</tr>
-</table>
-
-<h3 id="layers-control-event">LayersControlEvent</h3>
-
-<table data-id='layer-control-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>layer</b></code></td>
-		<td><code><a href="#layer">ILayer</a></code></td>
-		<td>The layer that was added or removed.</td>
-	</tr>
-	<tr>
-		<td><code><b>name</b></code></td>
-		<td><code>String</code></td>
-		<td>The name of the layer that was added or removed.</td>
-	</tr>
-</table>
-
-<h3 id="tile-event">TileEvent</h3>
-
-<table data-id='tile-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>tile</b></code></td>
+		<td><code><b>getPane</b>(<nobr>&lt;String&gt; <i>name?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td>The tile element (image).</td>
+		<td>Returns the <code>HTMLElement</code> representing the named pane on the map. Or if <code>name</code> is omitted the pane for this layer.</td>
 	</tr>
 </table>
 
-<h3 id="resize-event">ResizeEvent</h3>
+<h2 id="popups">Popup methods</h2>
 
-<table data-id='resize-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>oldSize</b></code></td>
-		<td><code><a href="#point">Point</a></code></td>
-		<td>The old size before resize event.</td>
-	</tr>
-	<tr>
-		<td><code><b>newSize</b></code></td>
-		<td><code><a href="#point">Point</a></code></td>
-		<td>The new size after the resize event.</td>
-	</tr>
-</table>
+A set of methods inherited from the <a href="#layer">Layer</a> base class that all Leaflet layers use. These methods provide convieniant ways of binding popups to any layer.
 
-<h3 id="geojson-event">GeoJSON event</h3>
+<pre><code class="javascript">var layer = L.Polgon(latlngs).bindPopup('Hi There!').addTo(map);
+layer.openPopup();
+layer.closePopup();
+</code></pre>
 
-<table data-id='geojson-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>layer</b></code></td>
-		<td><code><a href="#layer">ILayer</a></code></td>
-		<td>The layer for the GeoJSON feature that is being added to the map.</td>
-	</tr>
-	<tr>
-		<td><code><b>properties</b></code></td>
-		<td><code>Object</code></td>
-		<td>GeoJSON properties of the feature.</td>
-	</tr>
-	<tr>
-		<td><code><b>geometryType</b></code></td>
-		<td><code>String</code></td>
-		<td>GeoJSON geometry type of the feature.</td>
-	</tr>
-	<tr>
-		<td><code><b>id</b></code></td>
-		<td><code>String</code></td>
-		<td>GeoJSON ID of the feature (if present).</td>
-	</tr>
-</table>
+Popups will also be automatically opened when the layer is clicked on and closed when the layer is removed from the map or another popup is opened.
 
-<h3 id="popup-event">Popup event</h3>
-
-<table data-id='popup-event'>
+<h3>Methods</h3>
+<table>
 	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
+		<th>Method</th>
+		<th>Returns</th>
+		<th>Description</th>
 	</tr>
 	<tr>
-		<td><code><b>popup</b></code></td>
+		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|<a href="popup">Popup</a>&gt;</nobr> <i>content</i>, <nobr>&lt;<a href="#popup-options">PopupOptions</a>&gt; <i>options?</i>)</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Binds the passed <code>content</code> to the layer and sets up the neccessary event listeners.</td>
+	</tr>
+	<tr>
+		<td><code><b>unbindPopup</b>()</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Removes the popup previously bound with <code>bindPopup</code>.</td>
+	</tr>
+	<tr>
+		<td><code><b>openPopup</b>(<a href="#latlng">LatLng</a> <i>latlng?</i>)</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Opens the bound popup at the specificed <code>latlng</code> or at the default popup anchor if no <code>latlng</code> is passed.</td>
+	</tr>
+	<tr>
+		<td><code><b>closePopup</b>()</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Closes the popup if it is open.</td>
+	</tr>
+	<tr>
+		<td><code><b>togglePopup</b>()</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Opens or closes the popup depending on its current state.</td>
+	</tr>
+	<tr>
+		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|<a href="popup">Popup</a>&gt;</nobr> <i>content</i>, <nobr>&lt;<a href="#popup-options">PopupOptions</a>&gt; <i>options?</i>)</nobr></code></td>
+		<td><code class="javascript"><span class="keyword">this</span></code></td>
+		<td>Sets the content of the popup.</td>
+	</tr>
+	<tr>
+		<td><code><b>getPopup</b>()</nobr></code></td>
 		<td><code><a href="#popup">Popup</a></code></td>
-		<td>The popup that was opened or closed.</td>
+		<td>Returns the popup bound to this layer.</td>
 	</tr>
 </table>
-
-<h3 id="dragend-event">DragEndEvent</h3>
-
-<table data-id='layer-event'>
-	<tr>
-		<th class="width100">property</th>
-		<th class="width100">type</th>
-		<th>description</th>
-	</tr>
-	<tr>
-		<td><code><b>distance</b></code></td>
-		<td><code>Number</code></td>
-		<td>The distance in pixels the draggable element was moved by.</td>
-	</tr>
-</table>
-
-
-<!-- <h3>TileEvent</h3> -->
 
 <h2 id="browser">Browser</h2>
 
@@ -6307,6 +6284,280 @@ map.addControl(new MyControl());
 
 <p>If you want to use some obscure CRS not listed here, take a look at the <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.</p>
 
+<h2 id="event-objects">Event objects</h2>
+
+<p>Event object is an object that you recieve as an argument in a listener function when some event is fired, containing useful information about that event. For example:</p>
+
+<pre><code class="javascript">map.on('click', function(e) {
+	alert(e.latlng); // e is an event object (MouseEvent in this case)
+});</code></pre>
+
+<h3 id="event">Event</h3>
+
+<p>The base event object. All other event objects contain these properties too.</p>
+
+<table data-id='events'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>type</b></code></td>
+		<td><code>String</code></td>
+		<td>The event type (e.g. <code><span class="string">'click'</span></code>).</td>
+	</tr>
+	<tr>
+		<td><code><b>target</b></code></td>
+		<td><code>Object</code></td>
+		<td>The object that fired the event.</td>
+	</tr>
+</table>
+
+<h3 id="mouse-event">MouseEvent</h3>
+
+<table data-id='events'>
+	<tr>
+		<th class="width100">property</th>
+		<th>type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>latlng</b></code></td>
+		<td><code><a href="#latlng">LatLng</a></code></td>
+		<td>The geographical point where the mouse event occured.</td>
+	</tr>
+	<tr>
+		<td><code><b>layerPoint</b></code></td>
+		<td><code><a href="#point">Point</a></code></td>
+		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+	</tr>
+	<tr>
+		<td><code><b>containerPoint</b></code></td>
+		<td><code><a href="#point">Point</a></code></td>
+		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+	</tr>
+	<tr>
+		<td><code><b>originalEvent</b></code></td>
+		<td><code>DOMMouseEvent</code></td>
+		<td>The original DOM mouse event fired by the browser.</td>
+	</tr>
+</table>
+
+<h3 id="location-event">LocationEvent</h3>
+
+<table data-id='events'>
+	<tr>
+		<th class="width100">property</th>
+		<th>type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>latlng</b></code></td>
+		<td><code><a href="#latlng">LatLng</a></code></td>
+		<td>Detected geographical location of the user.</td>
+	</tr>
+	<tr>
+		<td><code><b>bounds</b></code></td>
+		<td><code><a href="#latlngbounds">LatLngBounds</a></code></td>
+		<td>Geographical bounds of the area user is located in (with respect to the accuracy of location).</td>
+	</tr>
+	<tr>
+		<td><code><b>accuracy</b></code></td>
+		<td><code>Number</code></td>
+		<td>Accuracy of location in meters.</td>
+	</tr>
+	<tr>
+		<td><code><b>altitude</b></code></td>
+		<td><code>Number</code></td>
+		<td>Height of the position above the WGS84 ellipsoid in meters.</td>
+	</tr>
+	<tr>
+		<td><code><b>altitudeAccuracy</b></code></td>
+		<td><code>Number</code></td>
+		<td>Accuracy of altitude in meters.</td>
+	</tr>
+	<tr>
+		<td><code><b>heading</b></code></td>
+		<td><code>Number</code></td>
+		<td>The direction of travel in degrees counting clockwise from true North.</td>
+	</tr>
+	<tr>
+		<td><code><b>speed</b></code></td>
+		<td><code>Number</code></td>
+		<td>Current velocity in meters per second.</td>
+	</tr>
+	<tr>
+		<td><code><b>timestamp</b></code></td>
+		<td><code>Number</code></td>
+		<td>The time when the position was acquired.</td>
+	</tr>
+</table>
+
+<h3 id="error-event">ErrorEvent</h3>
+
+<table data-id='error-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>message</b></code></td>
+		<td><code>String</code></td>
+		<td>Error message.</td>
+	</tr>
+	<tr>
+		<td><code><b>code</b></code></td>
+		<td><code>Number</code></td>
+		<td>Error code (if applicable).</td>
+	</tr>
+</table>
+
+<h3 id="layer-event">LayerEvent</h3>
+
+<table data-id='layer-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>layer</b></code></td>
+		<td><code><a href="#ilayer">ILayer</a></code></td>
+		<td>The layer that was added or removed.</td>
+	</tr>
+</table>
+
+<h3 id="layers-control-event">LayersControlEvent</h3>
+
+<table data-id='layer-control-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>layer</b></code></td>
+		<td><code><a href="#ilayer">ILayer</a></code></td>
+		<td>The layer that was added or removed.</td>
+	</tr>
+	<tr>
+		<td><code><b>name</b></code></td>
+		<td><code>String</code></td>
+		<td>The name of the layer that was added or removed.</td>
+	</tr>
+</table>
+
+<h3 id="tile-event">TileEvent</h3>
+
+<table data-id='tile-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>tile</b></code></td>
+		<td><code>HTMLElement</code></td>
+		<td>The tile element (image).</td>
+	</tr>
+</table>
+
+<h3 id="tileerror-event">TileErrorEvent</h3>
+
+<table data-id='tileerror-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>tile</b></code></td>
+		<td><code>HTMLElement</code></td>
+		<td>The tile element (image).</td>
+	</tr>
+</table>
+
+<h3 id="resize-event">ResizeEvent</h3>
+
+<table data-id='resize-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>oldSize</b></code></td>
+		<td><code><a href="#point">Point</a></code></td>
+		<td>The old size before resize event.</td>
+	</tr>
+	<tr>
+		<td><code><b>newSize</b></code></td>
+		<td><code><a href="#point">Point</a></code></td>
+		<td>The new size after the resize event.</td>
+	</tr>
+</table>
+
+<h3 id="geojson-event">GeoJSON event</h3>
+
+<table data-id='geojson-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>layer</b></code></td>
+		<td><code><a href="#ilayer">ILayer</a></code></td>
+		<td>The layer for the GeoJSON feature that is being added to the map.</td>
+	</tr>
+	<tr>
+		<td><code><b>properties</b></code></td>
+		<td><code>Object</code></td>
+		<td>GeoJSON properties of the feature.</td>
+	</tr>
+	<tr>
+		<td><code><b>geometryType</b></code></td>
+		<td><code>String</code></td>
+		<td>GeoJSON geometry type of the feature.</td>
+	</tr>
+	<tr>
+		<td><code><b>id</b></code></td>
+		<td><code>String</code></td>
+		<td>GeoJSON ID of the feature (if present).</td>
+	</tr>
+</table>
+
+<h3 id="popup-event">Popup event</h3>
+
+<table data-id='popup-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>popup</b></code></td>
+		<td><code><a href="#popup">Popup</a></code></td>
+		<td>The popup that was opened or closed.</td>
+	</tr>
+</table>
+
+<h3 id="dragend-event">DragEndEvent</h3>
+
+<table data-id='layer-event'>
+	<tr>
+		<th class="width100">property</th>
+		<th class="width100">type</th>
+		<th>description</th>
+	</tr>
+	<tr>
+		<td><code><b>distance</b></code></td>
+		<td><code>Number</code></td>
+		<td>The distance in pixels the draggable element was moved by.</td>
+	</tr>
+</table>
 
 <h2 id="global">Global Switches</h2>
 


### PR DESCRIPTION
This covers some more remaining layer and GridLayer items in https://github.com/Leaflet/Leaflet/issues/3098 including

* Docs for GridLayer
* Panes and pane management
* Reorganize shared methods for events, popups and layers

This doesn't remove a lot of documentation. For example TileLayer still retains all its options and method references even though half of them are in grid layer. I'm fine with removing them but that can be worked out in review.

@mourner for review
