### PR TITLE
Release for Beta .1 not .2 exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.1",
   "description": "JavaScript library for mobile-friendly interactive maps",
   "devDependencies": {
     "copyfiles": "0.2.1",


### PR DESCRIPTION
So I check the package.json for which release version to download and v1.0.0-beta.2.zip is not found but v1.0.0-beta.1.zip is. Is there any particular reason why the .2 was referenced here and no corresponding release exists?