### PR TITLE
Make sure to always reset _enforcingBounds.

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -177,17 +177,15 @@ L.Map = L.Evented.extend({
 
 	panInsideBounds: function (bounds, options) {
 		this._enforcingBounds = true;
-		try {
-			var center = this.getCenter(),
-			    newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
+		var center = this.getCenter(),
+		    newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
 
-			if (center.equals(newCenter)) { return this; }
-
+		if (!center.equals(newCenter)) {
 			this.panTo(newCenter, options);
-			return this;
-		} finally {
-			this._enforcingBounds = false;
 		}
+
+		this._enforcingBounds = false;
+		return this;
 	},
 
 	invalidateSize: function (options) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -177,14 +177,17 @@ L.Map = L.Evented.extend({
 
 	panInsideBounds: function (bounds, options) {
 		this._enforcingBounds = true;
-		var center = this.getCenter(),
-		    newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
+		try {
+			var center = this.getCenter(),
+			    newCenter = this._limitCenter(center, this._zoom, L.latLngBounds(bounds));
 
-		if (center.equals(newCenter)) { return this; }
+			if (center.equals(newCenter)) { return this; }
 
-		this.panTo(newCenter, options);
-		this._enforcingBounds = false;
-		return this;
+			this.panTo(newCenter, options);
+			return this;
+		} finally {
+			this._enforcingBounds = false;
+		}
 	},
 
 	invalidateSize: function (options) {


### PR DESCRIPTION
In some cases, the flag `_enforcingBounds` was not reset, especially now that we exit early when `center` and `newCenter` is equal.

This PR wraps the logic in a try-finally-block to make sure the flag is always reset.
