### PR TITLE
Ensure marker images are shown if a page has max-width configured for img elements

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -44,6 +44,7 @@
 /* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
 /* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
 .leaflet-container .leaflet-overlay-pane svg,
+.leaflet-container .leaflet-marker-pane img,
 .leaflet-container .leaflet-tile-pane img {
 	max-width: none !important;
 	}


### PR DESCRIPTION
Leaflet 1.0.0b1 will not display markers on pages with a general img max-width selector present, such as:
```
img {
    max-width: 100%;
}
```

Example: https://jsfiddle.net/davidjb/rx1qv17w/ (tested on Firefox 40a2 and Chromium 43 on Ubuntu 15.04 64-bit).

Previous versions of Leaflet had ``.leaflet-container img { max-width: none !important }`` prior to the change in https://github.com/Leaflet/Leaflet/commit/b3ff3a0e526d9644c0389e06d709075771d67905, when the selector became more specific, no longer overriding a general selector such as the one above.

Whether or not you consider a blanket img max-width as being harmful, [numerous](http://unstoppablerobotninja.com/entry/fluid-images) [well-meaning](http://www.sitepoint.com/maintain-image-aspect-ratios-responsive-web-design/) [web](http://www.smashingmagazine.com/2013/07/08/choosing-a-responsive-image-solution/) [sites](http://webdesignerwall.com/tutorials/5-useful-css-tricks-for-responsive-design) (including [W3Schools](http://www.w3schools.com/css/css_rwd_images.asp)) recommend setting max-width for all ``img`` elements in this way.  In addition, it was [present](https://github.com/twbs/bootstrap/commit/09cdee2f03aaad5c5a767fbec2e3896ad3d1f980) in Bootstrap up until version 3.

The solution here is is simply to turn max-width off for Leaflet's markers: see the code associated with this PR.  But the question boils down to whether this should be the responsibility of the the page loading Leaflet to change its CSS, or for Leaflet to defend itself against said styles.

I'm inclined to suggest the latter, hence this PR, for several reasons:  
1. The prevalence of resources suggesting ``max-width 100%`` use
2. The size of the change being small & non-invasive
3. Maintaining backwards compatibility with previous versions of Leaflet
4. This will save questions from new and existing users upgrading
