### PR TITLE
Updating .getLayers() to also accept an array of ids.

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -90,11 +90,12 @@ L.LayerGroup = L.Layer.extend({
 		return this._layers[id];
 	},
 
-	getLayers: function () {
-		var layers = [];
+	getLayers: function (ids) {
+		var layers = [],
+			l = ids ? ids : this._layers;
 
-		for (var i in this._layers) {
-			layers.push(this._layers[i]);
+		for (var i in ids) {
+			layers.push(this._layers[ids[i]]);
 		}
 		return layers;
 	},

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -95,7 +95,8 @@ L.LayerGroup = L.Layer.extend({
 			l = ids ? ids : this._layers;
 
 		for (var i in l) {
-			layers.push(this._layers[l[i]]);
+			var t = ids ? l[i] : l[i]._leaflet_id;
+			layers.push(this._layers[t]);
 		}
 		return layers;
 	},

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -94,8 +94,8 @@ L.LayerGroup = L.Layer.extend({
 		var layers = [],
 			l = ids ? ids : this._layers;
 
-		for (var i in ids) {
-			layers.push(this._layers[ids[i]]);
+		for (var i in l) {
+			layers.push(this._layers[l[i]]);
 		}
 		return layers;
 	},


### PR DESCRIPTION
While .getLayer(<layer id>) returns a specific layer, the getLayers() function does not accept an argument to get a list of matching layers.  This change modifies the .getLayers() function so that an array of layer ids may be passed into the function, and it will return the matching layers.  This change is backwards compatible, if no array is passed to function it will still return an array with all of the layers in the group.