### PR TITLE
Sourcemaps: replace magic-string with source-map.SourceNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-safari-launcher": "~0.1.1",
     "leafdoc": "^1.2.1",
-    "magic-string": "^0.11.4",
     "mocha": "~2.4.5",
     "phantomjs-prebuilt": "^2.1.7",
     "prosthetic-hand": "^1.3.0",
+    "source-map": "^0.5.3",
     "uglify-js": "~2.6.2"
   },
   "main": "dist/leaflet-src.js",


### PR DESCRIPTION
As @perliedman pointed out in the gitter chat, sourcemaps for -rc1 are broken and point to line 1 of all files (besides, they refuse to be loaded with sourcemap debugging tools like https://github.com/sokra/source-map-visualization).

I replaced the code for generating sourcemaps from the simplistic `magic-string` library to the more raw `source-map` library, by copy-pasting some code from my modifications to `gobble-concat`.