### PR TITLE
Add PolarMap.js plugin to basemap providers

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -166,6 +166,15 @@ Ready-to-go basemaps, with little or no configuration at all.
 			<a href="https://github.com/sigdeletras">Patricio Soriano</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/GeoSensorWebLab/polarmap.js">PolarMap.js</a>
+		</td><td>
+			JavaScript library for displaying tiles from <a href="http://webmap.arcticconnect.org">ArcticWebMap</a>, a free tile provider with OSM data in multiple Arctic polar projections. Includes lower-level API for deeper integration with other Leaflet plugins.
+		</td><td>
+			<a href="https://github.com/geosensorweblab">GeoSensorWeb Lab</a>
+		</td>
+	</tr>
 
 </table>
 


### PR DESCRIPTION
PolarMap.js is a wrapper library around Leaflet that makes integration with the ArcticWebMap tile server easy.

http://webmap.arcticconnect.org/polarmap.html

The API has a simple layer that makes it easy to get started, and a lower-level layer that can be used to integrate with other Leaflet plugins or applications.

ArcticWebMap is a tile server our research lab runs and it provides OpenStreetMap data in six Arctic-focused projections: EPSG:3571 – EPSG:3576. In these projections, Arctic areas do not suffer from the distortion present in Web Mercator at the expense that everything below 45˚N is highly distorted. See the [ArcticWebMap](http://webmap.arcticconnect.org/index.html) page for an example. We are using [a fork of the openstreetmap-carto style](https://github.com/GeoSensorWebLab/awm-styles) that has been modified to include bathymetry data, more lake data, CanVec contour data (Canadian Territories only), and other enhancements for northern communities.

Both ArcticWebMap and PolarMap.js are a part of the [ArcticConnect research project](http://arcticconnect.org). If you have any questions, feel free to ask!