### PR TITLE
Unit tests TileLayer.getTileUrl()

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -211,6 +211,7 @@ describe('Util', function () {
 
 			expect(str).to.eql('Hello Vlad and Dave!');
 		});
+
 		it('does not modify text without a token variable', function () {
 			expect(L.Util.template('foo', {})).to.eql('foo');
 		});
@@ -225,6 +226,11 @@ describe('Util', function () {
 			expect(function () {
 				L.Util.template(undefined, {foo: 'bar'});
 			}).to.throwError();
+		});
+
+		it('allows underscores and dashes in placeholders', function () {
+			expect(L.Util.template('{nice_stuff}', {'nice_stuff': 'foo'})).to.eql('foo');
+			expect(L.Util.template('{-y}', {'-y': 1})).to.eql('1');
 		});
 	});
 

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -287,6 +287,75 @@ describe('TileLayer', function () {
 
 	});
 
+	describe('url template', function () {
+		beforeEach(function () {
+			div = document.createElement('div');
+			div.style.width = '400px';
+			div.style.height = '400px';
+			div.style.visibility = 'hidden';
 
+			document.body.appendChild(div);
+
+			map = L.map(div).setView([0, 0], 2);
+		});
+
+		function eachImg(layer, callback) {
+			var imgtags = layer._container.children[0].children;
+			for (var i in imgtags) {
+				if (imgtags[i].tagName === 'IMG') {
+					callback(imgtags[i]);
+				}
+			}
+		}
+
+		it('replaces {y} with y coordinate', function () {
+			var layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png').addTo(map);
+
+			var urls = [
+				'http://example.com/2/1/1.png',
+				'http://example.com/2/1/2.png',
+				'http://example.com/2/2/1.png',
+				'http://example.com/2/2/2.png'
+			];
+
+			var i = 0;
+			eachImg(layer, function (img) {
+				expect(img.src).to.eql(urls[i]);
+				i++;
+			});
+		});
+
+		it('replaces {-y} with inverse y coordinate', function () {
+			var layer = L.tileLayer('http://example.com/{z}/{-y}/{x}.png').addTo(map);
+			var urls = [
+				'http://example.com/2/2/1.png',
+				'http://example.com/2/2/2.png',
+				'http://example.com/2/1/1.png',
+				'http://example.com/2/1/2.png'
+			];
+			var i = 0;
+			eachImg(layer, function (img) {
+				expect(img.src).to.eql(urls[i]);
+				i++;
+			});
+		});
+
+		it('replaces {s} with [abc] by default', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png').addTo(map);
+
+			eachImg(layer, function (img) {
+				expect(['a', 'b', 'c'].indexOf(img.src[7]) >= 0).to.eql(true);
+			});
+		});
+
+		it('replaces {s} with specified prefixes', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				subdomains: 'qrs'
+			}).addTo(map);
+
+			eachImg(layer, function (img) {
+				expect(['q', 'r', 's'].indexOf(img.src[7]) >= 0).to.eql(true);
+			});
+		});
+	});
 });
-

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -141,7 +141,7 @@ L.Util = {
 		});
 	},
 
-	templateRe: /\{ *([\w_]+) *\}/g,
+	templateRe: /\{ *([\w_\-]+) *\}/g,
 
 	isArray: Array.isArray || function (obj) {
 		return (Object.prototype.toString.call(obj) === '[object Array]');


### PR DESCRIPTION
My PR #4337 allowing `{-y}` was indeed broken, fixed now and adding some tests:
- For underscores and dashes in `L.Util.template()`.
- For `{z}/{y}/{x}` and `{z}/{-y}/{x}` in url templates.
- For `{s}` both default and customized in url templates.