### PR TITLE
Sanity check: test pxBounds validity before using it (fix #4153)

### DIFF
--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -136,7 +136,7 @@ L.Polyline = L.Path.extend({
 		var w = this._clickTolerance(),
 		    p = new L.Point(w, w);
 
-		if (this._bounds.isValid()) {
+		if (this._bounds.isValid() && pxBounds.isValid()) {
 			pxBounds.min._subtract(p);
 			pxBounds.max._add(p);
 			this._pxBounds = pxBounds;


### PR DESCRIPTION
Fix #4153 

Otherwise, we may have bug when polyline latlngs are cleared while
not updating the polyline bounds (so ending with empty latlngs
but this._bounds still valid).