### PR TITLE
Fix tile loading in IE8

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -85,7 +85,12 @@ L.TileLayer = L.GridLayer.extend({
 	},
 
 	_tileOnLoad: function (done, tile) {
-		done(null, tile);
+		// For https://github.com/Leaflet/Leaflet/issues/3332
+		if (L.Browser.ielt9) {
+			setTimeout(L.bind(done, this, null, tile), 0);
+		} else {
+			done(null, tile);
+		}
 	},
 
 	_tileOnError: function (done, tile, e) {


### PR DESCRIPTION
See #3332. Minimal steps to reproduce the bug:

1. Drag the map a couple of screens away (zooming is not necessary)
2. Drag back to original position

The problem is related to browser caching.  IE8 seems to call `onload` handlers of `<img>` elements synchronously (immediately after assignment to `tile.src`) if it gets the image from cache.

This caused the `_tileReady` handler (in `GridLayer`) to be called before a tile was added to `this._tiles` object, so the handler returned without applying `leaflet-tile-loaded` class to the element.

This pull request fixes the bug with a simple `setTimeout` hack. I wasn't able to find a more elegant solution without changing a lot of code.