### PR TITLE
Refactor move/zoom events

### DIFF
--- a/debug/map/zoompan.html
+++ b/debug/map/zoompan.html
@@ -27,13 +27,19 @@
 	<div id="map"></div>
 
 	<div style="position: absolute; left: 620px; top: 10px; z-index: 500">
-		<div><button id="dc">DC</button></div>
-		<div><button id="sf">SF</button></div>
+		<div><button id="dc">DC</button>(flyTo)</div>
+		<div><button id="sf">SF</button>(setView, 5 sec)</div>
 		<div><button id="trd">TRD</button>(flyTo 20 sec)</div>
 		<div><button id="lnd">LND</button>(fract. zoom)</div>
 		<div><button id="kyiv">KIEV</button>(setView, fract. zoom)</div>
+		<div><button id="nul">NUL</button>(image overlay)</div>
 		<div><button id="stop">stop</button></div>
-		<div id='pos'></div>
+		<table>
+		<tr><td>on movestart</td><td id='movestart'></td></tr>
+		<tr><td>on zoomstart</td><td id='zoomstart'></td></tr>
+		<tr><td>on move</td><td id='move'></td></tr>
+		<tr><td>on moveend</td><td id='moveend'></td></tr>
+		<tr><td>on zoomend</td><td id='zoomend'></td></tr>
 	</div>
 
 	<script type="text/javascript">
@@ -53,31 +59,33 @@
 
 		var marker1 = L.marker(kyiv).addTo(map),
 			marker2 = L.marker(lnd).addTo(map);
-			// marker3 = L.marker(dc).addTo(map),
-			// marker4 = L.marker(sf).addTo(map);
+			marker3 = L.marker(dc).addTo(map),
+			marker4 = L.marker(sf).addTo(map),
+			marker5 = L.marker(trd).addTo(map);
 
-		document.getElementById('dc').onclick = function () { map.flyTo(dc, 10); };
-		document.getElementById('sf').onclick = function () { map.flyTo(sf, 10); };
-		document.getElementById('trd').onclick = function () { map.flyTo(trd, 10, {duration: 20}); };
-		document.getElementById('lnd').onclick = function () { map.flyTo(lnd, 9.25); };
+		var nullIslandKitten = L.imageOverlay('http://placekitten.com/g/300/400', [[-0.2,-0.15], [0.2, 0.15]]).addTo(map);
+
+		document.getElementById('dc').onclick   = function () { map.flyTo(dc,  10); };
+		document.getElementById('sf').onclick   = function () { map.setView(sf, 10, {duration: 5}); };
+		document.getElementById('trd').onclick  = function () { map.flyTo(trd, 10, {duration: 20}); };
+		document.getElementById('lnd').onclick  = function () { map.flyTo(lnd, 9.25); };
 		document.getElementById('kyiv').onclick = function () { map.setView(kyiv, 9.25); };
+		document.getElementById('nul').onclick  = function () { map.flyTo([0, 0], 10); };
 		document.getElementById('stop').onclick = function () { map.stop(); };
 
 		function logEvent(e) { console.log(e.type); }
 
-		map.on('move', function(){
+		function attachMoveEvent(name) {
+			map.on(name, function(){
+				document.getElementById(name).innerHTML = map.getCenter() + ' z' + map.getZoom();
+			});
+		}
 
-			document.getElementById('pos').innerHTML = map.getCenter() + ' z' + map.getZoom();
-		});
-
-		// map.on('click', logEvent);
-
-		// map.on('movestart', logEvent);
-		// map.on('move', logEvent);
-		// map.on('moveend', logEvent);
-
-		// map.on('zoomstart', logEvent);
-		// map.on('zoomend', logEvent);
+		attachMoveEvent('movestart');
+		attachMoveEvent('zoomstart');
+		attachMoveEvent('move');
+		attachMoveEvent('moveend');
+		attachMoveEvent('zoomend');
 
 	</script>
 </body>

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -153,6 +153,11 @@
 .leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
 	opacity: 1;
 	}
