### PR TITLE
Workaround for flyTo bug

### DIFF
--- a/debug/map/zoompan.html
+++ b/debug/map/zoompan.html
@@ -56,7 +56,7 @@
 
 		var map = L.map('map', {
             zoomSnap: 0.25
-        }).setView(dc, 10);
+        }).setView(dc, 14);
 
 		var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
@@ -73,7 +73,7 @@
 
 		var nullIslandKitten = L.imageOverlay('http://placekitten.com/300/400?image=6', [[-0.2,-0.15], [0.2, 0.15]]).addTo(map);
 
-		document.getElementById('dc').onclick   = function () { map.flyTo(dc,  10); };
+		document.getElementById('dc').onclick   = function () { map.flyTo(dc,  4); };
 		document.getElementById('sf').onclick   = function () { map.setView(sf, 10, {duration: 5, animate: true}); };
 		document.getElementById('trd').onclick  = function () { map.flyTo(trd, 10, {duration: 20}); };
 		document.getElementById('lnd').onclick  = function () { map.flyTo(lnd, 9.25); };

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -646,14 +646,12 @@ describe("Map", function () {
 		it.skipInPhantom('flyTo start latlng == end latlng', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
-			var dc = [38.91, -77.04];
+			var dc = new L.LatLng(38.91, -77.04);
 			map.setView(dc, 14);
 
 			map.on('zoomend', function () {
-				console.log('zoomend');
-				console.log('done');
-				console.log(map.getCenter());
-				console.log(map.getZoom());
+				expect(map.getCenter()).to.eql(dc);
+				expect(map.getZoom()).to.eql(4);
 				done();
 			});
 

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -657,7 +657,7 @@ describe("Map", function () {
 				done();
 			});
 
-			map.flyTo(dc,  4);
+			map.flyTo(dc, 4);
 		});
 	});
 

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -609,8 +609,26 @@ describe("Map", function () {
 	});
 
 	describe('#flyTo', function () {
+		var div;
 
-		it('move to requested center and zoom, and call zoomend once', function (done) {
+		beforeEach(function () {
+			div = document.createElement('div');
+			div.style.width = '800px';
+			div.style.height = '600px';
+			div.style.visibility = 'hidden';
+
+			document.body.appendChild(div);
+
+			map = L.map(div);
+		});
+
+		afterEach(function () {
+			document.body.removeChild(div);
+		});
+
+		it.skipInPhantom('move to requested center and zoom, and call zoomend once', function (done) {
+			this.timeout(10000); // This test takes longer than usual due to frames
+
 			var spy = sinon.spy(),
 			    newCenter = new L.LatLng(10, 11),
 			    newZoom = 12;
@@ -622,7 +640,24 @@ describe("Map", function () {
 				done();
 			};
 			map.setView([0, 0], 0);
-			map.once('zoomend', callback).flyTo(newCenter, newZoom);
+			map.on('zoomend', callback).flyTo(newCenter, newZoom);
+		});
+
+		it.skipInPhantom('flyTo start latlng == end latlng', function (done) {
+			this.timeout(10000); // This test takes longer than usual due to frames
+
+			var dc = [38.91, -77.04];
+			map.setView(dc, 14);
+
+			map.on('zoomend', function () {
+				console.log('zoomend');
+				console.log('done');
+				console.log(map.getCenter());
+				console.log(map.getZoom());
+				done();
+			});
+
+			map.flyTo(dc,  4);
 		});
 	});
 

--- a/src/map/anim/Map.FlyTo.js
+++ b/src/map/anim/Map.FlyTo.js
@@ -29,8 +29,18 @@ L.Map.include({
 		    rho2 = rho * rho;
 
 		function r(i) {
-			var b = (w1 * w1 - w0 * w0 + (i ? -1 : 1) * rho2 * rho2 * u1 * u1) / (2 * (i ? w1 : w0) * rho2 * u1);
-			return Math.log(Math.sqrt(b * b + 1) - b);
+			var s1 = i ? -1 : 1,
+			    s2 = i ? w1 : w0,
+			    t1 = w1 * w1 - w0 * w0 + s1 * rho2 * rho2 * u1 * u1,
+			    b1 = 2 * s2 * rho2 * u1,
+			    b = t1 / b1,
+			    sq = Math.sqrt(b * b + 1) - b;
+
+			    // workaround for floating point precision bug when sq = 0, log = -Infinite,
+			    // thus triggering an infinite loop in flyTo
+			    var log = sq < 0.000000001 ? -18 : Math.log(sq);
+
+			return log;
 		}
 
 		function sinh(n) { return (Math.exp(n) - Math.exp(-n)) / 2; }


### PR DESCRIPTION
1. Made a test for checking the flyTo bug
2. Changed the old flyTo test to use a visible div, as it is required for flyTo animation.
3. Split the long line of r() inside flyTo to multiple lines.
4. Added workaround for floating point precision error in flyTo.
5. Changed the zoompan example to trigger this bug when clicking on DC.

This workaround now effectively limits the animation of flyTo to maximum 9 zoom levels, after that it jumps at the end. Still this is much better then making the browser go into an infinite loop.

Proper fix would be to change the r() function not to use a tiny number and then take it's logarithm.
cc: @mourner 