### PR TITLE
Add test for throwing error if circle radius is NaN

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -7,6 +7,12 @@ describe('Circle', function () {
 			expect(circle.getRadius()).to.eql(10);
 		});
 
+		it('throws error if radius is NaN', function () {
+			expect(function () {
+				L.circle([0, 0], NaN);
+			}).to.throwException('Circle radius cannot be NaN');
+		});
+
 	});
 
 	describe('#getBounds', function () {


### PR DESCRIPTION
This is a test for the new fix in #4236 