### PR TITLE
add missing class leaflet-zoom-anim in flyTo

### DIFF
--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -55,11 +55,15 @@ L.Map.include({
 					this.getScaleZoom(w0 / w(s), startZoom));
 
 			} else {
+
+				L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 				this
 					._move(targetCenter, targetZoom)
 					._moveEnd(true);
 			}
 		}
+
+		L.DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 
 		this._moveStart(true);
 


### PR DESCRIPTION
If you have any layer the uses the ‘leaflet-zoom-hide’ to be hidden while zooming, without the ‘leaflet-zoom-anim’ class in flyTo, that layer twill be shown while animating the fly.