### PR TITLE
Issue #3829 - Removed Path with mouseout throws error

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -135,7 +135,7 @@ L.Path = L.Path.extend({
 	},
 
 	_fireMouseEvent: function (e) {
-		if (!this.hasEventListeners(e.type)) { return; }
+		if (!this._map || !this.hasEventListeners(e.type)) { return; }
 
 		var map = this._map,
 		    containerPoint = map.mouseEventToContainerPoint(e),


### PR DESCRIPTION
- add check to avoid triggering mouseout events on paths that have already been removed from the map (e.g. when path is removed in onclick event)