### PR TITLE
Fix #4313 : correct simulated click handling in L.Path

### DIFF
--- a/src/layer/vector/Path.SVG.js
+++ b/src/layer/vector/Path.SVG.js
@@ -129,7 +129,7 @@ L.Path = L.Path.extend({
 	},
 
 	_onMouseClick: function (e) {
-		if (this._map.dragging && this._map.dragging.moved()) { return; }
+		if (!e._simulated && this._map.dragging && this._map.dragging.moved()) { return; }
 
 		this._fireMouseEvent(e);
 	},


### PR DESCRIPTION
Related to #4313 : add a test of e._simulated in `L.Path._onMouseClick` in SVG implementation