### PR TITLE
Forward original event on drag

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -99,13 +99,12 @@ L.Draggable = L.Evented.extend({
 		this._moving = true;
 
 		L.Util.cancelAnimFrame(this._animRequest);
-		var animationCallback = function () {
-			this._updatePosition(e);
-		};
-		this._animRequest = L.Util.requestAnimFrame(animationCallback, this, true, this._dragStartTarget);
+		this._lastEvent = e;
+		this._animRequest = L.Util.requestAnimFrame(this._updatePosition, this, true, this._dragStartTarget);
 	},
 
-	_updatePosition: function (e) {
+	_updatePosition: function () {
+		var e = {originalEvent: this._lastEvent};
 		this.fire('predrag', e);
 		L.DomUtil.setPosition(this._element, this._newPos);
 		this.fire('drag', e);

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -99,13 +99,16 @@ L.Draggable = L.Evented.extend({
 		this._moving = true;
 
 		L.Util.cancelAnimFrame(this._animRequest);
-		this._animRequest = L.Util.requestAnimFrame(this._updatePosition, this, true, this._dragStartTarget);
+		var animationCallback = function () {
+			this._updatePosition(e);
+		};
+		this._animRequest = L.Util.requestAnimFrame(animationCallback, this, true, this._dragStartTarget);
 	},
 
-	_updatePosition: function () {
-		this.fire('predrag');
+	_updatePosition: function (e) {
+		this.fire('predrag', e);
 		L.DomUtil.setPosition(this._element, this._newPos);
-		this.fire('drag');
+		this.fire('drag', e);
 	},
 
 	_onUp: function () {

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -46,7 +46,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		    .fire('dragstart');
 	},
 
-	_onDrag: function () {
+	_onDrag: function (e) {
 		var marker = this._marker,
 		    shadow = marker._shadow,
 		    iconPos = L.DomUtil.getPosition(marker._icon),
@@ -58,10 +58,11 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		}
 
 		marker._latlng = latlng;
+		e.latlng = latlng;
 
 		marker
-		    .fire('move', {latlng: latlng})
-		    .fire('drag');
+		    .fire('move', e)
+		    .fire('drag', e);
 	},
 
 	_onDragEnd: function (e) {

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -63,7 +63,7 @@ L.Map.Drag = L.Handler.extend({
 		}
 	},
 
-	_onDrag: function () {
+	_onDrag: function (e) {
 		if (this._map.options.inertia) {
 			var time = this._lastTime = +new Date(),
 			    pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
@@ -78,8 +78,8 @@ L.Map.Drag = L.Handler.extend({
 		}
 
 		this._map
-		    .fire('move')
-		    .fire('drag');
+		    .fire('move', e)
+		    .fire('drag', e);
 	},
 
 	_onViewReset: function () {


### PR DESCRIPTION
This PR adds forwarding of the original event when firing `drag` or `move` events.

Use case: handle ctrlKey/altKey, etc. while dragging for creating different UX scenarios (eg. do not snap if `ctrlKey` is pressed while dragging).

Thanks for reviewing :)