### PR TITLE
[docs] Remove insertAtTheBottom option from addLayer()

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -798,11 +798,10 @@ var map = L.map('map', {
 	<tr id="map-addlayer">
 		<td><code><b>addLayer</b>(
 			<nobr>&lt;<a href="#ilayer">ILayer</a>&gt; <i>layer</i>,</nobr>
-			<nobr>&lt;Boolean&gt; <i>insertAtTheBottom?</i> )</nobr>
 		</code></td>
 
 		<td><code><span class="keyword">this</span></code></td>
-		<td>Adds the given layer to the map. If optional <code>insertAtTheBottom</code> is set to <code><span class="literal">true</span></code>, the layer is inserted under all others (useful when switching base tile layers).</td>
+		<td>Adds the given layer to the map.</td>
 	</tr>
 	<tr>
 		<td><code><b>removeLayer</b>(


### PR DESCRIPTION
#3111 mentions that this option is no longer present in the Leaflet source. It was removed some time ago in [this commit](https://github.com/Leaflet/Leaflet/commit/cdfaad994f277a2eb90bcf4499c86786a6aa707f).