### PR TITLE
Remove extra init of drag start

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -97,7 +97,6 @@ L.Draggable = L.Evented.extend({
 		var first = e.touches ? e.touches[0] : e;
 
 		this._startPoint = new L.Point(first.clientX, first.clientY);
-		this._startPos = this._newPos = L.DomUtil.getPosition(this._element);
 
 		L.DomEvent
 			.on(document, L.Draggable.MOVE[e.type], this._onMove, this)


### PR DESCRIPTION
In Draggable.js, the `_startPos` for the drag operation gets initialized twice.

Once in  `_onDown`:

```javascript
this._startPos = this._newPos = L.DomUtil.getPosition(this._element);
```

And again when the movement first starts in `_onMove`:

```javascript
this._startPos = L.DomUtil.getPosition(this._element).subtract(offset);
```

This small edit removes the extra, unused initialization in `_onDown`. This also removes the unused initialization of `_newPos`, which is set on every call to `_onMove`.