### PR TITLE
Update Mapbox API URLs and IDs in tutorials

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,12 +41,11 @@
 	{% if page.css %}<style>{{ page.css }}</style>{% endif %}
 
 	<script>
+		ACCESS_TOKEN = 'pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ';
 		MB_ATTR = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-				'Imagery © <a href="http://mapbox.com">Mapbox</a>';
-
-		MB_URL = 'http://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png';
-
+			'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+			'Imagery © <a href="http://mapbox.com">Mapbox</a>';
+		MB_URL = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=' + ACCESS_TOKEN;
 		OSM_URL = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 		OSM_ATTRIB = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 	</script>

--- a/_layouts/v2.html
+++ b/_layouts/v2.html
@@ -40,17 +40,15 @@
 	{% if page.css %}<style>{{ page.css }}</style>{% endif %}
 
 	<script>
+		ACCESS_TOKEN = 'pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ';
 		CM_ATTR = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-				'Imagery © <a href="http://cloudmade.com">CloudMade</a>';
-
+			'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+			'Imagery © <a href="http://cloudmade.com">CloudMade</a>';
 		CM_URL = 'http://{s}.tile.cloudmade.com/d4fc77ea4a63471cab2423e66626cbb6/{styleId}/256/{z}/{x}/{y}.png';
-
-    MB_ATTR = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
-        '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
-        'Imagery © <a href="http://mapbox.com">Mapbox</a>';
-    MB_URL = 'http://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png';
-
+		MB_ATTR = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+			'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+			'Imagery © <a href="http://mapbox.com">Mapbox</a>';
+		MB_URL = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=' + ACCESS_TOKEN;
 		OSM_URL = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 		OSM_ATTRIB = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 	</script>

--- a/examples/choropleth-example.html
+++ b/examples/choropleth-example.html
@@ -51,12 +51,12 @@
 
 		var map = L.map('map').setView([37.8, -96], 4);
 
-		L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ', {
 			maxZoom: 18,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'examples.map-20v6611k'
+			id: 'mapbox.light'
 		}).addTo(map);
 
 

