### PR TITLE
Add third argument to pointToLayer call for MultiPoint

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -87,7 +87,7 @@ L.extend(L.GeoJSON, {
 		case 'MultiPoint':
 			for (i = 0, len = coords.length; i < len; i++) {
 				latlng = coordsToLatLng(coords[i]);
-				layers.push(pointToLayer ? pointToLayer(geojson, latlng) : new L.Marker(latlng));
+				layers.push(pointToLayer ? pointToLayer(geojson, latlng, i) : new L.Marker(latlng));
 			}
 			return new L.FeatureGroup(layers);
 


### PR DESCRIPTION
The third argument is the index of the point in the GeoJSON geometry. This enhances the ability to style the returned Marker based upon data stored in GeoJSON properties.

Without this change there is simply no way to utilise any properties you have, as you cannot tell what data you have been given, other than the `latlng`.