### PR TITLE
Do not set layer.options a reference to layer.defaultOptions (fix #3990)

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -1,4 +1,5 @@
 describe("L.GeoJSON", function () {
+
 	describe("addData", function () {
 		var geoJSON = {
 			type: 'Feature',
@@ -31,6 +32,29 @@ describe("L.GeoJSON", function () {
 			expect(layer.getLayers().length).to.eql(0);
 		});
 	});
+
+	describe('resetStyle', function () {
+
+		it('should reset init options', function () {
+			var feature = {
+				type: 'Feature',
+				geometry: {
+					type: 'LineString',
+					coordinates:[[-2.35, 51.38], [-2.38, 51.38]]
+				}
+			};
+			var geojson = L.geoJson(feature, {weight: 7, color: 'chocolate'});
+			geojson.setStyle({weight: 22, color: 'coral'});
+			var layer = geojson.getLayers()[0];
+			expect(layer.options.weight).to.be(22);
+			expect(layer.options.color).to.be('coral');
+			geojson.resetStyle(layer);
+			expect(layer.options.weight).to.be(7);
+			expect(layer.options.color).to.be('chocolate');
+		});
+
+	});
+
 });
 
 describe("L.Marker#toGeoJSON", function () {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -51,7 +51,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 
 	resetStyle: function (layer) {
 		// reset any custom styles
-		layer.options = layer.defaultOptions;
+		layer.options = L.Util.extend({}, layer.defaultOptions);
 		this._setLayerStyle(layer, this.options.style);
 		return this;
 	},


### PR DESCRIPTION
git bisect point at https://github.com/Leaflet/Leaflet/commit/ad9d0f8c7fbb080fa628f302bddb52e6c035c9d2#diff-4b892233603abc3c8825cfb5905b7453L110

Fix #3990