### PR TITLE
BUG: ._tryAnimatedPan() lies...

### DIFF
--- a/src/map/anim/Map.PanAnimation.js
+++ b/src/map/anim/Map.PanAnimation.js
@@ -96,6 +96,6 @@ L.Map.include({
 
 		this.panBy(offset, options);
 
-		return true;
+		return options.animate !== false;
 	}
 });


### PR DESCRIPTION
... to .setView() about whether or not an animation was initiated.

This causes downstream problems like ._tilesToLoad being NaN instead of a number since .setView() returns early before ._resetView() is never called.