### PR TITLE
Master: Allow fractional zoom stopping with Map.TouchZoom and fix CRS.scale calc with fractional zoom

### DIFF
--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -31,7 +31,13 @@ L.CRS = {
 
 	// defines how the world scales with zoom
 	scale: function (zoom) {
-		return 256 * Math.pow(2, zoom);
+		var iZoom = Math.floor(zoom);
+        var baseScale = 256 * Math.pow(2, iZoom);
+        var nextScale = 256 * Math.pow(2, iZoom + 1);
+        var scaleDiff = nextScale - baseScale;
+        var zDiff = (zoom - iZoom);
+
+        return baseScale + scaleDiff * zDiff;
 	},
 
 	// returns the bounds of the world in projected coords if applicable

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -104,7 +104,7 @@ L.Map.TouchZoom = L.Handler.extend({
 		var map = this._map,
 		    oldZoom = map.getZoom(),
 		    zoomDelta = this._zoom - oldZoom,
-		    finalZoom = map._limitZoom(zoomDelta > 0 ? Math.ceil(this._zoom) : Math.floor(this._zoom));
+		    finalZoom = map._limitZoom(this._zoom);
 
 		map._animateZoom(this._center, finalZoom, true, true);
 	},


### PR DESCRIPTION
Similar Pull to https://github.com/Leaflet/Leaflet/pull/3325, but different code for master.

I believe that I have found a fix to allow touch/pinch fractional zoom support (when using plain Leaflet object and or GeoJson objects). But I could not comment as to if this will break any map with tiles. I believe work has gone into master to support better fractional zoom levels, but in the latest master the problem described below still exists.

The underlying issue being solved is the "jump" in the map when stopping a touch/pinch zoom whilst the map snaps to a whole number zoom level. Our users on iPad's and Android were finding this very obvious and it was very hard for them to zoom in/out to the level of detail that they wanted.

Changes to Map.TouchZoom support stopping the zoom level exactly where the user has stopped the pinch.

The secondary issue uncovered is that the built in CRS.scale calculation also does not support fractional zoom. The side-affect of this is that when touch/pinch zooming, the percent with which the map is grown or shrunk does not reflect the final size that the map will be drawn at. Thus this means that there is still a "jump" in the map when stopping a touch/pinch zoom, even with the first fix in place.

The commit to CRS.js supports Scale calculation for fractional zoom levels.

Please refer to these related issues:
https://github.com/kartena/Proj4Leaflet/issues/57
https://github.com/kartena/Proj4Leaflet/pull/73
https://github.com/Leaflet/Leaflet/issues/426
https://github.com/Leaflet/Leaflet/pull/1309
http://stackoverflow.com/questions/24151177/fractional-zoom-levels
https://github.com/Leaflet/Leaflet/pull/2382
https://github.com/Leaflet/Leaflet/issues/2558