### PR TITLE
Change translate3d detection

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -35,6 +35,7 @@
 		android23: android23,
 		chrome: chrome,
 		safari: !chrome && ua.indexOf('safari') !== -1,
+		opera12: opera3d,
 
 		ie3d: ie3d,
 		webkit3d: webkit3d,

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -21,7 +21,7 @@
 	    ie3d = ie && ('transition' in doc.style),
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
 	    gecko3d = 'MozPerspective' in doc.style,
-	    opera3d = 'OTransition' in doc.style;
+	    opera12 = 'OTransition' in doc.style;
 
 	var touch = !window.L_NO_TOUCH && !phantomjs && (pointer || 'ontouchstart' in window ||
 			(window.DocumentTouch && document instanceof window.DocumentTouch));
@@ -35,13 +35,12 @@
 		android23: android23,
 		chrome: chrome,
 		safari: !chrome && ua.indexOf('safari') !== -1,
-		opera12: opera3d,
 
 		ie3d: ie3d,
 		webkit3d: webkit3d,
 		gecko3d: gecko3d,
-		opera3d: opera3d,
-		any3d: !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || opera3d) && !phantomjs,
+		opera12: opera12,
+		any3d: !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantomjs,
 
 		mobile: mobile,
 		mobileWebkit: mobile && webkit,

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -141,9 +141,9 @@ L.DomUtil = {
 
 	setTransform: function (el, offset, scale) {
 		var pos = offset || new L.Point(0, 0),
-			is3d = L.Browser.webkit3d,
-		    open = 'translate' + (is3d ? '3d' : '') + '(',
-		    close = (is3d ? ',0' : '') + ')';
+			is3d = !L.Browser.opera12,
+			open = 'translate' + (is3d ? '3d' : '') + '(',
+			close = (is3d ? ',0' : '') + ')';
 
 		el.style[L.DomUtil.TRANSFORM] =
 			open + pos.x + 'px,' + pos.y + 'px' + close + (scale ? ' scale(' + scale + ')' : '');

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -140,13 +140,10 @@ L.DomUtil = {
 	},
 
 	setTransform: function (el, offset, scale) {
-		var pos = offset || new L.Point(0, 0),
-			is3d = !L.Browser.opera12,
-			open = 'translate' + (is3d ? '3d' : '') + '(',
-			close = (is3d ? ',0' : '') + ')';
+		var pos = offset || new L.Point(0, 0);
 
 		el.style[L.DomUtil.TRANSFORM] =
-			open + pos.x + 'px,' + pos.y + 'px' + close + (scale ? ' scale(' + scale + ')' : '');
+			'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' + (scale ? ' scale(' + scale + ')' : '');
 	},
 
 	setPosition: function (el, point, no3d) { // (HTMLElement, Point[, Boolean])


### PR DESCRIPTION
https://github.com/Leaflet/Leaflet/pull/2574 created a year ago. Now, no webkit browsers like firefox works fine with `translate3d` property.

I added `L.Browser.opera12` to avoid the logical confusion with `is3d = !L.Browser.opera3d`.