### PR TITLE
GridLayer async mode

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -3387,8 +3387,10 @@ map.fitBounds(bounds);</code></pre>
 		tile.width = size.x;
 		tile.height = size.y;
 
+		return tile;
+		
 		// draw something and pass the tile to the done() callback
-		done(error, tile);
+		// done(error, tile);
 	}
 });</code></pre>
 


### PR DESCRIPTION
In function GridLayer.createTile we should return tile immediately even if we draw in async mode. Otherwise undefined exception will be thrown.