### PR TITLE
Build scripts: stop using magic-string and use git rev as semver metadata

### DIFF
--- a/build/publish.sh
+++ b/build/publish.sh
@@ -8,7 +8,7 @@ npm test || exit 1
 
 git checkout -b build
 
-npm run build
+jake build[,,true]
 git add dist/leaflet-src.js dist/leaflet.js dist/leaflet-src.map -f
 
 git commit -m "v$VERSION"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "eslint": "^2.8.0",
     "eslint-config-mourner": "^2.0.1",
+    "git-rev": "^0.2.1",
     "happen": "~0.3.1",
     "jake": "~8.0.12",
     "karma": "~0.13.22",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-safari-launcher": "~0.1.1",
     "leafdoc": "^1.2.1",
-    "magic-string": "^0.11.4",
     "mocha": "~2.4.5",
     "phantomjs-prebuilt": "^2.1.7",
     "prosthetic-hand": "^1.3.0",
+    "source-map": "^0.5.3",
     "uglify-js": "~2.6.2"
   },
   "main": "dist/leaflet-src.js",

--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -1,6 +1,6 @@
 
 var L = {
-	version: '1.0.0-rc.1'
+	version: 'dev'
 };
 
 function expose() {


### PR DESCRIPTION
As @perliedman pointed out in the gitter chat, sourcemaps for -rc1 are broken and point to line 1 of all files (besides, they refuse to be loaded with sourcemap debugging tools like https://github.com/sokra/source-map-visualization).

I replaced the code for generating sourcemaps from the simplistic `magic-string` library to the more raw `source-map` library, by copy-pasting some code from my modifications to `gobble-concat`.

---

After pondering with the release scripts, and after seeing a lot of bug reports of leaflet between beta2 and rc1 with the same value of `L.version`, I thought it would be a good idea to add "build metadata" as per the semver specs.

These build scripts will look in `package.json` for the version, then append the git rev automatically on `jake build`. e.g. `L.version = "1.0.0-rc.1+75dda76"`

This can be disabled by running `jake build[,,true]` (which is exactly what `publish.sh` does).

Hopefully this would help track "unofficial" builds, and tell the git rev of those.