### PR TITLE
Move L.LatLng.equals to L.CRS.equals.

### DIFF
--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -17,15 +17,7 @@ L.LatLng = function (lat, lng, alt) {
 
 L.LatLng.prototype = {
 	equals: function (obj, maxMargin) {
-		if (!obj) { return false; }
-
-		obj = L.latLng(obj);
-
-		var margin = Math.max(
-		        Math.abs(this.lat - obj.lat),
-		        Math.abs(this.lng - obj.lng));
-
-		return margin <= (maxMargin === undefined ? 1.0E-9 : maxMargin);
+		return L.CRS.Earth.equals(this, obj, maxMargin);
 	},
 
 	toString: function (precision) {

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -64,5 +64,18 @@ L.CRS = {
 		    alt = latlng.alt;
 
 		return L.latLng(lat, lng, alt);
+	},
+
+	equals: function (a, b, maxMargin) {
+		if (!a || !b) { return false; }
+
+		a = L.latLng(a);
+		b = L.latLng(b);
+
+		var margin = Math.max(
+		        Math.abs(a.lat - b.lat),
+		        Math.abs(a.lng - b.lng));
+
+		return margin <= (maxMargin === undefined ? 1.0E-9 : maxMargin);
 	}
 };

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -180,7 +180,7 @@ L.Map = L.Evented.extend({
 		var center = this.getCenter(),
 		    newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
 
-		if (center.equals(newCenter)) { return this; }
+		if (this.options.crs.equals(center, newCenter)) { return this; }
 
 		this.panTo(newCenter, options);
 		this._enforcingBounds = false;


### PR DESCRIPTION
This makes it possible to set a default margin (tolerance)
depending on CRS implementation, for example to address
problems with custom projections as mentioned in #2427.

`L.LatLng.equals` still exists, but uses `L.CRS.Earth.equals`, much like `L.LatLng.distanceTo` falls back to using `L.CRS.Earth.distance`.

I'm a bit unsure of the name - perhaps `equals` should have a more expressive name, to make it clear that it's two latlngs that are being compared?

Currently not covered by this PR: `L.LatLngBounds.equals` will still use `L.LatLng.equals`, and not be dependant on CRS, so there's no way to compare to bounds to each other with CRS dependant equals. I can see two alternatives to address this:

1. Create yet another method in `CRS` that compares two bounds instances
2. Make it possible to pass a CRS to `L.LatLngBounds.equals` as an option, which is used to compare the latlngs to each other, defaulting to `L.CRS.Earth`.

I prefer 2, since it's not really the bounds comparison that is CRS dependant, just the LatLng comparison that it uses. However, alternative 1 is more in line with `equals` and `distanceTo`.