### PR TITLE
Disable pointer events on popup tip

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -430,6 +430,7 @@
 .leaflet-popup {
 	position: absolute;
 	text-align: center;
+	margin-bottom: 20px;
 	}
 .leaflet-popup-content-wrapper {
 	padding: 1px;
@@ -444,11 +445,13 @@
 	margin: 18px 0;
 	}
 .leaflet-popup-tip-container {
-	margin: 0 auto;
 	width: 40px;
 	height: 20px;
-	position: relative;
+	position: absolute;
+	left: 50%;
+	margin-left: -20px;
 	overflow: hidden;
+	pointer-events: none;
 	}
 .leaflet-popup-tip {
 	width: 17px;


### PR DESCRIPTION
This is one possible solution to #4596 and the sidenote of #2880.

Please see the [comparison demo](http://jsbin.com/fovolugoco/1/edit?html,css,js,output). The new tip style is on the bottom map. Click to the sides of the tip to see how it differs. Pay attention to the cursor as well.

The `.leaftlet-popup-tip-container` is a fairly large 40x20 div under the popup content (see screenshot below). It needs extra space below the tip because of the shadow. This entire invisible region will block pointer events from reaching vectors around the popup tip, which can be a frustration when trying to do any sort of fine clicking. It can also be confusing as any clicks on this 40x20 rectangle register as map clicks.

This modification will make pointer events pass right through the invisible region and the tip element, on browsers that support `pointer-events`. Even for browsers that don't support `pointer-events`, it improves the situation on the sides of the tip. For IE8, the tip is still styled through `.leaflet-oldie` without issue.

![](https://gist.githubusercontent.com/atstp/02b49cc241f24a84d37f/raw/2952e4d2f3d0243100a4a4282a3923eb494ef13f/ChromeOnUbuntu.png)