### PR TITLE
Also listen to events on marker icon childs elements

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -166,5 +166,46 @@ describe("Marker", function () {
 
 			expect(spy.called).to.be.ok();
 		});
+
+		it('fires click event when clicked with DivIcon', function () {
+			var spy = sinon.spy();
+
+			var marker = L.marker([0, 0], {icon: new L.DivIcon()}).addTo(map);
+
+			marker.on('click', spy);
+			happen.click(marker._icon);
+
+			expect(spy.called).to.be.ok();
+		});
+
+		it('fires click event when clicked on DivIcon child element', function () {
+			var spy = sinon.spy();
+
+			var marker = L.marker([0, 0], {icon: new L.DivIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'})}).addTo(map);
+
+			marker.on('click', spy);
+
+			happen.click(marker._icon);
+			expect(spy.called).to.be.ok();
+
+			happen.click(marker._icon.querySelector('img'));
+			expect(spy.calledTwice).to.be.ok();
+		});
+
+		it('fires click event when clicked on DivIcon child element set using setIcon', function () {
+			var spy = sinon.spy();
+
+			var marker = L.marker([0, 0]).addTo(map);
+			marker.setIcon(new L.DivIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'}));
+
+			marker.on('click', spy);
+
+			happen.click(marker._icon);
+			expect(spy.called).to.be.ok();
+
+			happen.click(marker._icon.querySelector('img'));
+			expect(spy.calledTwice).to.be.ok();
+		});
+
 	});
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -575,11 +575,25 @@ L.Map = L.Evented.extend({
 		this._container.scrollLeft = 0;
 	},
 
+	_findEventTarget: function (src) {
+		while (src) {
+			var target = this._targets[L.stamp(src)];
+			if (target) {
+				return target;
+			}
+			if (src === this._container) {
+				break;
+			}
+			src = src.parentNode;
+		}
+		return null;
+	},
+
 	_handleDOMEvent: function (e) {
 		if (!this._loaded || L.DomEvent._skipped(e)) { return; }
 
 		// find the layer the event is propagating from
-		var target = this._targets[L.stamp(e.target || e.srcElement)],
+		var target = this._findEventTarget(e.target || e.srcElement),
 			type = e.type === 'keypress' && e.keyCode === 13 ? 'click' : e.type;
 
 		// special case for map mouseover/mouseout events so that they're actually mouseenter/mouseleave


### PR DESCRIPTION
When using a DivIcon, we often add DOM elements in it,
which can then be the actual targets of DOM events, so we need
to add them in the "listened" targets.