### PR TITLE
Wrap all SVG paths inside a <g>

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -9,6 +9,9 @@ L.SVG = L.Renderer.extend({
 
 		// makes it possible to click through svg root; we'll reset it back in individual paths
 		this._container.setAttribute('pointer-events', 'none');
+
+		this._rootGroup = L.SVG.create('g');
+		this._container.appendChild(this._rootGroup);
 	},
 
 	_update: function () {
@@ -51,7 +54,7 @@ L.SVG = L.Renderer.extend({
 	},
 
 	_addPath: function (layer) {
-		this._container.appendChild(layer._path);
+		this._rootGroup.appendChild(layer._path);
 		layer.addInteractiveTarget(layer._path);
 	},
 


### PR DESCRIPTION
Should fix #2751. I haven't tried the performance myself, but the SVG tree looks fine.