### PR TITLE
Add map presence check to onMoveEnd handler, fixes #3522

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -407,6 +407,8 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_onMoveEnd: function () {
+		if (!this._map) { return; }
+
 		this._update();
 		this._pruneTiles();
 	},


### PR DESCRIPTION
This will prevent `_onMoveEnd` handler from execution if it is called by `L.Util.throttle` after layer removal.