### PR TITLE
Scale down getWheelDelta() in win+chrome and ffx+retina, should fix #4538

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -26,6 +26,8 @@
 	    chrome    = ua.indexOf('chrome') !== -1,
 	    gecko     = ua.indexOf('gecko') !== -1  && !webkit && !window.opera && !ie,
 
+	    win = navigator.platform.indexOf('Win') === 0,
+
 	    mobile = typeof orientation !== 'undefined' || ua.indexOf('mobile') !== -1,
 	    msPointer = !window.PointerEvent && window.MSPointerEvent,
 	    pointer = window.PointerEvent || msPointer,
@@ -34,6 +36,7 @@
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
 	    gecko3d = 'MozPerspective' in doc.style,
 	    opera12 = 'OTransition' in doc.style;
+
 
 	var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
 			(window.DocumentTouch && document instanceof window.DocumentTouch));
@@ -75,6 +78,11 @@
 		// @property safari: Boolean
 		// `true` for the Safari browser.
 		safari: !chrome && ua.indexOf('safari') !== -1,
+
+
+		// @property win: Boolean
+		// `true` when the browser is running in a Windows platform
+		win: win,
 
 
 		// @property ie3d: Boolean

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -225,15 +225,21 @@ L.DomEvent = {
 			e.clientY - rect.top - container.clientTop);
 	},
 
+	// Chrome on Win scrolls double the pixels as in other platforms (see #4538),
+	// and Firefox scrolls device pixels, not CSS pixels
+	_wheelPxFactor: (L.Browser.win && L.Browser.chrome) ? 2 :
+	                (L.Browser.gecko) ? window.devicePixelRatio :
+	                1,
+
 	// @function getWheelDelta(ev: DOMEvent): Number
 	// Gets normalized wheel delta from a mousewheel DOM event, in vertical
 	// pixels scrolled (negative if scrolling down).
 	// Events from pointing devices without precise scrolling are mapped to
 	// a best guess of between 50-60 pixels.
 	getWheelDelta: function (e) {
-		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY :        // Pixels
-		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 :   // Lines
-		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 :   // Pages
+		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels
+		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 : // Lines
+		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 : // Pages
 		       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events
 		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
 		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 18 : // Legacy Moz lines


### PR DESCRIPTION
I feel dirty by making these kind of browser hacks.

Should fix #4538.