### PR TITLE
Don't prevent browser's touch scroll and/or zoom unless handlers are enabled

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -16,8 +16,6 @@
 	}
 .leaflet-container {
 	overflow: hidden;
-	-ms-touch-action: none;
-	touch-action: none;
 	}
 .leaflet-tile,
 .leaflet-marker-icon,
@@ -49,6 +47,18 @@
 .leaflet-container img.leaflet-image-layer {
 	max-width: none !important;
 	}
+
+.leaflet-container.leaflet-touch-zoom {
+	-ms-touch-action: pan-x pan-y;
+	touch-action: pan-x pan-y;
+	}
+.leaflet-container.leaflet-touch-drag {
+	-ms-touch-action: pinch-zoom;
+	}
+.leaflet-container.leaflet-touch-drag.leaflet-touch-drag {
+	-ms-touch-action: none;
+	touch-action: none;
+}
 .leaflet-tile {
 	filter: inherit;
 	visibility: hidden;

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -66,7 +66,7 @@ L.Map.Drag = L.Handler.extend({
 				map.whenReady(this._onZoomEnd, this);
 			}
 		}
-		L.DomUtil.addClass(this._map._container, 'leaflet-grab');
+		L.DomUtil.addClass(this._map._container, 'leaflet-grab leaflet-touch-drag');
 		this._draggable.enable();
 		this._positions = [];
 		this._times = [];
@@ -74,6 +74,7 @@ L.Map.Drag = L.Handler.extend({
 
 	removeHooks: function () {
 		L.DomUtil.removeClass(this._map._container, 'leaflet-grab');
+		L.DomUtil.removeClass(this._map._container, 'leaflet-touch-drag');
 		this._draggable.disable();
 	},
 

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -21,10 +21,12 @@ L.Map.mergeOptions({
 
 L.Map.TouchZoom = L.Handler.extend({
 	addHooks: function () {
+		L.DomUtil.addClass(this._map._container, 'leaflet-touch-zoom');
 		L.DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
 	},
 
 	removeHooks: function () {
+		L.DomUtil.removeClass(this._map._container, 'leaflet-touch-zoom');
 		L.DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
 	},
 


### PR DESCRIPTION
Currently, we set `touch-action: none` for the whole map container, preventing the browsers native scroll and zoom functionality, even when the touch zoom and map drag handlers are disabled. This is a problem, see #4051.

This adds to new CSS classes that are only added to the container when the drag and touch zoom handlers are enabled.

Currently, only IE supports enabling _just_ pinch zoom (touch zoom). This means that for Chrome/FF, etc. you still can't do browser zoom, even if the touch zoom handler is disabled.