### PR TITLE
Allow point and latlng expressions in all methods

### DIFF
--- a/spec/suites/geo/CRSSpec.js
+++ b/spec/suites/geo/CRSSpec.js
@@ -9,6 +9,11 @@ describe("CRS.EPSG3857", function () {
 		it("projects the northeast corner of the world", function () {
 			expect(crs.latLngToPoint(L.latLng(85.0511287798, 180), 0)).near(new L.Point(256, 0));
 		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.latLngToPoint([0, 0], 0)).near(new L.Point(128, 128), 0.01);
+			expect(crs.latLngToPoint({lat: 0, lng: 0}, 0)).near(new L.Point(128, 128), 0.01);
+		});
 	});
 
 	describe("#pointToLatLng", function () {
@@ -19,6 +24,10 @@ describe("CRS.EPSG3857", function () {
 		it("reprojects the northeast corner of the world", function () {
 			expect(crs.pointToLatLng(new L.Point(256, 0), 0)).nearLatLng(L.latLng(85.0511287798, 180));
 		});
+
+		it("accepts L.Point and L.Point expressions", function () {
+			expect(crs.pointToLatLng([128, 128], 0)).nearLatLng(L.latLng(0, 0), 0.01);
+		});
 	});
 
 	describe("project", function () {
@@ -27,6 +36,11 @@ describe("CRS.EPSG3857", function () {
 			expect(crs.project(new L.LatLng(85.0511287798, 180))).near(new L.Point(20037508.34279, 20037508.34278));
 			expect(crs.project(new L.LatLng(-85.0511287798, -180))).near(new L.Point(-20037508.34279, -20037508.34278));
 		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.project([50, 30])).near(new L.Point(3339584.7238, 6446275.84102));
+			expect(crs.project({lat: 50, lng: 30})).near(new L.Point(3339584.7238, 6446275.84102));
+		});
 	});
 
 	describe("unproject", function () {
@@ -34,6 +48,10 @@ describe("CRS.EPSG3857", function () {
 			expect(crs.unproject(new L.Point(3339584.7238, 6446275.84102))).nearLatLng(new L.LatLng(50, 30));
 			expect(crs.unproject(new L.Point(20037508.34279, 20037508.34278))).nearLatLng(new L.LatLng(85.051129, 180));
 			expect(crs.unproject(new L.Point(-20037508.34279, -20037508.34278))).nearLatLng(new L.LatLng(-85.051129, -180));
+		});
+
+		it("accepts L.Point and L.Point expressions", function () {
+			expect(crs.unproject([3339584.7238, 6446275.84102])).nearLatLng(new L.LatLng(50, 30));
 		});
 	});
 
@@ -71,6 +89,10 @@ describe("CRS.EPSG3857", function () {
 			expect(crs.wrapLatLng(new L.LatLng(0, 380, 1234)).alt).to.eql(1234);
 		});
 
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.wrapLatLng([0, 190]).lng).to.eql(-170);
+			expect(crs.wrapLatLng({lat: 0, lng: 190}).lng).to.eql(-170);
+		});
 	});
 
 });
@@ -105,6 +127,11 @@ describe("CRS.EPSG3395", function () {
 		it("projects the northeast corner of the world", function () {
 			expect(crs.latLngToPoint(L.latLng(85.0840591556, 180), 0)).near(new L.Point(256, 0));
 		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.latLngToPoint([0, 0], 0)).near(new L.Point(128, 128), 0.01);
+			expect(crs.latLngToPoint({lat: 0, lng: 0}, 0)).near(new L.Point(128, 128), 0.01);
+		});
 	});
 
 	describe("#pointToLatLng", function () {
@@ -114,6 +141,10 @@ describe("CRS.EPSG3395", function () {
 
 		it("reprojects the northeast corner of the world", function () {
 			expect(crs.pointToLatLng(new L.Point(256, 0), 0)).nearLatLng(L.latLng(85.0840591556, 180));
+		});
+
+		it("accepts L.Point and L.Point expressions", function () {
+			expect(crs.pointToLatLng([128, 128], 0)).nearLatLng(L.latLng(0, 0), 0.01);
 		});
 	});
 });
