### PR TITLE
Fix mouseout bubbling while initial target was not listening (fix #3648)

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -630,8 +630,8 @@ L.Map = L.Evented.extend({
 			target = this._targets[L.stamp(src)];
 			if (target && target.listens(type, true)) {
 				targets.push(target);
-				if (!bubble) { break; }
 			}
+			if (!bubble) { break; }
 			if (src === this._container) {
 				break;
 			}


### PR DESCRIPTION
This simple change should fix #3648.
Sadly, I can't add a unittest because happen doesn't seem to allow configuration of `relatedTarget` [when firing an event](https://github.com/tmcw/happen/blob/cf9e4fc8271b99dbd42ac13ae69b93de2b0445a0/happen.js#L95) (not sure why, cc @tmcw), so while in unittests [this check](https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L673) is always `true`.