### PR TITLE
Fix boxZoom._moved remaining in bad state after use (cf #3026)

### DIFF
--- a/debug/map/map.html
+++ b/debug/map/map.html
@@ -43,7 +43,7 @@
 
 		function logEvent(e) { console.log(e.type); }
 
-		// map.on('click', logEvent);
+		map.on('click', logEvent);
 
 		// map.on('movestart', logEvent);
 		// map.on('move', logEvent);

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -26,10 +26,14 @@ L.Map.BoxZoom = L.Handler.extend({
 		return this._moved;
 	},
 
+	_resetState: function () {
+		this._moved = false;
+	},
+
 	_onMouseDown: function (e) {
 		if (!e.shiftKey || ((e.which !== 1) && (e.button !== 1))) { return false; }
 
-		this._moved = false;
+		this._resetState();
 
 		L.DomUtil.disableTextSelection();
 		L.DomUtil.disableImageDrag();
@@ -88,6 +92,9 @@ L.Map.BoxZoom = L.Handler.extend({
 		this._finish();
 
 		if (!this._moved) { return; }
+		// Postpone to next JS tick so internal click event handling
+		// still see it as "moved".
+		setTimeout(L.bind(this._resetState, this), 0);
 
 		var bounds = new L.LatLngBounds(
 		        this._map.containerPointToLatLng(this._startPoint),


### PR DESCRIPTION
This very small fix seems to fix it for me, both on Firefox and Chromium.
I can't see a reason for this not to work on other browser, but I may have missed some edge case to test.