### PR TITLE
Clean up navigator.pointerEnabled

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -17,7 +17,7 @@
 
 	    mobile = typeof orientation !== 'undefined' || ua.indexOf('mobile') !== -1,
 	    msPointer = !window.PointerEvent && window.MSPointerEvent,
-	    pointer = (window.PointerEvent && navigator.pointerEnabled) || msPointer,
+	    pointer = window.PointerEvent || msPointer,
 
 	    ie3d = ie && ('transition' in doc.style),
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,


### PR DESCRIPTION
Quoting from https://docs.webplatform.org/wiki/dom/Navigator/pointerEnabled :

> In late 2013, pointerEnabled was removed from the specification as checking PointerEvent in Window object is sufficient for feature detection. Do not use this property and use PointerEvent instead. 

See also https://msdn.microsoft.com/en-us/library/windows/apps/hh972607.aspx , https://github.com/jquery/PEP/commit/30493f1c490200645294f516134a515bc2f4ccf7. This should be safe to remove.