### PR TITLE
flyTo: convert targetCenter to latLng

### DIFF
--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -9,6 +9,7 @@ L.Map.include({
 		    size = this.getSize(),
 		    startZoom = this._zoom;
 
+		targetCenter = L.latLng(targetCenter);
 		targetZoom = targetZoom === undefined ? startZoom : targetZoom;
 
 		var w0 = Math.max(size.x, size.y),


### PR DESCRIPTION
`flyTo` sets the map center to the `targetCenter` argument on the last frame. If an array was passed as `targetCenter`, this would cause `map.getCenter()` to start returning an array instead of a `latLng`.

Fixes #3139