### PR TITLE
Make drag handler insensitive to order of handlers events

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -166,6 +166,9 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onUp: function (e) {
+		// Ignore simulated events, since we handle both touch and
+		// mouse explicitly; otherwise we risk getting duplicates of
+		// touch events, see #4315.
 		if (e._simulated) { return; }
 
 		L.DomUtil.removeClass(document.body, 'leaflet-dragging');

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -69,6 +69,8 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onDown: function (e) {
+		if (e._simulated) { return; }
+
 		this._moved = false;
 
 		if (L.DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
@@ -100,6 +102,8 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onMove: function (e) {
+		if (e._simulated) { return; }
+
 		if (e.touches && e.touches.length > 1) {
 			this._moved = true;
 			return;
@@ -155,7 +159,9 @@ L.Draggable = L.Evented.extend({
 		this.fire('drag', e);
 	},
 
-	_onUp: function () {
+	_onUp: function (e) {
+		if (e._simulated) { return; }
+
 		L.DomUtil.removeClass(document.body, 'leaflet-dragging');
 
 		if (this._lastTarget) {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -69,6 +69,9 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onDown: function (e) {
+		// Ignore simulated events, since we handle both touch and
+		// mouse explicitly; otherwise we risk getting duplicates of
+		// touch events, see #4315.
 		if (e._simulated) { return; }
 
 		this._moved = false;
@@ -102,6 +105,9 @@ L.Draggable = L.Evented.extend({
 	},
 
 	_onMove: function (e) {
+		// Ignore simulated events, since we handle both touch and
+		// mouse explicitly; otherwise we risk getting duplicates of
+		// touch events, see #4315.
 		if (e._simulated) { return; }
 
 		if (e.touches && e.touches.length > 1) {


### PR DESCRIPTION
Draggable handles touch events, and does not rely on
simulated mouse events; under some circumstances, it
even breaks on simulated events (see #4315).

This PR ignores any simulated events in the event handlers,
to just deal with the real events. This makes it insensitive
to if the tap handler has run before, and fired simulated
events.

Close #4315.