### PR TITLE
Move functionality from point, latlng, bounds factory to constructor

### DIFF
--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -10,6 +10,12 @@ describe('LatLng', function () {
 			expect(b.lng).to.eql(-74);
 		});
 
+		it('throws an error if lng not specified', function () {
+			expect(function () {
+				var a = new L.LatLng(50);
+			}).to.throwError();
+		});
+
 		it('throws an error if invalid lat or lng', function () {
 			expect(function () {
 				var a = new L.LatLng(NaN, NaN);
@@ -105,6 +111,10 @@ describe('LatLng', function () {
 
 		it('returns null if lng not specified', function () {
 			expect(L.latLng(50)).to.be(null);
+		});
+
+		it('returns null if invalid lat/lng', function () {
+			expect(L.latLng(NaN, NaN)).to.be(null);
 		});
 
 		it('accepts altitude as third parameter', function () {

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -2,7 +2,30 @@
  * L.LatLng represents a geographical point with latitude and longitude coordinates.
  */
 
-L.LatLng = function (lat, lng, alt) {
+// constructs LatLng with different signatures
+// (LatLng) or ([Number, Number]) or (Number, Number) or (Object)
+L.LatLng = function (a, b, c) {
+	var lat, lng, alt;
+	if (L.Util.isArray(a) && typeof a[0] !== 'object') {
+		if (a.length === 3) {
+			lat = a[0];
+			lng = a[1];
+			alt = a[2];
+		}
+		if (a.length === 2) {
+			lat = a[0];
+			lng = a[1];
+		}
+	} else if (typeof a === 'object' && 'lat' in a) {
+		lat = a.lat;
+		lng = 'lng' in a ? a.lng : a.lon;
+		alt = a.alt;
+	} else {
+		lat = a;
+		lng = b;
+		alt = c;
+	}
+
 	if (isNaN(lat) || isNaN(lng)) {
 		throw new Error('Invalid LatLng object: (' + lat + ', ' + lng + ')');
 	}
@@ -53,30 +76,13 @@ L.LatLng.prototype = {
 };
 
 
-// constructs LatLng with different signatures
-// (LatLng) or ([Number, Number]) or (Number, Number) or (Object)
-
 L.latLng = function (a, b, c) {
-	if (a instanceof L.LatLng) {
+	if (a instanceof L.LatLng || a === null) {
 		return a;
 	}
-	if (L.Util.isArray(a) && typeof a[0] !== 'object') {
-		if (a.length === 3) {
-			return new L.LatLng(a[0], a[1], a[2]);
-		}
-		if (a.length === 2) {
-			return new L.LatLng(a[0], a[1]);
-		}
+	try {
+		return new L.LatLng(a, b, c);
+	} catch(err) {
 		return null;
 	}
-	if (a === undefined || a === null) {
-		return a;
-	}
-	if (typeof a === 'object' && 'lat' in a) {
-		return new L.LatLng(a.lat, 'lng' in a ? a.lng : a.lon, a.alt);
-	}
-	if (b === undefined) {
-		return null;
-	}
-	return new L.LatLng(a, b, c);
 };

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -154,7 +154,7 @@ L.LatLngBounds.prototype = {
 //TODO International date line?
 
 L.latLngBounds = function (a, b) { // (LatLngBounds) or (LatLng, LatLng)
-	if (!a || a instanceof L.LatLngBounds) {
+	if (a instanceof L.LatLngBounds || a === undefined || a === null) {
 		return a;
 	}
 	return new L.LatLngBounds(a, b);

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -88,7 +88,7 @@ L.Bounds.prototype = {
 };
 
 L.bounds = function (a, b) { // (Bounds) or (Point, Point) or (Point[])
-	if (!a || a instanceof L.Bounds) {
+	if (a instanceof L.Bounds || a === undefined || a === null) {
 		return a;
 	}
 	return new L.Bounds(a, b);

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -3,6 +3,12 @@
  */
 
 L.Point = function (x, y, round) {
+	if (L.Util.isArray(x)) {
+		round = y;
+		y = x[1];
+		x = x[0];
+	}
+
 	this.x = (round ? Math.round(x) : x);
 	this.y = (round ? Math.round(y) : y);
 };
@@ -116,13 +122,7 @@ L.Point.prototype = {
 };
 
 L.point = function (x, y, round) {
-	if (x instanceof L.Point) {
-		return x;
-	}
-	if (L.Util.isArray(x)) {
-		return new L.Point(x[0], x[1]);
-	}
-	if (x === undefined || x === null) {
+	if (x instanceof L.Point || x === null) {
 		return x;
 	}
 	return new L.Point(x, y, round);


### PR DESCRIPTION
Constructors for point, latlng, bounds, latlngbounds behave just like the factories.

Fixes #3408.

Note that `new L.LatLng(50);` will raise an error and `L.latLng(50)` will return null. This is as per the current specs.