@@ -127,6 +158,11 @@ describe("CRS.Simple", function () {
 			expect(crs.latLngToPoint(L.latLng(700, 300), 0)).near(new L.Point(300, -700));
 			expect(crs.latLngToPoint(L.latLng(-200, 1000), 1)).near(new L.Point(2000, 400));
 		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.latLngToPoint([0, 0], 0)).near(new L.Point(0, 0));
+			expect(crs.latLngToPoint({lat: 0, lng: 0}, 0)).near(new L.Point(0, 0));
+		});
 	});
 
 	describe("#pointToLatLng", function () {
@@ -134,6 +170,10 @@ describe("CRS.Simple", function () {
 			expect(crs.pointToLatLng(L.point(0, 0), 0)).nearLatLng(new L.LatLng(0, 0));
 			expect(crs.pointToLatLng(L.point(300, -700), 0)).nearLatLng(new L.LatLng(700, 300));
 			expect(crs.pointToLatLng(L.point(2000, 400), 1)).nearLatLng(new L.LatLng(-200, 1000));
+		});
+
+		it("accepts L.Point and L.Point expressions", function () {
+			expect(crs.pointToLatLng([0, 0], 0)).nearLatLng(new L.LatLng(0, 0));
 		});
 	});
 
@@ -147,6 +187,7 @@ describe("CRS.Simple", function () {
 		it("returns coords as is", function () {
 			expect(crs.wrapLatLng(new L.LatLng(270, 400)).equals(new L.LatLng(270, 400))).to.be(true);
 		});
+
 		it("wraps coords if configured", function () {
 			var crs = L.extend({}, L.CRS.Simple, {
 				wrapLng: [-200, 200],
@@ -154,6 +195,11 @@ describe("CRS.Simple", function () {
 			});
 
 			expect(crs.wrapLatLng(new L.LatLng(300, -250))).nearLatLng(new L.LatLng(-100, 150));
+		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(crs.wrapLatLng([270, 400]).equals(new L.LatLng(270, 400))).to.be(true);
+			expect(crs.wrapLatLng({lat: 270, lng: 400}).equals(new L.LatLng(270, 400))).to.be(true);
 		});
 	});
 });
