### PR TITLE
fix imageoverlay setBound when not added to map

### DIFF
--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -5,4 +5,13 @@ describe('ImageOverlay', function () {
 			expect(overlay.options.opacity).to.equal(0.5);
 		});
 	});
+	describe('#setBounds', function () {
+		it('sets bounds', function () {
+			var bounds = new L.LatLngBounds(
+				new L.LatLng(14, 12),
+				new L.LatLng(30, 40));
+			var overlay = L.imageOverlay().setBounds(bounds);
+			expect(overlay._bounds).to.equal(bounds);
+		});
+	});
 });

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -88,7 +88,9 @@ L.ImageOverlay = L.Layer.extend({
 	setBounds: function (bounds) {
 		this._bounds = bounds;
 
-		this._reset();
+		if (this._map) {
+			this._reset();
+		}
 		return this;
 	},
 


### PR DESCRIPTION
If imageoverlay#setBounds is called when the layer is not added to a map, the _reset method gets errors on execution (sorry for former incomplete PR)