### PR TITLE
Consistent returns for Map.addLayer

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -138,7 +138,7 @@ L.Map.include({
 	// Adds the given layer to the map
 	addLayer: function (layer) {
 		var id = L.stamp(layer);
-		if (this._layers[id]) { return layer; }
+		if (this._layers[id]) { return this; }
 		this._layers[id] = layer;
 
 		layer._mapToAdd = this;


### PR DESCRIPTION
If layer already exists, return `this` instead of `layer`