### PR TITLE
Do not try to remove drag class if marker as no icon

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -41,10 +41,16 @@ describe("Marker", function () {
 
 			expect(marker.dragging.enabled()).to.be(true);
 
-                        map.removeLayer(marker);
+			map.removeLayer(marker);
 			map.addLayer(marker);
 
 			expect(marker.dragging.enabled()).to.be(true);
+
+			map.removeLayer(marker);
+			// Dragging is still enabled, we should be able to disable it,
+			// even if marker is off the map.
+			marker.dragging.disable();
+			map.addLayer(marker);
 		});
 
 		it("changes the icon to another DivIcon", function () {

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -30,7 +30,9 @@ L.Handler.MarkerDrag = L.Handler.extend({
 			dragend: this._onDragEnd
 		}, this).disable();
 
-		L.DomUtil.removeClass(this._marker._icon, 'leaflet-marker-draggable');
+		if (this._marker._icon) {
+			L.DomUtil.removeClass(this._marker._icon, 'leaflet-marker-draggable');
+		}
 	},
 
 	moved: function () {


### PR DESCRIPTION
Since 4c46abe7810272704cc1a7ce0ccfb84c45456791 it's possible to have a marker off the map with dragging still enabled. We want to be able to disable it in this situation too.

Before 4c46abe7810272704cc1a7ce0ccfb84c45456791 removing a marker from the map was disabling dragging, so any subsequent call to `marker.dragging.disable` was not executed.