### PR TITLE
Leafdoc: fix internal links & inconsistent return types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "karma-mocha": "~0.2.2",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-safari-launcher": "~0.1.1",
-    "leafdoc": "^1.2.1",
+    "leafdoc": "^1.2.2",
     "mocha": "~2.4.5",
     "phantomjs-prebuilt": "^2.1.7",
     "prosthetic-hand": "^1.3.0",

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -81,21 +81,21 @@ L.Class.extend = function (props) {
 };
 
 
-// @function include(properties: Object)
+// @function include(properties: Object): this
 // [Includes a mixin](#class-includes) into the current class.
 L.Class.include = function (props) {
 	L.extend(this.prototype, props);
 	return this;
 };
 
-// @function mergeOptions(options: Object)
+// @function mergeOptions(options: Object): this
 // [Merges `options`](#class-options) into the defaults of the class.
 L.Class.mergeOptions = function (options) {
 	L.extend(this.prototype.options, options);
 	return this;
 };
 
-// @function addInitHook(fn: Function)
+// @function addInitHook(fn: Function): this
 // Adds a [constructor hook](#class-constructor-hooks) to the class.
 L.Class.addInitHook = function (fn) { // (Function) || (String, args...)
 	var args = Array.prototype.slice.call(arguments, 1);

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -65,12 +65,12 @@ Error code (if applicable).
 
 @miniclass LayerEvent (Event objects)
 @inherits Event
-@property layer: ILayer
+@property layer: Layer
 The layer that was added or removed.
 
 @miniclass LayersControlEvent (Event objects)
 @inherits Event
-@property layer: ILayer
+@property layer: Layer
 The layer that was added or removed.
 @property name: String
 The name of the layer that was added or removed.
@@ -94,7 +94,7 @@ The new size after the resize event.
 
 @miniclass GeoJSON event (Event objects)
 @inherits Event
-@property layer: ILayer
+@property layer: Layer
 The layer for the GeoJSON feature that is being added to the map.
 @property properties: Object
 GeoJSON properties of the feature.
@@ -103,7 +103,7 @@ GeoJSON geometry type of the feature.
 @property id: String
 GeoJSON ID of the feature (if present).
 
-@miniclass Popup event (Event objects)
+@miniclass PopupEvent (Event objects)
 @inherits Event
 @property popup: Popup
 The popup that was opened or closed.

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -216,12 +216,12 @@ L.Util = {
 	               getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); };
 
 
-	// @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): requestId: Number
+	// @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): Number
 	// Schedules `fn` to be executed when the browser repaints. `fn` is bound to
 	// `context` if given. When `immediate` is set, `fn` is called immediately if
 	// the browser doesn't have native support for
 	// [`window.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame),
