### PR TITLE
Implement 'overlaps' spatial operator on bounds and use it on gridlayers

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -143,6 +143,19 @@ describe('LatLngBounds', function () {
 			expect(a.intersects([[16, 20], [50, 60]])).to.eql(true);
 			expect(a.contains([[40, 50], [50, 60]])).to.eql(false);
 		});
+
+		it('returns true if just touches the boundary of the given bounds', function () {
+			expect(a.intersects([[25, 40], [55, 50]])).to.eql(true);
+		});
+	});
+
+	describe('#overlaps', function () {
+		it('returns true if overlaps the given bounds', function () {
+			expect(a.overlaps([[16, 20], [50, 60]])).to.eql(true);
+		});
+		it('returns false if just touches the boundary of the given bounds', function () {
+			expect(a.overlaps([[25, 40], [55, 50]])).to.eql(false);
+		});
 	});
 
 });

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -119,7 +119,7 @@ L.LatLngBounds.prototype = {
 		       (sw2.lng >= sw.lng) && (ne2.lng <= ne.lng);
 	},
 
-	intersects: function (bounds) { // (LatLngBounds)
+	intersects: function (bounds) { // (LatLngBounds) -> Boolean
 		bounds = L.latLngBounds(bounds);
 
 		var sw = this._southWest,
@@ -131,6 +131,20 @@ L.LatLngBounds.prototype = {
 		    lngIntersects = (ne2.lng >= sw.lng) && (sw2.lng <= ne.lng);
 
 		return latIntersects && lngIntersects;
+	},
+
+	overlaps: function (bounds) { // (LatLngBounds) -> Boolean
+		bounds = L.latLngBounds(bounds);
+
+		var sw = this._southWest,
+		    ne = this._northEast,
+		    sw2 = bounds.getSouthWest(),
+		    ne2 = bounds.getNorthEast(),
+
+		    latOverlaps = (ne2.lat > sw.lat) && (sw2.lat < ne.lat),
+		    lngOverlaps = (ne2.lng > sw.lng) && (sw2.lng < ne.lng);
+
+		return latOverlaps && lngOverlaps;
 	},
 
 	toBBoxString: function () {

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -82,6 +82,19 @@ L.Bounds.prototype = {
 		return xIntersects && yIntersects;
 	},
 
+	overlaps: function (bounds) { // (Bounds) -> Boolean
+		bounds = L.bounds(bounds);
+
+		var min = this.min,
+		    max = this.max,
+		    min2 = bounds.min,
+		    max2 = bounds.max,
+		    xOverlaps = (max2.x > min.x) && (min2.x < max.x),
+		    yOverlaps = (max2.y > min.y) && (min2.y < max.y);
+
+		return xOverlaps && yOverlaps;
+	},
+
 	isValid: function () {
 		return !!(this.min && this.max);
 	}

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -462,7 +462,7 @@ L.GridLayer = L.Layer.extend({
 
 		// don't load tile if it doesn't intersect the bounds in options
 		var tileBounds = this._tileCoordsToBounds(coords);
-		return L.latLngBounds(this.options.bounds).intersects(tileBounds);
+		return L.latLngBounds(this.options.bounds).overlaps(tileBounds);
 	},
 
 	_keyToBounds: function (key) {


### PR DESCRIPTION
Implement an 'overlap' spatial operator in both `L.Bounds` and `L.LatLngBounds`, with a semantic of "the intersection of the given rectangles is a rectangle".

Note that this is technically not the same as the [DE-9IM](https://en.wikipedia.org/wiki/DE-9IM) 'overlaps' operator, as will return `true` if both rectangles are the same.

This operator is used in `L.GridLayer` to prevent tiles just touching the later bounds from being loaded.