### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,5 @@
     "gis",
     "map"
   ],
-  "licenses": [
-    {
-      "type": "BSD-2-Clause",
-      "url": "https://github.com/Leaflet/Leaflet/blob/master/LICENSE"
-    }
-  ]
+  "license": "BSD-2-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/