### PR TITLE
Simple canvas optimizations

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -27,7 +27,7 @@ L.Canvas = L.Renderer.extend({
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
-		this._drawnLayers = [];
+		this._drawnLayers = {};
 
 		L.Renderer.prototype._update.call(this);
 
@@ -119,7 +119,7 @@ L.Canvas = L.Renderer.extend({
 
 		if (!len) { return; }
 
-		this._drawnLayers.push(layer);
+		this._drawnLayers[layer._leaflet_id] = layer;
 
 		ctx.beginPath();
 


### PR DESCRIPTION
I'm trying to use Leaflet with a large amount of polylines, and I've found a few low-hanging fruits which make things snappier when using the canvas renderer.

* throttle mouseover using L.Util.throttle
* don't check for hover when the map is being panned (since the mouse isn't moving in relation to the map)
* only check visible layers when checking for hover (by storing unculled layers in an array and only checking these layers)

Thank you for reviewing. I'm new to Leaflet, so I hope this doesn't break anything that I don't know about!