### PR TITLE
Fix touch drag in Edge browser

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -21,6 +21,7 @@
 .leaflet-container {
 	overflow: hidden;
 	-ms-touch-action: none;
+	touch-action: none;
 	}
 .leaflet-tile,
 .leaflet-marker-icon,


### PR DESCRIPTION
Should make it possible to panorate the map on touch devices using the Edge browser. This was fixed on master in e44179da12dd3aaa7b1a0684ec193de61d4ec207