### PR TITLE
Make non-interactive markers not fire pointer events

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -203,6 +203,15 @@
 	cursor:    -moz-grabbing;
 	}
 
+/* marker interactivity */
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+	pointer-events: none;
+	}
+
+.leaflet-marker-icon.leaflet-interactive {
+	pointer-events: auto;
+	}
 
 /* visual tweaks */
 

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -203,13 +203,17 @@
 	cursor:    -moz-grabbing;
 	}
 
-/* marker interactivity */
+/* marker & overlays interactivity */
 .leaflet-marker-icon,
-.leaflet-marker-shadow {
+.leaflet-marker-shadow,
+.leaflet-image-layer,
+.leaflet-pane > svg path {
 	pointer-events: none;
 	}
 
-.leaflet-marker-icon.leaflet-interactive {
+.leaflet-marker-icon.leaflet-interactive,
+.leaflet-image-layer.leaflet-interactive,
+.leaflet-pane > svg path.leaflet-interactive {
 	pointer-events: auto;
 	}
 

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -207,7 +207,8 @@
 .leaflet-marker-icon,
 .leaflet-marker-shadow,
 .leaflet-image-layer,
-.leaflet-pane > svg path {
+.leaflet-pane > svg path,
+.leaflet-tile-container {
 	pointer-events: none;
 	}
 

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -101,8 +101,6 @@ L.SVG = L.Renderer.extend({
 		} else {
 			path.setAttribute('fill', 'none');
 		}
-
-		path.setAttribute('pointer-events', options.pointerEvents || (options.interactive ? 'visiblePainted' : 'none'));
 	},
 
 	_updatePoly: function (layer, closed) {


### PR DESCRIPTION
Fixes #3936. Also fixes #2396.

Please note that I haven't tested this (yet) with IE10, which doesn't implement the CSS property `pointer-events:none`.