### PR TITLE
Update GeoJSON.js

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -165,7 +165,11 @@ L.extend(L.GeoJSON, {
 
 	asFeature: function (geoJSON) {
 		if (geoJSON.type === 'Feature') {
-			return geoJSON;
+			return {
+				type: geoJSON.type,
+				properties: geoJSON.properties,
+				geometry: geoJSON.geometry
+			};
 		}
 
 		return {


### PR DESCRIPTION
I modified the function to explicitly return the geoJSON properties. When using geoJSON's with different CRS's this function used to return the original CRS name but with geometry converted to WGS84 lat/lng format.  If the data was reused for another projection the locations would be in the wrong spots as the coordinates no longer matched the CRS.  Now this function just returns the lat/lng but without the CRS attached.