### PR TITLE
Fixing a typo

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -804,7 +804,7 @@ var map = L.map('map', {
 	</tr>
 	<tr id="map-addlayer">
 		<td><code><b>addLayer</b>(
-			<nobr>&lt;<a href="#ilayer">ILayer</a>&gt; <i>layer</i>,</nobr>
+			<nobr>&lt;<a href="#ilayer">ILayer</a>&gt; <i>layer</i> )</nobr>
 		</code></td>
 
 		<td><code><span class="hljs-keyword">this</span></code></td>


### PR DESCRIPTION
Replaced ',' with ' )'