--- a/examples/choropleth.md
+++ b/examples/choropleth.md
@@ -64,10 +64,11 @@ The GeoJSON with state shapes was kindly shared by [Mike Bostock](http://bost.oc
 
 Let's display our states data on a map with a custom Mapbox style for nice grayscale tiles that look perfect as a background for visualizations:
 
+	var mapboxAccessToken = {your access token here};
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	L.tileLayer('http://{s}.tiles.mapbox.com/{id}/{z}/{x}/{y}.png', {
-		id: 'examples.map-20v6611k',
+	L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=' + mapboxAccessToken, {
+		id: 'mapbox.light',
 		attribution: ...
 	}).addTo(map);
 
@@ -262,18 +263,18 @@ Enjoy the result on [the top of this page](#map) or on a [separate page](choropl
 <script src="us-states.js"></script>
 <script>
 	var map2 = L.map('map2').setView([37.8, -96], 4);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}).addTo(map2);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}).addTo(map2);
 	L.geoJson(statesData).addTo(map2);
 
 
 	var map3 = L.map('map3').setView([37.8, -96], 4);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}).addTo(map3);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}).addTo(map3);
 	L.geoJson(statesData, {style: style}).addTo(map3);
 
 
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}).addTo(map);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}).addTo(map);
 
 	// control that shows state info on hover
 	var InfoControl = L.Control.extend({

--- a/examples/custom-icons.md
+++ b/examples/custom-icons.md
@@ -84,7 +84,7 @@ That's it. Now take a look at the [full example](custom-icons-example.html), the
 <script>
 	var map = L.map('map').setView([51.5, -0.09], 13);
 
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}).addTo(map);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}).addTo(map);
 
 	var LeafIcon = L.Icon.extend({
 		options: {
@@ -116,7 +116,7 @@ That's it. Now take a look at the [full example](custom-icons-example.html), the
 
 	var map2 = L.map('map2').setView([51.505, -0.09], 13);
 
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}).addTo(map2);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}).addTo(map2);
 
 	var greenIcon2 = L.icon({
 		iconUrl: '../docs/images/leaf-green.png',

--- a/examples/geojson-example.html
+++ b/examples/geojson-example.html
@@ -17,12 +17,12 @@
 	<script>
 		var map = L.map('map').setView([39.74739, -105], 13);
 
-		L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ', {
 			maxZoom: 18,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'examples.map-20v6611k'
+			id: 'mapbox.light'
 		}).addTo(map);
 
 		var baseballIcon = L.icon({

--- a/examples/geojson.html
+++ b/examples/geojson.html
@@ -16,7 +16,7 @@ title: Using GeoJSON with Leaflet
 
 	L.tileLayer(MB_URL, {
 		attribution: MB_ATTR,
-		id: 'examples.map-20v6611k'
+		id: 'mapbox.light'
 	}).addTo(map);
 
 	var baseballIcon = L.icon({

--- a/examples/layers-control-example.html
+++ b/examples/layers-control-example.html
@@ -15,7 +15,7 @@
 	<script>
 		var cities = new L.LayerGroup();
 
-	    L.marker([39.61, -105.02]).bindPopup('This is Littleton, CO.').addTo(cities),
+		L.marker([39.61, -105.02]).bindPopup('This is Littleton, CO.').addTo(cities),
 		L.marker([39.74, -104.99]).bindPopup('This is Denver, CO.').addTo(cities),
 		L.marker([39.73, -104.8]).bindPopup('This is Aurora, CO.').addTo(cities),
 		L.marker([39.77, -105.23]).bindPopup('This is Golden, CO.').addTo(cities);
@@ -24,10 +24,10 @@
 	    var mbAttr = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			mbUrl = 'https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png';
+			mbUrl = 'https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ';
 
-	    var grayscale   = L.tileLayer(mbUrl, {id: 'examples.map-20v6611k', attribution: mbAttr}),
-		    streets  = L.tileLayer(mbUrl, {id: 'examples.map-i875mjb7',   attribution: mbAttr});
+	    var grayscale   = L.tileLayer(mbUrl, {id: 'mapbox.light', attribution: mbAttr}),
+		    streets  = L.tileLayer(mbUrl, {id: 'mapbox.streets',   attribution: mbAttr});
 
 		var map = L.map('map', {
 			center: [39.73, -104.99],

--- a/examples/layers-control.md
+++ b/examples/layers-control.md
@@ -71,8 +71,8 @@ Now let's [view the result on a separate page &rarr;](layers-control-example.htm
 	L.marker([39.73, -104.8]).bindPopup('This is Aurora, CO.').addTo(cities),
 	L.marker([39.77, -105.23]).bindPopup('This is Golden, CO.').addTo(cities);
 
-    var grayscale = L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-20v6611k'}),
-	    streets = L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-i875mjb7'});
+    var grayscale = L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.light'}),
+	    streets = L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'});
 
 	var map = L.map('map', {
 		center: [39.73, -104.99],

--- a/examples/mobile-example.html
+++ b/examples/mobile-example.html
@@ -25,12 +25,12 @@
 	<script>
 		var map = L.map('map');
 
-		L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ', {
 			maxZoom: 18,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'examples.map-i875mjb7'
+			id: 'mapbox.streets'
 		}).addTo(map);
 
 		function onLocationFound(e) {

--- a/examples/mobile.md
+++ b/examples/mobile.md
@@ -32,7 +32,7 @@ We'll now initialize the map in the JavaScript code exactly like we did in the [
 
 <pre><code class="javascript">var map = L.map('map');
 
-L.tileLayer('http://{s}.tiles.mapbox.com/v3/<a href="https://mapbox.com">MapID</a>/997/256/{z}/{x}/{y}.png', {
+L.tileLayer('https://api.tiles.mapbox.com/v4/<a href="https://mapbox.com">MapID</a>/997/256/{z}/{x}/{y}.png?access_token={accessToken}', {
 	attribution: 'Map data &amp;copy; <span class="text-cut" data-cut="[&hellip;]">&lt;a href="http://openstreetmap.org"&gt;OpenStreetMap&lt;/a&gt; contributors, &lt;a href="http://creativecommons.org/licenses/by-sa/2.0/"&gt;CC-BY-SA&lt;/a&gt;, Imagery &copy; &lt;a href="http://mapbox.com"&gt;Mapbox&lt;/a&gt;</span>',
 	maxZoom: 18
 }).addTo(map);</code></pre>

--- a/examples/quick-start-example.html
+++ b/examples/quick-start-example.html
@@ -16,12 +16,12 @@
 
 		var map = L.map('map').setView([51.505, -0.09], 13);
 
-		L.tileLayer('https://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
+		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6IjZjNmRjNzk3ZmE2MTcwOTEwMGY0MzU3YjUzOWFmNWZhIn0.Y8bhBaUMqFiPrDRW9hieoQ', {
 			maxZoom: 18,
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'examples.map-i875mjb7'
+			id: 'mapbox.streets'
 		}).addTo(map);
 
 

--- a/examples/quick-start.md
+++ b/examples/quick-start.md
@@ -143,7 +143,7 @@ Now you've learned Leaflet basics and can start building map apps straight away!
 
 	var map = L.map('map').setView([51.505, -0.09], 13);
 
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-i875mjb7'}).addTo(map);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map);
 
 	L.marker([51.5, -0.09]).addTo(map)
 		.bindPopup("<b>Hello world!</b><br />I am a popup.").openPopup();
@@ -175,12 +175,12 @@ Now you've learned Leaflet basics and can start building map apps straight away!
 
 
 	var map1 = L.map('map1').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-i875mjb7'}).addTo(map1);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map1);
 
 
 
 	var map2 = L.map('map2').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-i875mjb7'}).addTo(map2);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map2);
 
 	L.marker([51.5, -0.09]).addTo(map2);
 
@@ -199,7 +199,7 @@ Now you've learned Leaflet basics and can start building map apps straight away!
 
 
 	var map3 = L.map('map3').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'examples.map-i875mjb7'}).addTo(map3);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map3);
 
 	L.marker([51.5, -0.09]).addTo(map3)
 		.bindPopup("<b>Hello world!</b><br />I am a popup.").openPopup();


### PR DESCRIPTION
- Updates all references and URLs to the Mapbox v4 API
- Adds a Mapbox access token associated with the `mapbox` Mapbox account to make v4 API requests work
- Replaces all `examples` map IDs with `mapbox` map IDs (just `mapbox.light` and `mapbox.streets`)

Some things to note:

- This is a straight up find-and-replace, and it will be annoying (but not impossible) when we inevitably have to rotate out the access token. Curious to see how often we have to do this -- I will keep an eye on traffic/referrers.
- I did not change any of the tutorial language, just the URLs. If necessary, I can update language in the tutorials to add info about access tokens.

:microphone: :octopus: :last_quarter_moon_with_face: 