### PR TITLE
Batch canvas context switches

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -4,8 +4,14 @@
 
 var contextProps = ['fill', 'fillOpacity', 'fillColor', 'fillRule', 'color', 'stroke', 'weight',
 	'lineCap', 'lineJoin'];
+var contextPropsLen = contextProps.length;
+
 function getContextHash(layer, closed) {
-	return contextProps.map(function (prop) { return layer.options[prop]; }).join('#') + '#' + closed;
+	var hash = closed;
+	for (var i = 0; i < contextPropsLen; i++) {
+		hash += '|' + layer.options[contextProps[i]];
+	}
+	return hash;
 }
 
 L.Canvas = L.Renderer.extend({

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -114,6 +114,7 @@ L.Canvas = L.Renderer.extend({
 			this._updatePolys(color, this._fills[color]);
 		}
 
+		this._fills = {};
 		this._deferredUpdateRequest = null;
 	},
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -20,6 +20,7 @@ L.Canvas = L.Renderer.extend({
 		L.Renderer.prototype.onAdd.call(this);
 
 		this._layers = this._layers || {};
+		this._deferredUpdates = {};
 
 		// redraw vectors since canvas is cleared upon removal
 		this._draw();
@@ -37,8 +38,6 @@ L.Canvas = L.Renderer.extend({
 
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
-
-		this._deferredUpdates = {};
 
 		L.Renderer.prototype._update.call(this);
 	},


### PR DESCRIPTION
I'm using the canvas renderer with a large number of polygons and have found the following optimization helps. It is basically just removing one of your TODOs (hopefully!).
```
// TODO optimization: 1 fill/stroke for all features with equal style instead of 1 for each feature
```

It groups together features with the same styles by creating a hash of the options that the canvas renderer uses, then draws the features in batches in an animation frame. The hashing algorithm looks a bit ugly, but is the quickest I've tried. One potential optimization would be to cache the hash for each feature, but I'm not sure how that would interact with changing styles.