### PR TITLE
Don't prevent pointerdown if target is a form control

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -8,6 +8,7 @@ L.extend(L.DomEvent, {
 	POINTER_MOVE:   L.Browser.msPointer ? 'MSPointerMove'   : 'pointermove',
 	POINTER_UP:     L.Browser.msPointer ? 'MSPointerUp'     : 'pointerup',
 	POINTER_CANCEL: L.Browser.msPointer ? 'MSPointerCancel' : 'pointercancel',
+	TAG_WHITE_LIST: ['INPUT', 'SELECT', 'OPTION'],
 
 	_pointers: {},
 	_pointersCount: 0,
@@ -50,7 +51,11 @@ L.extend(L.DomEvent, {
 	_addPointerStart: function (obj, handler, id) {
 		var onDown = L.bind(function (e) {
 			if (e.pointerType !== 'mouse' && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
-				L.DomEvent.preventDefault(e);
+				if (this.TAG_WHITE_LIST.indexOf(e.target.tagName) < 0) {
+					L.DomEvent.preventDefault(e);
+				} else {
+					return;
+				}
 			}
 
 			this._handlePointer(e, handler);

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -51,6 +51,9 @@ L.extend(L.DomEvent, {
 	_addPointerStart: function (obj, handler, id) {
 		var onDown = L.bind(function (e) {
 			if (e.pointerType !== 'mouse' && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
+				// In IE11, some touch events needs to fire for form controls, or
+				// the controls will stop working. We keep a whitelist of tag names that
+				// need these events. For other target tags, we prevent default on the event.
 				if (this.TAG_WHITE_LIST.indexOf(e.target.tagName) < 0) {
 					L.DomEvent.preventDefault(e);
 				} else {


### PR DESCRIPTION
This is WIP to attempt fixing #2699.

The current approach is to white-list some tag types and not call `preventDefault` if they're the target, more or less what @fnicollet [suggests](https://github.com/Leaflet/Leaflet/issues/2699#issuecomment-61363343). This seems to fix the problem, but I can't say it's elegant.

The other alternative I've considered involves actually calling `stopPropagation` on every form element (like suggested by @danzel: https://github.com/Leaflet/Leaflet/issues/2699#issuecomment-44219069) which is messy and something people are likely to not understand that they have to do.

Any better solution? @danzel, do you have any suggestions?