### PR TITLE
Docstrings: non-standard WMS parameters as L.TileLayer.WMS options

### DIFF
--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -20,6 +20,9 @@ L.TileLayer.WMS = L.TileLayer.extend({
 
 	// @section
 	// @aka TileLayer.WMS options
+	// If any custom options not documented here are used, they will be sent to the
+	// WMS server as extra parameters in each request URL. This can be useful for
+	// [non-standard vendor WMS parameters](http://docs.geoserver.org/stable/en/user/services/wms/vendor.html).
 	defaultWmsParams: {
 		service: 'WMS',
 		request: 'GetMap',


### PR DESCRIPTION
In order to decrease user confusion, see https://gis.stackexchange.com/questions/192118/adding-wms-layer-with-cql-filter/192132#192132