### PR TITLE
Fix up some missing dependencies

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -144,7 +144,7 @@ var deps = {
 
 	Canvas: {
 		src: ['layer/vector/Canvas.js'],
-		deps: ['Path'],
+		deps: ['CircleMarker', 'Path', 'Polygon', 'Polyline'],
 		desc: 'Canvas backend for vector layers.'
 	},
 
@@ -185,6 +185,7 @@ var deps = {
 
 	BoxZoom: {
 		src: ['map/handler/Map.BoxZoom.js'],
+		deps: ['MouseZoom'],
 		desc: 'Enables zooming to bounding box by shift-dragging the map.'
 	},
 


### PR DESCRIPTION
I'm writing a tool that manually parses the deps.js file and builds the dependency tree for Leaflet's build. This hasn't historically been a problem since the build.js file parses deps.js in the order that the 'deps' entries are listed; the CircleMarker, Polygon and Polyline will already have been processed by the time it gets to Canvas, so the build will succeed. However if the entries are parsed and built in alphabetical order (which I'm forced to do for Reasons), it will fail since Canvas and BoxZoom actually depend on a few other targets. 

This should be a transparent change to just about everyone else.