### PR TITLE
Fade tiles with requestAnimationFrame rather than CSS

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -139,7 +139,6 @@
 
 /* zoom and fade animations */
 
-.leaflet-fade-anim .leaflet-tile,
 .leaflet-fade-anim .leaflet-popup {
 	opacity: 0;
 	-webkit-transition: opacity 0.2s linear;
@@ -147,7 +146,6 @@
 	     -o-transition: opacity 0.2s linear;
 	        transition: opacity 0.2s linear;
 	}
-.leaflet-fade-anim .leaflet-tile-loaded,
 .leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
 	opacity: 1;
 	}

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -100,27 +100,30 @@ L.DomUtil = {
 			el.style.opacity = value;
 
 		} else if ('filter' in el.style) {
+			L.DomUtil._setOpacityIE(el, value);
+		}
+	},
 
-			var filter = false,
-			    filterName = 'DXImageTransform.Microsoft.Alpha';
+	_setOpacityIE: function (el, value) {
+		var filter = false,
+		    filterName = 'DXImageTransform.Microsoft.Alpha';
 
-			// filters collection throws an error if we try to retrieve a filter that doesn't exist
-			try {
-				filter = el.filters.item(filterName);
-			} catch (e) {
-				// don't set opacity to 1 if we haven't already set an opacity,
-				// it isn't needed and breaks transparent pngs.
-				if (value === 1) { return; }
-			}
+		// filters collection throws an error if we try to retrieve a filter that doesn't exist
+		try {
+			filter = el.filters.item(filterName);
+		} catch (e) {
+			// don't set opacity to 1 if we haven't already set an opacity,
+			// it isn't needed and breaks transparent pngs.
+			if (value === 1) { return; }
+		}
 
-			value = Math.round(value * 100);
+		value = Math.round(value * 100);
 
-			if (filter) {
-				filter.Enabled = (value !== 100);
-				filter.Opacity = value;
-			} else {
-				el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
-			}
+		if (filter) {
+			filter.Enabled = (value !== 100);
+			filter.Opacity = value;
+		} else {
+			el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
 		}
 	},
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -402,13 +402,11 @@ L.GridLayer = L.Layer.extend({
 		if (center === undefined) { center = map.getCenter(); }
 		if (zoom === undefined) { zoom = map.getZoom(); }
 
-		var topLeftPoint = map._getNewPixelOrigin(center, zoom).subtract(map._getMapPanePos()),
-			pixelBounds = new L.Bounds(topLeftPoint, topLeftPoint.add(map.getSize())),
-			queue = [],
-			key,
+		var pixelBounds = map.getPixelBounds(center, zoom),
 			tileRange = this._pxBoundsToTileRange(pixelBounds),
 			tileCenter = tileRange.getCenter(),
-			j, i, coords;
+			queue = [],
+			key, j, i, coords;
 
 		for (key in this._tiles) {
 			this._tiles[key].retain = false;

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -604,7 +604,8 @@ L.GridLayer = L.Layer.extend({
 
 		tile.loaded = +new Date();
 		if (this._map._fadeAnimated) {
-			L.Util.requestAnimFrame(this._updateOpacity, this);
+			L.Util.cancelAnimFrame(this._fadeFrame);
+			this._fadeFrame = L.Util.requestAnimFrame(this._updateOpacity, this);
 		} else {
 			tile.active = true;
 			this._pruneTiles(coords);

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -192,8 +192,7 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_updateLevels: function () {
-		var zoom = this._tileZoom,
-			offset;
+		var zoom = this._tileZoom;
 
 		for (var z in this._levels) {
 			this._levels[z].el.style.zIndex = -Math.abs(zoom - z);
@@ -212,7 +211,7 @@ L.GridLayer = L.Layer.extend({
 			level.zoom = zoom;
 
 			this._setZoomTransform(level, map.getCenter(), map.getZoom());
-			offset = level.el.offsetWidth; // Force recalculation to trigger transitions.
+			L.Util.falseFn(level.el.offsetWidth); // Force recalculation to trigger transitions.
 		}
 
 		this._level = level;

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -323,10 +323,10 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
-		this._reset(e.center, e.zoom);
+		this._reset(e.center, e.zoom, false, true);
 	},
 
-	_reset: function (center, zoom, hard) {
+	_reset: function (center, zoom, hard, noPrune) {
 		var tileZoom = Math.round(zoom),
 			tileZoomChanged = this._tileZoom !== tileZoom;
 
@@ -337,7 +337,7 @@ L.GridLayer = L.Layer.extend({
 			this._tileZoom = tileZoom;
 			this._updateLevels();
 			this._resetGrid();
-			this._update(center, zoom);
+			this._update(center, zoom, noPrune);
 		}
 
 		this._setZoomTransforms(center, zoom);
@@ -386,8 +386,7 @@ L.GridLayer = L.Layer.extend({
 		this._update();
 	},
 
-	_update: function (center, zoom) {
-
+	_update: function (center, zoom, noPrune) {
 		var map = this._map;
 		if (!map) { return; }
 
@@ -453,6 +452,8 @@ L.GridLayer = L.Layer.extend({
 
 			this._level.el.appendChild(fragment);
 		}
+
+		if (noPrune) { return; }
 
 		for (key in this._tiles) {
 			if (!this._tiles[key].retain) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -239,11 +239,15 @@ L.GridLayer = L.Layer.extend({
 		var key = x2 + ':' + y2 + ':' + z2,
 			tile = this._tiles[key];
 
-		if (tile && tile.loaded) {
+		if (tile && tile.active) {
 			tile.retain = true;
 			return true;
 
-		} else if (z2 > minZoom) {
+		} else if (tile && tile.loaded) {
+			tile.retain = true;
+		}
+
+		if (z2 > minZoom) {
 			return this._retainParent(x2, y2, z2, minZoom);
 		}
 
@@ -258,7 +262,7 @@ L.GridLayer = L.Layer.extend({
 		var key = x2 + ':' + y2 + ':' + z2,
 			tile = this._tiles[key];
 
-		if (tile && tile.loaded) {
+		if (tile && tile.active) {
 			this._removeTile(key);
 			return true;
 
@@ -277,10 +281,15 @@ L.GridLayer = L.Layer.extend({
 				var key = i + ':' + j + ':' + (z + 1),
 					tile = this._tiles[key];
 
-				if (tile && tile.loaded) {
+				if (tile && tile.active) {
 					tile.retain = true;
+					continue;
 
-				} else if (z + 1 < maxZoom) {
+				} else if (tile && tile.loaded) {
+					tile.retain = true;
+				}
+
+				if (z + 1 < maxZoom) {
 					this._retainChildren(i, j, z + 1, maxZoom);
 				}
 			}
@@ -295,7 +304,7 @@ L.GridLayer = L.Layer.extend({
 				var key = i + ':' + j + ':' + (z + 1),
 					tile = this._tiles[key];
 
-				if (tile && tile.loaded) {
+				if (tile && tile.active) {
 					this._removeTile(key);
 
 				} else if (z + 1 < maxZoom) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -337,7 +337,7 @@ L.GridLayer = L.Layer.extend({
 			this._tileZoom = tileZoom;
 			this._updateLevels();
 			this._resetGrid();
-			this._update(center, zoom, noPrune);
+			this._update(center, tileZoom, noPrune);
 		}
 
 		this._setZoomTransforms(center, zoom);
@@ -397,7 +397,7 @@ L.GridLayer = L.Layer.extend({
 		//     zoom < this.options.minZoom) { return; }
 
 		if (center === undefined) { center = map.getCenter(); }
-		if (zoom === undefined) { zoom = map.getZoom(); }
+		if (zoom === undefined) { zoom = Math.round(map.getZoom()); }
 
 		var pixelBounds = map.getPixelBounds(center, zoom),
 			tileRange = this._pxBoundsToTileRange(pixelBounds),
@@ -414,7 +414,7 @@ L.GridLayer = L.Layer.extend({
 			for (i = tileRange.min.x; i <= tileRange.max.x; i++) {
 
 				coords = new L.Point(i, j);
-				coords.z = this._tileZoom;
+				coords.z = zoom;
 
 				if (!this._isValidTile(coords)) { continue; }
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -172,7 +172,8 @@ L.GridLayer = L.Layer.extend({
 		}
 
 		if (nextFrame) {
-			L.Util.requestAnimFrame(this._updateOpacity, this);
+			L.Util.cancelAnimFrame(this._fadeFrame);
+			this._fadeFrame = L.Util.requestAnimFrame(this._updateOpacity, this);
 		}
 	},
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -214,18 +214,6 @@ L.GridLayer = L.Layer.extend({
 
 		this._level = level;
 
-		if (this._map._fadeAnimated) {
-			var now = +new Date();
-			for (var key in this._tiles) {
-				var tile = this._tiles[key];
-				if (tile.loaded && this._keyToTileCoords(key).z === zoom) {
-					tile.active = false;
-					tile.loaded = now;
-				}
-			}
-			this._updateOpacity();
-		}
-
 		return level;
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -328,8 +328,8 @@ L.Map = L.Evented.extend({
 		return this._size.clone();
 	},
 
-	getPixelBounds: function () {
-		var topLeftPoint = this._getTopLeftPoint();
+	getPixelBounds: function (center, zoom) {
+		var topLeftPoint = this._getTopLeftPoint(center, zoom);
 		return new L.Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
 	},
 
@@ -636,8 +636,11 @@ L.Map = L.Evented.extend({
 		return pos && !pos.equals([0, 0]);
 	},
 
-	_getTopLeftPoint: function () {
-		return this.getPixelOrigin().subtract(this._getMapPanePos());
+	_getTopLeftPoint: function (center, zoom) {
+		var pixelOrigin = center && zoom !== undefined ?
+			this._getNewPixelOrigin(center, zoom) :
+			this.getPixelOrigin();
+		return pixelOrigin.subtract(this._getMapPanePos());
 	},
 
 	_getNewPixelOrigin: function (center, zoom) {


### PR DESCRIPTION
See #3053

There is currently some flickering with this approach around the edges of the map during a quick in-then-out zoom. For example, with quick zoom in to z15 and out to z14 you see z14 tiles at the edges flicker. They are visible for an instant because they are retained while z15 tiles are transitioning in as the first zoom in completes, and then they get pruned while the zoom animation to z14 is running.

This makes me want to see whether GridLayer can be notified of the new zoom level at the _beginning_ of the zoom animation rather than the end, so that tiles at the new zoom level can potentially fade and zoom concurrently, rather than having a 250ms zoom animation followed by a 200ms fade animation. I think this would make zooming feel much smoother and snappier.