### PR TITLE
Correct TileEvent and TileErrorEvent properties

### DIFF
--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -79,11 +79,17 @@ The name of the layer that was added or removed.
 @inherits Event
 @property tile: HTMLElement
 The tile element (image).
+@property coords: Point
+Point object with the tile's `x`, `y`, and `z` (zoom level) coordinates.
 
 @miniclass TileErrorEvent (Event objects)
 @inherits Event
 @property tile: HTMLElement
 The tile element (image).
+@property coords: Point
+Point object with the tile's `x`, `y`, and `z` (zoom level) coordinates.
+@property error: *
+Error passed to the tile's `done()` callback.
 
 @miniclass ResizeEvent (Event objects)
 @inherits Event

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -761,7 +761,7 @@ L.GridLayer = L.Layer.extend({
 		if (!this._map) { return; }
 
 		if (err) {
-			// @event tileerror: TileEvent
+			// @event tileerror: TileErrorEvent
 			// Fired when there is an error loading a tile.
 			this.fire('tileerror', {
 				error: err,
@@ -796,7 +796,7 @@ L.GridLayer = L.Layer.extend({
 
 		if (this._noTilesToLoad()) {
 			this._loading = false;
-			// @event load: TileEvent
+			// @event load: Event
 			// Fired when the grid layer loaded all visible tiles.
 			this.fire('load');
 


### PR DESCRIPTION
Both get passed a `coords` property. TileErrorEvent also gets a `error` property. Corrected which event types are called in L.GridLayer.