### PR TITLE
Add optional callback to map.flyTo

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -585,7 +585,7 @@ describe("Map", function () {
 					done();
 				};
 			map.setView([0, 0], 0);
-			map.flyTo(newCenter, newZoom, callback);
+			map.once('zoomend', callback).flyTo(newCenter, newZoom);
 		});
 
 	});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -570,4 +570,24 @@ describe("Map", function () {
 			expect(spy.called).to.be.ok();
 		});
 	});
+
+	describe('#flyTo', function () {
+
+		it('move to requested center and zoom, and call callback once', function (done) {
+			var spy = sinon.spy(),
+				newCenter = new L.LatLng(10, 11),
+				newZoom = 12,
+				callback = function () {
+					expect(map.getCenter()).to.eql(newCenter);
+					expect(map.getZoom()).to.eql(newZoom);
+					spy();
+					expect(spy.calledOnce).to.be.ok();
+					done();
+				};
+			map.setView([0, 0], 0);
+			map.flyTo(newCenter, newZoom, callback);
+		});
+
+	});
+
 });

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -573,7 +573,7 @@ describe("Map", function () {
 
 	describe('#flyTo', function () {
 
-		it('move to requested center and zoom, and call callback once', function (done) {
+		it('move to requested center and zoom, and call zoomend once', function (done) {
 			var spy = sinon.spy(),
 				newCenter = new L.LatLng(10, 11),
 				newZoom = 12,

--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -1,6 +1,6 @@
 
 L.Map.include({
-	flyTo: function (targetCenter, targetZoom) {
+	flyTo: function (targetCenter, targetZoom, callback) {
 
 		this.stop();
 
@@ -51,6 +51,9 @@ L.Map.include({
 
 			} else {
 				this._resetView(targetCenter, targetZoom, true, true);
+				if (callback) {
+					callback();
+				}
 			}
 		}
 

--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -1,6 +1,6 @@
 
 L.Map.include({
-	flyTo: function (targetCenter, targetZoom, callback) {
+	flyTo: function (targetCenter, targetZoom) {
 
 		this.stop();
 
@@ -51,9 +51,6 @@ L.Map.include({
 
 			} else {
 				this._resetView(targetCenter, targetZoom, true, true);
-				if (callback) {
-					callback();
-				}
 			}
 		}
 


### PR DESCRIPTION
I know that having callback arguments it's not a Leaflet pattern, but given that `requestAnimFrame` is asynchronous and that `flyTo` can be quite "long", I think having a callback in this case makes sense, as it allows smoother animation sequence (i.e. being able to run the step following `flyTo` only when its fully finished).