### PR TITLE
Clear tilelayer's BG buffer on zoomanim end if out of zoom limits

### DIFF
--- a/src/layer/tile/TileLayer.Anim.js
+++ b/src/layer/tile/TileLayer.Anim.js
@@ -29,6 +29,11 @@ L.TileLayer.include({
 		// force reflow
 		L.Util.falseFn(bg.offsetWidth);
 
+		var zoom = this._map.getZoom();
+		if (zoom > this.options.maxZoom || zoom < this.options.minZoom) {
+			this._clearBgBuffer();
+		}
+
 		this._animating = false;
 	},
 


### PR DESCRIPTION
Fixes #3777 