### PR TITLE
Add mobile touch events

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -172,15 +172,19 @@ L.DomEvent = {
 	},
 
 	getMousePosition: function (e, container) {
+		var evt = e;
+		if (evt.touches) {
+			evt = evt.touches[0] || evt.changedTouches[0];
+		}
 		if (!container) {
-			return new L.Point(e.clientX, e.clientY);
+			return new L.Point(evt.clientX, evt.clientY);
 		}
 
 		var rect = container.getBoundingClientRect();
 
 		return new L.Point(
-			e.clientX - rect.left - container.clientLeft,
-			e.clientY - rect.top - container.clientTop);
+			evt.clientX - rect.left - container.clientLeft,
+			evt.clientY - rect.top - container.clientTop);
 	},
 
 	getWheelDelta: function (e) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -607,7 +607,7 @@ L.Map = L.Evented.extend({
 		var onOff = remove ? 'off' : 'on';
 
 		L.DomEvent[onOff](this._container, 'click dblclick mousedown mouseup ' +
-			'mouseover mouseout mousemove contextmenu keypress', this._handleDOMEvent, this);
+			'mouseover mouseout mousemove contextmenu keypress touchstart touchmove touchend', this._handleDOMEvent, this);
 
 		if (this.options.trackResize) {
 			L.DomEvent[onOff](window, 'resize', this._onResize, this);


### PR DESCRIPTION
Adds support for adding touch events "touchstart touchmove touchend".

Events can be added with `L.DomEvent.addListener(map, "touchstart", touchStartHandlerFunction);`

I found the need for these events in leaflet while developing a drag and drop "orange man" style leaflet control so people could select a point on the map.

Its interesting to note that that touchend isn't the same as mouseup, as i understand it mouseup fires on the element where the mouse was released and touchend fires on the element where touchstart occurred.

Something strange i noticed was that touchend isn't propagated if touchstart's on leaflet controls so i needed to attach a touchend event to the leaflet control and figure out the lat,lng using `map.mouseEventToLatLng(event)` (as oppose to attaching touchend to the map and doing `event.latlng`)

a shim to add them is described in #1542  
also related to #3075
