### PR TITLE
Fix broken page scroll on touch devices

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -17,7 +17,6 @@
 .leaflet-container {
 	overflow: hidden;
 	-ms-touch-action: none;
-	touch-action: none;
 	}
 .leaflet-tile,
 .leaflet-marker-icon,


### PR DESCRIPTION
The css rule `.leaflet-container { touch-action: none }` breaks page scrolling for touch devices.
This line was added to fix an Edge zoom issue a year ago.
e44179d

I tested the current version of Edge and I can't reproduce any zoom bugs without the touch-action css rule.

I tested here http://jsfiddle.net/kzfv4jjt/2/