### PR TITLE
Add missing Leafdoc template files

### DIFF
--- a/build/leafdoc-templates/constructor.hbs
+++ b/build/leafdoc-templates/constructor.hbs
@@ -1,0 +1,17 @@
+<table><thead>
+	<tr>
+		<th>Constructor</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	{{#each documentables}}
+	<tr id='{{id}}'>
+		<td><code><b>{{name}}</b>(
+		{{~#each params~}}
+			{{#if type}}<nobr>&lt;{{{type type}}}&gt;</nobr> {{/if}}<i>{{name}}</i>
+			{{~#unless @last}}, {{/unless}}{{/each~}}
+		)</nobr></code></td>
+		<td>{{{markdown comments}}}</td>
+	</tr>
+	{{/each}}
+</tbody></table>

--- a/build/leafdoc-templates/destructor.hbs
+++ b/build/leafdoc-templates/destructor.hbs
@@ -1,0 +1,17 @@
+<table><thead>
+	<tr>
+		<th>Destructor</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	{{#each documentables}}
+	<tr id='{{id}}'>
+		<td><code><b>{{name}}</b>(
+		{{~#each params~}}
+			{{#if type}}<nobr>&lt;{{{type type}}}&gt;</nobr> {{/if}}<i>{{name}}</i>
+			{{~#unless @last}}, {{/unless}}{{/each~}}
+		)</nobr></code></td>
+		<td>{{{markdown comments}}}</td>
+	</tr>
+	{{/each}}
+</tbody></table>


### PR DESCRIPTION
Fix https://github.com/Leaflet/Leaflet/issues/4556

The `destructor.hbs` file was listed in Leafdoc so I've also added it, but it's actually not used by any Leaflet comment yet. I can remove it if we decide it's really useless.