### PR TITLE
L.Class.include & mergeOptions now return 'this'

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -171,7 +171,30 @@ describe("Class", function () {
 		});
 	});
 
-	// TODO Class.include
+
+	describe("#include", function () {
+		var Klass;
+
+		beforeEach(function () {
+			Klass = L.Class.extend({});
+		});
+
+		it("returns the class with the extra methods", function () {
+
+			var q = sinon.spy();
+
+			var Qlass = Klass.include({quux: q});
+
+			var a = new Klass();
+			var b = new Qlass();
+
+			a.quux();
+			expect(q.called).to.be.ok();
+
+			b.quux();
+			expect(q.called).to.be.ok();
+		});
+	});
 
 	// TODO Class.mergeOptions
 });

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -78,11 +78,13 @@ L.Class.extend = function (props) {
 // method for adding properties to prototype
 L.Class.include = function (props) {
 	L.extend(this.prototype, props);
+	return this;
 };
 
 // merge new default options to the Class
 L.Class.mergeOptions = function (options) {
 	L.extend(this.prototype.options, options);
+	return this;
 };
 
 // add a constructor hook
@@ -95,4 +97,5 @@ L.Class.addInitHook = function (fn) { // (Function) || (String, args...)
 
 	this.prototype._initHooks = this.prototype._initHooks || [];
 	this.prototype._initHooks.push(init);
+	return this;
 };


### PR DESCRIPTION
Not insanely useful, but at some point I wanted to do some `L.Class` chaining like `var EventedHandler = L.Handler.extend(...).include(L.Evented.prototype).mergeOptions(...)`