### PR TITLE
Skip call to this._update() if this._map is null

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -46,19 +46,19 @@ L.Control.Layers = L.Control.extend({
 
 	addBaseLayer: function (layer, name) {
 		this._addLayer(layer, name);
-		return this._update();
+		return (this._map) ? this._update() : this;
 	},
 
 	addOverlay: function (layer, name) {
 		this._addLayer(layer, name, true);
-		return this._update();
+		return (this._map) ? this._update() : this;
 	},
 
 	removeLayer: function (layer) {
 		layer.off('add remove', this._onLayerChange, this);
 
 		delete this._layers[L.stamp(layer)];
-		return this._update();
+		return (this._map) ? this._update() : this;
 	},
 
 	_initLayout: function () {


### PR DESCRIPTION
Changed `addBaseLayer()`, `addOverlay()`y and `removeLayer()` to only return `this._update()` if `this._map` is not null, and return `this`otherwise. Hopefully solves [issue 4274](https://github.com/Leaflet/Leaflet/issues/4274).