### PR TITLE
Change L.Circle radius calculations to fix getBounds()

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -79,8 +79,8 @@ L.Circle = L.CircleMarker.extend({
 			}
 
 			this._point = p.subtract(map.getPixelOrigin());
-			this._radius = isNaN(lngR) ? 0 : Math.max(Math.round(p.x - map.project([lat2, lng - lngR]).x), 1);
-			this._radiusY = Math.max(Math.round(p.y - top.y), 1);
+			this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
+			this._radiusY = p.y - top.y;
 
 		} else {
 			var latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));


### PR DESCRIPTION
Removing the `Math.round()` and `Math.max()` statements from radius calculations to fix `getBounds()`, per [issue 4582](https://github.com/Leaflet/Leaflet/issues/4582)
