### PR TITLE
Further UX work on the website redesign 

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -146,21 +146,27 @@ h1 a {
 }
 
 @-webkit-keyframes leafanim {
-	50% { -webkit-filter: hue-rotate(-70deg) saturate(1.2); }
+  50% { -webkit-filter: hue-rotate(-70deg) saturate(1.2); }
 }
 
 @keyframes leafanim {
   50% { -webkit-filter: hue-rotate(-70deg) saturate(1.2); }
 }
 
+h1 a img {
+  display: block;
+  margin: auto;
+  max-width: 100%;
+}
+
 h1 a:hover, h1 a:focus {
-	-webkit-filter: hue-rotate(-70deg) saturate(1.5);
+  -webkit-filter: hue-rotate(-70deg) saturate(1.5);
 }
 
 h3.tagline {
 	font-weight: 300;
-	font-size: 30px;
-	margin-top: -15px;
+	font-size: 1.5em;
+	margin-top: -.75em;
 	color: #777;
 	text-align: center;
 	margin-bottom: 30px;
@@ -171,15 +177,15 @@ h3.tagline {
 	list-style: none;
 	padding: 0 30px;
 	text-align: center;
-	font-size: 24px;
+	font-size: 1.25em;
 	margin-bottom: 40px;
 	border-bottom: 1px solid #ddd;
 	padding-bottom: 40px;
 }
 
 .nav li {
-	display: inline;
-	padding: 10px;
+  display: inline-block;
+  padding: .333em .5em;
 	color: #999;
 }
 
@@ -220,9 +226,8 @@ h3.tagline {
   -webkit-font-smoothing: subpixel-antialiased;
 }
 .container pre code {
+  font-size: 14px;
 	padding: .75em 1em;
-  background: #f5f5f5;
-  color: #444;
   border-radius: 5px;
   white-space: pre;
   overflow: scroll;
@@ -261,7 +266,7 @@ h3.tagline {
 .usedby {
   margin: 0;
   text-align: center;
-  padding: 0 3em 2em;
+  padding: 0 3em 3.5em;
   background-color: #f5f5f5;
 }
 
@@ -400,14 +405,25 @@ table.plugins td:first-child a {
 /* API docs */
 
 .api-page .toc-col {
-	float: left;
-	width: 160px;
+  position: relative;
+  float: left;
+  width: 20%;
+  padding-right: 1em;
+  margin: 0;
+  box-sizing: border-box;
 }
 
-.map-col {
-	width: 180px;
-	border-right: 1px solid #ddd;
-	margin-right: 40px;
+.api-page .toc-col.map-col {
+  padding-right: 1.5em;
+  border-right: thin solid #eee;
+}
+
+.api-page .toc-col.map-col ~ .toc-col {
+    right: -1.5em;
+}
+
+.api-page .toc-col.map-col h4 {
+    color: #666;
 }
 
 #toc h4 {
@@ -644,10 +660,9 @@ table.plugins td:first-child a {
     top: -1000px;
     bottom: -1000px;
     left: 0;
-    right: 3em;
+    width: 12.5em;
     background: white;
     background: rgba(255,255,255,0.9);
-    display: block;
   }
 
   #toc-copy h4:hover, #toc-copy h4.hover {
@@ -755,6 +770,7 @@ tr:target {
   #toc .toc-col {
     width: 50%;
     float: none;
+    position: static;
     display: inline-block;
     margin: 0;
     border: 0;
@@ -766,11 +782,6 @@ tr:target {
 
   .toc-col.last-col {
     clear: both;
-  }
-
-  .container pre code {
-    word-wrap: break-word;
-    white-space: pre;
   }
 
   table.plugins tbody tr {
@@ -872,9 +883,6 @@ tr:target {
   }
 
   .features { -webkit-column-count: 2; }
-
-  .api-page h2[id]:before {
-  }
 }
 
 @media screen and (max-width: 500px) {
@@ -904,6 +912,12 @@ tr:target {
     width: auto;
     margin: 0 0 -.25em;
     border: 0;
+  }
+
+  .post-date {
+    float: none;
+    width: auto;
+    margin: 0 0 .333em;
   }
 
   .api-page h2[id] { text-indent: 24px; }

--- a/docs/highlight/styles/github.css
+++ b/docs/highlight/styles/github.css
@@ -5,16 +5,17 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 */
 
 pre code {
-  display: block; padding: 0.5em;
-  color: #000;
-  background: #f8f8ff
+  display: block;
+  padding: 0.5em;
+  color: #f8f8f2;
+  background: #475457;
 }
 
 code .comment,
 pre .template_comment,
 pre .diff .header,
 pre .javadoc {
-  color: #998;
+  color: #8C8C8C;
 }
 
 code .keyword,
@@ -26,31 +27,31 @@ pre .nginx .title,
 pre .subst,
 pre .request,
 pre .status {
-  color: #026D97;
+  color: white;
   font-weight: normal;
 }
 
 pre .javascript .title {
-  color: black;
+  color: white;
   font-weight: bold;
 }
 
 code .number,
 pre .hexcolor,
 code .literal {
-  color: #00A707
+  color: #1DC925;
 }
 
 code .string,
 pre .tag .value,
 pre .phpdoc,
 pre .tex .formula {
-  color: #E43E59;
+  color: #FB5692;
 }
 
 pre .title,
 pre .id {
-  color: #900;
+  color: #F66;
   font-weight: bold
 }
 
@@ -72,7 +73,7 @@ pre .tag,
 pre .tag .title,
 pre .rules .property,
 pre .django .tag .keyword {
-  color: #000080;
+  color: #99F;
   font-weight: normal
 }
 
@@ -80,7 +81,7 @@ pre .attribute,
 pre .variable,
 pre .instancevar,
 pre .lisp .body {
-  color: #008080
+  color: #00E5E6;
 }
 
 pre .regexp {

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@ If you have any questions, take a look at the <a href="https://github.com/Leafle
 
 <h2 class="usedby-title">Trusted by the best</h2>
 <div class="usedby">
+  <div class="container">
     <a class="logo logo-github" href="#">GitHub</a>
     <a class="logo logo-foursquare" href="#">foursquare</a>
     <a class="logo logo-pinterest" href="#">Pinterest</a>
@@ -46,6 +47,7 @@ If you have any questions, take a look at the <a href="https://github.com/Leafle
     <a class="logo logo-npr" href="#">NPR</a>
     <a class="logo logo-usatoday" href="#">USA Today</a>
     <a class="logo logo-hipmunk" href="#">Hipmunk</a>
+  </div>
 </div>
 
 <div class="container">


### PR DESCRIPTION
Adds main UX aspects of changes made in #3566 to `redesign` branch.

@mourner I've moved the bulk of my UX features over. I didn't include the major design changes I added in the earlier PR, the main focus was the responsive tables, TOC menu and tidying up the existing responsive design.

Also:
- Adds new tutorial thumbnails.
- Updates broken logo images on homepage.

The `redesign` branch probably still needs a little bit of work, but hopefully now my additions/changes are going towards the direction you had in mind. :)

![screen shot 2015-06-30 at 1 17 37 am](https://cloud.githubusercontent.com/assets/729085/8411166/d805d7d4-1ec5-11e5-9a56-909f83a25c10.png)

![screen shot 2015-06-30 at 1 15 24 am](https://cloud.githubusercontent.com/assets/729085/8411114/8a2d5802-1ec5-11e5-8616-77b1849efbf1.png)

![screen shot 2015-06-30 at 1 10 30 am](https://cloud.githubusercontent.com/assets/729085/8411113/8a2cfc86-1ec5-11e5-8615-8ba5ed32b7e3.png)
