### PR TITLE
TileLayer with fractional `minZoom` doesn't always `_update` correctly

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -434,7 +434,7 @@ L.GridLayer = L.Layer.extend({
 		var tileZoom = Math.round(zoom);
 
 		if (tileZoom > this.options.maxZoom ||
-			tileZoom < this.options.minZoom) { return; }
+			zoom < this.options.minZoom) { return; }
 
 		var pixelBounds = this._getTiledPixelBounds(center, zoom, tileZoom);
 


### PR DESCRIPTION
There's an edge case in `GridLayer#_update` for layers with a fractional minZoom.

If a layer's minZoom is fractional and the map's zoom rounds down to `floor(minZoom)`, a check fails and `_update` returns early. The map doesn't fire `_update` when it should. 

If it's initialized this way nothing renders until the map is zoomed in. If it's zoomed back out it doesn't load the tiles that should appear around the edges (because it doesn't `_update` as it approaches `minZoom`).

[Here's an example](https://github.com/kjell/Leaflet/compare/master...fractional-minzoom-bug-example?expand=1) — [same thing on JSFiddle](https://jsfiddle.net/qheegwuw/2/)

It looks like an easy fix. (But I'm happy to re-work this if it breaks something or needs a test or doesn't match style.)
