### PR TITLE
Layer early events hanging up fix

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -45,11 +45,11 @@ L.Layer = L.Evented.extend({
 		this._map = map;
 		this._zoomAnimated = map._zoomAnimated;
 
+		this.onAdd(map);
+
 		if (this.getEvents) {
 			map.on(this.getEvents(), this);
 		}
-
-		this.onAdd(map);
 
 		if (this.getAttribution && this._map.attributionControl) {
 			this._map.attributionControl.addAttribution(this.getAttribution());


### PR DESCRIPTION
onAdd handler can changes '_zoomAnimated' property and 'getEvents' 'zoomanim' depends on this property. So it makes sense to call 'onAdd' first, then 'getEvents'. I got error in my project based on this wrong order and this PR is fixing it.
