### PR TITLE
Pan map on marker drag at the edges

### DIFF
--- a/debug/map/markers-autopan.html
+++ b/debug/map/markers-autopan.html
@@ -7,7 +7,7 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="../css/screen.css" />
+	<link rel="stylesheet" href="../css/mobile.css" />
 
 	<script type="text/javascript" src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
@@ -16,6 +16,8 @@
 	<div id="map"></div>
 
 <script type="text/javascript">
+//Function to calculate the 'map'-div position relative to the users window
+// TODO: change to a more elegant way to detect when to pan
 function getOffsetSum(elem) {
     var top=0, left=0;
     while(elem) {
@@ -44,21 +46,35 @@ function getOffsetSum(elem) {
 		markerDraggable.on('dragstart',function(e){
 			console.log('Start:', e, map.getSize())
 			var mapPosLeftTopRaw = getOffsetSum(map.getContainer()),
-				mapPosLeftTopPoint = L.point(mapPosLeftTopRaw.left,mapPosLeftTopRaw.top);
+				mapPosLeftTopPoint = L.point(mapPosLeftTopRaw.left,mapPosLeftTopRaw.top),
 				mapPosRightBottom = mapPosLeftTopPoint.add(map.getSize());
+		
 			mapScreenBounds = L.bounds(mapPosLeftTopPoint,mapPosRightBottom);
 		});
 
 		markerDraggable.on('drag',function(e){
-			var mouseLocation = L.point(e.originalEvent.clientX,e.originalEvent.clientY),
-				deltaPoint = mouseLocation.subtract(mapScreenBounds.getCenter()),
-				scalePoint = deltaPoint.unscaleBy(map.getSize().divideBy(2));
-			
+						//Re-center drag location into pixel location of the map bounding box
+			var first = (e.originalEvent.touches && e.originalEvent.touches.length === 1 ? e.originalEvent.touches[0] : e.originalEvent),
+			    dragLocation = L.point(first.clientX,first.clientY),
+			    deltaPoint = dragLocation.subtract(mapScreenBounds.getCenter()),
+			    scalePoint = deltaPoint.unscaleBy(map.getSize().divideBy(2));
+
 			var panVector;
 			if(!panBounds.contains(scalePoint)) {
-				sizeFromCenter = panBounds.getSize().divideBy(2);
-				panVector = scalePoint.unscaleBy(sizeFromCenter).multiplyBy(100);
-				map.panBy(panVector)
+				var absoluteVector = L.point(Math.abs(scalePoint.x),Math.abs(scalePoint.y)),
+				    direction = absoluteVector.unscaleBy(scalePoint).round(); //(1,1) || (-1,1) || (-1,-1) etc
+				
+				/*
+				 * Calculate smooth increase of pan by moving further to the edge by calculating
+				 * first a index between 0 (the pan bounding box edge) to 1 (the map edge)
+				 * and then plug that value into a sigmoid function to get a smooth transition
+				 */
+				panSizeOfVector = absoluteVector.subtract(panBounds.getSize().divideBy(2)).unscaleBy(L.point(1,1).subtract(panBounds.getSize().divideBy(2)));
+				var panX = 1/(1+Math.exp(-14*(panSizeOfVector.x-0.4))),
+				    panY = 1/(1+Math.exp(-14*(panSizeOfVector.y-0.4))),
+				    panVector = L.point(panX,panY).multiplyBy(50); //Max pan velocity: 50
+				
+				map.panBy(panVector.scaleBy(direction))
 			}
 		});
 		

--- a/debug/map/markers-autopan.html
+++ b/debug/map/markers-autopan.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+	<div id="map"></div>
+
+<script type="text/javascript">
+function getOffsetSum(elem) {
+    var top=0, left=0;
+    while(elem) {
+        top = top + parseInt(elem.offsetTop);
+        left = left + parseInt(elem.offsetLeft);
+        elem = elem.offsetParent;
+    }
+   return {top: top, left: left};
+}
+
+    var map = L.map('map', {
+        maxZoom: 12,
+        minZoom: 3,
+       // crs: L.CRS.Earth
+    }).setView([0,0],1)
+
+        var markerDraggable = new L.Marker([0, 10], {
+            draggable: true,
+            title: 'Draggable and on the edges I pan the map'
+        });
+		
+	var mapScreenBounds;
+
+	var panBounds = L.bounds(L.point(-0.85,-0.85),L.point(0.85,0.85));
+	
+		markerDraggable.on('dragstart',function(e){
+			console.log('Start:', e, map.getSize())
+			var mapPosLeftTopRaw = getOffsetSum(map.getContainer()),
+				mapPosLeftTopPoint = L.point(mapPosLeftTopRaw.left,mapPosLeftTopRaw.top);
+				mapPosRightBottom = mapPosLeftTopPoint.add(map.getSize());
+			mapScreenBounds = L.bounds(mapPosLeftTopPoint,mapPosRightBottom);
+		});
+
+		markerDraggable.on('drag',function(e){
+			var mouseLocation = L.point(e.originalEvent.clientX,e.originalEvent.clientY),
+				deltaPoint = mouseLocation.subtract(mapScreenBounds.getCenter()),
+				scalePoint = deltaPoint.unscaleBy(map.getSize().divideBy(2));
+			
+			var panVector;
+			if(!panBounds.contains(scalePoint)) {
+				sizeFromCenter = panBounds.getSize().divideBy(2);
+				panVector = scalePoint.unscaleBy(sizeFromCenter).multiplyBy(100);
+				map.panBy(panVector)
+			}
+		});
+		
+        map.addLayer(markerDraggable);
+        markerDraggable.bindPopup("Draggable");
+
+    		
+	L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+		attribution: "Map: Tiles Courtesy of MapQuest (OpenStreetMap, CC-BY-SA)",
+		subdomains: ["otile1","otile2","otile3","otile4"],
+		maxZoom: 12,
+		minZoom: 2
+	}).addTo(map);
+</script>
+</body>
+</html>

--- a/debug/map/markers-autopan.html
+++ b/debug/map/markers-autopan.html
@@ -16,78 +16,51 @@
 	<div id="map"></div>
 
 <script type="text/javascript">
-//Function to calculate the 'map'-div position relative to the users window
-// TODO: change to a more elegant way to detect when to pan
-function getOffsetSum(elem) {
-    var top=0, left=0;
-    while(elem) {
-        top = top + parseInt(elem.offsetTop);
-        left = left + parseInt(elem.offsetLeft);
-        elem = elem.offsetParent;
-    }
-   return {top: top, left: left};
-}
-
     var map = L.map('map', {
         maxZoom: 12,
         minZoom: 3,
-       // crs: L.CRS.Earth
-    }).setView([0,0],1)
-
-        var markerDraggable = new L.Marker([0, 10], {
-            draggable: true,
-            title: 'Draggable and on the edges I pan the map'
-        });
-		
-	var mapScreenBounds;
-
-	var panBounds = L.bounds(L.point(-0.85,-0.85),L.point(0.85,0.85));
-	
-		markerDraggable.on('dragstart',function(e){
-			console.log('Start:', e, map.getSize())
-			var mapPosLeftTopRaw = getOffsetSum(map.getContainer()),
-				mapPosLeftTopPoint = L.point(mapPosLeftTopRaw.left,mapPosLeftTopRaw.top),
-				mapPosRightBottom = mapPosLeftTopPoint.add(map.getSize());
-		
-			mapScreenBounds = L.bounds(mapPosLeftTopPoint,mapPosRightBottom);
-		});
-
-		markerDraggable.on('drag',function(e){
-						//Re-center drag location into pixel location of the map bounding box
-			var first = (e.originalEvent.touches && e.originalEvent.touches.length === 1 ? e.originalEvent.touches[0] : e.originalEvent),
-			    dragLocation = L.point(first.clientX,first.clientY),
-			    deltaPoint = dragLocation.subtract(mapScreenBounds.getCenter()),
-			    scalePoint = deltaPoint.unscaleBy(map.getSize().divideBy(2));
-
-			var panVector;
-			if(!panBounds.contains(scalePoint)) {
-				var absoluteVector = L.point(Math.abs(scalePoint.x),Math.abs(scalePoint.y)),
-				    direction = absoluteVector.unscaleBy(scalePoint).round(); //(1,1) || (-1,1) || (-1,-1) etc
-				
-				/*
-				 * Calculate smooth increase of pan by moving further to the edge by calculating
-				 * first a index between 0 (the pan bounding box edge) to 1 (the map edge)
-				 * and then plug that value into a sigmoid function to get a smooth transition
-				 */
-				panSizeOfVector = absoluteVector.subtract(panBounds.getSize().divideBy(2)).unscaleBy(L.point(1,1).subtract(panBounds.getSize().divideBy(2)));
-				var panX = 1/(1+Math.exp(-14*(panSizeOfVector.x-0.4))),
-				    panY = 1/(1+Math.exp(-14*(panSizeOfVector.y-0.4))),
-				    panVector = L.point(panX,panY).multiplyBy(50); //Max pan velocity: 50
-				
-				map.panBy(panVector.scaleBy(direction))
-			}
-		});
-		
-        map.addLayer(markerDraggable);
-        markerDraggable.bindPopup("Draggable");
-
-    		
-	L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
+    }).setView([0,0],1);
+    
+    L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {
 		attribution: "Map: Tiles Courtesy of MapQuest (OpenStreetMap, CC-BY-SA)",
 		subdomains: ["otile1","otile2","otile3","otile4"],
 		maxZoom: 12,
 		minZoom: 2
 	}).addTo(map);
