### PR TITLE
Prevent infinite loops inside once()

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -362,7 +362,7 @@ describe('Events', function () {
 			    spy = sinon.spy();
 
 			obj.once('test', spy, obj);
-			obj.off('test', spy, obj);
+			obj.off('test');
 
 			obj.fire('test');
 

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -183,16 +183,17 @@ L.Evented = L.Class.extend({
 			return this;
 		}
 
-		var handler = L.bind(function () {
-			this
-			    .off(types, fn, context)
-			    .off(types, handler, context);
-		}, this);
+		// remove the listener first to avoid potential recursion and then execute the function
 
-		// add a listener that's executed once and removed after that
+		var origFn = fn;
+		var _this = this;
+		fn = function () {
+			_this.off(types, fn, context);
+			return origFn.apply(_this, arguments);
+		};
+
 		return this
-		    .on(types, fn, context)
-		    .on(types, handler, context);
+			.on(types, fn, context);
 	},
 
 	// adds a parent to propagate events to (when you fire with true as a 3rd argument)


### PR DESCRIPTION
I changed `once()` to act like `one()` from jQuery (see [here](https://github.com/jquery/jquery/blob/master/src/event.js#L83)) per the discussion in #3979. 

This resolves the issue where an event can enter an infinite loop, as `once()` currently unbinds the event listener _after_ triggering it.
