### PR TITLE
give distinct names for map object, class, and map id in Quick Start Guide & Example

### DIFF
--- a/examples/quick-start-example.html
+++ b/examples/quick-start-example.html
@@ -9,12 +9,12 @@
 	<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
 </head>
 <body>
-	<div id="map" style="width: 600px; height: 400px"></div>
+	<div id="mapid" style="width: 600px; height: 400px"></div>
 
 	<script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
 	<script>
 
-		var map = L.map('map').setView([51.505, -0.09], 13);
+		var mymap = L.map('mapid').setView([51.505, -0.09], 13);
 
 		L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw', {
 			maxZoom: 18,
@@ -22,23 +22,23 @@
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
 			id: 'mapbox.streets'
-		}).addTo(map);
+		}).addTo(mymap);
 
 
-		L.marker([51.5, -0.09]).addTo(map)
+		L.marker([51.5, -0.09]).addTo(mymap)
 			.bindPopup("<b>Hello world!</b><br />I am a popup.").openPopup();
 
 		L.circle([51.508, -0.11], 500, {
 			color: 'red',
 			fillColor: '#f03',
 			fillOpacity: 0.5
-		}).addTo(map).bindPopup("I am a circle.");
+		}).addTo(mymap).bindPopup("I am a circle.");
 
 		L.polygon([
 			[51.509, -0.08],
 			[51.503, -0.06],
 			[51.51, -0.047]
-		]).addTo(map).bindPopup("I am a polygon.");
+		]).addTo(mymap).bindPopup("I am a polygon.");
 
 
 		var popup = L.popup();
@@ -47,10 +47,10 @@
 			popup
 				.setLatLng(e.latlng)
 				.setContent("You clicked the map at " + e.latlng.toString())
-				.openOn(map);
+				.openOn(mymap);
 		}
 
-		map.on('click', onMapClick);
+		mymap.on('click', onMapClick);
 
 	</script>
 </body>

--- a/examples/quick-start.md
+++ b/examples/quick-start.md
@@ -8,7 +8,7 @@ title: Quick Start Guide
 This step-by-step guide will quickly get you started on Leaflet basics, including setting up a Leaflet map, working with markers, polylines and popups, and dealing with events.
 
 
-<div id="map" class="map" style="height: 180px"></div>
+<div id="mapid" class="mapclass" style="height: 180px"></div>
 
 [View example on a separate page &rarr;](quick-start-example.html)
 
@@ -27,23 +27,23 @@ Before writing any code for the map, you need to do the following preparation st
 
  * Put a `div` element with a certain `id` where you want your map to be:
 
-		<div id="map"></div>
+		<div id="mapid"></div>
 
  * Make sure the map container has a defined height, for example by setting it in CSS:
 
-	<pre><code class="css">#map { height: 180px; }</code></pre>
+	<pre><code class="css">#mapclass { height: 180px; }</code></pre>
 
 Now you're ready to initialize the map and do some stuff with it.
 
 
 ### Setting up the map
 
-<div id="map1" class="map" style="height: 180px"></div>
+<div id="mapid1" class="mapclass" style="height: 180px"></div>
 
 
 Let's create a map of the center of London with pretty Mapbox Streets tiles. First we'll initialize the map and set its view to our chosen geographical coordinates and a zoom level:
 
-	var map = L.map('map').setView([51.505, -0.09], 13);
+	var mymap = L.map('mapid').setView([51.505, -0.09], 13);
 
 By default (as we didn't pass any options when creating the map instance), all mouse and touch interactions on the map are enabled, and it has zoom and attribution controls.
 
@@ -56,7 +56,7 @@ Next we'll add a tile layer to add to our map, in this case it's a Mapbox Street
 	maxZoom: 18,
 	id: '<a href="https://www.mapbox.com/projects/">your.mapbox.project.id</a>',
 	accessToken: '<a href="https://www.mapbox.com/account/apps/">your.mapbox.public.access.token</a>'
-}).addTo(map);</code></pre>
+}).addTo(mymap);</code></pre>
 
 Make sure all the code is called after the `div` and `leaflet.js` inclusion. That's it! You have a working Leaflet map now.
 
@@ -65,11 +65,11 @@ It's worth noting that Leaflet is provider-agnostic, meaning that it doesn't enf
 
 ### Markers, circles and polygons
 
-<div id="map2" class="map" style="height: 180px"></div>
+<div id="mapid2" class="mapclass" style="height: 180px"></div>
 
 Besides tile layers, you can easily add other things to your map, including markers, polylines, polygons, circles, and popups. Let's add a marker:
 
-	var marker = L.marker([51.5, -0.09]).addTo(map);
+	var marker = L.marker([51.5, -0.09]).addTo(mymap);
 
 Adding a circle is the same (except for specifying the radius in meters as a second argument), but lets you control how it looks by passing options as the last argument when creating the object:
 
@@ -77,7 +77,7 @@ Adding a circle is the same (except for specifying the radius in meters as a sec
 		color: 'red',
 		fillColor: '#f03',
 		fillOpacity: 0.5
-	}).addTo(map);
+	}).addTo(mymap);
 
 Adding a polygon is as easy:
 
@@ -85,12 +85,12 @@ Adding a polygon is as easy:
 		[51.509, -0.08],
 		[51.503, -0.06],
 		[51.51, -0.047]
-	]).addTo(map);
+	]).addTo(mymap);
 
 
 ### Working with popups
 
-<div id="map3" class="map" style="height: 180px"></div>
+<div id="mapid3" class="mapclass" style="height: 180px"></div>
 
 Popups are usually used when you want to attach some information to a particular object on a map. Leaflet has a very handy shortcut for this:
 
