### PR TITLE
Limit CSS selectors for SVG/Canvas

### DIFF
--- a/debug/tests/custom-panes.html
+++ b/debug/tests/custom-panes.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+	
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	
+	<link rel="stylesheet" href="../css/screen.css" />
+	
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+	
+	<style>
+		body { max-width: 1200px }
+		#mapSvg { width: 500px; height: 500px; margin: 20px }
+		#mapCanvas { width: 500px; height: 500px; margin: 20px }
+		.left { float: left; text-align: center }
+		.right { float: right; text-align: center }
+	</style>
+</head>
+<body>
+
+	<div class="right">
+		<h1>Canvas</h1>
+		<div id="mapCanvas"></div>
+	</div>
+	<div class="left">
+		<h1>SVG</h1>
+		<div id="mapSvg"></div>
+	</div>
+
+	<script type="text/javascript">
+
+		function makeMap(container, options) {
+			var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+				osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+				osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+			var map = L.map(container, options)
+				.setView([50.5, 30.51], 15)
+				.addLayer(osm);
+
+				map.createPane('custom1');
+				map.createPane('custom2');
+				map.getPane('custom1').style.zIndex = 601;
+				map.getPane('custom2').style.zIndex = 701;
+
+				var panes = ['overlayPane', 'custom1', 'custom2'];
+
+			function makeFeatures(i) {
+				L.marker([50.505-i*0.005, 30.51]).addTo(map);
+				L.circleMarker([50.505-i*0.005, 30.51], { radius: 30, pane: panes[i] })
+					.bindPopup(function(layer) {
+						return 'Pane: ' + panes[i];
+					})
+					.addTo(map);
+			}
+
+			for (var i = 0; i < 3; i++)
+				makeFeatures(i);
+		}
+
+		makeMap('mapSvg');
+		makeMap('mapCanvas', { preferCanvas: true });
+
+	</script>
+</body>
+</html>

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -5,8 +5,8 @@
 .leaflet-marker-icon,
 .leaflet-marker-shadow,
 .leaflet-tile-container,
-.leaflet-map-pane svg,
-.leaflet-map-pane canvas,
+.leaflet-pane > svg,
+.leaflet-pane > canvas,
 .leaflet-zoom-box,
 .leaflet-image-layer,
 .leaflet-layer {


### PR DESCRIPTION
Addresses #4575.

The CSS uses 3 different selectors to reference the SVG/Canvas elements for vectors:

`.leaflet-map-pane svg`
`.leaflet-overlay-pane svg`
`.leaflet-pane > svg`

This commit removes the first form in favor of the second, making the selectors a little more standardized and more specific. The `.leaflet-pane > svg` form was left as-is.
