### PR TITLE
Update phantomjs dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "karma-coverage": "~0.5.1",
     "karma-firefox-launcher": "~0.1.6",
     "karma-mocha": "~0.2.0",
-    "karma-phantomjs-launcher": "^0.2.0",
+    "karma-phantomjs-launcher": "^1.0.0",
     "karma-safari-launcher": "~0.1.1",
     "magic-string": "^0.7.0",
     "mocha": "~2.3.0",
-    "phantomjs": "^1.9.18",
+    "phantomjs-prebuilt": "^2.1.4",
     "uglify-js": "~2.4.23"
   },
   "main": "dist/leaflet-src.js",


### PR DESCRIPTION
Apparently updating PhantomJS to version > 2.1.0 now magically fixes the timeouts pf the `GridLayer` tests in #4288.

Pending stuff:

* [x] Check if the tests pass in Travis
* [x] Check if the tests pass in MacOSX
* [ ] Check if the tests pass in Windows
