### PR TITLE
restore minZoom and maxZoom check on _update

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -393,11 +393,11 @@ L.GridLayer = L.Layer.extend({
 		// TODO move to reset
 		// var zoom = this._map.getZoom();
 
-		// if (zoom > this.options.maxZoom ||
-		//     zoom < this.options.minZoom) { return; }
-
 		if (center === undefined) { center = map.getCenter(); }
 		if (zoom === undefined) { zoom = Math.round(map.getZoom()); }
+
+		if (zoom > this.options.maxZoom ||
+			zoom < this.options.minZoom) { return; }
 
 		var pixelBounds = map.getPixelBounds(center, zoom),
 			tileRange = this._pxBoundsToTileRange(pixelBounds),


### PR DESCRIPTION
2 TileLayers with difference minZoom and maxZoom will access out of zoom level and browser will get a lot of 404 errors.
Browser: Firefox 38.0.1, Google Chrome 43.0.2357.81
Leaflet: master branch
Also I use L.CRS.Simple and I didn't check other crs.