### PR TITLE
Do not render the stroke if the weight is explicitly set to 0

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -169,7 +169,7 @@ L.Canvas = L.Renderer.extend({
 			ctx.fill(options.fillRule || 'evenodd');
 		}
 
-		if (options.stroke) {
+		if (options.stroke && options.weight !== 0) {
 			ctx.globalAlpha = clear ? 1 : options.opacity;
 
 			// if clearing shape, do it with the previously drawn line width


### PR DESCRIPTION
When rendering to SVG, if the weight is 0 the outline is not displayed.
However, when rendering to canvas it will still display the outline.
This change makes the behaviour consistent when rendering to either.

According to MDN, the [lineWidth](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D.lineWidth) is ignored when set to 0. Since the code for rendering to the canvas simply copies the `weight` property onto `lineWidth` to the canvas, we end up with a border. Conversely the SVG documentation at MDN on [stroke-width](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-width) states that a value of 0 will result in the outline never being drawn, resulting in different behaviour between SVG and canvas.