+	
+	var markerDraggable = new L.Marker([0, 10], {
+		draggable: true,
+		title: 'Draggable and on the edges I pan the map'
+	}).addTo(map);
+
+	markerDraggable.bindPopup("Draggable");
+	
+	//Parameters for superellipse boundaries (feels more natural)
+	// https://en.wikipedia.org/wiki/Superellipse 
+	var panOptions = {a:0.90,b:0.90,n:5,maxVelocity:50};
+	
+	markerDraggable.on('drag',function(e){
+		//Transform mouse coordinates [0,0] to [mapSizeX,mapSizeY] to [-1,+1] to [+1,-1] coordinates
+		var halfMapSize = map.getSize()._divideBy(2),
+			//Fix event for touch input
+			fixedEvent = (e.originalEvent.touches && e.originalEvent.touches.length === 1) ? e.originalEvent.touches[0] : e.originalEvent,
+			dragPoint = map.mouseEventToContainerPoint(fixedEvent),
+			scaledPoint = dragPoint.subtract(halfMapSize).unscaleBy(halfMapSize),
+			superEllipse = Math.pow(Math.abs(scaledPoint.x/panOptions.a),panOptions.n) + Math.pow(Math.abs(scaledPoint.y/panOptions.b),panOptions.n);
+		
+		if(superEllipse >= 1) {
+			/*
+			 * Calculate smooth increase of pan by moving further to the edge by calculating
+			 * first a index between 0 (the pan bounding box edge) to 1 (the map edge)
+			 * and then plug that value into a sigmoid function to get a smooth transition
+			 */
+			var panSmoothed = 1/(1+Math.exp(-12*(superEllipse-1))),
+				panMagnitude = L.point(panSmoothed,panSmoothed).multiplyBy(panOptions.maxVelocity),
+				panAngle = Math.atan2(scaledPoint.y,scaledPoint.x);
+			
+			map.panBy(panMagnitude.scaleBy(L.point(Math.cos(panAngle),Math.sin(panAngle))))
+		}
+	});
 </script>
 </body>
 </html>

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -81,7 +81,7 @@ L.Draggable = L.Evented.extend({
 		    .on(document, L.Draggable.END[e.type], this._onUp, this);
 	},
 
-	_onMapMoved: function() {
+	_onMapMoved: function () {
 		if (!this._moved) { return; }
 
 		var oldOffset = this._offsetMap;

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -119,9 +119,9 @@ L.Draggable = L.Evented.extend({
 			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
 		}
 
-		if (this._contextMap) {    
-		    this._offsetMap = this._startPosMap.subtract(this._contextMap._getCenterLayerPoint());    
-        }
+		if (this._contextMap) {
+			this._offsetMap = this._startPosMap.subtract(this._contextMap._getCenterLayerPoint());
+		}
 		this._newPos = this._startPos.add(offset).subtract(this._offsetMap);
 		this._moving = true;
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -71,8 +71,8 @@ L.Draggable = L.Evented.extend({
 
 
 		if (this._contextMap) {
-        	this._offsetMap = L.point(0, 0);
-    		this._startPosMap = (this._contextMap ? this._contextMap._getCenterLayerPoint() : L.point(0, 0));
+			this._offsetMap = L.point(0, 0);
+			this._startPosMap = (this._contextMap ? this._contextMap._getCenterLayerPoint() : L.point(0, 0));
 			this._contextMap.on('moveend', this._onMapMoved, this);
 		}
 
@@ -119,13 +119,13 @@ L.Draggable = L.Evented.extend({
 			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
 		}
 
-		this._newPos = this._startPos.add(offset)
-		
+		this._newPos = this._startPos.add(offset);
+
 		if (this._contextMap) {
 			this._offsetMap = this._startPosMap.subtract(this._contextMap._getCenterLayerPoint());
 			this._newPos = this._newPos.subtract(this._offsetMap);
 		}
-		
+
 		this._moving = true;
 
 		L.Util.cancelAnimFrame(this._animRequest);

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -73,7 +73,7 @@ L.Draggable = L.Evented.extend({
 		this._offsetMap = L.point(0, 0);
 
 		if (this._contextMap) {
-			this._contextMap.on('move', this._onMapMoved, this);
+			this._contextMap.on('moveend', this._onMapMoved, this);
 		}
 
 		L.DomEvent
@@ -119,6 +119,9 @@ L.Draggable = L.Evented.extend({
 			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
 		}
 
+		if (this._contextMap) {    
+		    this._offsetMap = this._startPosMap.subtract(this._contextMap._getCenterLayerPoint());    
+        }
 		this._newPos = this._startPos.add(offset).subtract(this._offsetMap);
 		this._moving = true;
 
@@ -149,7 +152,7 @@ L.Draggable = L.Evented.extend({
 		}
 
 		if (this._contextMap) {
-			this._contextMap.off('move', this._onMapMoved, this);
+			this._contextMap.off('moveend', this._onMapMoved, this);
 		}
 
 		L.DomUtil.enableImageDrag();

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -24,7 +24,7 @@ L.Draggable = L.Evented.extend({
 		this._element = element;
 		this._dragStartTarget = dragStartTarget || element;
 		this._preventOutline = preventOutline;
-		this._contextMap = contextMap;
+		this._contextMap = (contextMap instanceof L.Map) ? contextMap : undefined;
 	},
 
 	enable: function () {
@@ -69,10 +69,10 @@ L.Draggable = L.Evented.extend({
 		this._startPoint = new L.Point(first.clientX, first.clientY);
 		this._startPos = this._newPos = L.DomUtil.getPosition(this._element);
 
-		this._startPosMap = (this._contextMap ? this._contextMap._getCenterLayerPoint() : L.point(0, 0));
-		this._offsetMap = L.point(0, 0);
 
 		if (this._contextMap) {
+        	this._offsetMap = L.point(0, 0);
+    		this._startPosMap = (this._contextMap ? this._contextMap._getCenterLayerPoint() : L.point(0, 0));
 			this._contextMap.on('moveend', this._onMapMoved, this);
 		}
 
@@ -119,10 +119,13 @@ L.Draggable = L.Evented.extend({
 			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
 		}
 
+		this._newPos = this._startPos.add(offset)
+		
 		if (this._contextMap) {
 			this._offsetMap = this._startPosMap.subtract(this._contextMap._getCenterLayerPoint());
+			this._newPos = this._newPos.subtract(this._offsetMap);
 		}
-		this._newPos = this._startPos.add(offset).subtract(this._offsetMap);
+		
 		this._moving = true;
 
 		L.Util.cancelAnimFrame(this._animRequest);

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -11,7 +11,7 @@ L.Handler.MarkerDrag = L.Handler.extend({
 		var icon = this._marker._icon;
 
 		if (!this._draggable) {
-			this._draggable = new L.Draggable(icon, icon, true);
+			this._draggable = new L.Draggable(icon, icon, true, this._marker._map);
 		}
 
 		this._draggable.on({


### PR DESCRIPTION
Hi,
As discussed in #3572 auto panning at the edges by markers is not supported.

I also gave it a shot and found a solution by giving the `L.Draggable` object a context when a marker is initialized (the map). It works pretty good and the marker stays at the cursor while panning. I am not aware of the current implementation details of `L.Draggable` and probably the code that I added should be in a plugin or extended class.

I tried to minimize the impact on the core code and therefore it uses the event handlers to check when to pan etc. The code could be implemented in `L.Marker.Drag` or an extension of that class.

An example is available in the folder `debug/map/markers-autopan.html`.
