### PR TITLE
Fix TileLayer._update so it doesn't break drag-then-pinch interactions.

### DIFF
--- a/debug/map/zoompan.html
+++ b/debug/map/zoompan.html
@@ -52,9 +52,8 @@
 
 		var map = L.map('map').setView(dc, 10);
 
-		var tiles = L.tileLayer('http://{s}.tiles.mapbox.com/v3/{id}/{z}/{x}/{y}.png', {
-			attribution: '<a href="https://www.mapbox.com/about/maps/">Terms and Feedback</a>',
-			id: 'examples.map-20v6611k'
+		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
 		}).addTo(map);
 
 		var marker1 = L.marker(kyiv).addTo(map),

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -354,7 +354,7 @@ L.GridLayer = L.Layer.extend({
 		if (!noUpdate || tileZoomChanged) {
 
 			this._tileZoom = tileZoom;
-			
+
 			if (this._abortLoading) {
 				this._abortLoading();
 			}
@@ -433,13 +433,14 @@ L.GridLayer = L.Layer.extend({
 		return new L.Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
 	},
 
+	// Private method to load tiles in the grid's active zoom level according to map bounds
 	_update: function (center, zoom) {
 		var map = this._map;
 		if (!map) { return; }
 
 		if (center === undefined) { center = map.getCenter(); }
 		if (zoom === undefined) { zoom = map.getZoom(); }
-		if (this._tileZoom === undefined) { return; }
+		if (this._tileZoom === undefined) { return; }	// if out of minzoom/maxzoom
 
 		var pixelBounds = this._getTiledPixelBounds(center, zoom, this._tileZoom);
 
@@ -451,7 +452,9 @@ L.GridLayer = L.Layer.extend({
 			this._tiles[key].current = false;
 		}
 
-		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, zoom); }
+		// _update just loads more tiles. If the tile zoom level differs too much
+		// from the map's, let _setView reset levels and prune old tiles.
+		if (Math.abs(zoom - this._tileZoom) > 1) { return this._setView(center, zoom); }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -454,7 +454,7 @@ L.GridLayer = L.Layer.extend({
 
 		// _update just loads more tiles. If the tile zoom level differs too much
 		// from the map's, let _setView reset levels and prune old tiles.
-		if (Math.abs(zoom - this._tileZoom) > 1) { return this._setView(center, zoom); }
+		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, zoom); return; }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -363,7 +363,7 @@ L.GridLayer = L.Layer.extend({
 			this._resetGrid();
 
 			if (tileZoom !== undefined) {
-				this._update(center, tileZoom);
+				this._update(center);
 			}
 
 			if (!noPrune) {
@@ -434,12 +434,12 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	// Private method to load tiles in the grid's active zoom level according to map bounds
-	_update: function (center, zoom) {
+	_update: function (center) {
 		var map = this._map;
 		if (!map) { return; }
+		var zoom = map.getZoom();
 
 		if (center === undefined) { center = map.getCenter(); }
-		if (zoom === undefined) { zoom = map.getZoom(); }
 		if (this._tileZoom === undefined) { return; }	// if out of minzoom/maxzoom
 
 		var pixelBounds = this._getTiledPixelBounds(center, zoom, this._tileZoom);

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -353,11 +353,12 @@ L.GridLayer = L.Layer.extend({
 
 		if (!noUpdate || tileZoomChanged) {
 
+			this._tileZoom = tileZoom;
+			
 			if (this._abortLoading) {
 				this._abortLoading();
 			}
 
-			this._tileZoom = tileZoom;
 			this._updateLevels();
 			this._resetGrid();
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -344,14 +344,12 @@ L.GridLayer = L.Layer.extend({
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
 		var tileZoom = Math.round(zoom);
-		if (this.options.maxZoom !== undefined) {
-			tileZoom = Math.min(tileZoom, this.options.maxZoom);
-		}
-		if (this.options.minZoom !== undefined) {
-			tileZoom = Math.max(tileZoom, this.options.minZoom);
+		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
+		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
+			tileZoom = undefined;
 		}
 
-		var tileZoomChanged = (Math.abs(tileZoom - this._tileZoom) > 1 || this._tileZoom === undefined);
+		var tileZoomChanged = (tileZoom !== this._tileZoom);
 
 		if (!noUpdate || tileZoomChanged) {
 
@@ -363,7 +361,9 @@ L.GridLayer = L.Layer.extend({
 			this._updateLevels();
 			this._resetGrid();
 
-			this._update(center, tileZoom);
+			if (tileZoom !== undefined) {
+				this._update(center, tileZoom);
+			}
 
 			if (!noPrune) {
 				this._pruneTiles();
@@ -589,7 +589,7 @@ L.GridLayer = L.Layer.extend({
 		// we know that tile is async and will be ready later; otherwise
 		if (this.createTile.length < 2) {
 			// mark tile as ready, but delay one frame for opacity animation to happen
-			L.Util.requestAnimFrame(this._tileReady, this, coords, null, tile);
+			L.Util.requestAnimFrame(L.bind(this._tileReady, this, coords, null, tile));
 		}
 
 		// we prefer top/left over translate3d so that we don't create a HW-accelerated layer from each tile

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -56,8 +56,8 @@ L.TileLayer = L.GridLayer.extend({
 	createTile: function (coords, done) {
 		var tile = document.createElement('img');
 
-		tile.onload = L.bind(this._tileOnLoad, this, done, tile);
-		tile.onerror = L.bind(this._tileOnError, this, done, tile);
+		L.DomEvent.on(tile, 'load', L.bind(this._tileOnLoad, this, done, tile));
+		L.DomEvent.on(tile, 'error', L.bind(this._tileOnError, this, done, tile));
 
 		if (this.options.crossOrigin) {
 			tile.crossOrigin = '';

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -140,14 +140,16 @@ L.TileLayer = L.GridLayer.extend({
 	_abortLoading: function () {
 		var i, tile;
 		for (i in this._tiles) {
-			tile = this._tiles[i].el;
+			if (this._tiles[i].coords.z !== this._tileZoom) {
+				tile = this._tiles[i].el;
 
-			tile.onload = L.Util.falseFn;
-			tile.onerror = L.Util.falseFn;
+				tile.onload = L.Util.falseFn;
+				tile.onerror = L.Util.falseFn;
 
-			if (!tile.complete) {
-				tile.src = L.Util.emptyImageUrl;
-				L.DomUtil.remove(tile);
+				if (!tile.complete) {
+					tile.src = L.Util.emptyImageUrl;
+					L.DomUtil.remove(tile);
+				}
 			}
 		}
 	}

--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -52,7 +52,8 @@ L.Map.include({
 
 				this._move(
 					this.unproject(from.add(to.subtract(from).multiplyBy(u(s) / u1)), startZoom),
-					this.getScaleZoom(w0 / w(s), startZoom));
+					this.getScaleZoom(w0 / w(s), startZoom),
+					{flyTo: true});
 
 			} else {
 				this


### PR DESCRIPTION
Fixes #3814.

So `_update` was using a rounded zoom level, but internally there were calls to `createTile`, which depended on `this._tileZoom`. The result was that, after a drag-then-pinch interaction, if a tile to be loaded had a index `x:y:z`, the URL would be `z+1/y/x` (or z-1), but the key stayed the same - which was breaking havoc on the tile loading/unloading algorithm.