### PR TITLE
Added Leaflet.FeatureGroup.LoadEvents (for v0.7.*)

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -499,6 +499,15 @@ The following plugins change the way that tile layers are loaded into the map.
 			<a href="https://github.com/ghybs">ghybs</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Outdooractive/Leaflet.FeatureGroup.LoadEvents">Leaflet.FeatureGroup.LoadEvents</a>
+		</td><td>
+			`FeatureGroup` that supports the `"loading"` and `"load"` events (for v0.7.*).
+		</td><td>
+			<a href="http://glat.info">G. Lathoud</a>, <a href="http://www.outdooractive.com">Outdooractive</a>.
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
`FeatureGroup` that supports the `"loading"` and `"load"` events by aggregating the events fired by its sublayers. This can be useful to show a loading indicator for groups of tilelayers.

See also:
 * a [detailed discussion](https://github.com/Leaflet/Leaflet/pull/4530) that led to the present pull request.
 * a corresponding [issue](https://github.com/ebrelsford/Leaflet.loading/issues/33) opened in [`Leaflet.loading`](https://github.com/ebrelsford/Leaflet.loading/).

