### PR TITLE
+ missing lineCap and lineJoin options for Path.Canvas.

### DIFF
--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -73,6 +73,13 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 		if (options.fill) {
 			this._ctx.fillStyle = options.fillColor || options.color;
 		}
+
+		if (options.lineCap) {
+			this._ctx.lineCap = options.lineCap;
+		}
+		if (options.lineJoin) {
+			this._ctx.lineJoin = options.lineJoin;
+		}
 	},
 
 	_drawPath: function () {


### PR DESCRIPTION
Add missing lineCap and lineJoin options for Path when we're rendering on canvas. 