### PR TITLE
Added option to avoid removing all tiles in GridLayer.redraw()

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -87,9 +87,13 @@ L.GridLayer = L.Layer.extend({
 		return this._loading;
 	},
 
-	redraw: function () {
+	redraw: function (removeTiles) {
+		if (typeof removeTiles === 'undefined') { removeTiles = true; }
+
 		if (this._map) {
-			this._removeAllTiles();
+			if (removeTiles) {
+				this._removeAllTiles();
+			}
 			this._update();
 		}
 		return this;


### PR DESCRIPTION
Enable external calls to GridLayer.redraw to trigger the tile update mechanism without first removing the tiles. Used for tile layers that can change over a small temporal period.