### PR TITLE
Move controls on top of layers

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -96,7 +96,7 @@
 
 .leaflet-control {
 	position: relative;
-	z-index: 7;
+	z-index: 800;
 	pointer-events: auto;
 	}
 .leaflet-top,


### PR DESCRIPTION
In my PR to expand the zindex of panes I forgot to also adjust the zindex of `.leaflet-control`. This will make controls appear on top of layers again.