### PR TITLE
Switch to wheel event where available

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -185,6 +185,7 @@ L.DomEvent = {
 		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY :        // Pixels
 		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 :   // Lines
 		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 :   // Pages
+		       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events
 		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
 		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 18 : // Legacy Moz lines
 		       e.detail ? e.detail / -32765 * 52 : // Legacy Moz pages

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -182,9 +182,13 @@ L.DomEvent = {
 	},
 
 	getWheelDelta: function (e) {
-		return e.deltaY ? -e.deltaY :
-			e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 40 :
-			e.detail ? -e.detail : 0;
+		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY :        // Pixels
+		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 :   // Lines
+		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 :   // Pages
+		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
+		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 18 : // Legacy Moz lines
+		       e.detail ? e.detail / -32765 * 52 : // Legacy Moz pages
+		       0;
 	},
 
 	_skipEvents: {},

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -61,8 +61,7 @@ L.DomEvent = {
 		} else if ('addEventListener' in obj) {
 
 			if (type === 'mousewheel') {
-				obj.addEventListener('DOMMouseScroll', handler, false);
-				obj.addEventListener(type, handler, false);
+				obj.addEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, false);
 
 			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
 				handler = function (e) {
@@ -108,8 +107,7 @@ L.DomEvent = {
 		} else if ('removeEventListener' in obj) {
 
 			if (type === 'mousewheel') {
-				obj.removeEventListener('DOMMouseScroll', handler, false);
-				obj.removeEventListener(type, handler, false);
+				obj.removeEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, false);
 
 			} else {
 				obj.removeEventListener(
@@ -184,16 +182,9 @@ L.DomEvent = {
 	},
 
 	getWheelDelta: function (e) {
-
-		var delta = 0;
-
-		if (e.wheelDelta) {
-			delta = e.wheelDelta / 120;
-		}
-		if (e.detail) {
-			delta = -e.detail / 3;
-		}
-		return delta;
+		return e.deltaY ? -e.deltaY :
+			e.wheelDelta ? e.wheelDelta / 40 :
+			e.detail ? -e.detail : 0;
 	},
 
 	_skipEvents: {},

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -139,7 +139,7 @@ L.DomEvent = {
 	},
 
 	disableScrollPropagation: function (el) {
-		return L.DomEvent.on(el, 'mousewheel MozMousePixelScroll', L.DomEvent.stopPropagation);
+		return L.DomEvent.on(el, 'mousewheel', L.DomEvent.stopPropagation);
 	},
 
 	disableClickPropagation: function (el) {
@@ -183,7 +183,7 @@ L.DomEvent = {
 
 	getWheelDelta: function (e) {
 		return e.deltaY ? -e.deltaY :
-			e.wheelDelta ? e.wheelDelta / 40 :
+			e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 40 :
 			e.detail ? -e.detail : 0;
 	},
 

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -26,6 +26,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 	_onWheelScroll: function (e) {
 		var delta = L.DomEvent.getWheelDelta(e);
+
 		var debounce = this._map.options.wheelDebounceTime;
 
 		this._delta += delta;
@@ -50,9 +51,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		map.stop(); // stop panning and fly animations if any
 
-		delta = delta > 0 ? Math.ceil(delta) : Math.floor(delta);
-		delta = Math.max(Math.min(delta, 4), -4);
-		delta = map._limitZoom(zoom + delta) - zoom;
+		delta = map._limitZoom(zoom + (delta > 0 ? 1 : -1)) - zoom;
 
 		this._delta = 0;
 		this._startTime = null;

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -9,19 +9,13 @@ L.Map.mergeOptions({
 
 L.Map.ScrollWheelZoom = L.Handler.extend({
 	addHooks: function () {
-		L.DomEvent.on(this._map._container, {
-			mousewheel: this._onWheelScroll,
-			MozMousePixelScroll: L.DomEvent.preventDefault
-		}, this);
+		L.DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
 
 		this._delta = 0;
 	},
 
 	removeHooks: function () {
-		L.DomEvent.off(this._map._container, {
-			mousewheel: this._onWheelScroll,
-			MozMousePixelScroll: L.DomEvent.preventDefault
-		}, this);
+		L.DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll, this);
 	},
 
 	_onWheelScroll: function (e) {

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -45,7 +45,9 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		map.stop(); // stop panning and fly animations if any
 
-		delta = map._limitZoom(zoom + (delta > 0 ? 1 : -1)) - zoom;
+		// map the delta with a sigmoid function to -4..4 range leaning on -1..1
+		var d2 = Math.ceil(4 * Math.log(2 / (1 + Math.exp(-Math.abs(delta / 200)))) / Math.LN2);
+		delta = map._limitZoom(zoom + (delta > 0 ? d2 : -d2)) - zoom;
 
 		this._delta = 0;
 		this._startTime = null;


### PR DESCRIPTION
May fix #2757 #2732. We don't care about FF17 and less where `MozMousePixelScroll` was needed anymore.