### PR TITLE
Fix inertial scrolling behavior on non-touch devices

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -83,18 +83,23 @@ L.Map.Drag = L.Handler.extend({
 		}
 	},
 
+	_rememberTimeAndPosition: function () {
+		var time = this._lastTime = +new Date(),
+		    pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
+
+		this._positions.push(pos);
+		this._times.push(time);
+
+		// Remove all data points older than 50 ms
+		while (time - this._times[0] > 50) {
+			this._positions.shift();
+			this._times.shift();
+		}
+	},
+
 	_onDrag: function (e) {
 		if (this._map.options.inertia) {
-			var time = this._lastTime = +new Date(),
-			    pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
-
-			this._positions.push(pos);
-			this._times.push(time);
-
-			if (time - this._times[0] > 50) {
-				this._positions.shift();
-				this._times.shift();
-			}
+			this._rememberTimeAndPosition();
 		}
 
 		this._map
@@ -144,9 +149,13 @@ L.Map.Drag = L.Handler.extend({
 
 	_onDragEnd: function (e) {
 		var map = this._map,
-		    options = map.options,
+		    options = map.options;
 
-		    noInertia = !options.inertia || this._times.length < 2;
+		if (options.inertia && !L.Browser.touch) {
+			this._rememberTimeAndPosition();
+		}
+
+		var noInertia = !options.inertia || this._times.length < 2;
 
 		map.fire('dragend', e);
 


### PR DESCRIPTION
See https://github.com/Leaflet/Leaflet/pull/3063/

In this PR `inertiaThreshold` option was removed. It seems to work well for touch devices, although when using a mouse, it results in a lot of unwanted map movement.

Here is how to reproduce the problem:

1. Start dragging map
2. Stop dragging abruptly, but don't release LMB
3. Wait a few seconds; don't move the mouse and keep LMB pressed
4. Release LMB

Expected result: map doesn't move.
Actual result: inertia animation is activated.

I fixed the issue by calling the code that records time and map position in `dragend` handler, immediately before calculating inertia speed. I do this only for non-touch devices not to affect fling gestures.