### PR TITLE
Getter/setter compatibility

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -169,6 +169,30 @@ describe("Class", function () {
 
 			expect(spy1.called).to.be.ok();
 		});
+
+		it("allows class(es) to have getter methods", function () {
+			var Klass2 = Klass.extend({
+				initialize: function (v) {
+					this._goo = v;
+				},
+				get goo () {
+					if (!this._goo) { throw "'initialize' should have run first!"; }   // using assert would need 'require("assert")';
+					return this._goo * 2;
+				}
+			});
+			var a = new Klass2(9);
+
+			expect(a.goo).to.eql(9 * 2);
+
+			var Klass3 = Klass2.extend({
+				initialize: function() {
+					Klass2.prototype.initialize.call(this, 11);
+				}
+			});
+			var b = new Klass3();
+
+			expect(b.goo).to.eql(11 * 2);
+		});
 	});
 
 	// TODO Class.include

--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -32,6 +32,18 @@ describe('Util', function () {
 				baz: 3
 			});
 		});
+
+		it('extends getters and setters (copying them, not their value)', function () {
+			L.Util.extend(a, {
+				_foo: 0,
+				get foo() { return this._foo * 2; },  // just some arbitrary transformation
+				set foo(v) { this._foo = v; }
+			});
+
+			expect(a.foo).to.eql(0);
+			a.foo = 12;
+			expect(a.foo).to.eql(24);
+		});
 	});
 
 	describe('#bind', function () {

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -10,7 +10,18 @@ L.Util = {
 		for (j = 1, len = arguments.length; j < len; j++) {
 			src = arguments[j];
 			for (i in src) {
-				dest[i] = src[i];
+        // handle getters/setters differently, so that we copy the getter/setter, not the
+        // initial value. See http://ejohn.org/blog/javascript-getters-and-setters/
+        //
+        var g = src.__lookupGetter__(i),
+            s = src.__lookupSetter__(i);
+
+        if (g || s) {
+          if (g) { dest.__defineGetter__(i, g); }
+          if (s) { dest.__defineSetter__(i, s); }
+        } else {
+				  dest[i] = src[i];
+				}
 			}
 		}
 		return dest;


### PR DESCRIPTION
Current Leaflet `L.Class.extend` does not work well if the derived class uses ECMAscript 5 get/set methods. This PR fixed that, based on [this blog from 2007](http://ejohn.org/blog/javascript-getters-and-setters/).

Why does this matter?

Getters/setters seem like a nice addition to JavaScript and the Leaflet class extension mechanism can be made to be compatible with them.

There are ways to bypass the current limitation (see [SO](http://stackoverflow.com/questions/30197434/javascript-getter-why-does-it-get-called-at-construction)) but those are kind of clumsy, causing get/set code to end up separated from normal methods.

Are there downsides?

- the suggested implementation does not check for browser capabilities. This should be added. Older Leaflet-supported browsers would not know of getters/setters. But this is doable.

- `jake test` now expects support for the get/set syntax from the underlying V8 engine. It works for mine (node 0.12.2) but I'm not sure about older node versions. Don't think this would be a major concern, though.

To sum up. This PR allows the library user to use `L.Class.extend` mechanism, together with his/her own code utilizing ECMAscript 5 getters/setters in his/her own code. It does not suggest Leaflet should use getters anywhere. I'd like to hear comments on the value of such a change - i.e. have others come across this current limitation.