### PR TITLE
Make sure mouse has an external relatedTarget on mouseout/over 

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -693,7 +693,7 @@ describe("Map", function () {
 			expect(mapSpy.called).not.to.be.ok();
 		});
 
-		it("mouseout is only forwared if fired on the original target", function () {
+		it("mouseout is forwarded if fired on the original target", function () {
 			var mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
 			    otherSpy = sinon.spy();
@@ -702,13 +702,60 @@ describe("Map", function () {
 			map.on("mouseout", mapSpy);
 			layer.on("mouseout", layerSpy);
 			other.on("mouseout", otherSpy);
-			happen.mouseout(layer._path);
+			happen.mouseout(layer._path, {relatedTarget: map._container});
 			expect(mapSpy.called).not.to.be.ok();
 			expect(otherSpy.called).not.to.be.ok();
 			expect(layerSpy.calledOnce).to.be.ok();
 		});
 
-		it("mouseout is not forwared to layers if fired on the map", function () {
+		it("mouseout is forwarded when using a DivIcon", function () {
+			var icon = L.divIcon({
+				html: "<p>this is text in a child element</p>",
+				iconSize: [100, 100]
+			});
+			var mapSpy = sinon.spy(),
+			    layerSpy = sinon.spy(),
+			    layer = L.marker([1, 2], {icon: icon}).addTo(map);
+			map.on("mouseout", mapSpy);
+			layer.on("mouseout", layerSpy);
+			happen.mouseout(layer._icon, {relatedTarget: map._container});
+			expect(mapSpy.called).not.to.be.ok();
+			expect(layerSpy.calledOnce).to.be.ok();
+		});
+
+		it("mouseout is not forwarded if relatedTarget is a target's child", function () {
+			var icon = L.divIcon({
+				html: "<p>this is text in a child element</p>",
+				iconSize: [100, 100]
+			});
+			var mapSpy = sinon.spy(),
+			    layerSpy = sinon.spy(),
+			    layer = L.marker([1, 2], {icon: icon}).addTo(map),
+			    child = layer._icon.querySelector('p');
+			map.on("mouseout", mapSpy);
+			layer.on("mouseout", layerSpy);
+			happen.mouseout(layer._icon, {relatedTarget: child});
+			expect(mapSpy.called).not.to.be.ok();
+			expect(layerSpy.calledOnce).not.to.be.ok();
+		});
+
+		it("mouseout is not forwarded if fired on target's child", function () {
+			var icon = L.divIcon({
+				html: "<p>this is text in a child element</p>",
+				iconSize: [100, 100]
+			});
+			var mapSpy = sinon.spy(),
+			    layerSpy = sinon.spy(),
+			    layer = L.marker([1, 2], {icon: icon}).addTo(map),
+			    child = layer._icon.querySelector('p');
+			map.on("mouseout", mapSpy);
+			layer.on("mouseout", layerSpy);
+			happen.mouseout(child, {relatedTarget: layer._icon});
+			expect(mapSpy.called).not.to.be.ok();
+			expect(layerSpy.calledOnce).not.to.be.ok();
+		});
+
+		it("mouseout is not forwarded to layers if fired on the map", function () {
 			var mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
 			    otherSpy = sinon.spy();

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -67,7 +67,7 @@ L.DomEvent = {
 			} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
 				handler = function (e) {
 					e = e || window.event;
-					if (L.DomEvent._checkMouse(obj, e)) {
+					if (L.DomEvent._isExternalTarget(obj, e)) {
 						originalHandler(e);
 					}
 				};
@@ -211,7 +211,7 @@ L.DomEvent = {
 	},
 
 	// check if element really left/entered the event target (for mouseenter/mouseleave)
-	_checkMouse: function (el, e) {
+	_isExternalTarget: function (el, e) {
 
 		var related = e.relatedTarget;
 


### PR DESCRIPTION
Fix #3797 #3708 

This commit controls that, on `mouseout` or `mouseover`, the relatedTarget was an external DOM element (and thus not a child).

This fixes #3797, but not reproducing the exact behaviour of 0.7.5, which conflicts with other choices on event management: basically, in 0.7.5 `mouseover` and `mouseout` was still bubbling (so fired twice when moving mouse from a div icon to its child), while now we are not firing those events when relatedTarget is a descendant element of the listener.

The frustrating point is that `happen` does not seem to be able to set the `relatedTarget` property, which prevents us from testing the scenarios. I'll have a look if this can be fixed on `happen`.

I've also renamed `_checkMouse` to `_isExternalTarget` because I found myself always needing to check the method content to remember what it is actually doing. I'm open to better names, though ;)