### PR TITLE
use CSS property to compute icon path

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -21,6 +21,10 @@ L.Icon.Default = L.Icon.extend({
 		var path = L.Icon.Default.imagePath;
 
 		if (!path) {
+			path = L.Icon.Default.imagePath = computeImagePath();
+		}
+
+		if (!path) {
 			throw new Error('Couldn\'t autodetect L.Icon.Default.imagePath, set it manually.');
 		}
 
@@ -28,11 +32,17 @@ L.Icon.Default = L.Icon.extend({
 	}
 });
 
-L.Icon.Default.imagePath = (function () {
-	var el = L.DomUtil.create('div', 'leaflet-control-layers-toggle', document.body),
-	    path = L.DomUtil.getStyle(el, 'background-image');
-	document.body.removeChild(el);
-	if (path) {
-		return path.replace(/^url\(\"?/, '').replace(/\/layers.+png\"?\)/, '');
+L.Icon.Default.imagePath = computeImagePath();
+
+function computeImagePath() {
+	try {
+		var el = L.DomUtil.create('div', 'leaflet-control-layers-toggle', document.body),
+		    path = L.DomUtil.getStyle(el, 'background-image');
+		document.body.removeChild(el);
+		if (path) {
+			return path.replace(/^url\(\"?/, '').replace(/\/layers.+png\"?\)/, '');
+		}
+	} catch (e) {
+		return null;
 	}
-}());
+}

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -29,17 +29,10 @@ L.Icon.Default = L.Icon.extend({
 });
 
 L.Icon.Default.imagePath = (function () {
-	var scripts = document.getElementsByTagName('script'),
-	    leafletRe = /[\/^]leaflet[\-\._]?([\w\-\._]*)\.js\??/;
-
-	var i, len, src, path;
-
-	for (i = 0, len = scripts.length; i < len; i++) {
-		src = scripts[i].src || '';
-
-		if (src.match(leafletRe)) {
-			path = src.split(leafletRe)[0];
-			return (path ? path + '/' : '') + 'images';
-		}
+	var el = L.DomUtil.create('div', 'leaflet-control-layers-toggle', document.body),
+	    path = L.DomUtil.getStyle(el, 'background-image');
+	document.body.removeChild(el);
+	if (path) {
+		return path.replace(/^url\(\"?/, '').replace(/\/layers.+png\"?\)/, '');
 	}
 }());

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -18,10 +18,16 @@ L.Icon.Default = L.Icon.extend({
 			return this.options[key];
 		}
 
-		var path = L.Icon.Default.imagePath;
+		var path = L.Icon.Default.imagePath, el;
 
 		if (!path) {
-			path = L.Icon.Default.imagePath = computeImagePath();
+			el = L.DomUtil.create('div', 'leaflet-control-layers-toggle', document.body);
+			path = L.DomUtil.getStyle(el, 'background-image');
+			document.body.removeChild(el);
+			if (path) {
+				path = path.replace(/^url\(\"?/, '').replace(/\/layers.+png\"?\)/, '');
+			}
+			L.Icon.Default.imagePath = path;
 		}
 
 		if (!path) {
@@ -31,18 +37,3 @@ L.Icon.Default = L.Icon.extend({
 		return path + '/marker-' + name + (L.Browser.retina && name === 'icon' ? '-2x' : '') + '.png';
 	}
 });
-
-L.Icon.Default.imagePath = computeImagePath();
-
-function computeImagePath() {
-	try {
-		var el = L.DomUtil.create('div', 'leaflet-control-layers-toggle', document.body),
-		    path = L.DomUtil.getStyle(el, 'background-image');
-		document.body.removeChild(el);
-		if (path) {
-			return path.replace(/^url\(\"?/, '').replace(/\/layers.+png\"?\)/, '');
-		}
-	} catch (e) {
-		return null;
-	}
-}


### PR DESCRIPTION
Here's an alternative to #2603.  Instead of determining the default `imagePath` based on `<script>` urls, this approach reads from the CSS to figure out where the layer icon is and assumes other images are in the same folder.  The one downside is that it requires creating a DOM element.  Another approach might be to scan through the stylesheet directly but that would require more code (I think).