### PR TITLE
Scrollbar for layers control with too many layers

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -326,6 +326,10 @@
 	color: #333;
 	background: #fff;
 	}
+.leaflet-control-layers-scrollbar {
+	overflow-y: scroll;
+	padding-right: 5px;
+	}
 .leaflet-control-layers-selector {
 	margin-top: 2px;
 	position: relative;

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -248,15 +248,11 @@ L.Control.Layers = L.Control.extend({
 
 	_expand: function () {
 		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
-		var getLegendDiv = document.getElementsByClassName('leaflet-control-layers-list')[0];
-		var legendHeight = getLegendDiv.clientHeight;
-		var getMap = document.getElementById('map');
-		var controlHeight = getMap.clientHeight - 40;
-		if (controlHeight < legendHeight)
+		var acceptableHeight = this._map._size.y - (this._container.offsetTop * 4);
+		if (acceptableHeight < this._form.clientHeight)
 		{
-			getLegendDiv.style.height = controlHeight + 'px';
-			getLegendDiv.style.overflowY = 'scroll';
-			getLegendDiv.style.paddingRight = '10px';
+			L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');
+			this._form.style.height = acceptableHeight + 'px';
 		}
 	},
 

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -248,6 +248,16 @@ L.Control.Layers = L.Control.extend({
 
 	_expand: function () {
 		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
+		var getLegendDiv = document.getElementsByClassName('leaflet-control-layers-list')[0];
+		var legendHeight = getLegendDiv.clientHeight;
+		var getMap = document.getElementById('map');
+		var controlHeight = getMap.clientHeight - 40;
+		if (controlHeight < legendHeight)
+		{
+			getLegendDiv.style.height = controlHeight + 'px';
+			getLegendDiv.style.overflowY = 'scroll';
+			getLegendDiv.style.paddingRight = '10px';
+		}
 	},
 
 	_collapse: function () {


### PR DESCRIPTION
Hi again,

This fix addresses #3167 
On the _expand function I check the map height and the legend height, and if the map is shorter than the legend I add some styling to the legend to give it an overflowY scrollbar.

Hope it helps!
Cheers
Rowan