### PR TITLE
edgeBuffer property for pre-loading tiles outside the current viewport

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -17,8 +17,11 @@ L.GridLayer = L.Layer.extend({
 		zIndex: null,
 		bounds: null,
 
-		minZoom: 0
+		minZoom: 0,
 		// maxZoom: <Number>
+
+		// edgeBuffer: the number of tiles to load beyond those required for the current viewport
+		edgeBuffer: 0
 	},
 
 	initialize: function (options) {
@@ -436,6 +439,12 @@ L.GridLayer = L.Layer.extend({
 			tileZoom < this.options.minZoom) { return; }
 
 		var pixelBounds = this._getTiledPixelBounds(center, zoom, tileZoom);
+
+		// add buffer so that we cache some off-screen tiles.
+		if (this.options.edgeBuffer > 0) {
+			var pixelEdgeBuffer = this.options.edgeBuffer * this._getTileSize();
+			pixelBounds = new L.Bounds(pixelBounds.min.subtract([pixelEdgeBuffer, pixelEdgeBuffer]), pixelBounds.max.add([pixelEdgeBuffer, pixelEdgeBuffer]));
+		}
 
 		var tileRange = this._pxBoundsToTileRange(pixelBounds),
 			tileCenter = tileRange.getCenter(),

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -413,6 +413,16 @@ L.GridLayer = L.Layer.extend({
 		this._pruneTiles();
 	},
 
+	_getTiledPixelBounds: function (center, zoom, tileZoom) {
+		var map = this._map;
+
+		var scale = map.getZoomScale(zoom, tileZoom),
+			pixelCenter = map.project(center, tileZoom).floor(),
+			halfSize = map.getSize().divideBy(scale * 2);
+
+		return new L.Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
+	},
+
 	_update: function (center, zoom) {
 
 		var map = this._map;
@@ -425,13 +435,11 @@ L.GridLayer = L.Layer.extend({
 		if (tileZoom > this.options.maxZoom ||
 			tileZoom < this.options.minZoom) { return; }
 
-		var scale = this._map.getZoomScale(zoom, tileZoom),
-		    pixelCenter = map.project(center, tileZoom).floor(),
-		    halfSize = map.getSize().divideBy(scale * 2),
-		    pixelBounds = new L.Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize)),
-		    tileRange = this._pxBoundsToTileRange(pixelBounds),
-		    tileCenter = tileRange.getCenter(),
-		    queue = [];
+		var pixelBounds = this._getTiledPixelBounds(center, zoom, tileZoom);
+
+		var tileRange = this._pxBoundsToTileRange(pixelBounds),
+			tileCenter = tileRange.getCenter(),
+			queue = [];
 
 		for (var key in this._tiles) {
 			this._tiles[key].current = false;


### PR DESCRIPTION
Reduces the likelihood of seeing blank map areas at the edge of the viewport when panning. Default value for the new property is 0, which disables the new feature.