### PR TITLE
Create points from objects with x and y properties

### DIFF
--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -96,6 +96,9 @@ describe("Point", function () {
 		it('creates a point from an array of coordinates', function () {
 			expect(L.point([50, 30])).to.eql(new L.Point(50, 30));
 		});
+		it("creates a point from an object with x and y properties", function () {
+			expect(L.point({x: 50, y: 30})).to.eql(new L.Point(50, 30));
+		});
 		it('does not fail on invalid arguments', function () {
 			expect(L.point(undefined)).to.be(undefined);
 			expect(L.point(null)).to.be(null);

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -177,6 +177,10 @@ L.Point.prototype = {
 // @alternative
 // @factory L.point(coords: Number[])
 // Expects an array of the form `[x, y]` instead.
+
+// @alternative
+// @factory L.point(coords: Object)
+// Expects a plain object of the form `{x: Number, y: Number}` instead.
 L.point = function (x, y, round) {
 	if (x instanceof L.Point) {
 		return x;
@@ -186,6 +190,9 @@ L.point = function (x, y, round) {
 	}
 	if (x === undefined || x === null) {
 		return x;
+	}
+	if (typeof x === 'object' && 'x' in x && 'y' in x) {
+		return new L.Point(x.x, x.y);
 	}
 	return new L.Point(x, y, round);
 };


### PR DESCRIPTION
Standardizes L.point() with L.latLng(). L.latLng accepts `{lat: Number, lng: Number}`, now L.point accepts `{x: Number, y: Number}`