### PR TITLE
Added zoomFactor map option

### DIFF
--- a/debug/map/zoom-factor.html
+++ b/debug/map/zoom-factor.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script type="text/javascript">
+
+		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var map = L.map('map', {zoomFactor: 0.25})
+				.setView([50.5, 30.51], 15)
+				.addLayer(osm);
+
+		function logEvent(e) { console.log(e.type); }
+
+		// map.on('click', logEvent);
+
+		// map.on('movestart', logEvent);
+		// map.on('move', logEvent);
+		// map.on('moveend', logEvent);
+
+		// map.on('zoomstart', logEvent);
+		// map.on('zoomend', logEvent);
+
+	</script>
+</body>
+</html>

--- a/debug/map/zoom-factor.html
+++ b/debug/map/zoom-factor.html
@@ -36,8 +36,9 @@
 
 		// map.on('zoomstart', logEvent);
 		// map.on('zoomend', logEvent);
+
 		map.on('zoomend', function(e){
-			console.log(e.target._zoom);
+			console.log("Current Zoom: " + e.target._zoom);
 		});
 
 	</script>

--- a/debug/map/zoom-factor.html
+++ b/debug/map/zoom-factor.html
@@ -22,7 +22,7 @@
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-		var map = L.map('map', {zoomFactor: 0.25})
+		var map = L.map('map', {zoomFactor: 0.45, maxZoom: 18})
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 
@@ -36,6 +36,9 @@
 
 		// map.on('zoomstart', logEvent);
 		// map.on('zoomend', logEvent);
+		map.on('zoomend', function(e){
+			console.log(e.target._zoom);
+		});
 
 	</script>
 </body>

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -45,13 +45,13 @@ L.Control.Zoom = L.Control.extend({
 
 	_zoomIn: function (e) {
 		if (!this._disabled) {
-			this._map.zoomIn(e.shiftKey ? 3 : 1);
+			this._map.zoomIn(e.shiftKey ? this._map.zoomFactor * 3 : this._map.zoomFactor);
 		}
 	},
 
 	_zoomOut: function (e) {
 		if (!this._disabled) {
-			this._map.zoomOut(e.shiftKey ? 3 : 1);
+			this._map.zoomOut(e.shiftKey ? this._map.zoomFactor * 3 : this._map.zoomFactor);
 		}
 	},
 

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -45,13 +45,13 @@ L.Control.Zoom = L.Control.extend({
 
 	_zoomIn: function (e) {
 		if (!this._disabled) {
-			this._map.zoomIn(e.shiftKey ? this._map.zoomFactor * 3 : this._map.zoomFactor);
+			this._map.zoomIn(e.shiftKey ? 3 : 1);
 		}
 	},
 
 	_zoomOut: function (e) {
 		if (!this._disabled) {
-			this._map.zoomOut(e.shiftKey ? this._map.zoomFactor * 3 : this._map.zoomFactor);
+			this._map.zoomOut(e.shiftKey ? 3 : 1);
 		}
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -15,7 +15,8 @@ L.Map = L.Evented.extend({
 
 		fadeAnimation: true,
 		trackResize: true,
-		markerZoomAnimation: true
+		markerZoomAnimation: true,
+		zoomFactor: 1
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)
@@ -45,6 +46,7 @@ L.Map = L.Evented.extend({
 		this._layers = {};
 		this._zoomBoundLayers = {};
 		this._sizeChanged = true;
+		this.zoomFactor = options.zoomFactor;
 
 		this.callInitHooks();
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -72,11 +72,11 @@ L.Map = L.Evented.extend({
 	},
 
 	zoomIn: function (delta, options) {
-		return this.setZoom(this._zoom + (delta || 1), options);
+		return this.setZoom(this._zoom + (delta || 1) * this.zoomFactor, options);
 	},
 
 	zoomOut: function (delta, options) {
-		return this.setZoom(this._zoom - (delta || 1), options);
+		return this.setZoom(this._zoom - (delta || 1) * this.zoomFactor, options);
 	},
 
 	setZoomAround: function (latlng, zoom, options) {

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -53,6 +53,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
 		delta = Math.max(Math.min(delta, 4), -4);
 		delta = map._limitZoom(zoom + delta) - zoom;
+		delta = delta * this._map.zoomFactor;
 
 		this._delta = 0;
 		this._startTime = null;

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -25,7 +25,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 	},
 
 	_onWheelScroll: function (e) {
-		var delta = L.DomEvent.getWheelDelta(e);
+		var delta = L.DomEvent.getWheelDelta(e) * this._map.zoomFactor;
 		var debounce = this._map.options.wheelDebounceTime;
 
 		this._delta += delta;
@@ -50,10 +50,8 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		map.stop(); // stop panning and fly animations if any
 
-		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
 		delta = Math.max(Math.min(delta, 4), -4);
 		delta = map._limitZoom(zoom + delta) - zoom;
-		delta = delta * this._map.zoomFactor;
 
 		this._delta = 0;
 		this._startTime = null;


### PR DESCRIPTION
Added the ability to control the zoom factor via Control.Zoom.js and ScrollWheel zooming.

This is in regards to fractional zooming. It will zoom the map in increments of whatever the zoomFactor is whenever you use the Zoom Control or Scrollwheel.

Pass the `zoomFactor` in the map options. Default value is 1. You can change the map's zoom factor at any time by using `map.zoomFactor = 0.25`.

I added a `zoom-factor.html` debug file to experiment with.

Also @mourner if you want, we can change the name zoomFactor to something else. Maybe zoomStep or zoomIncrement? zoomFactor sounded most straightforward at the time. This is a minor feature but it really should be in there in order to make fractional zooming shine.

Signed-off-by: Jake Wilson <jake.e.wilson@gmail.com>