### PR TITLE
Extract logic from getScaleZoom to CRS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -84,6 +84,9 @@
 	<!-- /map/handler -->
 	<script type="text/javascript" src="suites/map/handler/Map.DragSpec.js"></script>
 
+	<!-- /geo/crs -->
+	<script type="text/javascript" src="suites/geo/CRSSpec.js"></script>
+
 	<script>
 		(window.mochaPhantomJS || window.mocha).run();
 	</script>

--- a/spec/suites/geo/CRSSpec.js
+++ b/spec/suites/geo/CRSSpec.js
@@ -157,3 +157,43 @@ describe("CRS.Simple", function () {
 		});
 	});
 });
+
+describe("CRS", function () {
+	var crs = L.CRS;
+	
+	describe("#zoom && #scale", function () {
+		it("convert zoom to scale and viceversa and return the same values", function () {
+			var zoom = 2.5;
+			var scale = crs.scale(zoom);
+			expect(crs.zoom(scale)).to.eql(zoom);
+		});
+	});
+});
+
+describe("CRS.ZoomNotPowerOfTwo", function () {
+	var crs = L.extend({}, L.CRS, {
+		scale: function (zoom) {
+			return 256 * Math.pow(1.5, zoom);
+		},
+		zoom: function (scale) {
+			return Math.log(scale / 256) / Math.log(1.5);
+		}
+	});
+
+	describe("#scale", function () {
+		it("of zoom levels are related by a power of 1.5", function () {
+			var zoom = 5;
+			var scale = crs.scale(zoom);
+			expect(crs.scale(zoom + 1)).to.eql(1.5 * scale);
+			expect(crs.zoom(1.5 * scale)).to.eql(zoom + 1);
+		});
+	});
+	
+	describe("#zoom && #scale", function () {
+		it("convert zoom to scale and viceversa and return the same values", function () {
+			var zoom = 2;
+			var scale = crs.scale(zoom);
+			expect(crs.zoom(scale)).to.eql(zoom);
+		});
+	});
+});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -746,5 +746,13 @@ describe("Map", function () {
 		});
 
 	});
-
+	
+	describe('#getScaleZoom && #getZoomScale', function () {
+		it("convert zoom to scale and viceversa and return the same values", function () {
+			var toZoom = 6.25;
+			var fromZoom = 8.5;
+			var scale = map.getScaleZoom(toZoom, fromZoom);
+			expect(Math.round(map.getZoomScale(scale, fromZoom) * 100) / 100).to.eql(toZoom);
+		});
+	});
 });

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -33,6 +33,10 @@ L.CRS = {
 	scale: function (zoom) {
 		return 256 * Math.pow(2, zoom);
 	},
+	
+	zoom: function (scale) {
+		return Math.log(scale / 256) / Math.LN2;
+	},
 
 	// returns the bounds of the world in projected coords if applicable
 	getProjectedBounds: function (zoom) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -400,10 +400,10 @@ L.Map = L.Evented.extend({
 	},
 
 	getScaleZoom: function (scale, fromZoom) {
+		var crs = this.options.crs;
 		fromZoom = fromZoom === undefined ? this._zoom : fromZoom;
-		return fromZoom + (Math.log(scale) / Math.LN2);
+		return crs.zoom(scale * crs.scale(fromZoom));
 	},
-
 
 	// conversion methods
 


### PR DESCRIPTION
Trying to fix #2990 and #3808

Now, getScaleZoom relies on CRS.zoom. This way, custom CRS can override scale and zoom functions to handle maps with zooms that don't scale by a factor of two

Added tests for Map.getScaleZoom && Map.getZoomScale, CRS.zoom && CRS.scale

Added CRSSpec.js to spec/index.html to check new functions

PS: Sorry for the indentation, I still don't know how to solve it