### PR TITLE
fix for #3432

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -128,9 +128,9 @@ L.Map.Drag = L.Handler.extend({
 			    limitedSpeedVector = speedVector.multiplyBy(limitedSpeed / speed),
 
 			    decelerationDuration = limitedSpeed / (options.inertiaDeceleration * ease),
-			    offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2).round();
+			    offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2);
 
-			if (!offset.x || !offset.y) {
+			if (!offset.x && !offset.y) {
 				map.fire('moveend');
 
 			} else {


### PR DESCRIPTION
- we removed the .round(), since it did not handle small numbers very well
- we made the test a conjunction, since it should snap back even when only moving on one axis