### PR TITLE
Prevents L.DomUtil.create() from automatically setting the class name…

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -38,7 +38,7 @@ L.DomUtil = {
 	create: function (tagName, className, container) {
 
 		var el = document.createElement(tagName);
-		el.className = className;
+		el.className = className || '';
 
 		if (container) {
 			container.appendChild(el);


### PR DESCRIPTION
… to 'undefined' when no class is sent to the function.