@@ -204,8 +250,16 @@ describe("CRS.Earth", function () {
 		// we assume using mean earth radius (https://en.wikipedia.org/wiki/Earth_radius#Mean_radius)
 		// is correct, since that's what International Union of Geodesy and Geophysics recommends,
 		// and that sounds serious.
-		var p1 = L.latLng(36.12, -86.67);
-		var p2 = L.latLng(33.94, -118.40);
-		expect(L.CRS.Earth.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
+
+		it("calculates the distance between to latlng's", function () {
+			var p1 = L.latLng(36.12, -86.67);
+			var p2 = L.latLng(33.94, -118.40);
+			expect(L.CRS.Earth.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
+		});
+
+		it("accepts L.LatLng and L.LatLng expressions", function () {
+			expect(L.CRS.Earth.distance([36.12, -86.67], [33.94, -118.40])).to.be.within(2886444.43, 2886444.45);
+			expect(L.CRS.Earth.distance({lat: 36.12, lng: -86.67}, {lat: 33.94, lng: -118.40})).to.be.within(2886444.43, 2886444.45);
+		});
 	});
 });

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -185,7 +185,7 @@ L.DomUtil = {
 	// and optionally scaled by `scale`. Does not have an effect if the
 	// browser doesn't support 3D CSS transforms.
 	setTransform: function (el, offset, scale) {
-		var pos = offset || new L.Point(0, 0);
+		var pos = offset ? L.point(offset) : new L.Point(0, 0);
 
 		el.style[L.DomUtil.TRANSFORM] =
 			(L.Browser.ie3d ?
@@ -198,17 +198,18 @@ L.DomUtil = {
 	// Sets the position of `el` to coordinates specified by `position`,
 	// using CSS translate or top/left positioning depending on the browser
 	// (used by Leaflet internally to position its layers).
-	setPosition: function (el, point) { // (HTMLElement, Point[, Boolean])
+	setPosition: function (el, point) {
+		var pos = L.point(point);
 
 		/*eslint-disable */
-		el._leaflet_pos = point;
+		el._leaflet_pos = pos;
 		/*eslint-enable */
 
 		if (L.Browser.any3d) {
-			L.DomUtil.setTransform(el, point);
+			L.DomUtil.setTransform(el, pos);
 		} else {
-			el.style.left = point.x + 'px';
-			el.style.top = point.y + 'px';
+			el.style.left = pos.x + 'px';
+			el.style.top = pos.y + 'px';
 		}
 	},
 

--- a/src/geo/crs/CRS.Earth.js
+++ b/src/geo/crs/CRS.Earth.js
@@ -17,11 +17,13 @@ L.CRS.Earth = L.extend({}, L.CRS, {
 
 	// distance between two geographical points using spherical law of cosines approximation
 	distance: function (latlng1, latlng2) {
-		var rad = Math.PI / 180,
-		    lat1 = latlng1.lat * rad,
-		    lat2 = latlng2.lat * rad,
+		var _latlng1 = L.latLng(latlng1),
+		    _latlng2 = L.latLng(latlng2),
+		    rad = Math.PI / 180,
+		    lat1 = _latlng1.lat * rad,
+		    lat2 = _latlng2.lat * rad,
 		    a = Math.sin(lat1) * Math.sin(lat2) +
-		        Math.cos(lat1) * Math.cos(lat2) * Math.cos((latlng2.lng - latlng1.lng) * rad);
+		        Math.cos(lat1) * Math.cos(lat2) * Math.cos((_latlng2.lng - _latlng1.lng) * rad);
 
 		return this.R * Math.acos(Math.min(a, 1));
 	}

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -15,7 +15,7 @@ L.CRS = {
 	// @method latLngToPoint(latlng: LatLng, zoom: Number): Point
 	// Projects geographical coordinates into pixel coordinates for a given zoom.
 	latLngToPoint: function (latlng, zoom) {
-		var projectedPoint = this.projection.project(latlng),
+		var projectedPoint = this.projection.project(L.latLng(latlng)),
 		    scale = this.scale(zoom);
 
 		return this.transformation._transform(projectedPoint, scale);
@@ -26,7 +26,7 @@ L.CRS = {
 	// zoom into geographical coordinates.
 	pointToLatLng: function (point, zoom) {
 		var scale = this.scale(zoom),
-		    untransformedPoint = this.transformation.untransform(point, scale);
+		    untransformedPoint = this.transformation.untransform(L.point(point), scale);
 
 		return this.projection.unproject(untransformedPoint);
 	},
@@ -35,14 +35,14 @@ L.CRS = {
 	// Projects geographical coordinates into coordinates in units accepted for
 	// this CRS (e.g. meters for EPSG:3857, for passing it to WMS services).
 	project: function (latlng) {
-		return this.projection.project(latlng);
+		return this.projection.project(L.latLng(latlng));
 	},
 
 	// @method unproject(point: Point): LatLng
 	// Given a projected coordinate returns the corresponding LatLng.
 	// The inverse of `project`.
 	unproject: function (point) {
-		return this.projection.unproject(point);
+		return this.projection.unproject(L.point(point));
 	},
 
 	// @method scale(zoom: Number): Number
@@ -95,9 +95,11 @@ L.CRS = {
 	// Returns a `LatLng` where lat and lng has been wrapped according to the
 	// CRS's `wrapLat` and `wrapLng` properties, if they are outside the CRS's bounds.
 	wrapLatLng: function (latlng) {
-		var lng = this.wrapLng ? L.Util.wrapNum(latlng.lng, this.wrapLng, true) : latlng.lng,
-		    lat = this.wrapLat ? L.Util.wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat,
-		    alt = latlng.alt;
+		var _latlng = L.latLng(latlng);
+
+		var lng = this.wrapLng ? L.Util.wrapNum(_latlng.lng, this.wrapLng, true) : _latlng.lng,
+		    lat = this.wrapLat ? L.Util.wrapNum(_latlng.lat, this.wrapLat, true) : _latlng.lat,
+		    alt = _latlng.alt;
 
 		return L.latLng(lat, lng, alt);
 	}

--- a/src/geo/projection/Projection.LonLat.js
+++ b/src/geo/projection/Projection.LonLat.js
@@ -15,11 +15,15 @@ L.Projection = {};
 
 L.Projection.LonLat = {
 	project: function (latlng) {
-		return new L.Point(latlng.lng, latlng.lat);
+		var _latlng = L.latLng(latlng);
+
+		return new L.Point(_latlng.lng, _latlng.lat);
 	},
 
 	unproject: function (point) {
-		return new L.LatLng(point.y, point.x);
+		var _point = L.point(point);
+
+		return new L.LatLng(_point.y, _point.x);
 	},
 
 	bounds: L.bounds([-180, -90], [180, 90])

--- a/src/geo/projection/Projection.Mercator.js
+++ b/src/geo/projection/Projection.Mercator.js
@@ -12,9 +12,10 @@ L.Projection.Mercator = {
 	bounds: L.bounds([-20037508.34279, -15496570.73972], [20037508.34279, 18764656.23138]),
 
 	project: function (latlng) {
-		var d = Math.PI / 180,
+		var _latlng = L.latLng(latlng),
+		    d = Math.PI / 180,
 		    r = this.R,
-		    y = latlng.lat * d,
+		    y = _latlng.lat * d,
 		    tmp = this.R_MINOR / r,
 		    e = Math.sqrt(1 - tmp * tmp),
 		    con = e * Math.sin(y);
@@ -22,15 +23,16 @@ L.Projection.Mercator = {
 		var ts = Math.tan(Math.PI / 4 - y / 2) / Math.pow((1 - con) / (1 + con), e / 2);
 		y = -r * Math.log(Math.max(ts, 1E-10));
 
-		return new L.Point(latlng.lng * d * r, y);
+		return new L.Point(_latlng.lng * d * r, y);
 	},
 
 	unproject: function (point) {
-		var d = 180 / Math.PI,
+		var _point = L.point(point),
+		    d = 180 / Math.PI,
 		    r = this.R,
 		    tmp = this.R_MINOR / r,
 		    e = Math.sqrt(1 - tmp * tmp),
-		    ts = Math.exp(-point.y / r),
+		    ts = Math.exp(-_point.y / r),
 		    phi = Math.PI / 2 - 2 * Math.atan(ts);
 
 		for (var i = 0, dphi = 0.1, con; i < 15 && Math.abs(dphi) > 1e-7; i++) {
@@ -40,6 +42,6 @@ L.Projection.Mercator = {
 			phi += dphi;
 		}
 
-		return new L.LatLng(phi * d, point.x * d / r);
+		return new L.LatLng(phi * d, _point.x * d / r);
 	}
 };

--- a/src/geo/projection/Projection.SphericalMercator.js
+++ b/src/geo/projection/Projection.SphericalMercator.js
@@ -13,22 +13,24 @@ L.Projection.SphericalMercator = {
 	MAX_LATITUDE: 85.0511287798,
 
 	project: function (latlng) {
-		var d = Math.PI / 180,
+		var _latlng = L.latLng(latlng),
+		    d = Math.PI / 180,
 		    max = this.MAX_LATITUDE,
-		    lat = Math.max(Math.min(max, latlng.lat), -max),
+		    lat = Math.max(Math.min(max, _latlng.lat), -max),
 		    sin = Math.sin(lat * d);
 
 		return new L.Point(
-				this.R * latlng.lng * d,
+				this.R * _latlng.lng * d,
 				this.R * Math.log((1 + sin) / (1 - sin)) / 2);
 	},
 
 	unproject: function (point) {
-		var d = 180 / Math.PI;
+		var _point = L.point(point),
+		    d = 180 / Math.PI;
 
 		return new L.LatLng(
-			(2 * Math.atan(Math.exp(point.y / this.R)) - (Math.PI / 2)) * d,
-			point.x * d / this.R);
+			(2 * Math.atan(Math.exp(_point.y / this.R)) - (Math.PI / 2)) * d,
+			_point.x * d / this.R);
 	},
 
 	bounds: (function () {

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -16,6 +16,7 @@ L.LineUtil = {
 	// Used for a huge performance boost when processing/displaying Leaflet polylines for
 	// each zoom level and also reducing visual noise. tolerance affects the amount of
 	// simplification (lesser value means higher quality but slower and with more points).
+	// Only accepts real L.Point instances, not arrays.
 	// Also released as a separated micro-library [Simplify.js](http://mourner.github.com/simplify-js/).
 	simplify: function (points, tolerance) {
 		if (!tolerance || !points.length) {
@@ -35,12 +36,14 @@ L.LineUtil = {
 
 	// @function pointToSegmentDistance(p: Point, p1: Point, p2: Point): Number
 	// Returns the distance between point `p` and segment `p1` to `p2`.
+	// Only accepts real L.Point instances, not arrays.
 	pointToSegmentDistance:  function (p, p1, p2) {
 		return Math.sqrt(this._sqClosestPointOnSegment(p, p1, p2, true));
 	},
 
 	// @function closestPointOnSegment(p: Point, p1: Point, p2: Point): Number
 	// Returns the closest point from a point `p` on a segment `p1` to `p2`.
+	// Only accepts real L.Point instances, not arrays.
 	closestPointOnSegment: function (p, p1, p2) {
 		return this._sqClosestPointOnSegment(p, p1, p2);
 	},
@@ -112,6 +115,7 @@ L.LineUtil = {
 	// [Cohen-Sutherland algorithm](https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm)
 	// (modifying the segment points directly!). Used by Leaflet to only show polyline
 	// points that are on the screen or near, increasing performance.
+	// Only accepts real L.Point instances, not arrays.
 	clipSegment: function (a, b, bounds, useLastCode, round) {
 		var codeA = useLastCode ? this._lastCode : this._getBitCode(a, bounds),
 		    codeB = this._getBitCode(b, bounds),

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -223,12 +223,14 @@ L.extend(L.GeoJSON, {
 	// @function latLngToCoords(latlng: LatLng): Array
 	// Reverse of [`coordsToLatLng`](#geojson-coordstolatlng)
 	latLngToCoords: function (latlng) {
-		return latlng.alt !== undefined ?
-				[latlng.lng, latlng.lat, latlng.alt] :
-				[latlng.lng, latlng.lat];
+		var _latlng = L.latLng(latlng);
+
+		return _latlng.alt !== undefined ?
+				[_latlng.lng, _latlng.lat, _latlng.alt] :
+				[_latlng.lng, _latlng.lat];
 	},
 
-	// @function latLngsToCoords(latlngs: Array, levelsDeep?: Number, closed?: Boolean): Array
+	// @function latLngsToCoords(latlngs: LatLng[], levelsDeep?: Number, closed?: Boolean): Array
 	// Reverse of [`coordsToLatLngs`](#geojson-coordstolatlngs)
 	// `closed` determines whether the first point should be appended to the end of the array to close the feature, only used when `levelsDeep` is 0. False by default.
 	latLngsToCoords: function (latlngs, levelsDeep, closed) {


### PR DESCRIPTION
Found a couple methods that only accept L.Point and L.LatLng instances, instead of the expressions that all other methods accept ([number, number], {lat: number, lng: number}, etc). Only exception is LineUtil, so added a note in the docstring that only real L.Points are accepted.
