### PR TITLE
Better looking zoomOutText

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -7,7 +7,7 @@ L.Control.Zoom = L.Control.extend({
 		position: 'topleft',
 		zoomInText: '+',
 		zoomInTitle: 'Zoom in',
-		zoomOutText: '-',
+		zoomOutText: '&minus;',
 		zoomOutTitle: 'Zoom out'
 	},
 


### PR DESCRIPTION
Replace default zoomOutText: a minus sign instead of a dash, because it looks much better.

![](https://dl.dropboxusercontent.com/u/433404/leaflet-zoomOutText-change.png)