### PR TITLE
Fix init bug when we have script tags without src

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -35,7 +35,7 @@ L.Icon.Default.imagePath = (function () {
 	var i, len, src, path;
 
 	for (i = 0, len = scripts.length; i < len; i++) {
-		src = scripts[i].src;
+		src = scripts[i].src || '';
 
 		if (src.match(leafletRe)) {
 			path = src.split(leafletRe)[0];


### PR DESCRIPTION
Not all script tags have src attribute.

If we have script tags with injected js code and try to load leaflet we get crash with error.