### PR TITLE
Linear zooming animation with overhauled scroll behavior

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -156,10 +156,10 @@
 	will-change: transform;
 	}
 .leaflet-zoom-anim .leaflet-zoom-animated {
-	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
-	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);
-	     -o-transition:      -o-transform 0.25s cubic-bezier(0,0,0.25,1);
-	        transition:         transform 0.25s cubic-bezier(0,0,0.25,1);
+	-webkit-transition: -webkit-transform 0.2s linear;
+	   -moz-transition:    -moz-transform 0.2s linear;
+	     -o-transition:      -o-transform 0.2s linear;
+	        transition:         transform 0.2s linear;
 	}
 .leaflet-zoom-anim .leaflet-tile,
 .leaflet-pan-anim .leaflet-tile {

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -23,10 +23,13 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 	_onWheelScroll: function (e) {
 		var delta = L.DomEvent.getWheelDelta(e),
-			mousePos = this._map.mouseEventToContainerPoint(e);
+			map = this._map,
+			mousePos = map.mouseEventToContainerPoint(e);
 
 		if (!map._animatingZoom) {
 			this._performZoom(delta, mousePos);
+		} else {
+			map.once('moveend', L.bind(this._performZoom, this, delta, mousePos));
 		}
 
 		L.DomEvent.stop(e);
@@ -38,8 +41,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		map.stop(); // stop panning and fly animations if any
 
-		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
-		delta = Math.max(Math.min(delta, 4), -4);
+		delta = delta > 0 ? 1 : -1;
 		delta = map._limitZoom(zoom + delta) - zoom;
 
 		if (!delta) { return; }


### PR DESCRIPTION
This gives Leaflet zoom animation a very different feel, and should also solve all our problems with scroll wheel behavior. There was a similar attempt earlier, but this time, after recent tile loading and animation improvements, it feels much nicer. Tested both mouse and Macbook trackpad. Closes #2154, #2732, #2757.

@ChALkeR @moneytoo @CramericaIndustries @ekelleyv @robrecord @rossmeissl @mearsheimer @schovi @jfirebaugh @danzel I'd appreciate your feedback guys. How does the zoom feel in this branch?

Note: pretty broken in Safari (at least for me on OS X) atm.
