### PR TITLE
Never try to run _updateOpacity if this._map is undefined

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -72,10 +72,7 @@ L.GridLayer = L.Layer.extend({
 
 	setOpacity: function (opacity) {
 		this.options.opacity = opacity;
-
-		if (this._map) {
-			this._updateOpacity();
-		}
+		this._updateOpacity();
 		return this;
 	},
 
@@ -148,6 +145,7 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_updateOpacity: function () {
+		if (!this._map) { return; }
 		var opacity = this.options.opacity;
 
 		// IE doesn't inherit filter opacity properly, so we're forced to set it on tiles


### PR DESCRIPTION
Not sure exactly why, but the Leaflet.Storage unittests break from time to time because `this._map` is undefined on `GridLayer._updateOpacity`. When it occurs, it's called from `_tileReady` so probably it's a race condition.

It may be that something should be better handled on Leaflet.Storage side, but I thought it was safer anyway to move the test on `this._map` from `setOpacity` to `_updateOpacity`.