### PR TITLE
Round new map position before animating pan

### DIFF
--- a/src/map/anim/Map.PanAnimation.js
+++ b/src/map/anim/Map.PanAnimation.js
@@ -69,7 +69,7 @@ L.Map.include({
 		if (options.animate !== false) {
 			L.DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
 
-			var newPos = this._getMapPanePos().subtract(offset);
+			var newPos = this._getMapPanePos().subtract(offset).round();
 			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
 		} else {
 			this._rawPanBy(offset);


### PR DESCRIPTION
This prevents map from panning into a fractional position (and becoming blurry) if `panBy` is called while already panning.

Demo: http://jsfiddle.net/0x66297q/

Fixes https://github.com/Leaflet/Leaflet/issues/3913 which was closed as a duplicate, however, I think this particular case is worth fixing :)