### PR TITLE
When limiting center to bounds, ignore offsets less than a pixel.

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -790,6 +790,13 @@ L.Map = L.Evented.extend({
 		    viewBounds = new L.Bounds(centerPoint.subtract(viewHalf), centerPoint.add(viewHalf)),
 		    offset = this._getBoundsOffset(viewBounds, bounds, zoom);
 
+		// If offset is less than a pixel, ignore.
+		// This prevents unstable projections from getting into
+		// an infinite loop of tiny offsets.
+		if (offset.round().equals([0, 0])) {
+			return center;
+		}
+
 		return this.unproject(centerPoint.add(offset), zoom);
 	},
 


### PR DESCRIPTION
This PR contains a fix for #2427 that is much less intrusive than #4074.

In essence, this checks if the calculated offset is less than a pixel, and in that case ignores the offset and uses the current center.

I have verified that this fixes the issue with [the example code](https://github.com/Leaflet/Leaflet/issues/2427#issuecomment-162511649) provided by @emacgillavry: without the fix, I get a slow scroll to the north when the map is in fullscreen, but with it, the map performs as expected.

To me, this looks like a much cleaner solution. Specifying `equals` per projection might be correct in some sense, but looks like unnecessary complexity to me, if we can avoid it.