### PR TITLE
Fix vector in ie8

### DIFF
--- a/debug/map/popup.html
+++ b/debug/map/popup.html
@@ -60,7 +60,7 @@
     var polyline = L.polyline([
       getRandomLatLng(map),
       getRandomLatLng(map),
-      getRandomLatLng(map),
+      getRandomLatLng(map)
     ], {
       color: 'red'
     }).bindPopup('I\'m a red polyline').addTo(map);

--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -23,9 +23,6 @@ L.SVG.include(!L.Browser.vml ? {} : {
 
 	_initContainer: function () {
 		this._container = L.DomUtil.create('div', 'leaflet-vml-container');
-
-		this._paths = {};
-		this._initEvents();
 	},
 
 	_update: function () {
@@ -49,13 +46,13 @@ L.SVG.include(!L.Browser.vml ? {} : {
 	_addPath: function (layer) {
 		var container = layer._container;
 		this._container.appendChild(container);
-		this._paths[L.stamp(container)] = layer;
+		layer.addInteractiveTarget(container);
 	},
 
 	_removePath: function (layer) {
 		var container = layer._container;
 		L.DomUtil.remove(container);
-		delete this._paths[L.stamp(container)];
+		layer.removeInteractiveTarget(container);
 	},
 
 	_updateStyle: function (layer) {


### PR DESCRIPTION
In ie8 vector layers don't work.
Problem was in legacy code in SVG.VML.js file.

For test:
debug/map/popup.html
debug/tests/svg_clicks.html