### PR TITLE
Add 'focus' and 'blur' event handling

### DIFF
--- a/debug/map/marker-focus.html
+++ b/debug/map/marker-focus.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+	<div id="info"></div>
+
+
+	<script type="text/javascript">
+		map = L.map('map', { center: [0, 0], zoom: 4, maxZoom: 5 });
+
+		L.Icon.Default.imagePath = 'http://cdn.leafletjs.com/leaflet-0.7.3/images';
+
+		function onFocus(lat, lng){
+			return function(ev) {
+				var msg = "Now focused on: " + lat + ", " + lng;
+				document.getElementById('info').innerHTML = msg;
+// 				console.log(msg);
+			}
+		}
+
+		for (var lat=-10; lat<=10; lat+=0.5) {
+			for (var lng=-10; lng<=10; lng+=0.5) {
+				var marker = new L.Marker([lat, lng]);
+				marker.on('focus', onFocus(lat, lng));
+				marker.addTo(map);
+			}
+		}
+
+		L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+			attribution: "Map: Tiles Courtesy of MapQuest (OpenStreetMap, CC-BY-SA)",
+			subdomains: ["otile1","otile2","otile3","otile4"],
+			maxZoom: 12,
+			minZoom: 2
+		}).addTo(map);
+	</script>
+</body>
+</html>

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -79,7 +79,8 @@ L.DomEvent = {
 						return L.DomEvent._filterClick(e, originalHandler);
 					};
 				}
-				obj.addEventListener(type, handler, false);
+				// focus and blur are not bubbled up, so capture them down instead
+				obj.addEventListener(type, handler, type === 'focus' || type === 'blur');
 			}
 
 		} else if ('attachEvent' in obj) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -587,7 +587,8 @@ L.Map = L.Evented.extend({
 		var onOff = remove ? 'off' : 'on';
 
 		L.DomEvent[onOff](this._container, 'click dblclick mousedown mouseup ' +
-			'mouseover mouseout mousemove contextmenu keypress', this._handleDOMEvent, this);
+			'mouseover mouseout mousemove contextmenu ' +
+			'keypress focus blur', this._handleDOMEvent, this);
 
 		if (this.options.trackResize) {
 			L.DomEvent[onOff](window, 'resize', this._onResize, this);
@@ -651,7 +652,7 @@ L.Map = L.Evented.extend({
 		var data = {
 			originalEvent: e
 		};
-		if (e.type !== 'keypress') {
+		if (e.type !== 'keypress' && e.type !== 'focus' && e.type !== 'blur') {
 			data.containerPoint = target instanceof L.Marker ?
 					this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
 			data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -74,12 +74,15 @@ L.Map.Keyboard = L.Handler.extend({
 		window.scrollTo(left, top);
 	},
 
-	_onFocus: function () {
+	_onFocus: function (ev) {
+		// Focus events on DOM children are captured by DomEvent and should be ignored.
+		if (ev.eventPhase === Event.CAPTURING_PHASE) { return; }
 		this._focused = true;
 		this._map.fire('focus');
 	},
 
-	_onBlur: function () {
+	_onBlur: function (ev) {
+		if (ev.eventPhase === Event.CAPTURING_PHASE) { return; }
 		this._focused = false;
 		this._map.fire('blur');
 	},


### PR DESCRIPTION
My shot at implementing #3430, using Leaflet's event delegation to make Vladimir happy and keep the code simple.

@mourner: Do you think that forcing `useCapture` to true in AddEventListener is OK? If not, I could try to turn this into a plugin.