### PR TITLE
Plugins.md corrected link to Search & popups

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1287,7 +1287,7 @@ The following plugins enable users to interact with overlay data: edit geometrie
 
 * [Edit geometries](#edit-geometries)
 * [Time & elevation](#time--elevation)
-* [Search & popups](#ge#search--popups)
+* [Search & popups](#search--popups)
 * [Area/overlay selection](#areaoverlay-selection)
 
 ### Edit geometries


### PR DESCRIPTION
Inner link to section "Search & popups" was broken due to extra characters in the URL anchor.