### PR TITLE
Prevent listeners from being called when all listeners are removed

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -259,6 +259,17 @@ describe('Events', function () {
 
 			expect(spy.called).to.be(false);
 		});
+
+		it('makes sure an event is not triggered if all listeners are removed during dispatch', function () {
+			var obj = new L.Evented(),
+			    spy = sinon.spy();
+
+			obj.addEventListener('test', function () { obj.removeEventListener('test'); });
+			obj.addEventListener('test', spy);
+			obj.fire('test');
+
+			expect(spy.called).to.be(false);
+		});
 	});
 
 	describe('#on, #off & #fire', function () {

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -122,12 +122,23 @@ L.Evented = L.Class.extend({
 	_off: function (type, fn, context) {
 		var events = this._events,
 		    indexKey = type + '_idx',
-		    indexLenKey = type + '_len';
+		    indexLenKey = type + '_len',
+		    listener, listeners, i, len;
 
 		if (!events) { return; }
 
 		if (!fn) {
 			// clear all listeners for a type if function isn't specified
+			// set the removed listeners to noop so that's not called if remove happens in fire
+			listeners = events[indexKey];
+			for (i in listeners) {
+				listeners[i].fn = L.Util.falseFn;
+			}
+			listeners = events[type] || [];
+			for (i = 0, len = listeners.length; i < len; i++) {
+				listeners[i].fn = L.Util.falseFn;
+			}
+
 			delete events[type];
 			delete events[indexKey];
 			delete events[indexLenKey];
@@ -135,7 +146,7 @@ L.Evented = L.Class.extend({
 		}
 
 		var contextId = context && context !== this && L.stamp(context),
-		    listeners, i, len, listener, id;
+		    id;
 
 		if (contextId) {
 			id = L.stamp(fn) + '_' + contextId;


### PR DESCRIPTION
In the special case where all listeners for an event are removed by a call to `off`, we didn't clear the existing listeners in the same way we do when removing a single listener, which made it possible for listeners that had already been removed to be called.

This PR adds a fix and a test to verify.