### PR TITLE
Make latLngBounds factory return an empty bounds with not argument

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -17,6 +17,17 @@ describe('LatLngBounds', function () {
 			expect(b).to.eql(a);
 			expect(b.getNorthWest()).to.eql(new L.LatLng(30, 12));
 		});
+
+		it('returns an empty bounds when not argument is given', function () {
+			var bounds = new L.LatLngBounds();
+			expect(bounds instanceof L.LatLngBounds).to.be.ok(a);
+		});
+
+		it('returns an empty bounds when not argument is given to factory', function () {
+			var bounds = L.latLngBounds();
+			expect(bounds instanceof L.LatLngBounds).to.be.ok(a);
+		});
+
 	});
 
 	describe('#extend', function () {

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -168,7 +168,7 @@ L.LatLngBounds.prototype = {
 // TODO International date line?
 
 L.latLngBounds = function (a, b) { // (LatLngBounds) or (LatLng, LatLng)
-	if (!a || a instanceof L.LatLngBounds) {
+	if (a instanceof L.LatLngBounds) {
 		return a;
 	}
 	return new L.LatLngBounds(a, b);


### PR DESCRIPTION
Just like the constructor.

Fix #3408