### PR TITLE
Fire 'viewreset' on map.stop(), fixes #3985

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -237,6 +237,9 @@ L.Map = L.Evented.extend({
 
 	stop: function () {
 		this.setZoom(this._limitZoom(this._zoom));
+		if (!this.options.zoomSnap) {
+			this.fire('viewreset');
+		}
 		return this._stop();
 	},
 


### PR DESCRIPTION
Not sure if calling `_resetView()` instead would be a better solution.

Fixes #3985 