### PR TITLE
Fixed FeatureGroup crash

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -36,7 +36,9 @@ L.FeatureGroup = L.LayerGroup.extend({
 			layer = this._layers[layer];
 		}
 
-		layer.off(L.FeatureGroup.EVENTS, this._propagateEvent, this);
+		if ('off' in layer) {
+			layer.off(L.FeatureGroup.EVENTS, this._propagateEvent, this);
+		}
 
 		L.LayerGroup.prototype.removeLayer.call(this, layer);
 


### PR DESCRIPTION
Now a LayerGroup can be removed from a FeatureGroup without crashing. FeatureGroup's addLayer had the check in place, but removeLayer did not!