### PR TITLE
Fix #3355 by making GridLayer._resetAll less agressive at removing tiles

### DIFF
--- a/debug/map/panto.html
+++ b/debug/map/panto.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+<p>This page tests the "tiles not loading on pan animation frame" bug from <a href='https://github.com/Leaflet/Leaflet/issues/3355'>https://github.com/Leaflet/Leaflet/issues/3355</a></p>
+
+	<div id="map"></div>
+
+	<script type="text/javascript">
+
+	
+	var map = new L.map('map', {
+		layers: new L.TileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png'),
+		zoom:10,
+		center:new L.LatLng(-19.003049, 22.414856)
+	});   
+
+	var i = 0;
+	
+	function animate(){
+	
+// 		if (i++ >= 25) return;
+	
+		var target = map.getCenter();
+		target.lng += 0.0001;
+		map.panTo(target, {animate:false, duration:0});
+		requestAnimationFrame(animate);
+	}
+
+	setTimeout(animate,5000);
+
+	</script>
+</body>
+</html>

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -277,11 +277,14 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	_resetAll: function () {
+		var mapZoom = this._map.getZoom();
 		for (var z in this._levels) {
-			L.DomUtil.remove(this._levels[z].el);
-			delete this._levels[z];
+			if (parseInt(z) !== mapZoom) {
+				L.DomUtil.remove(this._levels[z].el);
+				delete this._levels[z];
+			}
 		}
-		this._removeAllTiles();
+		this._pruneTiles();
 
 		this._tileZoom = null;
 		this._resetView();


### PR DESCRIPTION
In #3355, GridLayer._resetAll() is called on every frame - this removes the tiles, and creates new tiles exactly on the same place, but tiles take more than one frame to be requested from cache and rendered.

I wonder if calling `GridLayer._pruneTiles()` instead of `GridLayer._removeAllTiles()` will trigger some dirty tiles in some edge case :-/