### PR TITLE
Redo some (ms)pointer work to be consistent and fix IE10

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -17,7 +17,7 @@
 
 	    mobile = typeof orientation !== 'undefined' || ua.indexOf('mobile') !== -1,
 	    msPointer = !window.PointerEvent && window.MSPointerEvent,
-	    pointer = (window.PointerEvent && navigator.pointerEnabled && navigator.maxTouchPoints) || msPointer,
+	    pointer = (window.PointerEvent && navigator.pointerEnabled) || msPointer,
 
 	    ie3d = ie && ('transition' in doc.style),
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -49,7 +49,9 @@ L.extend(L.DomEvent, {
 
 	_addPointerStart: function (obj, handler, id) {
 		var onDown = L.bind(function (e) {
-			L.DomEvent.preventDefault(e);
+			if (e.pointerType !== 'mouse' && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
+				L.DomEvent.preventDefault(e);
+			}
 
 			this._handlePointer(e, handler);
 		}, this);


### PR DESCRIPTION
Currently we preventDefault all of the pointer events, which means they don't create ```mousedown```/```mouseup``` events.
This stops mouse events on things on top of the map like popups. It also breaks leaflet.draw in IE10.

I've removed the maxTouchPoints detection as it just makes testing pointer events harder.

This is worth backporting as we broke IE10 a bit in the 0.7.4/5 updates.
Fixes #3804 