### PR TITLE
Implement L.Browser.edge

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -30,6 +30,7 @@
 	L.Browser = {
 		ie: ie,
 		ielt9: ie && !document.addEventListener,
+		edge: 'msLaunchUri' in navigator && !('documentMode' in document),
 		webkit: webkit,
 		gecko: gecko,
 		android: ua.indexOf('android') !== -1,


### PR DESCRIPTION
Detect the MS Edge browser without sniffing the user agent, by looking for a microsoft-specific API method, and the lack of a `documentMode` (because Edge is "evergreen")

This is a prerequisite for #4127