### PR TITLE
fitBounds round fix

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -518,11 +518,10 @@ L.Map = L.Evented.extend({
 		    snap = L.Browser.any3d ? this.options.zoomSnap : 1;
 
 		var scale = Math.min(size.x / boundsSize.x, size.y / boundsSize.y);
-		scale = Math.round(scale * 1e9) / 1e9;
 		zoom = this.getScaleZoom(scale, zoom);
 
 		if (snap) {
-			zoom = inside ? Math.ceil(zoom / snap) * snap : Math.floor(zoom / snap) * snap;
+			zoom = inside ? Math.ceil(zoom / snap) * snap : Math.round(zoom / snap) * snap;
 		}
 
 		return Math.max(min, Math.min(max, zoom));

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -521,7 +521,8 @@ L.Map = L.Evented.extend({
 		zoom = this.getScaleZoom(scale, zoom);
 
 		if (snap) {
-			zoom = inside ? Math.ceil(zoom / snap) * snap : Math.round(zoom / snap) * snap;
+			zoom = Math.round(zoom / (snap / 100)) * (snap / 100); // don't jump if within 1% of a snap level
+			zoom = inside ? Math.ceil(zoom / snap) * snap : Math.floor(zoom / snap) * snap;
 		}
 
 		return Math.max(min, Math.min(max, zoom));


### PR DESCRIPTION
I think this is the right fix for the fitBounds jumping bug.

1. The jump actually happens only inside the snap part (with zoomSnap: 0, there is no jumping).
2. It is because of the Math.floor function: zoom level 14.9999 becomes 14.
3. This fix rounds to the nearest snap level, if within 1% of it. So 14.9999 becomes 15 and then floor and ceil doesn't make a jump.