### PR TITLE
Simplify animation calculation

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -156,6 +156,12 @@
 	    -ms-transform-origin: 0 0;
 	        transform-origin: 0 0;
 	}
+svg.leaflet-zoom-animated,
+canvas.leaflet-zoom-animated {
+	-webkit-transform-origin: 50% 50%;
+	    -ms-transform-origin: 50% 50%;
+	        transform-origin: 50% 50%;
+	}
 .leaflet-zoom-anim .leaflet-zoom-animated {
 	will-change: transform;
 	}

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -56,14 +56,11 @@ L.Renderer = L.Layer.extend({
 	_updateTransform: function (center, zoom) {
 		var scale = this._map.getZoomScale(zoom, this._zoom),
 		    position = L.DomUtil.getPosition(this._container),
-		    viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding),
 		    currentCenterPoint = this._map.project(this._center, zoom),
 		    destCenterPoint = this._map.project(center, zoom),
-		    centerOffset = destCenterPoint.subtract(currentCenterPoint),
+		    centerOffset = currentCenterPoint.subtract(destCenterPoint);
 
-		    topLeftOffset = viewHalf.multiplyBy(-scale).add(position).add(viewHalf).subtract(centerOffset);
-
-		L.DomUtil.setTransform(this._container, topLeftOffset, scale);
+		L.DomUtil.setTransform(this._container, position.add(centerOffset), scale);
 	},
 
 	_reset: function () {


### PR DESCRIPTION
As suggested in #3964.

It changes the transform origin to the center of the Renderer pane, making it easier to translate and scale at the same time, without calculation overhead.