### PR TITLE
call getSize() instead of _size to avoid render error

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -254,7 +254,7 @@ L.Control.Layers = L.Control.extend({
 	_expand: function () {
 		L.DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
 		this._form.style.height = null;
-		var acceptableHeight = this._map._size.y - (this._container.offsetTop + 50);
+		var acceptableHeight = this._map.getSize().y - (this._container.offsetTop + 50);
 		if (acceptableHeight < this._form.clientHeight) {
 			L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');
 			this._form.style.height = acceptableHeight + 'px';


### PR DESCRIPTION
Resolves #4062 

Changed the call of `_map._size` in `L.Control.Layers._expand` to `_map.getSize()` so the value can be retrieved before rendering or user interaction.