### PR TITLE
Extend L.Class.include to allow references to previously defined methods

### DIFF
--- a/debug/tests/include-previous.html
+++ b/debug/tests/include-previous.html
@@ -1,0 +1,37 @@
+<html>
+	<head>
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<link rel="stylesheet" href="../css/screen.css" />
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+	</head>
+	<body>
+
+		<div id="map"></div>
+
+		<script>
+
+		// Modify the behaviour of the default tilelayer, running the previously
+		//   defined methid inside the newly defined method
+		L.TileLayer.include(function(previous) { return {
+			getTileUrl: function (coords) {
+				var url = previous.getTileUrl.call(this, coords);
+				console.log('The URL for the tile with coords ', coords, 'is', url);
+				return url;
+			}
+		}});
+
+
+		var map = L.map('map', {
+			center: [39.84, -96.591],
+			zoom: 4
+		});
+
+		L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+		}).addTo(map);
+
+		</script>
+
+	</body>
+</html>

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -77,7 +77,11 @@ L.Class.extend = function (props) {
 
 // method for adding properties to prototype
 L.Class.include = function (props) {
-	L.extend(this.prototype, props);
+	if (typeof props === 'function') {
+		L.extend(this.prototype, props(L.extend({}, this.prototype)));
+	} else {
+		L.extend(this.prototype, props);
+	}
 };
 
 // merge new default options to the Class


### PR DESCRIPTION
When writing plugins, I've run into the problem of modifying the behaviour of a class by having a method run the previously defined method.

So far I've been using the pattern from [leaflet.activearea.js](https://github.com/Mappy/Leaflet-active-area/blob/master/src/leaflet.activearea.js), but that involves creating global variables instead of anonymous closures.

The usual way to work with `L.Class.extend` is to call `previousclassname.prototype.methodname.call(params)`. I would like to use a similar pattern when using `L.Class.include` (as shown in `debug/tests/include-previous.html` in this PR).
