### PR TITLE
safeguard for being called on a removed popup

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -132,7 +132,7 @@ L.Popup = L.Layer.extend({
 		if (this._zoomAnimated) {
 			events.zoomanim = this._animateZoom;
 		}
-		if ('closeOnClick' in this.options ? this.options.closeOnClick : this._map.options.closePopupOnClick) {
+		if ('closeOnClick' in this.options ? this.options.closeOnClick : this._map && this._map.options.closePopupOnClick) {
 			events.preclick = this._close;
 		}
 		if (this.options.keepInView) {


### PR DESCRIPTION
it seems all methods protect here for the case `this._map` does not exists. I hit this one when programmatically removing popups from a map