### PR TITLE
Updates API docs heading styles

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -91,7 +91,8 @@ h2 {
 	font-size: 2em;
 	font-weight: 300;
 	color: black;
-	margin-top: 1.8em;
+	margin-top: 1.6em;
+	padding-top: .2em;
 }
 
 h2:first-child {
@@ -470,10 +471,14 @@ table.plugins td:first-child a {
 	right: -1.5em;
 }
 
-.api-page h2 {
-	border-bottom: 7px solid #bbb;
+.api-page #toc ~ h2 {
+	font-weight: 700;
+	font-size: 1.75em;
+	color: #333;
+	border-bottom: 3px solid #555;
+	transition: border-color .25s ease;
 }
-.api-page h2:target {
+.api-page #toc ~ h2:target {
 	border-color: #1EB300;
 }
 .api-page h2:first-child {


### PR DESCRIPTION
This updates the design of the heading on the API page to somewhere between my initial design for the headings and changes from @mourner  which are live on `gh-pages`.

I feel that currently the bottom border is too thick and doesn't fit with the reset of the design. To keep the high visual contrast I've used darker tones (and increased font-weight), but the weight is now consistent between the type and the border.

See screenshots for variations:

_Original_
![original](https://cloud.githubusercontent.com/assets/729085/8469054/e7a06454-20b7-11e5-929c-bbc0bc7c42f8.png)

_Current / Live_
![current](https://cloud.githubusercontent.com/assets/729085/8469053/e79d58b8-20b7-11e5-9fbc-cb2d5bfe2523.png)

_This PR_
![new](https://cloud.githubusercontent.com/assets/729085/8469055/e7a0e186-20b7-11e5-895c-8c30e10802fb.png)

This is just my opinion, I won't be offended if everyone else disagrees!