### PR TITLE
Added Leaflet.PM to plugin list

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1342,6 +1342,15 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 	<tr>
 		<td>
+			<a href="https://github.com/codeofsumit/leaflet.pm">Leaflet.PM</a>
+		</td><td>
+			Polygon Management specifically for Leaflet 1.0. Draw, Edit and listen to changes.
+		</td><td>
+			<a href="https://github.com/codeofsumit">Sumit Kumar</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/Wildhoney/Leaflet.FreeDraw">Leaflet.FreeDraw</a>
 		</td><td>
 			Zoopla inspired freehand polygon creation using Leaflet.js and D3.


### PR DESCRIPTION
Hi there,

as we're using Leaflet 1.0 in some rather big productions apps, we needed a 1.0 compatible plugin for drawing & editing polygons similar to Google Drawing Tools.
As Leaflet.Draw compatibility isn't there yet, I created my own plugin.

Leaflet Polygon Management => Leaflet.PM

[Check out the Demo](http://codeofsumit.github.io/leaflet.pm/)

The plugin is already used in our apps, but more features that we need will be added regularly.