### PR TITLE
Fix undefined error when removing control layer

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -220,7 +220,7 @@ L.Control.Layers = L.Control.extend({
 
 		this._handlingClick = true;
 
-		for (var i = 0, len = inputs.length; i < len; i++) {
+		for (var i = inputs.length - 1; i >= 0; i--) {
 			input = inputs[i];
 			layer = this._layers[input.layerId].layer;
 			hasLayer = this._map.hasLayer(layer);


### PR DESCRIPTION
When removing control layers during an `baselayerchange` event, there's the possibility of layers being removed during the `_onInputClick` loop, causing `input` to be undefined. This PR simply loops backwards to handle removals.

The use case is that I have differing layers depending on which base layer is selected. When the base layer is changed, I remove layers that are no longer applicable and add new ones, throwing the error on [Control.Layers.js:225](https://github.com/Leaflet/Leaflet/blob/master/src/control/Control.Layers.js#L225).

This is also an issue in current stable, but was unsure what branch to branch/merge from/to for the fix.