### PR TITLE
Fix g4 issues

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -182,11 +182,12 @@ L.DomUtil = {
 	// webkitTransition comes first because some browser versions that drop vendor prefix don't do
 	// the same for the transitionend event, in particular the Android 4.1 stock browser
 
-	var transition = L.DomUtil.TRANSITION = L.DomUtil.testProp(
+	L.DomUtil.TRANSITION = L.DomUtil.testProp(
 			['webkitTransition', 'transition', 'OTransition', 'MozTransition', 'msTransition']);
 
-	L.DomUtil.TRANSITION_END =
-			transition === 'webkitTransition' || transition === 'OTransition' ? transition + 'End' : 'transitionend';
+	// trying to decide which type is appropriate is not as robust as adding all available types
+	// although this adds overhead (e.g LG G4 stock browser uses webkitTransition but fires transitionend)
+	L.DomUtil.TRANSITION_END = 'webkitTransitionEnd OTransitionEnd transitionend';
 
 
 	if ('onselectstart' in document) {

--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -21,7 +21,7 @@ if (zoomAnimated) {
 
 			this._createAnimProxy();
 
-			L.DomEvent.on(this._proxy, L.DomUtil.TRANSITION_END, this._catchTransitionEnd, this);
+			L.DomEvent.on(this._panes.mapPane, L.DomUtil.TRANSITION_END, this._catchTransitionEnd, this);
 		}
 	});
 }
@@ -30,7 +30,7 @@ L.Map.include(!zoomAnimated ? {} : {
 
 	_createAnimProxy: function () {
 
-		var proxy = this._proxy = L.DomUtil.create('div', 'leaflet-proxy leaflet-zoom-animated');
+		var proxy = L.DomUtil.create('div', 'leaflet-proxy leaflet-zoom-animated');
 		this._panes.mapPane.appendChild(proxy);
 
 		this.on('zoomanim', function (e) {


### PR DESCRIPTION
That's my solution for the stock browser issue on the G4. By listening to all possible "transitionend" types you never miss one, and since only the one that is appropriate for the device/browser is fired, it's just the initial overhead in binding the events. But I'm honest. At this point I did only basic testing. The other part of the fix removes the proxy element that is created for listening on the "transitionend" events. The proxy element somehow doesn't get the "transitionend" event. However the mapPane does. I didn't change too much at this place. Hope that helps you somehow. These changes seem to work quite well in our project.  