### PR TITLE
Update Control.js to allow custom control containers

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -66,10 +66,14 @@ L.Control = L.Class.extend({
 
 		L.DomUtil.addClass(container, 'leaflet-control');
 
-		if (pos.indexOf('bottom') !== -1) {
-			corner.insertBefore(container, corner.firstChild);
+		if (corner) {
+			if (pos.indexOf('bottom') !== -1) {
+				corner.insertBefore(container, corner.firstChild);
+			} else {
+				corner.appendChild(container);
+			}
 		} else {
-			corner.appendChild(container);
+			map._controlContainer.appendChild(container);
 		}
 
 		return this;


### PR DESCRIPTION
This update allows a control to be added to the map even if it does not fall into one of the 4 control corner containers.
When a control is added without a defined corner container, the map will now append the control after the existing corner containers allowing for custom containers to be added to the map.