### PR TITLE
Fix GridLayer move event handler, fixes #3522

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -104,7 +104,11 @@ L.GridLayer = L.Layer.extend({
 
 		if (!this.options.updateWhenIdle) {
 			// update tiles on move, but not more often than once per given interval
-			events.move = L.Util.throttle(this._onMoveEnd, this.options.updateInterval, this);
+			if (!this._onMove) {
+				this._onMove = L.Util.throttle(this._onMoveEnd, this.options.updateInterval, this);
+			}
+
+			events.move = this._onMove;
 		}
 
 		if (this._zoomAnimated) {


### PR DESCRIPTION
`getEvents` function in `GridLayer` created a brand new listener for `move` event each time it was called. So, if a tile layer was removed from map, this listener didn't get cleared and continued to be called on every map move, which resulted in an exception.