### PR TITLE
fixed error in _tryAnimatedPan when options is undefined

### DIFF
--- a/src/map/anim/Map.PanAnimation.js
+++ b/src/map/anim/Map.PanAnimation.js
@@ -96,6 +96,6 @@ L.Map.include({
 
 		this.panBy(offset, options);
 
-		return options.animate !== false;
+		return (options && options.animate) !== false;
 	}
 });


### PR DESCRIPTION
Commit #48a374d introduced a bug causing 'Cannot read property animate of undefined' errors to appear when scrolling/zooming in maps with a fixed boundary.

I've tested this bug with the included debug/map/max-bounds.html test site and allocated the bug (using git bisect) in #48a374d.

My knowledge of the Leaflet internals may only be rudimentary, but I think the fix should be the intended use.