### PR TITLE
Always force GridLayer to have a zIndex

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -9,12 +9,12 @@ L.GridLayer = L.Layer.extend({
 
 		tileSize: 256,
 		opacity: 1,
+		zIndex: 1,
 
 		updateWhenIdle: L.Browser.mobile,
 		updateInterval: 200,
-
+		
 		attribution: null,
-		zIndex: null,
 		bounds: null,
 
 		minZoom: 0

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -13,7 +13,7 @@ L.GridLayer = L.Layer.extend({
 
 		updateWhenIdle: L.Browser.mobile,
 		updateInterval: 200,
-		
+
 		attribution: null,
 		bounds: null,
 


### PR DESCRIPTION
This is a super naive fix for https://github.com/Leaflet/Leaflet/issues/3721. If all grid containers have a z index of 1 they will default to DOM ordering which is usually the order they were added in which is the expected behavior. Also since the container now has a z index all their children (levels) get ordered relative to their parent.

@mourner let me know if my reading of the source code was correct and Ill squash this down and merge it.