### PR TITLE
Added L.Handler.ContainerMutation to call invalidateSize() automatically

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -194,6 +194,11 @@ var deps = {
 		desc: 'Enables keyboard pan/zoom when the map is focused.'
 	},
 
+	ContainerMutation: {
+		src: ['map/handler/Map.ContainerMutation.js'],
+		desc: 'Enables tracking DOM mutations to the map container size.'
+	},
+
 	MarkerDrag: {
 		src: ['layer/marker/Marker.Drag.js'],
 		deps: ['Marker'],

--- a/debug/tests/mutation.html
+++ b/debug/tests/mutation.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<button onclick="change()">Change map container size</button>
+	<div id="count"></div>
+	<div id="map"></div>
+
+	<script type="text/javascript">
+
+		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var map = L.map('map', { trackContainerMutation: true })
+				.setView([50.5, 30.51], 15)
+				.addLayer(osm);
+
+		var markers = new L.FeatureGroup();
+
+		function populate() {
+			for (var i = 0; i < 10; i++) {
+				L.marker(getRandomLatLng(map)).addTo(markers);
+			}
+			return false;
+		}
+
+		markers.bindPopup("<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>").addTo(map);
+
+		populate();
+
+		function change() {
+			var div = document.getElementById('map');
+			div.style.height = (400 + (Math.random() * 200)) + 'px';
+			div.style.width = (600 + (Math.random() * 200)) + 'px';
+		}
+
+		var count = 0;
+
+		map.on('resize', function(){
+			document.getElementById('count').innerHTML = 'invalidateSize() called ' + ++count + ' times';
+		});
+
+	</script>
+</body>
+</html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -90,6 +90,7 @@
 	<!-- /map/handler -->
 	<script type="text/javascript" src="suites/map/handler/Map.DragSpec.js"></script>
 	<script type="text/javascript" src="suites/map/handler/Map.TouchZoomSpec.js"></script>
+	<script type="text/javascript" src="suites/map/handler/Map.ContainerMutationSpec.js"></script>
 
 	<!-- /geo/crs -->
 	<script type="text/javascript" src="suites/geo/CRSSpec.js"></script>

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -134,7 +134,11 @@
 
 		// @property retina: Boolean
 		// `true` for browsers on a high-resolution "retina" screen.
-		retina: (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1
+		retina: (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1,
+
+		// @property retina: Boolean
+		// `true` for browsers which implement [mutation observers](https://developer.mozilla.org/docs/Web/API/MutationObserver)
+		mutation: 'MutationObserver' in window
 	};
 
 }());

--- a/src/map/handler/Map.ContainerMutation.js
+++ b/src/map/handler/Map.ContainerMutation.js
@@ -1,0 +1,49 @@
+/*
+ * L.Handler.ContainerMutation triggers `invalidateResize` when the map's DOM container mutates.
+ */
+
+// @namespace Map
+// @section Interaction Options
+L.Map.mergeOptions({
+	// @option trackContainerMutation: Boolean = false
+	// Whether the map uses [mutation observers](https://developer.mozilla.org/docs/Web/API/MutationObserver)
+	// to detect changes in its container and trigger `invalidateSize`. Disabled
+	// by default due to support not being available in all web browsers.
+	trackContainerMutation: false
+});
+
+L.Map.ContainerMutation = L.Handler.extend({
+	addHooks: function () {
+		if (!L.Browser.mutation) {
+			return;
+		}
+
+		if (!this._observer) {
+			this._observer = new MutationObserver(L.Util.bind(this._onMutation, this));
+		}
+
+		this._observer.observe(this._map.getContainer(), {
+			childList: false,
+			attributes: true,
+			characterData: false,
+			subtree: false,
+			attributeFilter: ['style']
+		});
+	},
+
+	removeHooks: function () {
+		if (!L.Browser.mutation) {
+			return;
+		}
+		this._observer.disconnect();
+	},
+
+	_onMutation: function () {
+		this._map.invalidateSize();
+	}
+});
+
+// @section Handlers
+// @property containerMutation: Handler
+// Container mutation handler (disabled unless [`trackContainerMutation`](#map-trackcontainermutation) is set).
+L.Map.addInitHook('addHandler', 'trackContainerMutation', L.Map.ContainerMutation);


### PR DESCRIPTION
Detecting size changes in the map container through `MutationObserver` is doable, even though [@mourner disagreed with the idea a few years back](https://github.com/Leaflet/Leaflet/issues/941#issuecomment-8456510).

I'm not 100% convinced this will cover all use cases, as a mutation observer only checks changes in the CSS attributes, not in the actual rendered values. Relative CSS units like `50%` and a parent size change might break this :-/
