### PR TITLE
Fix regression when setting style of Path with canvas renderer

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -98,4 +98,18 @@ describe('Canvas', function () {
 
 	});
 
+	describe('#dashArray', function () {
+		it('can add polyline with dashArray', function () {
+			var layer = L.polygon(latLngs, {
+				dashArray: "5,5"
+			}).addTo(map);
+		});
+		it('can setStyle with dashArray', function () {
+			var layer = L.polygon(latLngs).addTo(map);
+			layer.setStyle({
+				dashArray: "5,5"
+			});
+		});
+	});
+
 });

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -103,7 +103,7 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_updateStyle: function (layer) {
-		this._updateDashArray();
+		this._updateDashArray(layer);
 		this._requestRedraw(layer);
 	},
 


### PR DESCRIPTION
Pass layer on when calling _updateDashArray
Add specs to verify intialization and setStyle with dashArray.
Close #4401.