### PR TITLE
Fire tileunload for all unloading of tiles

### DIFF
--- a/debug/map/grid.html
+++ b/debug/map/grid.html
@@ -38,6 +38,7 @@
 
 		grid.on('loading', function() { console.log('loading'); });
 		grid.on('load', function() { console.log('load'); });
+		grid.on('tileunload', function(tile) { console.log('tileunload ' + tile.coords.x + ',' + tile.coords.y + ',' + tile.coords.z); });
 
 		var map = L.map('map')
 				.setView([50.5, 30.51], 10)

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -41,6 +41,7 @@ L.GridLayer = L.Layer.extend({
 	},
 
 	onRemove: function (map) {
+		this._removeAllTiles();
 		L.DomUtil.remove(this._container);
 		map._removeZoomLimit(this);
 		this._container = null;
@@ -217,6 +218,7 @@ L.GridLayer = L.Layer.extend({
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
 			} else {
 				L.DomUtil.remove(this._levels[z].el);
+				this._removeTilesAtZoom(z);
 				delete this._levels[z];
 			}
 		}
@@ -270,6 +272,15 @@ L.GridLayer = L.Layer.extend({
 			if (!this._tiles[key].retain) {
 				this._removeTile(key);
 			}
+		}
+	},
+
+	_removeTilesAtZoom: function (zoom) {
+		for (var key in this._tiles) {
+			if (this._tiles[key].coords.z !== zoom) {
+				continue;
+			}
+			this._removeTile(key);
 		}
 	},
 


### PR DESCRIPTION
Following from #4093 this change fires tileunload in additional situations, like zoom changes and layer removal.