### PR TITLE
Add Jakefile to bower ignore list

### DIFF
--- a/build/bower.json
+++ b/build/bower.json
@@ -17,6 +17,7 @@
     "debug",
     "spec",
     "src",
-    "build"
+    "build",
+    "Jakefile.js"
   ]
 }


### PR DESCRIPTION
I noticed that, when installing beta2 from bower, the Jakefile is still there.

I wonder if `component.json` and the plugin guide need to be there too, though.

![bower-files](https://cloud.githubusercontent.com/assets/1125786/10541784/117c102a-7414-11e5-87d5-d6267552bc94.png)
