### PR TITLE
quick start guide should reference the Leaflet maintained CDN

### DIFF
--- a/examples/quick-start.md
+++ b/examples/quick-start.md
@@ -19,11 +19,11 @@ Before writing any code for the map, you need to do the following preparation st
 
  * Include Leaflet CSS file in the head section of your document:
 
-		<link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.4/leaflet.css" />
+		<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.4/leaflet.css" />
 
  * Include Leaflet JavaScript file:
 
-		<script src="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.4/leaflet.js"></script>
+		<script src="http://cdn.leafletjs.com/leaflet-0.7.4/leaflet.js"></script>
 
  * Put a `div` element with a certain `id` where you want your map to be:
 


### PR DESCRIPTION
Rather than the cdnjs, reference the one maintained by Leaflet