### PR TITLE
Fix L.Polyline._flat returning true for a nested empty array

### DIFF
--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -88,4 +88,29 @@ describe('Polyline', function () {
 
 	});
 
+	describe('#_flat', function () {
+		var layer = L.polyline([]);
+
+		it('should return true for an array of LatLngs', function () {
+			expect(layer._flat([L.latLng([0, 0])])).to.be(true);
+		});
+
+		it('should return true for an array of LatLngs arrays', function () {
+			expect(layer._flat([[0, 0]])).to.be(true);
+		});
+
+		it('should return true for an empty array', function () {
+			expect(layer._flat([])).to.be(true);
+		});
+
+		it('should return false for a nested array of LatLngs', function () {
+			expect(layer._flat([[L.latLng([0, 0])]])).to.be(false);
+		});
+
+		it('should return false for a nested empty array', function () {
+			expect(layer._flat([[]])).to.be(false);
+		});
+
+	});
+
 });

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -131,7 +131,7 @@ L.Polyline = L.Path.extend({
 
 	_flat: function (latlngs) {
 		// true if it's a flat array of latlngs; false if nested
-		return !L.Util.isArray(latlngs[0]) || typeof latlngs[0][0] !== 'object';
+		return !L.Util.isArray(latlngs[0]) || (typeof latlngs[0][0] !== 'object' && typeof latlngs[0][0] !== 'undefined');
 	},
 
 	_project: function () {


### PR DESCRIPTION
`L.Polyline._flat` was returning true for `[[]]`, which seems to me a valid use case of an empty nested latlngs array (case of a Polygon).

While I'm on it, I've some use cases where I would like to call `L.Polyline._flat` without being in a context of a given `Polyline` instance, what do you think about moving `_flat` as a class method instead of an instance method (i.e. `L.Polyline._flat` instead of `this._flat` to use it)?