### PR TITLE
Vector renderers for custom Pane Management added

### DIFF
--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -64,7 +64,7 @@ L.Renderer = L.Layer.extend({
 L.Map.include({
 	// used by each vector layer to decide which renderer to use
 	getRenderer: function (layer) {
-		var renderer = layer.options.renderer || this.options.renderer || this._renderer;
+		var renderer = layer.options.renderer || this._getPaneRenderer(layer.options.pane) || this.options.renderer || this._renderer;
 
 		if (!renderer) {
 			renderer = this._renderer = (L.SVG && L.svg()) || (L.Canvas && L.canvas());
@@ -74,5 +74,16 @@ L.Map.include({
 			this.addLayer(renderer);
 		}
 		return renderer;
-	}
+	},
+
+	_getPaneRenderer: function (name) {
+		if (name == 'overlayPane' || typeof name === 'undefined') return false;
+
+		var renderer = this._paneRenderers[name];
+		if (typeof renderer === 'undefined') {
+			renderer = (L.SVG && L.svg({pane: name})) || (L.Canvas && L.canvas({pane: name}));
+			this._paneRenderers[name] = renderer;
+		}
+		return renderer;
+	},
 });

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -77,7 +77,9 @@ L.Map.include({
 	},
 
 	_getPaneRenderer: function (name) {
-		if (name == 'overlayPane' || typeof name === 'undefined') return false;
+		if (name == 'overlayPane' || typeof name == 'undefined') {
+			return false;
+		}
 
 		var renderer = this._paneRenderers[name];
 		if (typeof renderer === 'undefined') {
@@ -85,5 +87,5 @@ L.Map.include({
 			this._paneRenderers[name] = renderer;
 		}
 		return renderer;
-	},
+	}
 });

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -77,12 +77,12 @@ L.Map.include({
 	},
 
 	_getPaneRenderer: function (name) {
-		if (name == 'overlayPane' || typeof name == 'undefined') {
+		if (name === 'overlayPane' || name === undefined) {
 			return false;
 		}
 
 		var renderer = this._paneRenderers[name];
-		if (typeof renderer === 'undefined') {
+		if (renderer === undefined) {
 			renderer = (L.SVG && L.svg({pane: name})) || (L.Canvas && L.canvas({pane: name}));
 			this._paneRenderers[name] = renderer;
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -470,6 +470,7 @@ L.Map = L.Evented.extend({
 
 	_initPanes: function () {
 		var panes = this._panes = {};
+		this._paneRenderers = {};
 
 		this._mapPane = this.createPane('mapPane', this._container);
 


### PR DESCRIPTION
For reference, original pull request for this feature was here: #2786. This was rejected because it broke backwards compatibility and was maybe too confusing and had too much magic. I have closed that pull request and this one replaces it.

This pull request allows you to specify a custom pane for any vector layer. It is very simple, it maintains backwards compatibility and it is very flexible. 

You can do any of the following:

#### Create a vector layer like normal
```
var polygon = L.polygon([[0,0],[10,10],[0,20]]).addTo(map);
```
No renderer or pane is specified. So the vector layer is added to the map's default renderer on the `overlayPane`. This is normal operation for creating a basic vector layer. This keeps the implementation fully backwards compatible.

#### Create vector layer on custom pane
```
var pane = map.createPane("testPane");
var polygon = L.polygon([[0,0],[10,10],[0,20]], {pane: "testPane"}).addTo(map);
```
Here, a custom pane is specified. Each pane can have a "default renderer", similar to how the renderer on the `overlayPane` is the map's default renderer. When a pane is specified, like in this example, first it is determined if a default renderer has already been created for that pane. If not, a renderer is created and defined as the `testPane`'s default renderer. The vector layer is added to this renderer on the `testPane`.

All subsequent vector layers added to the `testPane` will use the pane's default renderer that was already created.

#### Create vector layer on custom renderer
```
var pane = map.createPane('testPane');
var myRenderer = L.svg({pane:'testPane'}).addTo(map);
var polygon = L.polygon([[0,0],[10,10],[0,20]], {renderer: myRenderer}).addTo(map);
```
In this example, a custom renderer is specified and added to a custom pane. When creating the vector layer, you specify the custom renderer. So the vector layer ends up using the custom renderer on the custom pane. This allows you to add as many custom renderers to a pane as you want and control exactly which renderer you want your vector layers to be on.

Adding a custom renderer to a pane does NOT make that renderer the "default renderer" for that pane. It is simply another renderer that has been added to the pane.

#### Renderer vs Pane Specificity
```
var pane = map.createPane('testPane');
var pane = map.createPane('testPane2');
var myRenderer = L.svg({pane:'testPane'}).addTo(map);
var polygon = L.polygon([[0,0],[10,10],[0,20]], {renderer: myRenderer, pane: 'testPane2'}).addTo(map);
```
In this example, when creating the vector layer, both a renderer and pane was specified. Renderers are more specific than panes. Therefore they take priority. In this example, the vector layer will be created in the custom renderer on `testPane`. Not on `testPane2`. If anyone has any opinions on this please chime in, but it seems like since renderers are a subset of panes in the DOM, that specifying a renderer would take priority in the case that both were provides in the options.

Here is a simple flowchart for how this all works:

![wn7f8oe](https://cloud.githubusercontent.com/assets/87356/6429443/c59375c0-bf8e-11e4-9b53-962b826ae240.png)

This code change is very simple and maintainable. It's a very straightforward API this is consistent with the rest of Leaflet. It's fully backwards compatible. Yet it allows you complete flexibility to add any vector layer to any custom pane but also create as many renderers on any custom pane as you want and add as many vector layers as you want to any of those custom renderers.

@mourner @perliedman @jfirebaugh please take a look at this and let me know what you think. I think it's a winner for 1.0 ;-)