### PR TITLE
Fix baselayerchange event argument (fix #3677)

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -6,18 +6,24 @@ describe("Control.Layers", function () {
 	});
 
 	describe("baselayerchange event", function () {
+		beforeEach(function () {
+			map.setView([0, 0], 14);
+		});
+
 		it("is fired on input that changes the base layer", function () {
-			var baseLayers = {"Layer 1": L.tileLayer(), "Layer 2": L.tileLayer()},
+			var baseLayers = {"Layer 1": L.tileLayer(''), "Layer 2": L.tileLayer('')},
 				layers = L.control.layers(baseLayers).addTo(map),
 				spy = sinon.spy();
 
-			map.on('baselayerchange', spy)
-				.whenReady(function () {
-					happen.click(layers._baseLayersList.getElementsByTagName("input")[0]);
-
-					expect(spy.called).to.be.ok();
-					expect(spy.mostRecentCall.args[0].layer).to.be(baseLayers["Layer 1"]);
-				});
+			map.on('baselayerchange', spy);
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[0]);
+			expect(spy.called).to.be.ok();
+			expect(spy.args[0][0].name).to.be("Layer 1");
+			expect(spy.args[0][0].layer).to.be(baseLayers["Layer 1"]);
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[1]);
+			expect(spy.calledTwice).to.be.ok();
+			expect(spy.args[1][0].name).to.be("Layer 2");
+			expect(spy.args[1][0].layer).to.be(baseLayers["Layer 2"]);
 		});
 
 		it("is not fired on input that doesn't change the base layer", function () {

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -154,14 +154,14 @@ L.Control.Layers = L.Control.extend({
 			this._update();
 		}
 
-		var overlay = this._layers[L.stamp(e.target)].overlay;
+		var obj = this._layers[L.stamp(e.target)];
 
-		var type = overlay ?
+		var type = obj.overlay ?
 			(e.type === 'add' ? 'overlayadd' : 'overlayremove') :
 			(e.type === 'add' ? 'baselayerchange' : null);
 
 		if (type) {
-			this._map.fire(type, e.target);
+			this._map.fire(type, obj);
 		}
 	},
 


### PR DESCRIPTION
Should fix #3677 
Unittest wasn't actually run, because of missing `map.setView`.