### PR TITLE
Fix Marker dragging with changing Icon

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -130,7 +130,10 @@ L.Marker = L.Layer.extend({
 		}
 
 		this._icon = icon;
-		this._initInteraction();
+
+		if (addIcon) {
+			this._initInteraction();
+		}
 
 		if (options.riseOnHover) {
 			this.on({


### PR DESCRIPTION
Fix Maker dragging and changing the Icon inside a 'drag[start]' event handler.
Try http://jsfiddle.net/v1so6m56/6/ If you try to drag the green leaf you'll see that the shadow doesn't move, and if you try to drag again the marker starts over from original position.

In http://jsfiddle.net/v1so6m56/7/ is implemented the proposed PR: try to drag again the marker: the shadow moves and if you drag again the marker starts from last position.