### PR TITLE
No Border on a.leaflet-popup-close-button

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -458,6 +458,7 @@
 	top: 0;
 	right: 0;
 	padding: 4px 4px 0 0;
+	border: none;
 	text-align: center;
 	width: 18px;
 	height: 14px;


### PR DESCRIPTION
I had a problem with a strange line crossing the close-button of leaflet popups. It turned out it was a `border-bottom: 1px solid #333;` set for links by the css-stylesheet of the page. This underlining is not erased by `text-decoration: none;`.