### PR TITLE
Experiment: Use preprojected points and reduce object allocations

### DIFF
--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -42,17 +42,6 @@ L.Polygon = L.Polyline.extend({
 		return this._map.layerPointToLatLng(center);
 	},
 
-	_convertLatLngs: function (latlngs) {
-		var result = L.Polyline.prototype._convertLatLngs.call(this, latlngs),
-		    len = result.length;
-
-		// remove last point if it equals first one
-		if (len >= 2 && result[0] instanceof L.LatLng && result[0].equals(result[len - 1])) {
-			result.pop();
-		}
-		return result;
-	},
-
 	_setLatLngs: function (latlngs) {
 		L.Polyline.prototype._setLatLngs.call(this, latlngs);
 		if (L.Polyline._flat(this._latlngs)) {


### PR DESCRIPTION
This pull request isn't intended for merging (it almost certainly breaks things), its more of a proof of concept around more performant zooming with vector layers.

This is what currently happens when you zoom:
![image](https://cloud.githubusercontent.com/assets/2084823/9006564/b4e08fb4-3780-11e5-83bc-3e0a8e4d03f7.png)

It seems that Leaflet spends about half the time projecting, the other half rendering. The screenshot above shows three problems I think: 1) projecting takes a while, 2) there are too many GC events and 3) rendering takes a while.

I'm not sure there's much to be done to improve rendering, batching together canvas contexts (#3577) doesn't actually seem to have the impact I thought it would. However for 1) and 2), we could pre-project the coordinates and remove a lot of the object allocation (mainly new `Point` instances)

Zooming then looks like this:
![image](https://cloud.githubusercontent.com/assets/2084823/9006636/96d9a216-3781-11e5-8889-d2f6ea6b8644.png)
Object allocations pre/post optimization:
![image](https://cloud.githubusercontent.com/assets/2084823/9007664/6dba0f2e-378b-11e5-96cf-058373d60107.png)

This seems pretty good. It works well for me but then I have a very specific use case. Obviously not everyone is going to want to pre-project their features (for reference my pre-projection code is here: https://gist.github.com/wpf500/37d288c3991527a21017), but it could probably be done in `_convertLatLngs`? The code changes I've made are very specific to my project (I'm not suggesting this gets merged), but before trying to write a general implementation I thought it was worth asking what things might break as a result that I haven't thought about?