### PR TITLE
provide a default popup text color of #333

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -440,7 +440,7 @@
 .leaflet-popup-content-wrapper,
 .leaflet-popup-tip {
 	background: white;
-
+	color: #333;
 	box-shadow: 0 3px 14px rgba(0,0,0,0.4);
 	}
 .leaflet-container a.leaflet-popup-close-button {


### PR DESCRIPTION
Handle pages with default font color schemes that are lighter a bit more gracefully.

References #3112
