### PR TITLE
0.73: Allow fractional zoom stopping with Map.TouchZoom and fix CRS.scale calc with fractional zoom

### DIFF
--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -22,7 +22,13 @@ L.CRS = {
 	},
 
 	scale: function (zoom) {
-		return 256 * Math.pow(2, zoom);
+		var iZoom = Math.floor(zoom);
+        var baseScale = 256 * Math.pow(2, iZoom);
+        var nextScale = 256 * Math.pow(2, iZoom + 1);
+        var scaleDiff = nextScale - baseScale;
+        var zDiff = (zoom - iZoom);
+
+        return baseScale + scaleDiff * zDiff;
 	},
 
 	getSize: function (zoom) {

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -109,10 +109,8 @@ L.Map.TouchZoom = L.Handler.extend({
 
 		    oldZoom = map.getZoom(),
 		    floatZoomDelta = map.getScaleZoom(this._scale) - oldZoom,
-		    roundZoomDelta = (floatZoomDelta > 0 ?
-		            Math.ceil(floatZoomDelta) : Math.floor(floatZoomDelta)),
 
-		    zoom = map._limitZoom(oldZoom + roundZoomDelta),
+		    zoom = map._limitZoom(oldZoom + floatZoomDelta),
 		    scale = map.getZoomScale(zoom) / this._scale;
 
 		map._animateZoom(center, zoom, origin, scale);


### PR DESCRIPTION
Hi.

I believe that I have found a fix to allow touch/pinch fractional zoom support (when using plain Leaflet object and or GeoJson objects). But I could not comment as to if this will break any map with tiles. We currently don't use tiles, so I don't have expertise.

This Pull is for stable (sorry if this is the wrong destination), I will create a second for master https://github.com/Leaflet/Leaflet/pull/3326 (as the code is different). I believe work has been done in master for version 1.0 to support better zooming so if this Pull is ignored in favour of the master pull then at least this code might serve as a reference for others using 0.7.

The underlying issue being solved is the "jump" in the map when stopping a touch/pinch zoom whilst the map snaps to a whole number zoom level. Our users on iPad's and Android were finding this very obvious and it was very hard for them to zoom in/out to the level of detail that they wanted. 

Changes to Map.TouchZoom support stopping the zoom level exactly where the user has stopped the pinch.

The secondary issue uncovered is that the built in CRS.scale calculation also does not support fractional zoom. The side-affect of this is that when touch/pinch zooming, the percent with which the map is grown or shrunk does not reflect the final size that the map will be drawn at. Thus this means that there is still a "jump" in the map when stopping a touch/pinch zoom, even with the first fix in place.

The commit to CRS.js supports Scale calculation for fractional zoom levels.

Please refer to these related issues:
https://github.com/kartena/Proj4Leaflet/issues/57
https://github.com/kartena/Proj4Leaflet/pull/73
https://github.com/Leaflet/Leaflet/issues/426
https://github.com/Leaflet/Leaflet/pull/1309
http://stackoverflow.com/questions/24151177/fractional-zoom-levels
https://github.com/Leaflet/Leaflet/pull/2382
https://github.com/Leaflet/Leaflet/issues/2558