### PR TITLE
Set popup source to marker when marker.bindPopup gets an instance of L.Popup

### DIFF
--- a/src/layer/marker/Marker.Popup.js
+++ b/src/layer/marker/Marker.Popup.js
@@ -52,6 +52,7 @@ L.Marker.include({
 		if (content instanceof L.Popup) {
 			L.setOptions(content, options);
 			this._popup = content;
+			content._source = this;
 		} else {
 			this._popup = new L.Popup(options, this)
 				.setContent(content);


### PR DESCRIPTION
If you use an instance of L.Popup to bind a popup to a marker in the current stable version (it's fixed in master) the source of the popup is not set. So if you close a popup the popupclose event is only fired on the map and not on the marker. See [fiddle](http://jsfiddle.net/Eschon/a87woskf/)

This probably won't be a big deal for most people but it broke a few things in my code.