### PR TITLE
Allow to use console in tests

### DIFF
--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -17,7 +17,8 @@
     "strict": 0,
     "key-spacing": 0,
     "no-shadow": 0,
-    "no-irregular-whitespace": 0
+    "no-irregular-whitespace": 0,
+    "no-console": 0
   },
   "globals": {
     "L": true,


### PR DESCRIPTION
This prevents us from adding `/* eslint no-console: 0 */` each time
we need to use console.log/trace for debugging in tests files.

This also means that we will not be blocked if we forget a console
in the tests before commiting, which is bad; but this could also happen while using
the inline "no-console" config, and given that this only affects tests
files, I think the confort of being able to use console easily worth
the risk of pushing a console in the tests files. ;)

But I let you decide :)