### PR TITLE
Replace links to google groups with ones to Stack Overflow

### DIFF
--- a/_layouts/v2.html
+++ b/_layouts/v2.html
@@ -113,7 +113,7 @@
 <nav class="ext-links">
   <a class="ext-link twitter" href="http://twitter.com/LeafletJS" title="Follow LeafletJS on Twitter"><img alt="Follow LeafletJS on Twitter" src="{{root}}docs/images/twitter-round.png" width="46" /></a>
   <a class="ext-link github" href="http://github.com/Leaflet/Leaflet" title="View Source on GitHub"><img alt="View Source on GitHub" src="{{root}}docs/images/github-round.png" width="46" /></a>
-  <a class="ext-link forum" href="https://groups.google.com/forum/#!forum/leaflet-js" title="Ask for help on the Leaflet forum"><img alt="Official Leaflet forum" src="{{root}}docs/images/forum-round.png" width="46" /></a>
+  <a class="ext-link forum" href="https://stackoverflow.com/questions/tagged/leaflet" title="Ask for help on Stack Overflow"><img alt="Leaflet questions on Stack Overflow" src="{{root}}docs/images/forum-round.png" width="46" /></a>
 </nav>
 
 <script>

--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@ If you have any questions, take a look at the <a href="https://github.com/Leafle
 However, there are many more ways to get involved with the development of Leaflet.</p>
 
 <p>You can help the project tremendously by discovering and <a href="https://github.com/Leaflet/Leaflet/blob/master/CONTRIBUTING.md#reporting-bugs">reporting bugs</a>, <a href="https://github.com/Leaflet/Leaflet/blob/master/CONTRIBUTING.md#improving-documentation">improving documentation</a>,
-helping others on the <a href="https://groups.google.com/forum/#!forum/leaflet-js">Leaflet forum</a>
+helping others on <a href="https://stackoverflow.com/questions/tagged/leaflet">Stack Overflow</a>, <a href="https://gis.stackexchange.com/questions/tagged/leaflet">GIS Stack Exchange</a>
 and <a href="https://github.com/Leaflet/Leaflet/issues">GitHub issues</a>,
 showing your support for your favorite feature suggestions on <a href="http://leaflet.uservoice.com">Leaflet UserVoice page</a>,
 tweeting to <a href="http://twitter.com/LeafletJS">@LeafletJS</a>


### PR DESCRIPTION
Following discussion in PR #3886, proposition to switch to Stack Overflow instead of Google Groups.

GIS is still mentioned though (besides SO) on bottom of Overview page, as the community is also active there (but less material than in SO as of today).

As mentioned in #3886, if this PR is accepted, next step would be to update CONTRIBUTING in master ([here](https://github.com/Leaflet/Leaflet/blame/master/CONTRIBUTING.md#L15) and [there](https://github.com/Leaflet/Leaflet/blame/master/CONTRIBUTING.md#L41)), and to post an "official" notice in the google group.