### PR TITLE
Use border-box sizing for scale control (fix #3668)

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -384,8 +384,8 @@
 	font-size: 11px;
 	white-space: nowrap;
 	overflow: hidden;
-	-moz-box-sizing: content-box;
-	     box-sizing: content-box;
+	-moz-box-sizing: border-box;
+	     box-sizing: border-box;
 
 	background: #fff;
 	background: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
Since https://github.com/Leaflet/Leaflet/commit/8a33e94c0e56634a749f378256905e9e23243483 we are not more removing the padding programatically.