### PR TITLE
removing obsolete browser detection reference for IE6&7

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -5179,16 +5179,6 @@ MyClass.FOO; // 'bar'</code></pre>
 		<td><code><span class="hljs-literal">true</span></code> for all Internet Explorer versions.</td>
 	</tr>
 	<tr>
-		<td><code><b>ie6</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code><span class="hljs-literal">true</span></code> for Internet Explorer 6.</td>
-	</tr>
-	<tr>
-		<td><code><b>ie7</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code><span class="hljs-literal">true</span></code> for Internet Explorer 7.</td>
-	</tr>
-	<tr>
 		<td><code><b>webkit</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code><span class="hljs-literal">true</span></code> for webkit-based browsers like Chrome and Safari (including mobile versions).</td>


### PR DESCRIPTION
IE6 and IE7 browser detection was removed from leaflet in Nov 2013. 
https://github.com/Leaflet/Leaflet/commit/e45db4cd5b760c09225ad52e863c55e0730252e9