### PR TITLE
prosthetic-hand unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "magic-string": "^0.7.0",
     "mocha": "~2.3.0",
     "phantomjs-prebuilt": "^2.1.4",
+    "prosthetic-hand": "^1.2.0",
     "uglify-js": "~2.4.23"
   },
   "main": "dist/leaflet-src.js",

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -12,6 +12,7 @@
   "globals": {
     "expect": false,
     "sinon": false,
-    "happen": false
+    "happen": false,
+    "Hand": false
   }
 }

--- a/spec/index.html
+++ b/spec/index.html
@@ -11,9 +11,14 @@
 	<script src="expect.js"></script>
 	<script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
 	<script type="text/javascript" src="../node_modules/happen/happen.js"></script>
+	<script type="text/javascript" src="../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>
 	<script type="text/javascript" src="sinon.js"></script>
 
 	<!-- source files -->
+	<script>
+		// Trick Leaflet into believing we have a touchscreen (for Chrome)
+		if (window.Touch) { window.ontouchstart = function(){} };
+	</script>
 	<script type="text/javascript" src="../build/deps.js"></script>
 
 	<script type="text/javascript" src="../debug/leaflet-include.js"></script>
@@ -84,6 +89,7 @@
 
 	<!-- /map/handler -->
 	<script type="text/javascript" src="suites/map/handler/Map.DragSpec.js"></script>
