### PR TITLE
Disable `_onZoomStart` in canvas renderer

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -25,6 +25,8 @@ L.Canvas = L.Renderer.extend({
 		this._ctx = container.getContext('2d');
 	},
 
+	_onZoomStart: L.Util.falseFn,
+
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -25,8 +25,6 @@ L.Canvas = L.Renderer.extend({
 		this._ctx = container.getContext('2d');
 	},
 
-	_onZoomStart: L.Util.falseFn,
-
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -54,12 +54,8 @@ L.Renderer = L.Layer.extend({
 		this._updateTransform(this._map.getCenter(), this._map.getZoom());
 	},
 
-	_onZoomStart: function () {
-		// Drag-then-pinch interactions might mess up the center and zoom.
-		// In this case, the easiest way to prevent this is re-do the renderer
-		//   bounds and padding when the zooming starts.
-		this._update();
-	},
+	// subclasses can opt-in to do some work when zooming starts
+	_onZoomStart: L.Util.falseFn,
 
 	_updateTransform: function (center, zoom) {
 		var scale = this._map.getZoomScale(zoom, this._zoom),

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -14,6 +14,13 @@ L.SVG = L.Renderer.extend({
 		this._container.appendChild(this._rootGroup);
 	},
 
+	_onZoomStart: function () {
+		// Drag-then-pinch interactions might mess up the center and zoom.
+		// In this case, the easiest way to prevent this is re-do the renderer
+		//   bounds and padding when the zooming starts.
+		this._update();
+	},
+
 	_update: function () {
 		if (this._map._animatingZoom && this._bounds) { return; }
 


### PR DESCRIPTION
This fixes disappearing paths when starting an animated zoom. See #3947