### PR TITLE
Do not stop scroll events if already at min/max zoom.

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -4,7 +4,8 @@
 
 L.Map.mergeOptions({
 	scrollWheelZoom: true,
-	wheelDebounceTime: 40
+	wheelDebounceTime: 40,
+	scrollAtZoomLimits: false
 });
 
 L.Map.ScrollWheelZoom = L.Handler.extend({
@@ -44,13 +45,15 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 	_preventScroll: function(e, delta) {
 		var map = this._map;
-		if (!delta) { delta = L.DomEvent.getWheelDelta(e); }
-
-		var zoom = map.getZoom();
-		if ((delta < 0 && map.getMinZoom() < zoom) ||
-			(delta > 0 && map.getMaxZoom() > zoom)) {
-			L.DomEvent.stop(e);
+		if (map.options.scrollAtZoomLimits) {
+			if (!delta) { delta = L.DomEvent.getWheelDelta(e); }
+			var zoom = map.getZoom();
+			if ((delta < 0 && map.getMinZoom() >= zoom) ||
+				(delta > 0 && map.getMaxZoom() <= zoom)) {
+				return;
+			}
 		}
+		L.DomEvent.stop(e);
 	},
 
 	_performZoom: function () {


### PR DESCRIPTION
@jieter's comments on #3576 and the scrollbars in nested code snippets in #3578 made me think.

Whenever a user uses the scrollwheel in a scrollable element, it scrolls that element until it reaches either the top of the bottom and, if so, passes the scroll event to the parent scrollable element.

I guess it's not an insane assumption that Leaflet should behave in a similar way - bubble the mousewheel event upwards when the zoom is at min/max already. This should be useful in any cases a non-fullscreen map is shown in a big page in a small screen.

I'm not 100% of the UX, and I'm not sure if this should become an option somehow.