### PR TITLE
Build sourcemaps via magic-string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp/**/*
 *.sublime-*
 _site
 dist/*.js
+dist/*.map
 coverage/
 *.js.html
 index.html

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "karma-mocha": "~0.2.0",
     "karma-phantomjs-launcher": "^0.2.0",
     "karma-safari-launcher": "~0.1.1",
+    "magic-string": "^0.6.4",
     "mocha": "~2.2.5",
     "tin": "^0.5.0",
     "uglify-js": "~2.4.23"


### PR DESCRIPTION
Because having sourcemaps is cool. Pretty much based on https://www.npmjs.com/package/magic-string#bundling

Build system works just the same, just run `npm install` and `jake`, and the sourcemap for `leaflet-src.js` will be automatically generated.