### PR TITLE
TileLayer - Use correct tileSize when checking tile bounds

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -360,7 +360,7 @@ L.TileLayer = L.Class.extend({
 		}
 
 		if (options.bounds) {
-			var tileSize = options.tileSize,
+			var tileSize = this._getTileSize(),
 			    nwPoint = tilePoint.multiplyBy(tileSize),
 			    sePoint = nwPoint.add([tileSize, tileSize]),
 			    nw = this._map.unproject(nwPoint),


### PR DESCRIPTION
When using options.bounds in combination with options.maxNativezoom,
the tileSize used in _tileShouldBeLoaded can be incorrect, causing
tiles to not get loaded or not get displayed.