### PR TITLE
Allow for wide use of pane z-index for ordering.

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -70,16 +70,16 @@
 	-moz-user-select: none;
 	}
 
-.leaflet-pane         { z-index: 4; }
+.leaflet-pane         { z-index: 400; }
 
-.leaflet-tile-pane    { z-index: 2; }
-.leaflet-overlay-pane { z-index: 4; }
-.leaflet-shadow-pane  { z-index: 5; }
-.leaflet-marker-pane  { z-index: 6; }
-.leaflet-popup-pane   { z-index: 7; }
+.leaflet-tile-pane    { z-index: 200; }
+.leaflet-overlay-pane { z-index: 400; }
+.leaflet-shadow-pane  { z-index: 500; }
+.leaflet-marker-pane  { z-index: 600; }
+.leaflet-popup-pane   { z-index: 700; }
 
-.leaflet-map-pane canvas { z-index: 1; }
-.leaflet-map-pane svg    { z-index: 2; }
+.leaflet-map-pane canvas { z-index: 100; }
+.leaflet-map-pane svg    { z-index: 200; }
 
 .leaflet-vml-shape {
 	width: 1px;


### PR DESCRIPTION
@mourner I expect one of the big uses of the new `createPane` API will be something like this.


```js
var map = new L.Map(...);

// these polygons should always appear OVER other overlays
var polygonPane =  map.createPane('polygonPane');
polygonPane.style.zIndex = 5;

// these polylines should always appear OVER the polygons
var polylinePane = map.createPane('polylinePane');
polygonPane.style.zIndex = 6;

var polygon = new L.Polygon(..., {
 pane: 'polygonPane'
}).addTo(map);

var polyline = new L.Polyline(..., {
 pane: 'polylinePane'
}).addTo(map);
```

This creates a problem because our custom panes will now interfere with the marker and shadow panes.

This PR simply multiplies all the panes `z-index` values by 100 giving people more flexibility when using the API this way.