### PR TITLE
Fix Control Scale padding

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -380,7 +380,7 @@
 	border: 2px solid #777;
 	border-top: none;
 	line-height: 1.1;
-	padding: 2px 5px 1px;
+	padding: 2px 0 1px;
 	font-size: 11px;
 	white-space: nowrap;
 	overflow: hidden;
@@ -390,6 +390,9 @@
 	background: #fff;
 	background: rgba(255, 255, 255, 0.5);
 	}
+.leaflet-control-scale-line span {
+	padding: 5px;
+ 	}
 .leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;
 	border-bottom: none;

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -81,7 +81,7 @@ L.Control.Scale = L.Control.extend({
 
 	_updateScale: function (scale, text, ratio) {
 		scale.style.width = Math.round(this.options.maxWidth * ratio) + 'px';
-		scale.innerHTML = '<span>'+text+'</span>';
+		scale.innerHTML = '<span>' + text + '</span>';
 	},
 
 	_getRoundNum: function (num) {

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -81,7 +81,7 @@ L.Control.Scale = L.Control.extend({
 
 	_updateScale: function (scale, text, ratio) {
 		scale.style.width = Math.round(this.options.maxWidth * ratio) + 'px';
-		scale.innerHTML = text;
+		scale.innerHTML = '<span>'+text+'</span>';
 	},
 
 	_getRoundNum: function (num) {


### PR DESCRIPTION
The Control Scale is too big: the horizontal padding (5px) makes the line too wide (and incorrect).

This PR adds a <span> element around the scale text with the appropriate padding.
The difference:

Before:
<img width="150" alt="before" src="https://cloud.githubusercontent.com/assets/1065152/8869804/9a958f26-31e8-11e5-980f-aa0ec275572e.png">

After:
<img width="150" alt="after" src="https://cloud.githubusercontent.com/assets/1065152/8869805/a11258d4-31e8-11e5-9051-b6007b545d06.png">
 