### PR TITLE
Skip _updateLevels when out of min/max zoom (prevents IE8 exceptions)

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -210,6 +210,8 @@ L.GridLayer = L.Layer.extend({
 		var zoom = this._tileZoom,
 		    maxZoom = this.options.maxZoom;
 
+		if (zoom === undefined) { return undefined; }
+
 		for (var z in this._levels) {
 			if (this._levels[z].el.children.length || z === zoom) {
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);


### PR DESCRIPTION
So when a zoom operation makes a gridlayer go past the minzoom/maxzoom boundary, `_updateLevels` is run before `_update` or `_pruneTiles`, which means the tile level containers are still there while `this._tileZoom` is `undefined`.

This creates a IE8-specific problem because `undefined - number` triggers an exception, whereas other browsers just evaluate that expression as `NaN` and keep going.

Skipping the reordering of the tile level containers when out of min/max zoom seems to me like the simplest solution.