### PR TITLE
Stop click on _openPopup

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -207,5 +207,35 @@ describe("Marker", function () {
 			expect(spy.calledTwice).to.be.ok();
 		});
 
+		it("do not propagate click event", function () {
+			var spy = sinon.spy();
+			var spy2 = sinon.spy();
+			var mapSpy = sinon.spy();
+			var marker = new L.Marker(new L.LatLng(55.8, 37.6));
+			map.addLayer(marker);
+			marker.on('click', spy);
+			marker.on('click', spy2);
+			map.on('click', mapSpy);
+			happen.click(marker._icon);
+			expect(spy.called).to.be.ok();
+			expect(spy2.called).to.be.ok();
+			expect(mapSpy.called).not.to.be.ok();
+		});
+
+		it("do not propagate dblclick event", function () {
+			var spy = sinon.spy();
+			var spy2 = sinon.spy();
+			var mapSpy = sinon.spy();
+			var marker = new L.Marker(new L.LatLng(55.8, 37.6));
+			map.addLayer(marker);
+			marker.on('dblclick', spy);
+			marker.on('dblclick', spy2);
+			map.on('dblclick', mapSpy);
+			happen.dblclick(marker._icon);
+			expect(spy.called).to.be.ok();
+			expect(spy2.called).to.be.ok();
+			expect(mapSpy.called).not.to.be.ok();
+		});
+
 	});
 });

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -147,6 +147,13 @@ L.Util = {
 		return (Object.prototype.toString.call(obj) === '[object Array]');
 	},
 
+	indexOf: function (array, el) {
+		for (var i = 0; i < array.length; i++) {
+			if (array[i] === el) { return i; }
+		}
+		return -1;
+	},
+
 	// minimal image URI, set to an image when disposing to flush memory
 	emptyImageUrl: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='
 };

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -2,7 +2,8 @@
 L.Layer = L.Evented.extend({
 
 	options: {
-		pane: 'overlayPane'
+		pane: 'overlayPane',
+		nonBubblingEvents: []  // Array of events that should not be bubbled to DOM parents (like the map)
 	},
 
 	addTo: function (map) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -6,6 +6,7 @@ L.Marker = L.Layer.extend({
 
 	options: {
 		pane: 'markerPane',
+		nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu'],
 
 		icon: new L.Icon.Default(),
 		// title: '',

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -696,7 +696,8 @@ L.Map = L.Evented.extend({
 		for (var i = 0; i < targets.length; i++) {
 			if (targets[i].listens(type, true)) {
 				targets[i].fire(type, data, true);
-				if (data.originalEvent._stopped) { return; }
+				if (data.originalEvent._stopped
+					|| (targets[i].options.nonBubblingEvents && L.Util.indexOf(targets[i].options.nonBubblingEvents, type) !== -1)) { return; }
 			}
 		}
 	},


### PR DESCRIPTION
Fix #3604.
I had a quick break.
Bubbling from marker is supposed to be the default, now, so I just stopped the event on `_openPopup`.
I could also just add it on `bindPopup`, if you prefer this pattern.