### PR TITLE
zoom to integer levels

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -72,11 +72,11 @@ L.Map = L.Evented.extend({
 	},
 
 	zoomIn: function (delta, options) {
-		return this.setZoom(this._zoom + (delta || 1), options);
+		return this.setZoom(Math.floor(this._zoom) + (delta || 1), options);
 	},
 
 	zoomOut: function (delta, options) {
-		return this.setZoom(this._zoom - (delta || 1), options);
+		return this.setZoom(Math.ceil(this._zoom) - (delta || 1), options);
 	},
 
 	setZoomAround: function (latlng, zoom, options) {


### PR DESCRIPTION
Round target zoom levels for zoom controls, like it's done at DoubleClickZoom already:

https://github.com/Leaflet/Leaflet/blob/161172bbb92e60d2d7fc21173da7e58fc725dd2b/src/map/handler/Map.DoubleClickZoom.js#L21