### PR TITLE
"onFocus" option to scrollWheelZoom

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -67,4 +67,12 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 	}
 });
 
+L.Map.addInitHook(function () {
+	if (this.options.scrollWheelZoom === 'onFocus') {
+		this.options.scrollWheelZoom = false;
+		this.on('blur', function() { this.scrollWheelZoom.disable(); });
+		this.on('focus', function() { this.scrollWheelZoom.enable(); });
+	}
+});
+
 L.Map.addInitHook('addHandler', 'scrollWheelZoom', L.Map.ScrollWheelZoom);


### PR DESCRIPTION
I've been confronted to this problem. My website content is scrollable and I had to set scrollWheelZoom on false. However, when interacting to the map, I'm frustrated about not being able to use the scroll wheel to (de)zoom as I always do on other maps.
I found this issue : https://github.com/Leaflet/Leaflet/issues/2076 and wanted to show one idea.
I add a "onFocus" option to scrollWheelZoom parameter which triggers scrollWheelZoom only when the map is on focus.

Here is a demo in which I already use this modification : http://kara.62.free.fr/scrollonfocus.html

(Sorry if my code is bad, I'm very new to javascript & git.)