### PR TITLE
Branch L.Renderer.updateTransform when not L.Browser.any3d, fixes #4211

### DIFF
--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -63,7 +63,11 @@ L.Renderer = L.Layer.extend({
 
 		    topLeftOffset = viewHalf.multiplyBy(-scale).add(position).add(viewHalf).subtract(centerOffset);
 
-		L.DomUtil.setTransform(this._container, topLeftOffset, scale);
+		if (L.Browser.any3d) {
+			L.DomUtil.setTransform(this._container, topLeftOffset, scale);
+		} else {
+			L.DomUtil.setPosition(this._container, topLeftOffset);
+		}
 	},
 
 	_reset: function () {


### PR DESCRIPTION
I'm not 100% sure this is the right fix - maybe a new `L.DomUtil.setPositionScale()` function could be added, which then can be statically assigned to either `L.DomUtil.setTransform()` or `L.DomUtil.setPosition()`, but maybe that's premature optimization.