### PR TITLE
Give popups an id

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -25,6 +25,7 @@ L.Popup = L.Layer.extend({
 		autoClose: true,
 		// keepInView: false,
 		// className: '',
+		// id: '',
 		zoomAnimation: true
 	},
 
@@ -170,6 +171,10 @@ L.Popup = L.Layer.extend({
 		    container = this._container = L.DomUtil.create('div',
 			prefix + ' ' + (this.options.className || '') +
 			' leaflet-zoom-' + (this._zoomAnimated ? 'animated' : 'hide'));
+
+		if (this.options.id !== '') {
+			container.id = this.options.id;
+		}
 
 		if (this.options.closeButton) {
 			var closeButton = this._closeButton = L.DomUtil.create('a', prefix + '-close-button', container);


### PR DESCRIPTION
Useful in the case where having a class is too general and finer-grain control is necessary.