### PR TITLE
Give CRS a relation for their zooms

### DIFF
--- a/src/geo/crs/CRS.Simple.js
+++ b/src/geo/crs/CRS.Simple.js
@@ -6,10 +6,6 @@ L.CRS.Simple = L.extend({}, L.CRS, {
 	projection: L.Projection.LonLat,
 	transformation: new L.Transformation(1, 0, -1, 0),
 
-	scale: function (zoom) {
-		return Math.pow(2, zoom);
-	},
-
 	distance: function (latlng1, latlng2) {
 		var dx = latlng2.lng - latlng1.lng,
 		    dy = latlng2.lat - latlng1.lat;

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -3,6 +3,8 @@
  */
 
 L.CRS = {
+  zoomRelation: 2,
+  
 	// converts geo coords to pixel ones
 	latLngToPoint: function (latlng, zoom) {
 		var projectedPoint = this.projection.project(latlng),
@@ -31,7 +33,11 @@ L.CRS = {
 
 	// defines how the world scales with zoom
 	scale: function (zoom) {
-		return 256 * Math.pow(2, zoom);
+		return 256 * Math.pow(this.zoomRelation, zoom);
+	},
+	
+	zoom: function (scale) {
+	  return Math.pow(scale / 256, 1 / this.zoomRelation);
 	},
 
 	// returns the bounds of the world in projected coords if applicable

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -400,10 +400,10 @@ L.Map = L.Evented.extend({
 	},
 
 	getScaleZoom: function (scale, fromZoom) {
+		var crs = this.options.crs;
 		fromZoom = fromZoom === undefined ? this._zoom : fromZoom;
-		return fromZoom + (Math.log(scale) / Math.LN2);
+		return fromZoom + crs.zoom(scale);
 	},
-
 
 	// conversion methods
 


### PR DESCRIPTION
This relation is used when it calculates zoom from scale and viceversa. I hope this fixes #2990 

This is a "test" pull request as there are no tests that cover the changes and I'm quite new with this

Sorry for the indentation (I could not resolve what happened with line 6 of src/geo/crs/CRS.js)

