### PR TITLE
Make panInsideBounds method accept bounds in array form

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -175,7 +175,7 @@ L.Map = L.Evented.extend({
 
 	panInsideBounds: function (bounds, options) {
 		var center = this.getCenter(),
-			newCenter = this._limitCenter(center, this._zoom, bounds);
+			newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
 
 		if (center.equals(newCenter)) { return this; }
 


### PR DESCRIPTION
See https://github.com/2gis/mapsapi/issues/200. `panInsideBounds` method failed if bounds were passed as a simple array.