@@ -105,7 +105,7 @@ You can also use popups as layers (when you need something more than attaching a
 	var popup = L.popup()
 		.setLatLng([51.5, -0.09])
 		.setContent("I am a standalone popup.")
-		.openOn(map);
+		.openOn(mymap);
 
 Here we use `openOn` instead of `addTo` because it handles automatic closing of a previously opened popup when opening a new one which is good for usability.
 
@@ -118,7 +118,7 @@ Every time something happens in Leaflet, e.g. user clicks on a marker or map zoo
 		alert("You clicked the map at " + e.latlng);
 	}
 
-	map.on('click', onMapClick);
+	mymap.on('click', onMapClick);
 
 Each object has its own set of events --- see [documentation](../reference.html) for details. The first argument of the listener function is an event object --- it contains useful information about the event that happened. For example, map click event object (`e` in the example above) has `latlng` property which is a location at which the click occured.
 
@@ -130,10 +130,10 @@ Let's improve our example by using a popup instead of an alert:
 		popup
 			.setLatLng(e.latlng)
 			.setContent("You clicked the map at " + e.latlng.toString())
-			.openOn(map);
+			.openOn(mymap);
 	}
 
-	map.on('click', onMapClick);
+	mymap.on('click', onMapClick);
 
 Try clicking on the map and you will see the coordinates in a popup. <a target="_blank" href="quick-start-example.html">View the full example &rarr;</a>
 
@@ -141,24 +141,24 @@ Now you've learned Leaflet basics and can start building map apps straight away!
 
 <script>
 
-	var map = L.map('map').setView([51.505, -0.09], 13);
+	var mymap = L.map('mapid').setView([51.505, -0.09], 13);
 
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(mymap);
 
-	L.marker([51.5, -0.09]).addTo(map)
+	L.marker([51.5, -0.09]).addTo(mymap)
 		.bindPopup("<b>Hello world!</b><br />I am a popup.").openPopup();
 
 	L.circle([51.508, -0.11], 500, {
 		color: 'red',
 		fillColor: '#f03',
 		fillOpacity: 0.5
-	}).addTo(map).bindPopup("I am a circle.");
+	}).addTo(mymap).bindPopup("I am a circle.");
 
 	L.polygon([
 		[51.509, -0.08],
 		[51.503, -0.06],
 		[51.51, -0.047]
-	]).addTo(map).bindPopup("I am a polygon.");
+	]).addTo(mymap).bindPopup("I am a polygon.");
 
 
 	/*var popup = L.popup();
@@ -174,46 +174,46 @@ Now you've learned Leaflet basics and can start building map apps straight away!
 
 
 
-	var map1 = L.map('map1').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map1);
+	var mymap1 = L.map('mapid1').setView([51.505, -0.09], 13);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(mymap1);
 
 
 
-	var map2 = L.map('map2').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map2);
+	var mymap2 = L.map('mapid2').setView([51.505, -0.09], 13);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(mymap2);
 
-	L.marker([51.5, -0.09]).addTo(map2);
+	L.marker([51.5, -0.09]).addTo(mymap2);
 
 	L.circle([51.508, -0.11], 500, {
 		color: 'red',
 		fillColor: '#f03',
 		fillOpacity: 0.5
-	}).addTo(map2);
+	}).addTo(mymap2);
 
 	L.polygon([
 		[51.509, -0.08],
 		[51.503, -0.06],
 		[51.51, -0.047]
-	]).addTo(map2);
+	]).addTo(mymap2);
 
 
 
-	var map3 = L.map('map3').setView([51.505, -0.09], 13);
-	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(map3);
+	var mymap3 = L.map('mapid3').setView([51.505, -0.09], 13);
+	L.tileLayer(MB_URL, {attribution: MB_ATTR, id: 'mapbox.streets'}).addTo(mymap3);
 
-	L.marker([51.5, -0.09]).addTo(map3)
+	L.marker([51.5, -0.09]).addTo(mymap3)
 		.bindPopup("<b>Hello world!</b><br />I am a popup.").openPopup();
 
 	L.circle([51.508, -0.11], 500, {
 		color: 'red',
 		fillColor: '#f03',
 		fillOpacity: 0.5
-	}).addTo(map3).bindPopup("I am a circle.");
+	}).addTo(mymap3).bindPopup("I am a circle.");
 
 	L.polygon([
 		[51.509, -0.08],
 		[51.503, -0.06],
 		[51.51, -0.047]
-	]).addTo(map3).bindPopup("I am a polygon.");
+	]).addTo(mymap3).bindPopup("I am a polygon.");
 
 </script>


### PR DESCRIPTION
Hi, 

I was introducing Leaflet to a couple people this afternoon and showed them the [leaflet examples](http://leafletjs.com/examples/quick-start.html). 

They were quite confused when the same word ('map') was being used to describe four different things (the id, css class, the object that's being created in leaflet, and Leaflet's map class) in the [quick-start guide](http://leafletjs.com/examples/quick-start.html) and example. 

I've made several edits to this quickstart page and example to help readers follow along by creating distinct names for object, class, and id. 

When I was learning javascript with leaflet (and mapbox.js), I remember having this same experience, and found it very confusing and frankly a little discouraging. If I didn't feel intimidated as a new user, I likely would have asked someone to make the same changes. Even while writing this PR, I had an aha! moment of better understanding Leaflet. 
I also viewed the changes locally with jekyll and didn't find any errors. 

Thanks for your consideration. I would be happy to make similar changes to the other tutorials if you wish.