### PR TITLE
Do not calculate inverted y coords for CRSes with infinite: true

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -340,6 +340,26 @@ describe('TileLayer', function () {
 			});
 		});
 
+		it('Does not replace {-y} on map with infinite CRS', function () {
+			var simplediv = document.createElement('div');
+			simplediv.style.width = '400px';
+			simplediv.style.height = '400px';
+			simplediv.style.visibility = 'hidden';
+
+			document.body.appendChild(simplediv);
+			var simpleMap = L.map(simplediv, {
+				crs: L.CRS.Simple
+			}).setView([0, 0], 5);
+			var layer = L.tileLayer('http://example.com/{z}/{-y}/{x}.png');
+
+			expect(function () {
+				layer.addTo(simpleMap);
+			}).to.throwError('No value provided for variable {-y}');
+
+			simpleMap.remove();
+			document.body.removeChild(simplediv);
+		});
+
 		it('replaces {s} with [abc] by default', function () {
 			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png').addTo(map);
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -75,16 +75,22 @@ L.TileLayer = L.GridLayer.extend({
 	},
 
 	getTileUrl: function (coords) {
-		var invertedY = this._globalTileRange.max.y - coords.y;
-
-		return L.Util.template(this._url, L.extend({
+		var data = {
 			r: L.Browser.retina ? '@2x' : '',
 			s: this._getSubdomain(coords),
 			x: coords.x,
-			y: this.options.tms ? invertedY : coords.y,
-			'-y': invertedY,
+			y: coords.y,
 			z: this._getZoomForUrl()
-		}, this.options));
+		};
+		if (this._map && !this._map.options.crs.infinite) {
+			var invertedY = this._globalTileRange.max.y - coords.y;
+			if (this.options.tms) {
+				data['y'] = invertedY;
+			}
+			data['-y'] = invertedY;
+		}
+
+		return L.Util.template(this._url, L.extend(data, this.options));
 	},
 
 	_tileOnLoad: function (done, tile) {


### PR DESCRIPTION
Do not calculate inverted y coords for CRSes with infinite: true 

fix for #4338

With this change, this example: 
```JavaScript
var map = L.map('map', {
    crs: L.CRS.Simple
}).setView([0, 0], 5);
L.tileLayer('http://example.com/{z}/{-y}/{x}.png').addTo(map);
```
will give the error message 
`No value provided for variable {-y}`
