### PR TITLE
Only mouse over one feature at a time

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -200,37 +200,35 @@ L.Canvas = L.Renderer.extend({
 		if (!this._map || this._map._animatingZoom) { return; }
 
 		var point = this._map.mouseEventToLayerPoint(e);
-		var id;
-
-		// TODO don't do on each move event, throttle since it's expensive
-		for (id in this._layers) {
-			this._handleMouseOut(this._layers[id], e, point);
-		}
-
-		for (id in this._layers) {
-			this._handleMouseHover(this._layers[id], e, point);
-		}
+		this._handleMouseOut(e, point);
+		this._handleMouseHover(e, point);
 	},
 
-	_handleMouseOut: function (layer, e, point) {
-		if (layer.options.interactive && layer._mouseInside && !layer._containsPoint(point)) {
+	_handleMouseOut: function (e, point) {
+		var layer = this._hoveredLayer;
+		if (layer && !layer._containsPoint(point)) {
 			// if we're leaving the layer, fire mouseout
 			L.DomUtil.removeClass(this._container, 'leaflet-interactive');
 			this._fireEvent(layer, e, 'mouseout');
-			layer._mouseInside = false;
+			this._hoveredLayer = null;
 		}
 	},
 
-	_handleMouseHover: function (layer, e, point) {
-		if (layer.options.interactive && layer._containsPoint(point)) {
-			// if we just got inside the layer, fire mouseover
-			if (!layer._mouseInside) {
-				L.DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
-				this._fireEvent(layer, e, 'mouseover');
-				layer._mouseInside = true;
+	_handleMouseHover: function (e, point) {
+		var id, layer;
+		if (!this._hoveredLayer) {
+			for (id in this._layers) {
+				layer = this._layers[id];
+				if (layer.options.interactive && layer._containsPoint(point)) {
+					L.DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
+					this._fireEvent(layer, e, 'mouseover');
+					this._hoveredLayer = layer;
+					break;
+				}
 			}
-			// fire mousemove
-			this._fireEvent(layer, e);
+		}
+		if (this._hoveredLayer) {
+			this._fireEvent(this._hoveredLayer, e);
 		}
 	},
 


### PR DESCRIPTION
This should fix #3568. It stores the currently hovered layer in `_hoveredLayer` and only checks that for mouse events until `mouseout`.