### PR TITLE
Added plugin entry: L.Control.AutoLayers

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -437,6 +437,15 @@ The following plugins change the way that tile layers are loaded into the map.
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 	<tr>
 		<td>
+			<a href="https://github.com/aebadirad/Leaflet.AutoLayers">Leaflet.AutoLayers</a>
+		</td><td>
+			Automatically pull layers from multiple mapservers and organize/search them with user controlled overlay zindex management.
+		</td><td>
+			<a href="https://github.com/aebadirad">Alex Ebadirad</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/mattiasb/Leaflet.MultiTileLayer">Leaflet.MultiTileLayer</a>
 		</td><td>
 			Allows to compose a TileLayer from several tile sources. Each source is active only on a defined set of zoomlevels.

--- a/plugins.md
+++ b/plugins.md
@@ -437,15 +437,6 @@ The following plugins change the way that tile layers are loaded into the map.
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 	<tr>
 		<td>
-			<a href="https://github.com/aebadirad/Leaflet.AutoLayers">Leaflet.AutoLayers</a>
-		</td><td>
-			Automatically pull layers from multiple mapservers and organize/search them with user controlled overlay zindex management.
-		</td><td>
-			<a href="https://github.com/aebadirad">Alex Ebadirad</a>
-		</td>
-	</tr>
-	<tr>
-		<td>
 			<a href="https://github.com/mattiasb/Leaflet.MultiTileLayer">Leaflet.MultiTileLayer</a>
 		</td><td>
 			Allows to compose a TileLayer from several tile sources. Each source is active only on a defined set of zoomlevels.
@@ -1797,6 +1788,15 @@ New ways to interact with the map itself.
 The following plugins enhance or extend `L.Control.Layers`.
 
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
+	<tr>
+		<td>
+			<a href="https://github.com/aebadirad/Leaflet.AutoLayers">Leaflet.AutoLayers</a>
+		</td><td>
+			Automatically pull layers from multiple mapservers and organize/search them with user controlled overlay zindex management.
+		</td><td>
+			<a href="https://github.com/aebadirad">Alex Ebadirad</a>
+		</td>
+	</tr>
 	<tr>
 		<td>
 			<a href="https://github.com/vogdb/SelectLayersControl">Leaflet.SelectLayers</a>


### PR DESCRIPTION
A new plugin to dynamically pull from multiple mapservers who publish a
service dictionary and automagically add/organize/search and z-index
order them.