### PR TITLE
More targeted max-width: !important in CSS

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -43,8 +43,8 @@
 	}
 /* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
 /* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container svg,
-.leaflet-container img {
+.leaflet-container .leaflet-overlay-pane svg,
+.leaflet-container .leaflet-tile-pane img {
 	max-width: none !important;
 	}
 /* stupid Android 2 doesn't understand "max-width: none" properly */


### PR DESCRIPTION
This for example allows to have images in popups not affected by the `max-width: none !important`.

I think 1.0 is good time to tackle this small annoying thing ;)