### PR TITLE
Do not set draggable flags during a zoom animation

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -46,14 +46,14 @@ L.Draggable = L.Evented.extend({
 	_onDown: function (e) {
 		this._moved = false;
 
+		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
+
 		if (L.Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches) || !this._enabled) { return; }
 		L.Draggable._dragging = true;  // Prevent dragging multiple objects at once.
 
 		if (this._preventOutline) {
 			L.DomUtil.preventOutline(this._element);
 		}
-
-		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 
 		L.DomUtil.disableImageDrag();
 		L.DomUtil.disableTextSelection();


### PR DESCRIPTION
Fixes #3685.

Has the side effect of making draggable markers jump around if dragged during a zoom animation, but I don't expect anyone to drag a marker within 0.25 secs of starting a zoom animation.