### PR TITLE
Check bounds before clipping

### DIFF
--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -65,11 +65,6 @@ L.Polygon = L.Polyline.extend({
 	},
 
 	_clipPoints: function () {
-		if (this.options.noClip) {
-			this._parts = this._rings;
-			return;
-		}
-
 		// polygons need a different clipping algorithm so we redefine that
 
 		var bounds = this._renderer._bounds,
@@ -81,6 +76,11 @@ L.Polygon = L.Polyline.extend({
 
 		this._parts = [];
 		if (!this._pxBounds || !this._pxBounds.intersects(bounds)) {
+			return;
+		}
+
+		if (this.options.noClip) {
+			this._parts = this._rings;
 			return;
 		}
 

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -80,6 +80,9 @@ L.Polygon = L.Polyline.extend({
 		bounds = new L.Bounds(bounds.min.subtract(p), bounds.max.add(p));
 
 		this._parts = [];
+		if (!this._pxBounds || !this._pxBounds.intersects(bounds)) {
+			return;
+		}
 
 		for (var i = 0, len = this._rings.length, clipped; i < len; i++) {
 			clipped = L.PolyUtil.clipPolygon(this._rings[i], bounds, true);

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -165,15 +165,19 @@ L.Polyline = L.Path.extend({
 
 	// clip polyline by renderer bounds so that we have less to render for performance
 	_clipPoints: function () {
+		var bounds = this._renderer._bounds;
+
+		this._parts = [];
+		if (!this._pxBounds || !this._pxBounds.intersects(bounds)) {
+			return;
+		}
+
 		if (this.options.noClip) {
 			this._parts = this._rings;
 			return;
 		}
 
-		this._parts = [];
-
 		var parts = this._parts,
-		    bounds = this._renderer._bounds,
 		    i, j, k, len, len2, segment, points;
 
 		for (i = 0, k = 0, len = this._rings.length; i < len; i++) {


### PR DESCRIPTION
Hi, I'm working with a map that has a lot of polygons outside of the map view at any one time. I'd like to suggest a change that checks if the polygon is visible within the renderer before clipping, which I have found is more performant with no discernible impact on clipping visible polygons.

Performance test:
- Out-of-bounds polygon: http://jsperf.com/leaflet-bounds-test
- Visible polygon: http://jsperf.com/leaflet-in-bounds-test