### PR TITLE
TouchZoom and MouseWheelScroll

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -35,7 +35,8 @@
 	    ie3d = ie && ('transition' in doc.style),
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,
 	    gecko3d = 'MozPerspective' in doc.style,
-	    opera12 = 'OTransition' in doc.style;
+	    opera12 = 'OTransition' in doc.style,
+	    edge = 'msLaunchUri' in navigator && !('documentMode' in document);
 
 
 	var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
@@ -53,7 +54,7 @@
 
 		// @property edge: Boolean
 		// `true` for the Edge web browser.
-		edge: 'msLaunchUri' in navigator && !('documentMode' in document),
+		edge: edge,
 
 		// @property webkit: Boolean
 		// `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
@@ -73,7 +74,7 @@
 
 		// @property chrome: Boolean
 		// `true` for the Chrome browser.
-		chrome: chrome,
+		chrome: chrome && !edge,
 
 		// @property safari: Boolean
 		// `true` for the Safari browser.

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -227,9 +227,10 @@ L.DomEvent = {
 
 	// Chrome on Win scrolls double the pixels as in other platforms (see #4538),
 	// and Firefox scrolls device pixels, not CSS pixels
-	_wheelPxFactor: (L.Browser.win && L.Browser.chrome) ? 2 :
-	                (L.Browser.gecko) ? window.devicePixelRatio :
-	                1,
+	_wheelPxFactor: ((L.Browser.win && L.Browser.chrome)||L.Browser.safari) ? 2 :
+					L.Browser.edge ? 3 :
+					(L.Browser.gecko) ? window.devicePixelRatio :
+					1,
 
 	// @function getWheelDelta(ev: DOMEvent): Number
 	// Gets normalized wheel delta from a mousewheel DOM event, in vertical

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -109,6 +109,12 @@ L.Map.TouchZoom = L.Handler.extend({
 		    .off(document, 'touchmove', this._onTouchMove)
 		    .off(document, 'touchend', this._onTouchEnd);
 
+		var snap = L.Browser.any3d ? this._map.options.zoomSnap : 1;
+		if (snap) {
+			if (this._startZoom > this._zoom) this._zoom = this._zoom - snap;
+			else if (this._startZoom < this._zoom) this._zoom = this._zoom + snap;
+		}
+
 		// Pinch updates GridLayers' levels only when snapZoom is off, so snapZoom becomes noUpdate.
 		if (this._map.options.zoomAnimation) {
 			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.snapZoom);


### PR DESCRIPTION
- DomEvent.js:
    With default value 3 lines to scroll on Windows 10 64 bit I have this._delta:
    Chrome: 50
    Firefox: 54
    Safari: 120
    Edge: 122.7
    IE11: 60
    Without special handling of Edge and Safari it jumps 2 zoom levels having zoomSnap: 1 (default)

- Browser.js:
    L.Browser.edge detection. Edge sends "chrome" in navigator.userAgent.

- Map.TouchZoom.js:
   With zoomSnap != 0 it does not feel naturally that TouchZoom bounce back when not zoomed more than zoomSnap/2