+	<script type="text/javascript" src="suites/map/handler/Map.TouchZoomSpec.js"></script>
 
 	<!-- /geo/crs -->
 	<script type="text/javascript" src="suites/geo/CRSSpec.js"></script>

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -9,6 +9,7 @@ module.exports = function (config) {
 	].concat(libSources, [
 		"spec/after.js",
 		"node_modules/happen/happen.js",
+		"node_modules/prosthetic-hand/dist/prosthetic-hand.js",
 		"spec/suites/SpecHelper.js",
 		"spec/suites/**/*.js",
 		{pattern: "dist/images/*.png", included: false}

--- a/spec/spec.hintrc.js
+++ b/spec/spec.hintrc.js
@@ -1,7 +1,7 @@
 {
 	"browser": true,
 	"node": true,
-	"predef": ["define", "L", "expect", "describe", "it", "sinon", "happen", "beforeEach", "afterEach"],
+	"predef": ["define", "L", "expect", "describe", "it", "sinon", "happen", "beforeEach", "afterEach", "Hand"],
 	"strict": false,
 	"bitwise": true,
 	"camelcase": true,

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -75,5 +75,11 @@ happen.drag = function (fromX, fromY, toX, toY, then, duration) {
 	}, duration || 100);
 };
 
-// We'll want to skip a couple of things when in PhantomJS :-/
+// We'll want to skip a couple of things when in PhantomJS, due to lack of CSS animations
 it.skipInPhantom = L.Browser.any3d ? it : it.skip;
+
+// A couple of tests need the browser to be touch-capable
+it.skipIfNotTouch = window.TouchEvent ? it : it.skip;
+
+// A couple of tests need the browser to be pointer-capable
+it.skipIfNotEdge = window.PointerEvent ? it : it.skip;

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -124,7 +124,7 @@ describe('GridLayer', function () {
 		});
 
 		// Passes on Firefox, but fails on phantomJS: done is never called.
-		xit('only creates tiles for visible area on zoom in', function (done) {
+		it.skipInPhantom('only creates tiles for visible area on zoom in', function (done) {
 			map.remove();
 			map = L.map(div);
 			map.setView([0, 0], 10);

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -35,4 +35,80 @@ describe("Map.Drag", function () {
 			expect(map.dragging.enabled()).to.be(true);
 		});
 	});
+
+
+	describe("mouse events", function () {
+		it("change the center of the map", function (done) {
+			var container = document.createElement('div');
+			container.style.width = container.style.height = '600px';
+			container.style.top = container.style.left = 0;
+			container.style.position = 'absolute';
+// 			container.style.background = '#808080';
+
+			document.body.appendChild(container);
+
+			var map = new L.Map(container, {
+				dragging: true,
+				inertia: false
+			});
+			map.setView([0, 0], 1);
+
+			var hand = new Hand({timing: 'fastframe'});
+			var mouse = hand.growFinger('mouse');
+
+			// We move 5 pixels first to overcome the 3-pixel threshold of
+			// L.Draggable.
+			mouse.wait(100).moveTo(200, 200, 0)
+				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
+
+			setTimeout(function () {
+				var center = map.getCenter();
+				var zoom = map.getZoom();
+				document.body.removeChild(container);
+				expect(center.lat).to.be.within(21.9430, 21.9431);
+				expect(center.lng).to.be(-180);
+				expect(zoom).to.be(1);
+
+				done();
+			}, 100);
+		});
+	});
+
+	describe("touch events", function () {
+		it.skipIfNotTouch("change the center of the map", function (done) {
+			var container = document.createElement('div');
+			container.style.width = container.style.height = '600px';
+			container.style.top = container.style.left = 0;
+			container.style.position = 'absolute';
+// 			container.style.background = '#808080';
+
+			document.body.appendChild(container);
+
+			var map = new L.Map(container, {
+				dragging: true,
+				inertia: false
+			});
+			map.setView([0, 0], 1);
+
+			var hand = new Hand({timing: 'fastframe'});
+			var toucher = hand.growFinger('touch');
+
+			// We move 5 pixels first to overcome the 3-pixel threshold of
+			// L.Draggable.
+			toucher.wait(100).moveTo(200, 200, 0)
+				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
+
+			setTimeout(function () {
+				var center = map.getCenter();
+				var zoom = map.getZoom();
+				document.body.removeChild(container);
+				expect(center.lat).to.be.within(21.9430, 21.9431);
+				expect(center.lng).to.be(-180);
+				expect(zoom).to.be(1);
+
+				done();
+			}, 100);
+		});
+	});
+
 });

--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -1,0 +1,83 @@
+describe("Map.TouchZoom", function () {
+	it.skipIfNotTouch("Increases zoom when pinching out", function (done) {
+		var container = document.createElement('div');
+		container.style.width = container.style.height = '600px';
+		container.style.top = container.style.left = 0;
+		container.style.position = 'absolute';
+		document.body.appendChild(container);
+
+		var map = new L.Map(container, {
+			touchZoom: true,
+			inertia: false,
+			zoomAnimation: false	// If true, the test has to wait extra 250msec
+		});
+		map.setView([0, 0], 1);
+
+		var hand = new Hand({timing: 'fastframe'});
+		var f1 = hand.growFinger('touch');
+		var f2 = hand.growFinger('touch');
+
+// 		L.DomEvent.on(document, 'prostheticHandStop', function () {
+		setTimeout(function () {
+			var center = map.getCenter();
+			var zoom = map.getZoom();
+			document.body.removeChild(container);
+			expect(center.lat).to.be(0);
+			expect(center.lng).to.be(0);
+
+			// Initial zoom 1, initial distance 50px, final distance 450px
+			expect(zoom).to.be(4);
+
+			done();
+		}, 100);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(275, 300, 0)
+			.down().moveBy(-200, 0, 500).up(100);
+		f2.wait(100).moveTo(325, 300, 0)
+			.down().moveBy(200, 0, 500).up(100);
+	});
+
+
+	it.skipIfNotTouch("Decreases zoom when pinching in", function (done) {
+		var container = document.createElement('div');
+		container.style.width = container.style.height = '600px';
+		container.style.top = container.style.left = 0;
+		container.style.position = 'absolute';
+		document.body.appendChild(container);
+
+		var map = new L.Map(container, {
+			touchZoom: true,
+			inertia: false,
+			zoomAnimation: false	// If true, the test has to wait extra 250msec
+		});
+		map.setView([0, 0], 4);
+
+		var hand = new Hand({timing: 'fastframe'});
+		var f1 = hand.growFinger('touch');
+		var f2 = hand.growFinger('touch');
+
+// 		L.DomEvent.on(document, 'prostheticHandStop', function () {
+		setTimeout(function () {
+			var center = map.getCenter();
+			var zoom = map.getZoom();
+			document.body.removeChild(container);
+			expect(center.lat).to.be(0);
+			expect(center.lng).to.be(0);
+
+			// Initial zoom 4, initial distance 450px, final distance 50px
+			expect(zoom).to.be(1);
+
+			done();
+		}, 100);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(75, 300, 0)
+			.down().moveBy(200, 0, 500).up(100);
+		f2.wait(100).moveTo(525, 300, 0)
+			.down().moveBy(-200, 0, 500).up(100);
+	});
+
+
+
+});

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -24,7 +24,7 @@
 	    gecko3d = 'MozPerspective' in doc.style,
 	    opera12 = 'OTransition' in doc.style;
 
-	var touch = !window.L_NO_TOUCH && !phantomjs && (pointer || 'ontouchstart' in window ||
+	var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
 			(window.DocumentTouch && document instanceof window.DocumentTouch));
 
 	L.Browser = {

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -98,7 +98,11 @@ L.Map.TouchZoom = L.Handler.extend({
 		    .off(document, 'touchend', this._onTouchEnd);
 
 		// Pinch updates GridLayers' levels only when snapZoom is off, so snapZoom becomes noUpdate.
-		this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.snapZoom);
+		if (this._map.options.zoomAnimation) {
+			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.snapZoom);
+		} else {
+			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
+		}
 	}
 });
 


### PR DESCRIPTION
Proof of concept of unit tests for mouse events, part of what needs to be done for #3530.

This reverts the "Force PhantomJS to be non-touch" behaviour of #1434 - recent versions of PhantomJS do indeed implement `TouchEvent`s more or less properly.