### PR TITLE
Remove images from Bower's main field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,12 +3,7 @@
   "description": "JavaScript library for mobile-friendly interactive maps",
   "main": [
     "dist/leaflet.css",
-    "dist/leaflet-src.js",
-    "dist/images/layers-2x.png",
-    "dist/images/layers.png",
-    "dist/images/marker-icon-2x.png",
-    "dist/images/marker-icon.png",
-    "dist/images/marker-shadow.png"
+    "dist/leaflet-src.js"
   ],
    "ignore": [
     ".*",


### PR DESCRIPTION
https://github.com/bower/spec/blob/master/json.md#main

Otherwise I'm getting this when installing via Bower:

```bash
[17:34:03] bower resolved https://github.com/Leaflet/Leaflet.git#0.7.7
[17:34:03] bower invalid-meta The "main" field cannot contain font, image, audio, or video files
```

...which is understandable, they wouldn't work well with build process scripts like Wiredep, I suppose.

This is due changes in [Bower v1.7.9](https://github.com/bower/bower/releases/tag/v1.7.9)