### PR TITLE
Fix Internet Explorer 11 map overflow outside container

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -143,7 +143,7 @@ L.DomUtil = {
 		var pos = offset || new L.Point(0, 0);
 
 		el.style[L.DomUtil.TRANSFORM] =
-			'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)' + (scale ? ' scale(' + scale + ')' : '');
+			(L.Browser.ie3d ? 'translate(' + pos.x + 'px,' + pos.y + 'px' + ')' : 'translate3d(' + pos.x + 'px,' + pos.y + 'px' + ',0)') + (scale ? ' scale(' + scale + ')' : '');
 	},
 
 	setPosition: function (el, point) { // (HTMLElement, Point[, Boolean])


### PR DESCRIPTION
Please see http://jsfiddle.net/v1so6m56/8/ : try to zoom (by double click, o wheel) with IE 11 (and IE 10 emulated in Dev Tools). The map overflows outside the container.

The proposed PR is tested in  http://jsfiddle.net/v1so6m56/9/ 

Basically this change disable the usage of css transform3d for ie3d. 

Microsoft Edge on Windows 10 is not affected (L.Browser.ie3d is false, because L.Browser.ie is false )

Should Fix #2788 
