### PR TITLE
Add option type for 'center' value docstrings

### DIFF
--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -6,7 +6,7 @@
 // @section Interaction Options
 
 L.Map.mergeOptions({
-	// @option doubleClickZoom: Boolean = true
+	// @option doubleClickZoom: Boolean|String = true
 	// Whether the map can be zoomed in by double clicking on it and
 	// zoomed out by double clicking while holding shift. If passed
 	// `'center'`, double-click zoom will zoom to the center of the

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -6,7 +6,7 @@
 // @section Interaction Options
 L.Map.mergeOptions({
 	// @section Mousewheel options
-	// @option scrollWheelZoom: Boolean = true
+	// @option scrollWheelZoom: Boolean|String = true
 	// Whether the map can be zoomed by using the mouse wheel. If passed `'center'`,
 	// it will zoom to the center of the view regardless of where the mouse was.
 	scrollWheelZoom: true,

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -6,7 +6,7 @@
 // @section Interaction Options
 L.Map.mergeOptions({
 	// @section Touch interaction options
-	// @option touchZoom: Boolean = *
+	// @option touchZoom: Boolean|String = *
 	// Whether the map can be zoomed by touch-dragging with two fingers. If
 	// passed `'center'`, it will zoom to the center of the view regardless of
 	// where the touch events (fingers) were. Enabled for touch-capable web


### PR DESCRIPTION
doubleClickZoom, scrollWheelZoom and touchZoom all allow the string 'center' to be passed (besides the default boolean values). This adds 'string' as a type for those options.