### PR TITLE
Uncomment maxZoom option in L.GridLayer

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -97,7 +97,7 @@ L.GridLayer = L.Layer.extend({
 
 		// @option maxZoom: Number = undefined
 		// The maximum zoom level that tiles will be loaded at.
-//		maxZoom: undefined,
+		maxZoom: undefined,
 
 		// @option noWrap: Boolean = false
 		// Whether the layer is wrapped around the antimeridian. If `true`, the


### PR DESCRIPTION
Not sure why this was commented out in @IvanSanchez's doc fixes. It will be undefined regardless.