### PR TITLE
Change parameter type in docstring from |null to optional

### DIFF
--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -70,14 +70,14 @@ L.Icon = L.Class.extend({
 		L.setOptions(this, options);
 	},
 
-	// @method createIcon(oldIcon: HTMLElement|null): HTMLElement
+	// @method createIcon(oldIcon?: HTMLElement): HTMLElement
 	// Called internally when the icon has to be shown, returns a `<img>` HTML element
 	// styled according to the options.
 	createIcon: function (oldIcon) {
 		return this._createIcon('icon', oldIcon);
 	},
 
-	// @method createShadow(oldIcon: HTMLElement|null): HTMLElement
+	// @method createShadow(oldIcon?: HTMLElement): HTMLElement
 	// As `createIcon`, but for the shadow beneath it.
 	createShadow: function (oldIcon) {
 		return this._createIcon('shadow', oldIcon);


### PR DESCRIPTION
createIcon and createShadow both take an optional oldIcon parameter that should probably not be null for consistent types. It's checked with `||`, so undefined will work here.