### PR TITLE
Canvas path holes fillRule fix

### DIFF
--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -117,7 +117,7 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 
 		if (options.fill) {
 			ctx.globalAlpha = options.fillOpacity;
-			ctx.fill();
+			ctx.fill(options.fillRule || 'evenodd');
 		}
 
 		if (options.stroke) {


### PR DESCRIPTION
Paths with holes rendering is broken if you use `L_PREFER_CANVAS`
![screenshot 2015-05-18 14 07 13](https://cloud.githubusercontent.com/assets/26884/7680507/6ead56ce-fd67-11e4-8d94-8569e51676c0.png)
[Test case](http://jsfiddle.net/w8r/81zs9uam/)

Fix applied from master version of canvas renderer:
![screenshot 2015-05-18 14 07 09](https://cloud.githubusercontent.com/assets/26884/7680513/75c06d52-fd67-11e4-9f31-234baa54e7c7.png)

[Fix](http://jsfiddle.net/w8r/orstkqn7/)

It's a [one-liner at src/layer/vector/Path.Canvas.js:120](https://github.com/w8r/Leaflet/commit/ec0b5ee49611a73b64ce7008a947a4712e7ba96a#diff-64456bf8d5fbb7e32767ddc44f451d48R120)
```
ctx.fill(options.fillRule || 'evenodd');
```

I can't see any side-effects so far