### PR TITLE
fix maxNativeZoom wording

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1846,7 +1846,7 @@ var map = L.map('map', {
 		<td><code><b>maxNativeZoom</b></code></td>
 		<td><code>Number</code></td>
 		<td><code><span class="hljs-literal">null</span></code></td>
-		<td>Maximum zoom number the tiles source has available. If it is specified, the tiles on all zoom levels higher than <code>maxNativeZoom</code> will be loaded from <code>maxZoom</code> level and auto-scaled.</td>
+		<td>Maximum zoom number the tiles source has available. If it is specified, the tiles on all zoom levels higher than <code>maxNativeZoom</code> will be loaded from <code>maxNativeZoom</code> level and auto-scaled.</td>
 	</tr>
 	<tr>
 		<td><code><b>tileSize</b></code></td>


### PR DESCRIPTION
e.g. If my tile source only goes up to z15 but I want users to zoom into z17, then I set maxNativeZoom=15, maxZoom=17, and for all zoom levels higher than maxNativeZoom, tiles from maxNativeZoom will be loaded and auto-scaled.