### PR TITLE
Better handling of markerZoomAnimation event hooks

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -86,7 +86,11 @@ L.Layer = L.Evented.extend({
 		this._zoomAnimated = map._zoomAnimated;
 
 		if (this.getEvents) {
-			map.on(this.getEvents(), this);
+			var events = this.getEvents();
+			map.on(events, this);
+			this.on('remove', function () {
+				map.off(events, this);
+			}, this);
 		}
 
 		this.onAdd(map);
@@ -165,10 +169,6 @@ L.Map.include({
 
 		if (layer.getAttribution && this.attributionControl) {
 			this.attributionControl.removeAttribution(layer.getAttribution());
-		}
-
-		if (layer.getEvents) {
-			this.off(layer.getEvents(), layer);
 		}
 
 		delete this._layers[id];

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -88,7 +88,7 @@ L.Layer = L.Evented.extend({
 		if (this.getEvents) {
 			var events = this.getEvents();
 			map.on(events, this);
-			this.on('remove', function () {
+			this.once('remove', function () {
 				map.off(events, this);
 			}, this);
 		}

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -100,14 +100,22 @@ L.Marker = L.Layer.extend({
 	onAdd: function (map) {
 		this._zoomAnimated = this._zoomAnimated && map.options.markerZoomAnimation;
 
+		if (this._zoomAnimated) {
+			map.on('zoomanim', this._animateZoom, this);
+		}
+
 		this._initIcon();
 		this.update();
 	},
 
-	onRemove: function () {
+	onRemove: function (map) {
 		if (this.dragging && this.dragging.enabled()) {
 			this.options.draggable = true;
 			this.dragging.removeHooks();
+		}
+
+		if (this._zoomAnimated) {
+			map.off('zoomanim', this._animateZoom, this);
 		}
 
 		this._removeIcon();
@@ -115,16 +123,10 @@ L.Marker = L.Layer.extend({
 	},
 
 	getEvents: function () {
-		var events = {
+		return {
 			zoom: this.update,
 			viewreset: this.update
 		};
-
-		if (this._zoomAnimated) {
-			events.zoomanim = this._animateZoom;
-		}
-
-		return events;
 	},
 
 	// @method getLatLng: LatLng


### PR DESCRIPTION
Fixes #4453. This is two-fold:

* `L.Layer` shall remove the same layer events that it attached. No longer assume that two calls to `L.Layer.getEvents()` will return the same values. (not 100% needed for this bug, but it is a sane change)
* `L.Marker` needs to know a map option before deciding whether to attach a `zoomanim` event handler or not. Manual handling on `onAdd` and `onRemove` is thus needed.

Despite my efforts, I couldn't make a failing test case before the bugfixes, so no new unit tests :-(