### PR TITLE
Add shiftkey option to scroll wheel zoom

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -25,6 +25,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 	},
 
 	_onWheelScroll: function (e) {
+		if (this._map.options.scrollWheelZoom === 'shiftkey' && !e.shiftKey) { return false; }
 		var delta = L.DomEvent.getWheelDelta(e);
 		var debounce = this._map.options.wheelDebounceTime;
 


### PR DESCRIPTION
This PR adds the possibility to set the map option "scrollWheelZoom" to enable scroll wheel zoom only when the shift key is pressed. Useful when you want to disable scroll wheel zoom but still make it possible to use the scroll wheel in some way. 

I'm not sure if this breaks any other mouse/keyboard events so it would be great if someone with better Leaflet knowledge could take a look at it.
