### PR TITLE
Work around IE10 CSS transform glitch by tweaking map container z-index.

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -470,6 +470,10 @@ L.Map = L.Evented.extend({
 			throw new Error('Map container is already initialized.');
 		}
 
+		if (L.Browser.ie3d && !L.DomUtil.getStyle(container, 'z-index')) {
+			container.style['z-index'] = -1;
+		}
+
 		L.DomEvent.addListener(container, 'scroll', this._onScroll, this);
 		container._leaflet = true;
 	},


### PR DESCRIPTION
Should work around #2788 for most users. I do guess that the bug has to do with the z-index of the tile pane relative to the rest of the elements of the page, and ideally the z-index of the map container should be lower than its DOM parent for this to work reliably, but meh.