### PR TITLE
Map panBy always return map object

### DIFF
--- a/src/map/anim/Map.PanAnimation.js
+++ b/src/map/anim/Map.PanAnimation.js
@@ -47,7 +47,8 @@ L.Map.include({
 		//If we pan too far then chrome gets issues with tiles
 		// and makes them disappear or appear in the wrong place (slightly offset) #2602
 		if (options.animate !== true && !this.getSize().contains(offset)) {
-			return this._resetView(this.unproject(this.project(this.getCenter()).add(offset)), this.getZoom());
+			this._resetView(this.unproject(this.project(this.getCenter()).add(offset)), this.getZoom());
+			return this;
 		}
 
 		if (!this._panAnim) {


### PR DESCRIPTION
In some cases, method `panBy` return `_resetView`, but `_resetView` return `undefined`.