### PR TITLE
Fixing negative acceptableHeights and supporting browser resize

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -248,10 +248,13 @@ L.Control.Layers = L.Control.extend({
 
 	_expand: function () {
 		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
-		var acceptableHeight = this._map._size.y - (this._container.offsetTop * 4);
+		this._form.style.height=null;
+		var acceptableHeight = this._map._size.y - (this._container.offsetTop + 50);
 		if (acceptableHeight < this._form.clientHeight) {
 			L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');
 			this._form.style.height = acceptableHeight + 'px';
+		} else {
+			L.DomUtil.removeClass(this._form, 'leaflet-control-layers-scrollbar');	
 		}
 	},
 

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -248,7 +248,7 @@ L.Control.Layers = L.Control.extend({
 
 	_expand: function () {
 		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
-		this._form.style.height=null;
+		this._form.style.height = null;
 		var acceptableHeight = this._map._size.y - (this._container.offsetTop + 50);
 		if (acceptableHeight < this._form.clientHeight) {
 			L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');


### PR DESCRIPTION
This is for the layer control when it is hovered over and expands:
The previous formula calculated acceptableHeight as (map height - (4 * element offset).  If the element had other controls above it, it might be pushed lower on the screen, which depending on screen size means that the acceptableHeight could quickly become a negative value which causes a bug.   For example: my map has a height of 815px, and my layer control is offset from the top 277px so it is almost halfway down my screen.  Using the old formula, the acceptable height would be 815 - (277 * 4) = -293.  Since the acceptable height was less than the client height the scrollbar would show up, but it would be greyed out, and because the height limit was negative, the window would not have a height limit and expand off the map. Using the new formula it takes the vertical offset, and adds 50px(element is 36px,+ bottom credits height + a few pixels for a bottom margin) to determine max height.  This means the element will be able to expand until it is a few pixels above the credits at the bottom of the map before it stops expanding.

Additionally, by resetting the form.style.height to null before checking the clientHeight, we are removing the limit on the height of the control, so that if someone resizes their browser window to make it larger when viewing the layer list, the list will reset the max height instead of keeping the smaller max height that was already set, and in addition, if the scrollbar is no longer needed, it will be removed.