### PR TITLE
MapSpec #addLayer fix test

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -309,8 +309,10 @@ describe("Map", function () {
 			map.on('layeradd', spy);
 			map.addLayer(layer);
 			map.removeLayer(layer);
-			map.setView([0, 0], 0);
-			expect(spy.called).not.to.be.ok();
+			map.on('layerremove', function () {
+				map.setView([0, 0], 0);
+				expect(spy.called).not.to.be.ok();
+			});
 		});
 
 		it("adds the layer before firing layeradd", function (done) {


### PR DESCRIPTION
Hi. We use this tests for our code and have one problem. If layers is a lot of then .removeLayer 
hasn't time to remove the layer and spy is called. We can use event 'layerremove' for this. Thanks.