### PR TITLE
whenReady callback fails

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -742,7 +742,7 @@ L.Map = L.Evented.extend({
 	},
 
 	whenReady: function (callback, context) {
-		callback = callback || function(e) {};
+		callback = callback ? callback : function() {};
 		if (this._loaded) {
 			callback.call(context || this, {target: this});
 		} else {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -742,7 +742,7 @@ L.Map = L.Evented.extend({
 	},
 
 	whenReady: function (callback, context) {
-		callback = callback ? callback : function() {};
+		callback = callback || function () {};
 		if (this._loaded) {
 			callback.call(context || this, {target: this});
 		} else {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -742,6 +742,7 @@ L.Map = L.Evented.extend({
 	},
 
 	whenReady: function (callback, context) {
+		callback = callback || function(e) {};
 		if (this._loaded) {
 			callback.call(context || this, {target: this});
 		} else {


### PR DESCRIPTION
Experimenting with multiple vector layers adding/removing dynamically the callback is undefined for the previous GeoJson layer and will cause an exception to be triggered on a dead layer.  When an undefined callback is handled by a layer it falls back to a no op function as last resort.
