### PR TITLE
Use radius if radiusY is not set

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -21,7 +21,7 @@ L.Circle = L.CircleMarker.extend({
 	},
 
 	getBounds: function () {
-		var half = [this._radius, this._radiusY];
+		var half = [this._radius, this._radiusY || this._radius];
 
 		return new L.LatLngBounds(
 			this._map.layerPointToLatLng(this._point.subtract(half)),


### PR DESCRIPTION
`_radiusY` may not be set, use `_radius` instead in that case as done in other places.