### PR TITLE
Do not fire preclick when dragging (fix #3632)

### DIFF
--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -40,3 +40,38 @@ expect.Assertion.prototype.nearLatLng = function (expected, delta) {
 	expect(this.obj.lng).to
 		.be.within(expected.lng - delta, expected.lng + delta);
 };
+
+happen.at = function (what, x, y, props) {
+	this.once(document.elementFromPoint(x, y), L.Util.extend({
+        type: what,
+        clientX: x,
+        clientY: y,
+        screenX: x,
+        screenY: y,
+        which: 1,
+        button: 0
+    }, props || {}));
+};
+happen.drag = function (fromX, fromY, toX, toY, then, duration) {
+	happen.at('mousemove', fromX, fromY);
+	happen.at('mousedown', fromX, fromY);
+	var moveX = function () {
+		if (fromX <= toX) {
+			happen.at('mousemove', fromX++, fromY);
+			window.setTimeout(moveX, 5);
+		}
+	};
+	moveX();
+	var moveY = function () {
+		if (fromY <= toY) {
+			happen.at('mousemove', fromX, fromY++);
+			window.setTimeout(moveY, 5);
+		}
+	};
+	moveY();
+	window.setTimeout(function () {
+		happen.at('mouseup', toX, toY);
+		happen.at('click', toX, toY);
+		if (then) { then(); }
+	}, duration || 100);
+};

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -275,4 +275,25 @@ describe("L.Map#openPopup", function () {
 		expect(map.hasLayer(p1)).to.be(true);
 		expect(map.hasLayer(p2)).to.be(true);
 	});
+
+	it('should not be closen when dragging map', function (done) {
+		document.body.appendChild(c);
+		c.style.position = 'absolute';
+		c.style.left = 0;
+		c.style.top = 0;
+		c.style.zIndex = 10000;
+		var coords = map._container.getBoundingClientRect();
+		var spy = sinon.spy();
+		var p = new L.Popup().setLatLng(new L.LatLng(55.8, 37.6));
+		map.openPopup(p);
+		expect(map.hasLayer(p)).to.be(true);
+		map.on('drag', spy);
+		happen.drag(coords.left + 100, coords.top + 100, coords.left + 110, coords.top + 110, function () {
+			expect(spy.called).to.be(true);
+			expect(map.hasLayer(p)).to.be(true);
+			document.body.removeChild(c);
+			done();
+		});
+	});
+
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -680,7 +680,7 @@ L.Map = L.Evented.extend({
 		var target = targets[0];
 
 		// prevents firing click after you just dragged an object
-		if (e.type === 'click' && !e._simulated && this._draggableMoved(target)) { return; }
+		if ((e.type === 'click' || e.type === 'preclick') && !e._simulated && this._draggableMoved(target)) { return; }
 
 		var data = {
 			originalEvent: e


### PR DESCRIPTION
Should fix #3632.
Don't merge yet, I'll see if I can add a unittest to cover this.