### PR TITLE
docstrings: fix typos and mistakes in L.GridLayer

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -4,13 +4,13 @@
  * @aka L.GridLayer
  *
  * Generic class for handling a tiled grid of HTML elements. This is the base class for all tile layers and replaces `TileLayer.Canvas`.
- * GridLayer can be extended to create a tiled grid of HTML Elements like `<canvas>`, `<img>` or `<div>`. GridLayer will handle creating and animating these DOM elements for you.
+ * GridLayer can be extended to create a tiled grid of HTML elements like `<canvas>`, `<img>` or `<div>`. GridLayer will handle creating and animating these DOM elements for you.
  *
  *
  * @section Synchronous usage
  * @example
  *
- * To create a custom layer, extend GridLayer and impliment the `createTile()` method, which will be passed a `Point` object with the `x`, `y`, and `z` (zoom level) coordinates to draw your tile.
+ * To create a custom layer, extend GridLayer and implement the `createTile()` method, which will be passed a `Point` object with the `x`, `y`, and `z` (zoom level) coordinates to draw your tile.
  *
  * ```js
  * var CanvasLayer = L.GridLayer.extend({
@@ -24,7 +24,7 @@
  *         tile.height = size.y;
  *
  *         // get a canvas context and draw something on it using coords.x, coords.y and coords.z
- *         var ctx = canvas.getContext('2d');
+ *         var ctx = tile.getContext('2d');
  *
  *         // return the tile so it can be rendered on screen
  *         return tile;
@@ -32,10 +32,10 @@
  * });
  * ```
  *
- * @section Asynchrohous usage
+ * @section Asynchronous usage
  * @example
  *
- * Tile creation can also be asyncronous, this is useful when using a third-party drawing library. Once the tile is finsihed drawing it can be passed to the done() callback.
+ * Tile creation can also be asynchronous, this is useful when using a third-party drawing library. Once the tile is finished drawing it can be passed to the `done()` callback.
  *
  * ```js
  * var CanvasLayer = L.GridLayer.extend({
@@ -66,6 +66,8 @@
 
 L.GridLayer = L.Layer.extend({
 
+	// @section
+	// @aka GridLayer options
 	options: {
 		// @option tileSize: Number|Point = 256
 		// Width and height of tiles in the grid. Use a number if width and height are equal, or `L.point(width, height)` otherwise.
@@ -96,7 +98,7 @@ L.GridLayer = L.Layer.extend({
 		zIndex: 1,
 
 		// @option bounds: LatLngBounds = undefined
-		// If set, tiles will only be loaded inside inside the set `LatLngBounds`.
+		// If set, tiles will only be loaded inside the set `LatLngBounds`.
 		bounds: null,
 
 		// @option minZoom: Number = 0
@@ -630,7 +632,7 @@ L.GridLayer = L.Layer.extend({
 			if (!this._loading) {
 				this._loading = true;
 				// @event loading: Event
-				// Fired when the grid layer starts loading tiles
+				// Fired when the grid layer starts loading tiles.
 				this.fire('loading');
 			}
 


### PR DESCRIPTION
Various typos, duplicated word, wrong variable in code example, and added an anchor link to options section like other classes.