### PR TITLE
Prevent to use extreme values in transform3d

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -586,8 +586,6 @@ L.GridLayer = L.Layer.extend({
 			setTimeout(L.bind(this._tileReady, this, coords, null, tile), 0);
 		}
 
-		// we prefer top/left over translate3d so that we don't create a HW-accelerated layer from each tile
-		// which is slow, and it also fixes gaps between tiles in Safari
 		L.DomUtil.setPosition(tile, tilePos);
 
 		// save tile in cache

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -16,7 +16,8 @@ L.Map = L.Evented.extend({
 		fadeAnimation: true,
 		trackResize: true,
 		markerZoomAnimation: true,
-		maxBoundsViscosity: 0.0
+		maxBoundsViscosity: 0.0,
+		transform3DLimit: 9999990
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)
@@ -611,6 +612,8 @@ L.Map = L.Evented.extend({
 		if (this.options.trackResize) {
 			L.DomEvent[onOff](window, 'resize', this._onResize, this);
 		}
+
+		this[onOff]('moveend', this._onMoveEnd);
 	},
 
 	_onResize: function () {
@@ -622,6 +625,16 @@ L.Map = L.Evented.extend({
 	_onScroll: function () {
 		this._container.scrollTop  = 0;
 		this._container.scrollLeft = 0;
+	},
+
+	_onMoveEnd: function () {
+		if (L.Browser.any3d && this.options.transform3DLimit &&
+			(Math.abs(this._mapPane._leaflet_pos.x) >= this.options.transform3DLimit
+			 || Math.abs(this._mapPane._leaflet_pos.y) >= this.options.transform3DLimit)) {
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=1203873 but Webkit also have
+			// a pixel offset on very high values, see: http://jsfiddle.net/dg6r5hhb/
+			this._resetView(this.getCenter(), this.getZoom());
+		}
 	},
 
 	_findEventTargets: function (src, type, bubble) {


### PR DESCRIPTION
Prevent to use extreme values in transform3d:

- FF bugs in positioning the element
- Chrom(e|ium) have a one pixel offset

Fix #3608 

Just took the suggestion from https://github.com/Leaflet/Leaflet/issues/3608#issuecomment-121403977
Not really proud of this patch actually, I'm sure there is something lighter to do, without asking for full resetView, but cannot put my brain on it :/

«Lost in translate3d» would be the name of my yesterday movie! ;)