### PR TITLE
issue #3995 fixed check for maxZoom option to honor maxZoom 0

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -100,7 +100,7 @@ L.Map = L.Evented.extend({
 
 		    zoom = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR));
 
-		zoom = options.maxZoom ? Math.min(options.maxZoom, zoom) : zoom;
+		zoom = (typeof options.maxZoom === 'number') ? Math.min(options.maxZoom, zoom) : zoom;
 
 		var paddingOffset = paddingBR.subtract(paddingTL).divideBy(2),
 


### PR DESCRIPTION
Checking if maxZoom is a number will work fine for {maxZoom: 0} where
options.maxZoom evaluates to false.

Same as https://github.com/Leaflet/Leaflet/pull/3996 now for the master.