### PR TITLE
update the url of the leaflet-tilejson plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -555,7 +555,7 @@ While Leaflet is meant to be as lightweight as possible, and focuses on a core s
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/perliedman/leaflet-tilejson">leaflet-tilejson</a>
+			<a href="https://github.com/kartena/leaflet-tilejson">leaflet-tilejson</a>
 		</td><td>
 			Adds support for the <a href="https://github.com/mapbox/TileJSON">TileJSON</a> specification to Leaflet.
 		</td><td>


### PR DESCRIPTION
The current url is pointing to what seems to be an outdated repo. The original repo has been forked and now lives in the kartena account.