### PR TITLE
do not show tile and fire tileload event if image failed to load

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -630,12 +630,14 @@ L.GridLayer = L.Layer.extend({
 			this._pruneTiles();
 		}
 
-		L.DomUtil.addClass(tile.el, 'leaflet-tile-loaded');
+		if (!err) {
+			L.DomUtil.addClass(tile.el, 'leaflet-tile-loaded');
 
-		this.fire('tileload', {
-			tile: tile.el,
-			coords: coords
-		});
+			this.fire('tileload', {
+				tile: tile.el,
+				coords: coords
+			});
+		}
 
 		if (this._noTilesToLoad()) {
 			this._loading = false;


### PR DESCRIPTION
If `tileErrorUrl` is set, it will call _tileReady again, so the replacement image will be displayed correctly. If it's not set, the tile should not be displayed, otherwise you'll see a broken image.

See the previous pull request and discussion at #2346
