### PR TITLE
update geometryToLayer method signature in documentation

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -3416,7 +3416,7 @@ map.fitBounds(bounds);</code></pre>
 	<tr>
 		<td><code><b>geometryToLayer</b>(
 			<nobr>&lt;GeoJSON&gt; <i>featureData</i></nobr>,
-			<nobr>&lt;<a href="#geojson-pointtolayer">Function</a>&gt; <i>pointToLayer?</i> )</nobr>
+			<nobr>&lt;<a href="#geojson-options">GeoJSON options</a>&gt; <i>options?</i> )</nobr>
 		</code></td>
 
 		<td><code><a href="#ilayer">ILayer</a></code></td>


### PR DESCRIPTION
the optional second argument for `L.geoJson.geometryToLayer()` is now a [GeoJSON options](http://localhost:4000/reference.html#geojson-options) object.  42b39bf24777cf411a198742aeac728659be84ed.