### PR TITLE
Just keep _moveEnd inside requestAnimFrame. Close #4023.

### DIFF
--- a/src/map/anim/Map.ZoomAnimation.js
+++ b/src/map/anim/Map.ZoomAnimation.js
@@ -114,13 +114,13 @@ L.Map.include(!zoomAnimated ? {} : {
 
 		L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 
+		this._animatingZoom = false;
+
+		this._move(this._animateToCenter, this._animateToZoom);
+
 		// This anim frame should prevent an obscure iOS webkit tile loading race condition.
 		L.Util.requestAnimFrame(function () {
-			this._animatingZoom = false;
-
-			this
-				._move(this._animateToCenter, this._animateToZoom)
-				._moveEnd(true);
+			this._moveEnd(true);
 		}, this);
 	}
 });


### PR DESCRIPTION
Modifications for avoiding duplicate zoom events from firing, as I suggested in https://github.com/Leaflet/Leaflet/issues/4023#issuecomment-204461090.

Note that this change changes behaviour: previously then `moveend` event fired _immediately_ after the last `move` event, but this change will make other code run between the two events.