### PR TITLE
Fix SVG dragging in IE and Edge.

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -118,6 +118,11 @@ L.Draggable = L.Evented.extend({
 			L.DomUtil.addClass(document.body, 'leaflet-dragging');
 
 			this._lastTarget = e.target || e.srcElement;
+			// IE and Edge do not give the <use> element, so fetch it
+			// if necessary
+			if ((window.SVGElementInstance) && (this._lastTarget instanceof SVGElementInstance)) {
+				this._lastTarget = this._lastTarget.correspondingUseElement;
+			}
 			L.DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
 		}
 


### PR DESCRIPTION
Fixes #4359 more or less by using the fix suggested in the report.

Example without the fix: https://playground-leaflet.rhcloud.com/qib/edit?html,output
Example _with_ the fix: http://playground-leaflet.rhcloud.com/tat/edit?html,output

Tested and verified in IE11.