### PR TITLE
Remove check for webkitMobile before calling update on GridLayer._setView

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -356,9 +356,7 @@ L.GridLayer = L.Layer.extend({
 			this._updateLevels();
 			this._resetGrid();
 
-			if (!L.Browser.mobileWebkit) {
-				this._update(center, tileZoom);
-			}
+			this._update(center, tileZoom);
 
 			if (!noPrune) {
 				this._pruneTiles();


### PR DESCRIPTION
Fix #3659

I've not been able to spot any regression of https://github.com/Leaflet/Leaflet/commit/142e0661b190581c6e45c74c3419e46fdf98a5c5 so I'm pushing this for consideration.

@mourner do you remember any specific use case to check? Otherwise, I'm in favour of the "merge and see" workflow ;)