### PR TITLE
FlyTo with targetCenter == currentCenter not animated

### DIFF
--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -19,7 +19,7 @@ L.Map.include({
 
 		var w0 = Math.max(size.x, size.y),
 		    w1 = w0 * this.getZoomScale(startZoom, targetZoom),
-		    u1 = to.distanceTo(from),
+		    u1 = (to.distanceTo(from)) || 1,
 		    rho = 1.42,
 		    rho2 = rho * rho;
 


### PR DESCRIPTION
Please see http://jsfiddle.net/v1so6m56/4/

If targetCenter is the same of currenteCenter, the parameter u1 (the distance between "to" and "from") is 0.

The proposed patch resolve this by forcing the distance to 1.