### PR TITLE
Prevent MSIE from focusing a tilelayer container.

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -220,6 +220,12 @@ L.GridLayer = L.Layer.extend({
 
 			// force the browser to consider the newly added element for transition
 			L.Util.falseFn(level.el.offsetWidth);
+
+			if (L.Browser.ie) {
+				L.DomEvent.on(level.el, 'focus', function() {
+					this._map._container.focus();
+				}, this);
+			}
 		}
 
 		this._level = level;


### PR DESCRIPTION
Fixes #3314. For some weird reason MSIE allows `leaflet-tile-container`s to grab focus.

I don't know if this might have any side effects.