### PR TITLE
Persist marker dragging when removing/readding it.

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -33,6 +33,7 @@ L.Marker = L.Layer.extend({
 
 	onRemove: function () {
 		if (this.dragging && this.dragging.enabled()) {
+			this.options.draggable = true;
 			this.dragging.removeHooks();
 		}
 


### PR DESCRIPTION
This *should* persist runtime changes to the draggable state of a marker, in the case of removing it from the map and adding it later, but I haven't really tested it.