### PR TITLE
Hardcoded dependency L.CRS.Earth in L.Control.Scale

### DIFF
--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -41,7 +41,7 @@ L.Control.Scale = L.Control.extend({
 		var map = this._map,
 		    y = map.getSize().y / 2;
 
-		var maxMeters = L.CRS.Earth.distance(
+		var maxMeters = map.distance(
 				map.containerPointToLatLng([0, y]),
 				map.containerPointToLatLng([this.options.maxWidth, y]));
 


### PR DESCRIPTION
Currently,  L.Control.Scale uses hard-coded the L.CRS.Earth.distance function, while this CRS could have been changed by the user during map creation. 
Changing this to map.distance will remove this hard-coded dependency adding flexibility, while maintaining the same functionality.