### PR TITLE
accept geojson with null geometry

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -7,6 +7,10 @@ describe("L.GeoJSON", function () {
 				type: 'Point',
 				coordinates: [20, 10, 5]
 			}
+		}, geoJSONEmpty = {
+			type: 'Feature',
+			properties: {},
+			geometry: null
 		};
 
 		it("sets feature property on member layers", function () {
@@ -19,6 +23,12 @@ describe("L.GeoJSON", function () {
 			var layer = new L.GeoJSON();
 			layer.addData(geoJSON.geometry);
 			expect(layer.getLayers()[0].feature).to.eql(geoJSON);
+		});
+
+		it("accepts geojson with null geometry", function () {
+			var layer = new L.GeoJSON();
+			layer.addData(geoJSONEmpty);
+			expect(layer.getLayers().length).to.eql(0);
 		});
 	});
 });

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -34,6 +34,9 @@ L.GeoJSON = L.FeatureGroup.extend({
 		if (options.filter && !options.filter(geojson)) { return this; }
 
 		var layer = L.GeoJSON.geometryToLayer(geojson, options);
+		if (!layer) {
+			return this;
+		}
 		layer.feature = L.GeoJSON.asFeature(geojson);
 
 		layer.defaultOptions = layer.options;
@@ -73,11 +76,15 @@ L.extend(L.GeoJSON, {
 	geometryToLayer: function (geojson, options) {
 
 		var geometry = geojson.type === 'Feature' ? geojson.geometry : geojson,
-		    coords = geometry.coordinates,
+		    coords = geometry ? geometry.coordinates : null,
 		    layers = [],
 		    pointToLayer = options && options.pointToLayer,
 		    coordsToLatLng = options && options.coordsToLatLng || this.coordsToLatLng,
 		    latlng, latlngs, i, len;
+
+		if (!coords && !geometry) {
+			return null;
+		}
 
 		switch (geometry.type) {
 		case 'Point':
@@ -103,12 +110,15 @@ L.extend(L.GeoJSON, {
 
 		case 'GeometryCollection':
 			for (i = 0, len = geometry.geometries.length; i < len; i++) {
-
-				layers.push(this.geometryToLayer({
+				var layer = this.geometryToLayer({
 					geometry: geometry.geometries[i],
 					type: 'Feature',
 					properties: geojson.properties
-				}, options));
+				}, options);
+
+				if (layer) {
+					layers.push(layer);
+				}
 			}
 			return new L.FeatureGroup(layers);
 


### PR DESCRIPTION
When creating a layer with  `L.geoJson(geojson.data, geojson.options)` where `geojson.data.geometry` is `null` (a valid value according to spec) an error message appears. This PR fixes that.