### PR TITLE
Prevent map refocus if control click event is from the keyboard

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -72,7 +72,7 @@ L.Control = L.Class.extend({
 	},
 
 	_refocusOnMap: function (e) {
-		// if map exists and event is keyboard event
+		// if map exists and event is not a keyboard event
 		if (this._map && e && e.screenX > 0 && e.screenY > 0) {
 			this._map.getContainer().focus();
 		}

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -73,7 +73,7 @@ L.Control = L.Class.extend({
 
 	_refocusOnMap: function (e) {
 		// if map exists and event is keyboard event
-		if (this._map && (e.x > 0 && e.y > 0 && e.screenX > 0 && e.screenY > 0)) {
+		if (this._map && e && e.screenX > 0 && e.screenY > 0) {
 			this._map.getContainer().focus();
 		}
 	}

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -71,8 +71,9 @@ L.Control = L.Class.extend({
 		return this;
 	},
 
-	_refocusOnMap: function () {
-		if (this._map) {
+	_refocusOnMap: function (e) {
+		// if map exists and event is keyboard event
+		if (this._map && (e.x > 0 && e.y > 0 && e.screenX > 0 && e.screenY > 0)) {
 			this._map.getContainer().focus();
 		}
 	}


### PR DESCRIPTION
Prevent map refocus if control click event is from the keyboard, which is determined/assumed by the click X,Y being at 0,0. There is definitely an assumption there that it is extremely unlikely that you would be clicking a control with your mouse at 0,0 (at the very top left of the screen).

Not sure if this is the best solution, but it does work.