### PR TITLE
Added plugin LayerGroupWithEvents.

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -499,6 +499,15 @@ The following plugins change the way that tile layers are loaded into the map.
 			<a href="https://github.com/ghybs">ghybs</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Outdooractive/leaflet-layergroup-with-events_0.7">LayerGroupWithEvents</a>
+		</td><td>
+			Extends LayerGroup to support events "loading" and "load" (use case: tile loading indicator).
+		</td><td>
+			<a href="https://github.com/glathoud">G. Lathoud</a>, <a href="https://www.outdooractive.com">Outdooractive</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Rationale: 
- TileLayer fires "loading" and "load" events, making e.g. tile loading indicators possible (e.g. plugin Leaflet.loading).
- LayerGroup does not support any event.

Content: LayerGroupWithEvents extends LayerGroup to add event support ("loading" and "load").

For more details: https://github.com/Outdooractive/leaflet-layergroup-with-events_0.7

Remark: a direct modification of Leaflet's core's LayerGroup could be possible, but might be [too much code](https://github.com/glathoud/Leaflet-layergroup-loading-load/commit/a6b3515ddb58054239b206a466237848f39c7cf6) for what it does.