### PR TITLE
Document passing an array of GeoJSON objects

### DIFF
--- a/examples/geojson.html
+++ b/examples/geojson.html
@@ -113,6 +113,17 @@ title: Using GeoJSON with Leaflet
 
 <pre><code>L.geoJson(geojsonFeature).addTo(map);</code></pre>
 
+<p>GeoJSON objects may also be passed as an array of valid GeoJSON objects.</p>
+
+<pre><code>var myLines = [{
+	"type": "LineString",
+	"coordinates": [[-100, 40], [-105, 45], [-110, 55]]
+}, {
+	"type": "LineString",
+	"coordinates": [[-105, 40], [-110, 45], [-115, 55]]
+}];
+</code></pre>
+
 <p>Alternatively, we could create an empty GeoJSON layer and assign it to a variable so that we can add more features to it later.</p>
 
 <pre><code>var myLayer = L.geoJson().addTo(map);

--- a/reference.html
+++ b/reference.html
@@ -3290,7 +3290,7 @@ map.fitBounds(bounds);</code></pre>
 
 <h2 id="geojson">GeoJson</h2>
 
-<p>Represents a <a href="http://geojson.org/geojson-spec.html">GeoJSON</a> layer. Allows you to parse GeoJSON data and display it on the map. Extends <a href="#featuregroup">FeatureGroup</a>.</p>
+<p>Represents a <a href="http://geojson.org/geojson-spec.html">GeoJSON</a> object or an array of GeoJSON objects. Allows you to parse GeoJSON data and display it on the map. Extends <a href="#featuregroup">FeatureGroup</a>.</p>
 
 <pre><code class="javascript">L.geoJson(data, {
 	style: function (feature) {


### PR DESCRIPTION
There is no explicit documentation of passing an array of GeoJSON objects.

See #3191 and https://github.com/Leaflet/Leaflet/blob/master/src/layer/GeoJSON.js#L18