### PR TITLE
init interaction regardless of new icon or not

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -159,8 +159,8 @@ L.Marker = L.Layer.extend({
 
 		if (addIcon) {
 			this.getPane().appendChild(this._icon);
-			this._initInteraction();
 		}
+		this._initInteraction();
 		if (newShadow && addShadow) {
 			this.getPane('shadowPane').appendChild(this._shadow);
 		}


### PR DESCRIPTION
[issue #3976]

previously interaction only get inited when not reusing icon, i.e. when `addIcon`
flag is set to `true`. by taking the statement out of the if condition,
interaction is inited whenever `_initIcon` is called.