### PR TITLE
Fix polygon.addTo(map) failing when latlngs was empty.

### DIFF
--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -67,6 +67,12 @@ describe('Polygon', function () {
 			]);
 			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
 		});
+
+		it("can be added to the map when empty", function () {
+			var polygon = new L.Polygon([]).addTo(map);
+			expect(map.hasLayer(polygon)).to.be(true);
+		});
+
 	});
 
 	describe("#setLatLngs", function () {

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -42,6 +42,11 @@ describe('Polyline', function () {
 			expect(polyline.getLatLngs()).to.eql(polyline._latlngs);
 		});
 
+		it("can be added to the map when empty", function () {
+			var polyline = new L.Polyline([]).addTo(map);
+			expect(map.hasLayer(polyline)).to.be(true);
+		});
+
 	});
 
 	describe("#setLatLngs", function () {

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -132,7 +132,7 @@ L.Polyline = L.Path.extend({
 		var w = this._clickTolerance(),
 			p = new L.Point(w, -w);
 
-		if (this._latlngs.length) {
+		if (this._bounds.isValid()) {
 			this._pxBounds = new L.Bounds(
 				this._map.latLngToLayerPoint(this._bounds.getSouthWest())._subtract(p),
 				this._map.latLngToLayerPoint(this._bounds.getNorthEast())._add(p));


### PR DESCRIPTION
Since #3279 an empty polygon as a nested array [[]] as latlngs,
so testing _latlngs.length returns true.

I'm thinking that is a breaking change: I guess many users rely on `this._latlngs.length` to check if a polygon has some latlngs. So we need to make this very clear in the change log.

What about maybe a `hasLatLngs` method, to have a clean API instead of this kind of widespread usage based on a private property?