### PR TITLE
fix for safari css syntax warning

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -487,7 +487,7 @@
 	margin: 0 auto;
 
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
-	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	}
 .leaflet-oldie .leaflet-popup-tip-container {
 	margin-top: -1px;


### PR DESCRIPTION
fix for a warning flagged by Safari `9.0.2`
![unexpected token](https://dl.dropboxusercontent.com/u/59331579/Screenshot%202015-12-30%2016.35.32.png)