### PR TITLE
Always call renderer.getEvents before Path.getEvents (fix #3836)

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -23,8 +23,13 @@ L.Path = L.Layer.extend({
 		interactive: true
 	},
 
+	beforeAdd: function (map) {
+		// Renderer is set here because we need to call renderer.getEvents
+		// before this.getEvents.
+		this._renderer = map.getRenderer(this);
+	},
+
 	onAdd: function () {
-		this._renderer = this._map.getRenderer(this);
 		this._renderer._initPath(this);
 		this._reset();
 		this._renderer._addPath(this);


### PR DESCRIPTION
Fix #3836 

61c07bd3e3d9a5a2bb4855ba81e1f368cc80090b inverted order in which Path._update and Rendered._update were called.

I think that we want to keep 61c07bd3e3d9a5a2bb4855ba81e1f368cc80090b changes, so here is a possible fix.