### PR TITLE
Fixing hover/mouseover for circle/circleMarker with Cavas renderer

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -198,6 +198,8 @@ L.Canvas = L.Renderer.extend({
 
 		if (layer._empty()) { return; }
 
+		this._drawnLayers[layer._leaflet_id] = layer;
+		
 		var p = layer._point,
 		    ctx = this._ctx,
 		    r = layer._radius,


### PR DESCRIPTION
I ran into a problem using the canvas render. With SVG, it is mouseover on ``L.CircleMarker`` or ``L.Circle`` works just fine. However, with ``L.Canvas`` the mouseover event will not fire. 

Example:

```
var oxf = [51.751944, -1.257778];
var map = L.map('mapid',{preferCanvas:true}).setView(oxf, 5);
L.CircleMarker(oxf, 
	{"radius":10, fill: true, fillColor: "#00FF00", fillOpacity: 1, stroke: false})
	.on("mouseover click",function(e){console.log(e)})
	.addTo(map);
```

I traced this to the fact that in ``L.Canvas._updateCircle`` does not add the circle/circleMarkers to the ``_drawnLayers`` object.

This pull requeset adds that code so that mouseover behaves consistently between SVG and Canvas. I have not seen an unexpected behaviour or ill-effects from this change, but I defer to you if there is a good reason not to do this.

Thank you for a great library!