-	// otherwise it's delayed. Returns an id that can be used to cancel the request.
+	// otherwise it's delayed. Returns an request ID that can be used to cancel the request.
 	L.Util.requestAnimFrame = function (fn, context, immediate) {
 		if (immediate && requestFn === timeoutDefer) {
 			fn.call(context);
@@ -230,7 +230,7 @@ L.Util = {
 		}
 	};
 
-	// @function cancelAnimFrame(id: Number)
+	// @function cancelAnimFrame(id: Number): undefined
 	// Cancels a previous `requestAnimFrame`. See also [window.cancelAnimationFrame](https://developer.mozilla.org/docs/Web/API/window/cancelAnimationFrame).
 	L.Util.cancelAnimFrame = function (id) {
 		if (id) {

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -221,7 +221,7 @@ L.Util = {
 	// `context` if given. When `immediate` is set, `fn` is called immediately if
 	// the browser doesn't have native support for
 	// [`window.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame),
-	// otherwise it's delayed. Returns an request ID that can be used to cancel the request.
+	// otherwise it's delayed. Returns a request ID that can be used to cancel the request.
 	L.Util.requestAnimFrame = function (fn, context, immediate) {
 		if (immediate && requestFn === timeoutDefer) {
 			fn.call(context);

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -37,14 +37,15 @@ L.DomEvent = {
 		return this;
 	},
 
-	// @function off(el: HTMLElement, types: String, fn: Function, context?: Object)
+	// @function off(el: HTMLElement, types: String, fn: Function, context?: Object): this
 	// Removes a previously added listener function. If no function is specified,
 	// it will remove all the listeners of that particular DOM event from the element.
 	// Note that if you passed a custom context to on, you must pass the same
 	// context to `off` in order to remove the listener.
 
 	// @alternative
-	// @function off(el: HTMLElement, types: eventMap: Object, context?: Object): this
+	// @function off(el: HTMLElement, eventMap: Object, context?: Object): this
+	// Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
 	off: function (obj, types, fn, context) {
 
 		if (typeof types === 'object') {

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -107,7 +107,7 @@ L.LineUtil = {
 	},
 
 
-	// @function clipSegment(a: Point, b: Point, bounds: Bounds, useLastCode?: Boolean, round?: Boolean): Point[]|boolean
+	// @function clipSegment(a: Point, b: Point, bounds: Bounds, useLastCode?: Boolean, round?: Boolean): Point[]|Boolean
 	// Clips the segment a to b by rectangular bounds with the
 	// [Cohen-Sutherland algorithm](https://en.wikipedia.org/wiki/Cohen%E2%80%93Sutherland_algorithm)
 	// (modifying the segment points directly!). Used by Leaflet to only show polyline

--- a/src/geometry/Transformation.js
+++ b/src/geometry/Transformation.js
@@ -27,7 +27,7 @@ L.Transformation = function (a, b, c, d) {
 };
 
 L.Transformation.prototype = {
-	// @method transform(point: Point, scale?: Number)
+	// @method transform(point: Point, scale?: Number): Point
 	// Returns a transformed point, optionally multiplied by the given scale.
 	// Only accepts real `L.Point` instances, not arrays.
 	transform: function (point, scale) { // (Point, Number) -> Point
@@ -42,7 +42,7 @@ L.Transformation.prototype = {
 		return point;
 	},
 
-	// @method untransform(point: Point, scale?: Number)
+	// @method untransform(point: Point, scale?: Number): Point
 	// Returns the reverse transformation of the given point, optionally divided
 	// by the given scale. Only accepts real `L.Point` instances, not arrays.
 	untransform: function (point, scale) {

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -76,7 +76,7 @@ L.LayerGroup = L.Layer.extend({
 		return this;
 	},
 
-	// @method invoke(methodName: string, …): this
+	// @method invoke(methodName: String, …): this
 	// Calls `methodName` on every layer contained in this group, passing any
 	// additional parameters. Has no effect if the layers contained do not
 	// implement `methodName`.

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -415,7 +415,7 @@ L.Popup = L.Layer.extend({
 
 		// @namespace Map
 		// @section Popup events
-		// @event autopanstart
+		// @event autopanstart: Event
 		// Fired when the map starts autopanning when opening a popup.
 		if (dx || dy) {
 			map

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -13,8 +13,10 @@
 
 L.Marker = L.Layer.extend({
 
+	// @section
+	// @aka Marker options
 	options: {
-		// @option icon: L.Icon = *
+		// @option icon: Icon = *
 		// Icon class to use for rendering the marker. See [Icon documentation](#L.Icon) for details on how to customize the marker icon. Set to new `L.Icon.Default()` by default.
 		icon: new L.Icon.Default(),
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -26,13 +26,13 @@
  * ```
  * L.tileLayer('http://{s}.somedomain.com/{foo}/{z}/{x}/{y}.png', {foo: 'bar'});
  * ```
- *
- * @section
  */
 
 
 L.TileLayer = L.GridLayer.extend({
 
+	// @section
+	// @aka TileLayer options
 	options: {
 		// @option minZoom: Number = 0
 		// Minimum zoom number.
@@ -236,7 +236,7 @@ L.TileLayer = L.GridLayer.extend({
 });
 
 
-// @factory L.tilelayer(urlTemplate: String, options? TileLayer options)
+// @factory L.tilelayer(urlTemplate: String, options?: TileLayer options)
 // Instantiates a tile layer object given a `URL template` and optionally an options object.
 
 L.tileLayer = function (url, options) {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -316,7 +316,7 @@ L.Browser.canvas = (function () {
 }());
 
 // @namespace Canvas
-// @factory L.canvas(options?: Canvas options)
+// @factory L.canvas(options?: Renderer options)
 // Creates a Canvas renderer with the given options.
 L.canvas = function (options) {
 	return L.Browser.canvas ? new L.Canvas(options) : null;

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -46,7 +46,7 @@ L.Polyline = L.Path.extend({
 		// better performance and smoother look, and less means more accurate representation.
 		smoothFactor: 1.0,
 
-		// @option noClip: Boolean: false
+		// @option noClip: Boolean = false
 		// Disable polyline clipping.
 		noClip: false
 	},

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -17,6 +17,8 @@
 
 L.Renderer = L.Layer.extend({
 
+	// @section
+	// @aka Renderer options
 	options: {
 		// @option padding: Number = 0.1
 		// How much to extend the clip area around the map view (relative to its size)

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -86,7 +86,7 @@ L.SVG = L.Renderer.extend({
 		var path = layer._path = L.SVG.create('path');
 
 		// @namespace Path
-		// @option className: string = null
+		// @option className: String = null
 		// Custom class name set on an element. Only for SVG renderer.
 		if (layer.options.className) {
 			L.DomUtil.addClass(path, layer.options.className);
@@ -196,7 +196,7 @@ L.extend(L.SVG, {
 		return document.createElementNS('http://www.w3.org/2000/svg', name);
 	},
 
-	// @function pointsToPath(rings: [], closed: Boolean): String
+	// @function pointsToPath(rings: Point[], closed: Boolean): String
 	// Generates a SVG path string for multiple rings, with each ring turning
 	// into "M..L..L.." instructions
 	pointsToPath: function (rings, closed) {
@@ -226,7 +226,7 @@ L.Browser.svg = !!(document.createElementNS && L.SVG.create('svg').createSVGRect
 
 
 // @namespace SVG
-// @factory L.svg(options?: SVG options)
+// @factory L.svg(options?: Renderer options)
 // Creates a SVG renderer with the given options.
 L.svg = function (options) {
 	return L.Browser.svg || L.Browser.vml ? new L.SVG(options) : null;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -134,7 +134,7 @@ L.Map = L.Evented.extend({
 
 	// @section Methods for modifying map state
 
-	// @method setView(center: LatLnt, zoom: Number, options?: Zoom/Pan options): this
+	// @method setView(center: LatLng, zoom: Number, options?: Zoom/pan options): this
 	// Sets the view of the map (geographical center and zoom) with the given
 	// animation options.
 	setView: function (center, zoom) {
@@ -144,7 +144,7 @@ L.Map = L.Evented.extend({
 		return this;
 	},
 
-	// @method setZoom(zoom: Number, options: Zoom/Pan options): this
+	// @method setZoom(zoom: Number, options: Zoom/pan options): this
 	// Sets the zoom of the map.
 	setZoom: function (zoom, options) {
 		if (!this._loaded) {


### PR DESCRIPTION
I did a read-through of the docs, and found quite a few uppercase/lowercase inconsistencies and minor typos.

Also, due to a bug in Leafdoc, some of the internal links were not working. After bumping to Leafdoc 1.2.2 (which adds a call to `trim()` these should work fine.