### PR TITLE
Fix cursor when dragging is set to false.

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -192,7 +192,8 @@
 	cursor: auto;
 	}
 .leaflet-dragging .leaflet-grab,
-.leaflet-dragging .leaflet-grab .leaflet-interactive {
+.leaflet-dragging .leaflet-grab .leaflet-interactive,
+.leaflet-dragging .leaflet-marker-draggable {
 	cursor: move;
 	cursor: -webkit-grabbing;
 	cursor:    -moz-grabbing;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -179,7 +179,7 @@
 .leaflet-interactive {
 	cursor: pointer;
 	}
-.leaflet-container {
+.leaflet-grab {
 	cursor: -webkit-grab;
 	cursor:    -moz-grab;
 	}
@@ -191,8 +191,8 @@
 .leaflet-control {
 	cursor: auto;
 	}
-.leaflet-dragging .leaflet-container,
-.leaflet-dragging .leaflet-interactive {
+.leaflet-dragging .leaflet-grab,
+.leaflet-dragging .leaflet-grab .leaflet-interactive {
 	cursor: move;
 	cursor: -webkit-grabbing;
 	cursor:    -moz-grabbing;

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -35,10 +35,12 @@ L.Map.Drag = L.Handler.extend({
 				map.whenReady(this._onViewReset, this);
 			}
 		}
+		L.DomUtil.addClass(this._map._container, 'leaflet-grab');
 		this._draggable.enable();
 	},
 
 	removeHooks: function () {
+		L.DomUtil.removeClass(this._map._container, 'leaflet-grab');
 		this._draggable.disable();
 	},
 


### PR DESCRIPTION
As said in issue https://github.com/Leaflet/Leaflet/issues/3219 , the cursor is still "grab" by default even when dragging is set to false.

This commit change the css by removing default grab-cursor and this style is added when dragging is activated in Handler.

Demo here : http://kara.62.free.fr/cursor_issue/