### PR TITLE
rm spurious fadeAnimated check, fixes #4068

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -30,6 +30,17 @@ describe('GridLayer', function () {
 			var grid = L.gridLayer().addTo(map);
 			expect(grid.setOpacity(0.5)).to.equal(grid);
 		});
+
+		it('works when map has fadeAnimated=false (IE8 is exempt)', function (done) {
+			map.remove();
+			map = L.map(div, {fadeAnimation: false}).setView([0, 0], 0);
+
+			var grid = L.gridLayer().setOpacity(0.5).addTo(map);
+			grid.on('load', function () {
+				expect(grid._container.style.opacity).to.equal('0.5');
+				done();
+			});
+		});
 	});
 
 	it('positions tiles correctly with wrapping and bounding', function () {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -273,9 +273,7 @@ L.GridLayer = L.Layer.extend({
 		if (!this._map) { return; }
 
 		// IE doesn't inherit filter opacity properly, so we're forced to set it on tiles
-		if (L.Browser.ielt9 || !this._map._fadeAnimated) {
-			return;
-		}
+		if (L.Browser.ielt9) { return; }
 
 		L.DomUtil.setOpacity(this._container, this.options.opacity);
 


### PR DESCRIPTION
Turns out that `this._map._fadeAnimated` is not needed at all in `_updateOpacity`, as `tileload` will not call `_updateOpacity` at all when that option is set to `false`.