+.leaflet-zoom-animated {
+	-webkit-transform-origin: 0 0;
+	    -ms-transform-origin: 0 0;
+	        transform-origin: 0 0;
+	}
 .leaflet-zoom-anim .leaflet-zoom-animated {
 	will-change: transform;
 	}

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -107,7 +107,7 @@ describe('GridLayer', function () {
 	});
 
 	describe("#onAdd", function () {
-		it('is called after viewreset on first map load', function () {
+		it('is called after zoomend on first map load', function () {
 			var layer = L.gridLayer().addTo(map);
 
 			var onAdd = layer.onAdd,
@@ -118,7 +118,7 @@ describe('GridLayer', function () {
 			};
 
 			var onReset = sinon.spy();
-			map.on('viewreset', onReset);
+			map.on('zoomend', onReset);
 			map.setView([0, 0], 0);
 
 			expect(onReset.calledBefore(onAddSpy)).to.be.ok();

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -129,6 +129,14 @@ describe("Map", function () {
 			expect(map.getCenter().distanceTo([51.605, -0.11])).to.be.lessThan(5);
 		});
 
+		it("limits initial zoom when no zoom specified", function () {
+			map.options.maxZoom = 20;
+			map.setZoom(100);
+			expect(map.setView([51.605, -0.11])).to.be(map);
+			expect(map.getZoom()).to.be(20);
+			expect(map.getCenter().distanceTo([51.605, -0.11])).to.be.lessThan(5);
+		});
+
 		it("defaults to zoom passed as map option", function () {
 			map = L.map(document.createElement('div'), {zoom: 13});
 			expect(map.setView([51.605, -0.11])).to.be(map);

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -118,13 +118,14 @@ L.ImageOverlay = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
+		var scale = this._map.getZoomScale(e.zoom);
 		var bounds = new L.Bounds(
 			this._map._latLngToNewLayerPoint(this._bounds.getNorthWest(), e.zoom, e.center),
 		    this._map._latLngToNewLayerPoint(this._bounds.getSouthEast(), e.zoom, e.center));
 
-		var offset = bounds.min.add(bounds.getSize()._multiplyBy((1 - 1 / e.scale) / 2));
+		var offset = bounds.min.add(bounds.getSize()._multiplyBy((1 - 1 / scale) / 2));
 
-		L.DomUtil.setTransform(this._image, offset, e.scale);
+		L.DomUtil.setTransform(this._image, offset, scale);
 	},
 
 	_reset: function () {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -118,13 +118,9 @@ L.ImageOverlay = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
-		var scale = this._map.getZoomScale(e.zoom);
-		var bounds = new L.Bounds(
-			this._map._latLngToNewLayerPoint(this._bounds.getNorthWest(), e.zoom, e.center),
-		    this._map._latLngToNewLayerPoint(this._bounds.getSouthEast(), e.zoom, e.center));
-
-		var offset = bounds.min.add(bounds.getSize()._multiplyBy((1 - 1 / scale) / 2));
-
+		var scale = this._map.getZoomScale(e.zoom),
+			offset = this._map._latLngToNewLayerPoint(this._bounds.getNorthWest(), e.zoom, e.center);
+			
 		L.DomUtil.setTransform(this._image, offset, scale);
 	},
 

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -87,7 +87,7 @@ L.ImageOverlay = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
-			viewreset: this._reset
+			zoomend: this._reset
 		};
 
 		if (this._zoomAnimated) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -87,7 +87,7 @@ L.ImageOverlay = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
-			zoomend: this._reset
+			zoom: this._reset
 		};
 
 		if (this._zoomAnimated) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -121,7 +121,7 @@ L.ImageOverlay = L.Layer.extend({
 	_animateZoom: function (e) {
 		var scale = this._map.getZoomScale(e.zoom),
 			offset = this._map._latLngToNewLayerPoint(this._bounds.getNorthWest(), e.zoom, e.center);
-			
+
 		L.DomUtil.setTransform(this._image, offset, scale);
 	},
 

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -87,7 +87,8 @@ L.ImageOverlay = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
-			zoom: this._reset
+			zoom: this._reset,
+			viewreset: this._reset
 		};
 
 		if (this._zoomAnimated) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -122,7 +122,7 @@ L.Popup = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {viewreset: this._updatePosition},
+		var events = {zoomend: this._updatePosition},
 		    options = this.options;
 
 		if (this._zoomAnimated) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -122,16 +122,18 @@ L.Popup = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {zoom: this._updatePosition},
-		    options = this.options;
+		var events = {
+			zoom: this._updatePosition,
+			viewreset: this._updatePosition
+		};
 
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;
 		}
-		if ('closeOnClick' in options ? options.closeOnClick : this._map.options.closePopupOnClick) {
+		if ('closeOnClick' in this.options ? this.options.closeOnClick : this._map.options.closePopupOnClick) {
 			events.preclick = this._close;
 		}
-		if (options.keepInView) {
+		if (this.options.keepInView) {
 			events.moveend = this._adjustPan;
 		}
 		return events;

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -122,7 +122,7 @@ L.Popup = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {zoomend: this._updatePosition},
+		var events = {zoom: this._updatePosition},
 		    options = this.options;
 
 		if (this._zoomAnimated) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -42,7 +42,7 @@ L.Marker = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {viewreset: this.update};
+		var events = {zoomend: this.update};
 
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -42,7 +42,7 @@ L.Marker = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {zoomend: this.update};
+		var events = {zoom: this.update};
 
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -42,7 +42,10 @@ L.Marker = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {zoom: this.update};
+		var events = {
+			zoom: this.update,
+			viewreset: this.update
+		};
 
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -311,8 +311,9 @@ L.GridLayer = L.Layer.extend({
 		}
 	},
 
-	_resetView: function () {
-		this._setView(this._map.getCenter(), this._map.getZoom());
+	_resetView: function (e) {
+		var pinch = e && e.pinch;
+		this._setView(this._map.getCenter(), this._map.getZoom(), pinch, pinch);
 	},
 
 	_animateZoom: function (e) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -97,7 +97,7 @@ L.GridLayer = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
-			zoomend: this._resetView,
+			zoom: this._resetView,
 			moveend: this._onMoveEnd
 		};
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -97,6 +97,7 @@ L.GridLayer = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
+			viewreset: this._resetAll,
 			zoom: this._resetView,
 			moveend: this._onMoveEnd
 		};
@@ -195,6 +196,7 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_updateLevels: function () {
+
 		var zoom = this._tileZoom,
 			maxZoom = this.options.maxZoom;
 
@@ -263,6 +265,17 @@ L.GridLayer = L.Layer.extend({
 		for (var key in this._tiles) {
 			this._removeTile(key);
 		}
+	},
+
+	_resetAll: function () {
+		for (var z in this._levels) {
+			L.DomUtil.remove(this._levels[z].el);
+			delete this._levels[z];
+		}
+		this._removeAllTiles();
+
+		this._tileZoom = null;
+		this._resetView();
 	},
 
 	_retainParent: function (x, y, z, minZoom) {
@@ -395,11 +408,9 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_update: function (center, zoom) {
+
 		var map = this._map;
 		if (!map) { return; }
-
-		// TODO move to reset
-		// var zoom = this._map.getZoom();
 
 		if (center === undefined) { center = map.getCenter(); }
 		if (zoom === undefined) { zoom = Math.round(map.getZoom()); }

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -31,7 +31,7 @@ L.GridLayer = L.Layer.extend({
 		this._levels = {};
 		this._tiles = {};
 
-		this._viewReset();
+		this._resetView();
 		this._update();
 	},
 
@@ -97,13 +97,13 @@ L.GridLayer = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
-			viewreset: this._viewReset,
-			moveend: this._move
+			zoomend: this._resetView,
+			moveend: this._onMoveEnd
 		};
 
 		if (!this.options.updateWhenIdle) {
 			// update tiles on move, but not more often than once per given interval
-			events.move = L.Util.throttle(this._move, this.options.updateInterval, this);
+			events.move = L.Util.throttle(this._onMoveEnd, this.options.updateInterval, this);
 		}
 
 		if (this._zoomAnimated) {
@@ -311,19 +311,19 @@ L.GridLayer = L.Layer.extend({
 		}
 	},
 
-	_viewReset: function (e) {
-		this._reset(this._map.getCenter(), this._map.getZoom(), e && e.hard);
+	_resetView: function () {
+		this._setView(this._map.getCenter(), this._map.getZoom());
 	},
 
 	_animateZoom: function (e) {
-		this._reset(e.center, e.zoom, false, true, e.noUpdate);
+		this._setView(e.center, e.zoom, true, e.noUpdate);
 	},
 
-	_reset: function (center, zoom, hard, noPrune, noUpdate) {
+	_setView: function (center, zoom, noPrune, noUpdate) {
 		var tileZoom = Math.round(zoom),
 			tileZoomChanged = this._tileZoom !== tileZoom;
 
-		if (!noUpdate && (hard || tileZoomChanged)) {
+		if (!noUpdate && tileZoomChanged) {
 
 			if (this._abortLoading) {
 				this._abortLoading();
@@ -388,7 +388,7 @@ L.GridLayer = L.Layer.extend({
 		return this.options.tileSize;
 	},
 
-	_move: function () {
+	_onMoveEnd: function () {
 		this._update();
 		this._pruneTiles();
 	},

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -40,7 +40,7 @@ L.Path = L.Layer.extend({
 
 	getEvents: function () {
 		return {
-			zoom: this._project,
+			zoomend: this._project,
 			moveend: this._update
 		};
 	},

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -40,7 +40,7 @@ L.Path = L.Layer.extend({
 
 	getEvents: function () {
 		return {
-			zoomend: this._project,
+			zoom: this._project,
 			moveend: this._update
 		};
 	},

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -40,7 +40,7 @@ L.Path = L.Layer.extend({
 
 	getEvents: function () {
 		return {
-			viewreset: this._project,
+			zoomend: this._project,
 			moveend: this._update
 		};
 	},

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -26,11 +26,7 @@ L.Path = L.Layer.extend({
 	onAdd: function () {
 		this._renderer = this._map.getRenderer(this);
 		this._renderer._initPath(this);
-
-		// defined in children classes
-		this._project();
-		this._update();
-
+		this._reset();
 		this._renderer._addPath(this);
 	},
 
@@ -41,7 +37,8 @@ L.Path = L.Layer.extend({
 	getEvents: function () {
 		return {
 			zoomend: this._project,
-			moveend: this._update
+			moveend: this._update,
+			viewreset: this._reset
 		};
 	},
 
@@ -76,6 +73,12 @@ L.Path = L.Layer.extend({
 
 	getElement: function () {
 		return this._path;
+	},
+
+	_reset: function () {
+		// defined in children classes
+		this._project();
+		this._update();
 	},
 
 	_clickTolerance: function () {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -44,9 +44,9 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
-		var origin = this._map.latLngToLayerPoint(e.center).subtract(this._map._getCenterLayerPoint()),
-			scale = this._map.getZoomScale(e.zoom),
-		    offset = this._bounds.min.add(origin.multiplyBy(1 - scale)).subtract(this._map._getCenterOffset(e.center)).round();
+		var scale = this._map.getZoomScale(e.zoom),
+		    origin = this._map._getCenterOffset(e.center).multiplyBy(scale),
+		    offset = this._bounds.min.subtract(origin).round();
 
 		L.DomUtil.setTransform(this._container, offset, scale);
 	},

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -44,10 +44,11 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
-		var origin = e.origin.subtract(this._map._getCenterLayerPoint()),
-		    offset = this._bounds.min.add(origin.multiplyBy(1 - e.scale)).add(e.offset).round();
+		var origin = this._map.latLngToLayerPoint(e.center).subtract(this._map._getCenterLayerPoint()),
+			scale = this._map.getZoomScale(e.zoom),
+		    offset = this._bounds.min.add(origin.multiplyBy(1 - scale)).subtract(this._map._getCenterOffset(e.center)).round();
 
-		L.DomUtil.setTransform(this._container, offset, e.scale);
+		L.DomUtil.setTransform(this._container, offset, scale);
 	},
 
 	_update: function () {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -35,6 +35,7 @@ L.Renderer = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
+			zoom: this._updateTransform,
 			moveend: this._update
 		};
 		if (this._zoomAnimated) {
@@ -46,6 +47,15 @@ L.Renderer = L.Layer.extend({
 	_animateZoom: function (e) {
 		var scale = this._map.getZoomScale(e.zoom, this._zoom),
 		    offset = this._map._latLngToNewLayerPoint(this._topLeft, e.zoom, e.center);
+
+		L.DomUtil.setTransform(this._container, offset, scale);
+	},
+
+	_updateTransform: function () {
+		var zoom = this._map.getZoom(),
+			center = this._map.getCenter(),
+			scale = this._map.getZoomScale(zoom, this._zoom),
+		    offset = this._map._latLngToNewLayerPoint(this._topLeft, zoom, center);
 
 		L.DomUtil.setTransform(this._container, offset, scale);
 	},

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -8,7 +8,7 @@ L.Renderer = L.Layer.extend({
 	options: {
 		// how much to extend the clip area around the map view (relative to its size)
 		// e.g. 0.1 would be 10% of map view in each direction; defaults to clip with the map view
-		padding: 0
+		padding: 0.1
 	},
 
 	initialize: function (options) {
@@ -44,9 +44,8 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_animateZoom: function (e) {
-		var scale = this._map.getZoomScale(e.zoom),
-		    origin = this._map._getCenterOffset(e.center).multiplyBy(scale),
-		    offset = this._bounds.min.subtract(origin).round();
+		var scale = this._map.getZoomScale(e.zoom, this._zoom),
+		    offset = this._map._latLngToNewLayerPoint(this._topLeft, e.zoom, e.center);
 
 		L.DomUtil.setTransform(this._container, offset, scale);
 	},
@@ -58,6 +57,9 @@ L.Renderer = L.Layer.extend({
 		    min = this._map.containerPointToLayerPoint(size.multiplyBy(-p)).round();
 
 		this._bounds = new L.Bounds(min, min.add(size.multiplyBy(1 + p * 2)).round());
+		
+		this._topLeft = this._map.layerPointToLatLng(min);
+		this._zoom = this._map.getZoom();
 	}
 });
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -35,6 +35,7 @@ L.Renderer = L.Layer.extend({
 
 	getEvents: function () {
 		var events = {
+			viewreset: this._reset,
 			zoom: this._updateTransform,
 			moveend: this._update
 		};
@@ -58,6 +59,11 @@ L.Renderer = L.Layer.extend({
 		    offset = this._map._latLngToNewLayerPoint(this._topLeft, zoom, center);
 
 		L.DomUtil.setTransform(this._container, offset, scale);
+	},
+
+	_reset: function () {
+		this._update();
+		this._updateTransform();
 	},
 
 	_update: function () {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -54,8 +54,8 @@ L.Renderer = L.Layer.extend({
 
 	_updateTransform: function () {
 		var zoom = this._map.getZoom(),
-			center = this._map.getCenter(),
-			scale = this._map.getZoomScale(zoom, this._zoom),
+		    center = this._map.getCenter(),
+		    scale = this._map.getZoomScale(zoom, this._zoom),
 		    offset = this._map._latLngToNewLayerPoint(this._topLeft, zoom, center);
 
 		L.DomUtil.setTransform(this._container, offset, scale);
@@ -73,7 +73,7 @@ L.Renderer = L.Layer.extend({
 		    min = this._map.containerPointToLayerPoint(size.multiplyBy(-p)).round();
 
 		this._bounds = new L.Bounds(min, min.add(size.multiplyBy(1 + p * 2)).round());
-		
+
 		this._topLeft = this._map.layerPointToLatLng(min);
 		this._zoom = this._map.getZoom();
 	}

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -23,8 +23,6 @@ L.SVG = L.Renderer.extend({
 		    size = b.getSize(),
 		    container = this._container;
 
-		L.DomUtil.setPosition(container, b.min);
-
 		// set size of svg-container if changed
 		if (!this._svgSize || !this._svgSize.equals(size)) {
 			this._svgSize = size;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -546,7 +546,7 @@ L.Map = L.Evented.extend({
 		return this.fire('movestart');
 	},
 
-	_move: function (center, zoom) {
+	_move: function (center, zoom, data) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -558,9 +558,9 @@ L.Map = L.Evented.extend({
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
 		if (zoomChanged) {
-			this.fire('zoom');
+			this.fire('zoom', data);
 		}
-		return this.fire('move');
+		return this.fire('move', data);
 	},
 
 	_moveEnd: function (zoomChanged) {
@@ -715,7 +715,6 @@ L.Map = L.Evented.extend({
 
 	_getNewPixelOrigin: function (center, zoom) {
 		var viewHalf = this.getSize()._divideBy(2);
-		// TODO round on display, not calculation to increase precision?
 		return this.project(center, zoom)._subtract(viewHalf)._add(this._getMapPanePos())._round();
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -58,13 +58,13 @@ L.Map = L.Evented.extend({
 	// replaced by animation-powered implementation in Map.PanAnimation.js
 	setView: function (center, zoom) {
 		zoom = zoom === undefined ? this.getZoom() : zoom;
-		this._resetView(L.latLng(center), this._limitZoom(zoom));
+		this._resetView(L.latLng(center), zoom);
 		return this;
 	},
 
 	setZoom: function (zoom, options) {
 		if (!this._loaded) {
-			this._zoom = this._limitZoom(zoom);
+			this._zoom = zoom;
 			return this;
 		}
 		return this.setView(this.getCenter(), zoom, {zoom: options});
@@ -527,6 +527,7 @@ L.Map = L.Evented.extend({
 
 		var loading = !this._loaded;
 		this._loaded = true;
+		zoom = this._limitZoom(zoom);
 
 		var zoomChanged = this._zoom !== zoom;
 		this

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -535,6 +535,8 @@ L.Map = L.Evented.extend({
 			._move(center, zoom)
 			._moveEnd(zoomChanged);
 
+		this.fire('viewreset');
+
 		if (loading) {
 			this.fire('load');
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -545,19 +545,19 @@ L.Map = L.Evented.extend({
 		var loading = !this._loaded;
 		this._loaded = true;
 
+		// WARNING: viewreset event deprecated
 		this.fire('viewreset', {hard: !preserveMapOffset});
-
-		if (loading) {
-			this.fire('load');
-		}
-
-		this.fire('move');
 
 		if (zoomChanged || afterZoomAnim) {
 			this.fire('zoomend');
 		}
 
-		this.fire('moveend', {hard: !preserveMapOffset});
+		this.fire('move');
+		this.fire('moveend');
+
+		if (loading) {
+			this.fire('load');
+		}
 	},
 
 	_rawPanBy: function (offset) {

--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -50,16 +50,19 @@ L.Map.include({
 			if (t <= 1) {
 				this._flyToFrame = L.Util.requestAnimFrame(frame, this);
 
-				this._resetView(
+				this._move(
 					this.unproject(from.add(to.subtract(from).multiplyBy(u(s) / u1)), startZoom),
-					this.getScaleZoom(w0 / w(s), startZoom), true, true);
+					this.getScaleZoom(w0 / w(s), startZoom));
 
 			} else {
-				this._resetView(targetCenter, targetZoom, true, true);
+				this
+					._move(targetCenter, targetZoom)
+					._moveEnd(true);
 			}
 		}
 
-		this.fire('zoomstart');
+		this._moveStart(true);
+
 		frame.call(this);
 		return this;
 	},

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -102,9 +102,6 @@ L.Map.include(!zoomAnimated ? {} : {
 		this.fire('zoomanim', {
 			center: center,
 			zoom: zoom,
-			scale: this.getZoomScale(zoom),
-			origin: this.latLngToLayerPoint(center),
-			offset: this._getCenterOffset(center).multiplyBy(-1),
 			noUpdate: noUpdate
 		});
 	},

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -81,8 +81,7 @@ L.Map.include(!zoomAnimated ? {} : {
 
 		L.Util.requestAnimFrame(function () {
 			this
-			    .fire('movestart')
-			    .fire('zoomstart')
+			    ._moveStart(true)
 			    ._animateZoom(center, zoom, true);
 		}, this);
 
@@ -116,6 +115,8 @@ L.Map.include(!zoomAnimated ? {} : {
 
 		L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 
-		this._resetView(this._animateToCenter, this._animateToZoom, true, true);
+		this
+			._move(this._animateToCenter, this._animateToZoom)
+			._moveEnd(true);
 	}
 });

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -31,9 +31,9 @@ L.Map.Drag = L.Handler.extend({
 			this._draggable.on('predrag', this._onPreDragLimit, this);
 			if (map.options.worldCopyJump) {
 				this._draggable.on('predrag', this._onPreDragWrap, this);
-				map.on('viewreset', this._onViewReset, this);
+				map.on('zoomend', this._onZoomEnd, this);
 
-				map.whenReady(this._onViewReset, this);
+				map.whenReady(this._onZoomEnd, this);
 			}
 		}
 		L.DomUtil.addClass(this._map._container, 'leaflet-grab');
@@ -98,7 +98,7 @@ L.Map.Drag = L.Handler.extend({
 		    .fire('drag', e);
 	},
 
-	_onViewReset: function () {
+	_onZoomEnd: function () {
 		var pxCenter = this._map.getSize().divideBy(2),
 		    pxWorldCenter = this._map.latLngToLayerPoint([0, 0]);
 


### PR DESCRIPTION
A work in progress to make movement-related events in Leaflet less confusing, more consistent across different types of movements/animations and fitting the new paradigm with fractional zoom levels and flyTo animations better.

- [x] remove `viewreset` event and depend solely on `zoom` event in layers instead
- [x] refactor confusing `Map` `_resetView` code into small separate methods
- [x] refactor `Map.TouchZoom` code to rely on `zoom` events during pinch-zoom
- [x] decide how to reset view when doing long-distance panning
- [x] simplify transformation math to enable transforming vector layers from any state
- [x] make `Renderer` rely on `zoom` events to scale renderer
- [x] get rid of the ambiguity of relying on `zoomanim` in places when there's no actual animation
- [x] stop vector reprojection/clipping/simplification on every frame #2982 
- [x] bring `viewreset` event back but in a different meaning (not zoom but full reset)
- [x] fix tests

Closes #3216, closes #3134. Related: #2982 