### PR TITLE
prevent undefined property from removing all click events when removed from map

### DIFF
--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -37,7 +37,7 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 		    .off('moveend', this._updatePath, this);
 
 		if (this.options.clickable) {
-			this._map.off('click', this._onClick, this);
+			this._map.off('click', this._onClick || function() {}, this);
 			this._map.off('mousemove', this._onMouseMove, this);
 		}
 

--- a/src/layer/vector/canvas/Path.Canvas.js
+++ b/src/layer/vector/canvas/Path.Canvas.js
@@ -36,8 +36,8 @@ L.Path = (L.Path.SVG && !window.L_PREFER_CANVAS) || !L.Browser.canvas ? L.Path :
 		    .off('viewreset', this.projectLatlngs, this)
 		    .off('moveend', this._updatePath, this);
 
-		if (this.options.clickable) {
-			this._map.off('click', this._onClick || function() {}, this);
+		if (this.options.clickable && this._onClick !== undefined) {
+			this._map.off('click', this._onClick, this);
 			this._map.off('mousemove', this._onMouseMove, this);
 		}
 


### PR DESCRIPTION
If a class does not have a click event, and it is removed, it causes all click events to be removed from map.  This prevents that from happening.