### PR TITLE
update default Control position to match leafdoc

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -13,7 +13,7 @@ L.Control = L.Class.extend({
 		// @option position: String = 'topleft'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
-		position: 'topright'
+		position: 'topleft'
 	},
 
 	initialize: function (options) {


### PR DESCRIPTION
It looks like after merging the :fallen_leaf:doc changes, the Zoom control is appearing on the `topright`.  I fixed this by adjusting the default position on `L.Control` to match what :fallen_leaf: doc says is the default.  However, I wonder if it might be best to also restore an explicit `position: "topleft"` in `L.Control.Zoom`.