### PR TITLE
Use array in L.Control.Layers internally, fixes #2086

### DIFF
--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+	<div id="map"></div>
+
+	<script type="text/javascript">
+		var geojson = {
+			"type": "Polygon",
+			"coordinates": [[
+				[5.4931640625, 51.781435604431195],
+				[0.9008789062499999, 53.35710874569601],
+				[-2.30712890625, 51.795027225829145],
+				[2.8125, 49.109837790524416],
+				[5.4931640625, 51.781435604431195]
+			]]
+		};
+
+		var map = L.map('map').setView([50.5, 0], 5);
+
+		var OSM_Mapnik = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			maxZoom: 19,
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+		}).addTo(map);
+		var OSM_BlackAndWhite = L.tileLayer('http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', {
+			maxZoom: 18,
+			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+		});
+
+		L.control.layers({
+			'OSM': OSM_Mapnik,
+			'OSM BW': OSM_BlackAndWhite
+		}, {
+			'Circle': L.circle([53, 4], 111111).addTo(map),
+			'Polygon': L.polygon([[48, -3], [50, -4], [52, 4]]),
+			'GeoJSON': L.geoJson(geojson),
+		}, {
+			collapsed: false
+		}).addTo(map);
+	</script>
+</body>
+</html>

--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -4,6 +4,9 @@ describe("Control.Layers", function () {
 	beforeEach(function () {
 		map = L.map(document.createElement('div'));
 	});
+	afterEach(function () {
+		map.remove();
+	});
 
 	describe("baselayerchange event", function () {
 		beforeEach(function () {
@@ -43,7 +46,7 @@ describe("Control.Layers", function () {
 			map.setView([0, 0], 14);
 		});
 
-		it("when an included layer is addded or removed", function () {
+		it("when an included layer is added or removed from the map", function () {
 			var baseLayer = L.tileLayer(),
 			    overlay = L.marker([0, 0]),
 			    layers = L.control.layers({"Base": baseLayer}, {"Overlay": overlay}).addTo(map);
@@ -57,6 +60,23 @@ describe("Control.Layers", function () {
 			expect(spy.callCount).to.eql(2);
 		});
 
+		it("when an included layer is added or removed from the map, it's (un)checked", function () {
+			document.body.appendChild(map._container);
+			var baseLayer = L.tileLayer(),
+			    overlay = L.marker([0, 0]),
+			    layers = L.control.layers({"Baselayer": baseLayer}, {"Overlay": overlay}).addTo(map);
+
+			function isChecked() {
+				return !!(map._container.querySelector('.leaflet-control-layers-overlays input').checked);
+			}
+
+			expect(isChecked()).to.not.be.ok();
+			map.addLayer(overlay);
+			expect(isChecked()).to.be.ok();
+			map.removeLayer(overlay);
+			expect(isChecked()).to.not.be.ok();
+		});
+
 		it("not when a non-included layer is added or removed", function () {
 			var baseLayer = L.tileLayer(),
 			    overlay = L.marker([0, 0]),
@@ -68,6 +88,17 @@ describe("Control.Layers", function () {
 			map.removeLayer(overlay);
 
 			expect(spy.called).to.not.be.ok();
+		});
+
+		it("updates when an included layer is removed from the control", function () {
+			document.body.appendChild(map._container);
+			var baseLayer = L.tileLayer(),
+			    overlay = L.marker([0, 0]),
+			    layers = L.control.layers({"Base": baseLayer}, {"Overlay": overlay}).addTo(map);
+
+			layers.removeLayer(overlay);
+			expect(map._container.querySelector('.leaflet-control-layers-overlays').children.length)
+				.to.be.equal(0);
 		});
 	});
 
@@ -84,7 +115,6 @@ describe("Control.Layers", function () {
 			expect(function () {
 				map.removeLayer(baseLayer);
 			}).to.not.throwException();
-
 		});
 	});
 

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -13,7 +13,7 @@ L.Control.Layers = L.Control.extend({
 	initialize: function (baseLayers, overlays, options) {
 		L.setOptions(this, options);
 
-		this._layers = {};
+		this._layers = [];
 		this._lastZIndex = 0;
 		this._handlingClick = false;
 
@@ -57,7 +57,8 @@ L.Control.Layers = L.Control.extend({
 	removeLayer: function (layer) {
 		layer.off('add remove', this._onLayerChange, this);
 
-		delete this._layers[L.stamp(layer)];
+		var obj = this._getLayer(L.stamp(layer));
+		this._layers.splice(this._layers.indexOf(obj), 1);
 		return (this._map) ? this._update() : this;
 	},
 
@@ -113,16 +114,22 @@ L.Control.Layers = L.Control.extend({
 		container.appendChild(form);
 	},
 
+	_getLayer: function (id) {
+		for (var i = 0; i <= this._layers.length; i++) {
+			if (L.stamp(this._layers[i].layer) === id) {
+				return this._layers[i];
+			}
+		}
+	},
+
 	_addLayer: function (layer, name, overlay) {
 		layer.on('add remove', this._onLayerChange, this);
 
-		var id = L.stamp(layer);
-
-		this._layers[id] = {
+		this._layers.push({
 			layer: layer,
 			name: name,
 			overlay: overlay
-		};
+		});
 
 		if (this.options.autoZIndex && layer.setZIndex) {
 			this._lastZIndex++;
@@ -162,7 +169,7 @@ L.Control.Layers = L.Control.extend({
 			this._update();
 		}
 
-		var obj = this._layers[L.stamp(e.target)];
+		var obj = this._getLayer(L.stamp(e.target));
 
 		var type = obj.overlay ?
 			(e.type === 'add' ? 'overlayadd' : 'overlayremove') :
@@ -231,7 +238,7 @@ L.Control.Layers = L.Control.extend({
 
 		for (var i = inputs.length - 1; i >= 0; i--) {
 			input = inputs[i];
-			layer = this._layers[input.layerId].layer;
+			layer = this._getLayer(input.layerId).layer;
 			hasLayer = this._map.hasLayer(layer);
 
 			if (input.checked && !hasLayer) {
@@ -280,7 +287,7 @@ L.Control.Layers = L.Control.extend({
 
 		for (var i = inputs.length - 1; i >= 0; i--) {
 			input = inputs[i];
-			layer = this._layers[input.layerId].layer;
+			layer = this._getLayer(input.layerId).layer;
 			input.disabled = (layer.options.minZoom !== undefined && zoom < layer.options.minZoom) ||
 			                 (layer.options.maxZoom !== undefined && zoom > layer.options.maxZoom);
 


### PR DESCRIPTION
Quick implementation of using an array to keep the layers in order in `L.Control.Layers`.

Fixes #2086

When calling the constructor with numerical keys is still not preserved, so this:
```JavaScript
L.control.layers({
    2: layer,
    1: other_layer
}).addTo(map);
```
will result in:
![2016-02-12-164628_140x49_scrot](https://cloud.githubusercontent.com/assets/1470389/13011689/4030944e-d1a8-11e5-803d-258b702b299e.png)

To fix that, we'll need to accept arrays of [name, layer]-arrays in stead of objects in case order is important.
