### PR TITLE
Replace links to google groups with ones to GIS StackExchange

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Third-party patches are absolutely essential on our quest to create the best map
 However, they're not the only way to get involved with the development of Leaflet.
 You can help the project tremendously by discovering and [reporting bugs](#reporting-bugs),
 [improving documentation](#improving-documentation),
-helping others on the [Leaflet forum](https://groups.google.com/forum/#!forum/leaflet-js)
+helping others on [GIS StackExchange](https://gis.stackexchange.com/questions/tagged/leaflet)
 and [GitHub issues](https://github.com/Leaflet/Leaflet/issues),
 showing your support for your favorite feature suggestions on [Leaflet UserVoice page](http://leaflet.uservoice.com),
 tweeting to [@LeafletJS](http://twitter.com/LeafletJS)

--- a/_layouts/v2.html
+++ b/_layouts/v2.html
@@ -117,7 +117,7 @@
 <nav class="ext-links">
   <a class="ext-link twitter" href="http://twitter.com/LeafletJS" title="Follow LeafletJS on Twitter"><img alt="Follow LeafletJS on Twitter" src="{{root}}docs/images/twitter-round.png" width="46" /></a>
   <a class="ext-link github" href="http://github.com/Leaflet/Leaflet" title="View Source on GitHub"><img alt="View Source on GitHub" src="{{root}}docs/images/github-round.png" width="46" /></a>
-  <a class="ext-link forum" href="https://groups.google.com/forum/#!forum/leaflet-js" title="Ask for help on the Leaflet forum"><img alt="Official Leaflet forum" src="{{root}}docs/images/forum-round.png" width="46" /></a>
+  <a class="ext-link forum" href="https://gis.stackexchange.com/questions/tagged/leaflet" title="Ask for help on the GIS StackExchange"><img alt="Leaflet questions on GIS StackExchange" src="{{root}}docs/images/forum-round.png" width="46" /></a>
 </nav>
 
 <script>


### PR DESCRIPTION
I hereby propose getting rid of the "user forum" and using gis.stackexchange.com instead. The volume and quality on the current "forum" is quite low, and there is quite a high number of people using stackexchange nowadays, anyway.

This would need a bit of follow-up: posting a notice in the google group, and pushing the changes to CONTRIBUTING.md to the master branch.