### PR TITLE
Fix GridLayer pixelBounds computation

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -106,6 +106,48 @@ describe('GridLayer', function () {
 		});
 	});
 
+	describe('#createTile', function () {
+
+		beforeEach(function () {
+			// Simpler sizes to test.
+			div.style.width = '512px';
+			div.style.height = '512px';
+		});
+
+		afterEach(function () {
+			div.style.width = '800px';
+			div.style.height = '600px';
+		});
+
+		// Passes on Firefox, but fails on phantomJS: done is never called.
+		xit('only creates tiles for visible area on zoom in', function (done) {
+			map.remove();
+			map = L.map(div);
+			map.setView([0, 0], 10);
+
+			var grid = L.gridLayer(),
+			    count = 0,
+			    loadCount = 0;
+			grid.createTile = function (coords) {
+				count++;
+				return document.createElement('div');
+			};
+			var onLoad = function (e) {
+				expect(count).to.eql(4);
+				count = 0;
+				loadCount++;
+				if (loadCount === 1) {  // On layer add.
+					map.zoomIn();
+				} else {  // On zoom in.
+					done();
+				}
+			};
+			grid.on('load', onLoad);
+			map.addLayer(grid);
+		});
+
+	});
+
 	describe("#onAdd", function () {
 		it('is called after zoomend on first map load', function () {
 			var layer = L.gridLayer().addTo(map);

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -426,11 +426,10 @@ L.GridLayer = L.Layer.extend({
 		this._resetView();
 	},
 
-	_getTiledPixelBounds: function (center, zoom, tileZoom) {
+	_getTiledPixelBounds: function (center) {
 		var map = this._map,
-		    scale = map.getZoomScale(zoom, tileZoom),
-		    pixelCenter = map.project(center, tileZoom).floor(),
-		    halfSize = map.getSize().divideBy(scale * 2);
+		    pixelCenter = map.project(center, this._tileZoom).floor(),
+		    halfSize = map.getSize().divideBy(2);
 
 		return new L.Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
 	},
@@ -444,7 +443,7 @@ L.GridLayer = L.Layer.extend({
 		if (center === undefined) { center = map.getCenter(); }
 		if (this._tileZoom === undefined) { return; }	// if out of minzoom/maxzoom
 
-		var pixelBounds = this._getTiledPixelBounds(center, zoom, this._tileZoom),
+		var pixelBounds = this._getTiledPixelBounds(center),
 		    tileRange = this._pxBoundsToTileRange(pixelBounds),
 		    tileCenter = tileRange.getCenter(),
 		    queue = [];


### PR DESCRIPTION
Map size does not change from one zoom to another, so we don't need
to scale it.

Without this change, we are creating more or less 4x tiles when
zooming in.
There are still cases where we are requesting a bit more tiles than
what I would expect, but I see it also happens on 0.7.3.

I've added a test, it passes on Firefox or Chromium, but it fails on phantomJS, not clue why, joy of headless browser… Not sure if we want to keep it or not, then.