### PR TITLE
Fix bug with maxNativeZoom == 0

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -128,7 +128,7 @@ L.TileLayer = L.GridLayer.extend({
 
 		zoom += options.zoomOffset;
 
-		return options.maxNativeZoom ? Math.min(zoom, options.maxNativeZoom) : zoom;
+		return options.maxNativeZoom !== null ? Math.min(zoom, options.maxNativeZoom) : zoom;
 	},
 
 	_getSubdomain: function (tilePoint) {


### PR DESCRIPTION
Setting `maxNativeZoom` to `0` does not work as expected (only use zoom level 0) but instead disables the function.
This PR fixes this problem.
Same fix applies for (afaik current stable) 0.7.5