### PR TITLE
Adds Leaflet.hotline plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1309,6 +1309,15 @@ Most data is two-dimensional (latitude and longitude), but some data has more di
 			<a href="https://github.com/MrMufflon">Felix Bache</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/iosphere/Leaflet.hotline">Leaflet.hotline</a>
+		</td><td>
+			A Leaflet plugin for drawing gradients along polylines.
+		</td><td>
+			<a href="https://github.com/iosphere">iosphere</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
The plugin only works with the latest Leaflet from the master branch.
Should this go into the gh-pages or into the gh-pages-master branch?