### PR TITLE
Gridlayer prunes all tiles when zooming out of minzoom/maxzoom.

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -230,6 +230,10 @@ L.GridLayer = L.Layer.extend({
 	_pruneTiles: function () {
 		var key, tile;
 
+		var zoom = map.getZoom();
+		if (zoom > this.options.maxZoom ||
+			zoom < this.options.minZoom) { return this._removeAllTiles(); }
+
 		for (key in this._tiles) {
 			tile = this._tiles[key];
 			tile.retain = tile.current;


### PR DESCRIPTION
This will fix #3506.