### PR TITLE
Prevent Popup._adjustPan while already panning (fix #3744)

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -248,7 +248,7 @@ L.Popup = L.Layer.extend({
 	},
 
 	_adjustPan: function () {
-		if (!this.options.autoPan) { return; }
+		if (!this.options.autoPan || (this._map._panAnim && this._map._panAnim._inProgress)) { return; }
 
 		var map = this._map,
 		    containerHeight = this._container.offsetHeight,


### PR DESCRIPTION
Fix #3744 

Bisect point at a33eff73f0d46b326d6fe59a7072f31624527c23 

Basically, when calling openPopup *while* the map is animating, the `Popup._adjustPan` maths are wrong, and I think we just don't want to do them in this situation.

Thoughts?