### PR TITLE
Check canvas mouseout

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -18,7 +18,8 @@ L.Canvas = L.Renderer.extend({
 
 		L.DomEvent
 			.on(container, 'mousemove', this._onMouseMove, this)
-			.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this);
+			.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this)
+			.on(container, 'mouseout', this._handleMouseOut, this);
 
 		this._ctx = container.getContext('2d');
 	},
@@ -204,9 +205,10 @@ L.Canvas = L.Renderer.extend({
 		this._handleMouseHover(e, point);
 	},
 
+
 	_handleMouseOut: function (e, point) {
 		var layer = this._hoveredLayer;
-		if (layer && !layer._containsPoint(point)) {
+		if (layer && (e.type === 'mouseout' || !layer._containsPoint(point))) {
 			// if we're leaving the layer, fire mouseout
 			L.DomUtil.removeClass(this._container, 'leaflet-interactive');
 			this._fireEvent(layer, e, 'mouseout');


### PR DESCRIPTION
The canvas renderer was not checking for its own `mouseout` event, so a feature wouldn't get a `mouseout` event even if there was something above it (e.g. an absolutely positioned `<div>`). I think if the browser was handling mouse events (i.e. for SVGs), the `mouseout` event would trigger, so this PR brings the behaviour inline with that.