### PR TITLE
Do not stop mousedown event propagation on L.Draggable

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -46,9 +46,8 @@ L.Draggable = L.Evented.extend({
 	_onDown: function (e) {
 		this._moved = false;
 
-		if (e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
-
-		L.DomEvent.stopPropagation(e);
+		if (L.Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
+		L.Draggable._dragging = true;  // Prevent dragging multiple objects at once.
 
 		if (this._preventOutline) {
 			L.DomUtil.preventOutline(this._element);
@@ -142,5 +141,6 @@ L.Draggable = L.Evented.extend({
 		}
 
 		this._moving = false;
+		L.Draggable._dragging = false;
 	}
 });


### PR DESCRIPTION
Rationale is to let Leaflet plugins use the mousedown event.

@mourner feedback? :)