### PR TITLE
CSS-based paths for L.Icon.Default. #4604, #3696, #4579

### DIFF
--- a/debug/leaflet-include.js
+++ b/debug/leaflet-include.js
@@ -39,7 +39,6 @@
     for (var i = 0; i < scripts.length; i++) {
 		document.writeln("<script src='" + path + scripts[i] + "'></script>");
 	}
-    document.writeln('<script defer>L.Icon.Default.imagePath = "' + path + '../dist/images";</script>');
 })();
 
 function getRandomLatLng(map) {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -374,6 +374,11 @@
 	margin: 5px -10px 5px -6px;
 	}
 
+/* Default icon URLs */
+.leaflet-default-icon-path {
+	background-image: url(images/);
+	}
+
 
 /* attribution and scale controls */
 

--- a/spec/after.js
+++ b/spec/after.js
@@ -1,2 +1,0 @@
-// put after Leaflet files as imagePath can't be detected in a PhantomJS env
-L.Icon.Default.imagePath = "/base/dist/images";

--- a/spec/index.html
+++ b/spec/index.html
@@ -75,6 +75,7 @@
 
 	<!-- /layer/marker/ -->
 	<script type="text/javascript" src="suites/layer/marker/MarkerSpec.js"></script>
+	<script type="text/javascript" src="suites/layer/marker/Icon.DefaultSpec.js"></script>
 
 	<!-- /layer/vector/ -->
 	<script type="text/javascript" src="suites/layer/vector/CircleSpec.js"></script>

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -1,0 +1,33 @@
+describe("Icon.Default", function () {
+
+	it("icon measures 25x41px", function () {
+		var div = document.createElement('div');
+		div.style.height = '100px';
+		document.body.appendChild(div);
+
+		var map = L.map(div).setView([0, 0], 0);
+
+		var marker = new L.Marker([0, 0]).addTo(map);
+
+		var img = map.getPane('markerPane').querySelector('img');
+		expect(img.clientHeight).to.be(41);
+		expect(img.clientWidth).to.be(25);
+		document.body.removeChild(div);
+	});
+
+	it("shadow measures 41x41px", function () {
+		var div = document.createElement('div');
+		div.style.height = '100px';
+		document.body.appendChild(div);
+
+		var map = L.map(div).setView([0, 0], 0);
+
+		var marker = new L.Marker([0, 0]).addTo(map);
+
+		var img = map.getPane('shadowPane').querySelector('img');
+		expect(img.clientHeight).to.be(41);
+		expect(img.clientWidth).to.be(41);
+		document.body.removeChild(div);
+	});
+
+});

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -13,8 +13,8 @@ describe("Marker", function () {
 		map = L.map(div).setView([0, 0], 0);
 		icon1 = new L.Icon.Default();
 		icon2 = new L.Icon.Default({
-			iconUrl: icon1._getIconUrl('icon') + '?2',
-			shadowUrl: icon1._getIconUrl('shadow') + '?2'
+			iconUrl: icon1.options.iconUrl + '?2',
+			shadowUrl: icon1.options.shadowUrl + '?2'
 		});
 	});
 

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -32,11 +32,11 @@ L.Icon.Default = L.Icon.extend({
 		// way, set this option to point to the right absolute path.
 		if (!('imagePath' in this.options)) {
 			var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-			this.options.imagePath = L.DomUtil.getStyle(el, 'background-image')
-				.replace(/^url\([\"\']?/, '')
-				.replace(/[\"\']?\)$/, '');
+			var path = L.DomUtil.getStyle(el, 'background-image');
 
-			console.log(this.options.imagePath);
+			this.options.imagePath = path.indexOf('url') === 0 ?
+				path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';
+
 			document.body.removeChild(el);
 		}
 

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -32,7 +32,7 @@ L.Icon.Default = L.Icon.extend({
 		// way, set this option to point to the right absolute path.
 		if (!('imagePath' in this.options)) {
 			var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-			var path = L.DomUtil.getStyle(el, 'background-image');
+			var path = L.DomUtil.getStyle(el, 'background-image') || L.DomUtil.getStyle(el, 'backgroundImage');
 
 			this.options.imagePath = path.indexOf('url') === 0 ?
 				path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -25,28 +25,25 @@ L.Icon.Default = L.Icon.extend({
 	},
 
 	_getIconUrl: function (name) {
+		if (!L.Icon.Default.imagePath) {	// Deprecated, backwards-compatibility only
+			L.Icon.Default.imagePath = this._detectIconPath();
+		}
 
 		// @option imagePath: String
 		// `L.Icon.Default` will try to auto-detect the absolute location of the
 		// blue icon images. If you are placing these images in a non-standard
 		// way, set this option to point to the right absolute path.
-		if (!('imagePath' in this.options)) {
+		return (this.options.imagePath || L.Icon.Default.imagePath) + L.Icon.prototype._getIconUrl.call(this, name);
+	},
 
-			if (L.Icon.Default.imagePath) {	// Deprecated, backwards-compatibility only
-				this.options.imagePath = L.Icon.Default.imagePath;
-			} else {
+	_detectIconPath: function () {
+		var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
+		var path = L.DomUtil.getStyle(el, 'background-image') ||
+		           L.DomUtil.getStyle(el, 'backgroundImage');	// IE8
 
-				var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-				var path = L.DomUtil.getStyle(el, 'background-image') ||
-				           L.DomUtil.getStyle(el, 'backgroundImage');	// IE8
+		document.body.removeChild(el);
 
-				this.options.imagePath = path.indexOf('url') === 0 ?
-					path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';
-
-				document.body.removeChild(el);
-			}
-		}
-
-		return this.options.imagePath + L.Icon.prototype._getIconUrl.call(this, name);
+		return path.indexOf('url') === 0 ?
+			path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';
 	}
 });

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -7,7 +7,7 @@
  * no icon is specified. Points to the blue marker image distributed with Leaflet
  * releases.
  *
- * In order to change the default icon, just change the properties of `L.Icon.Default.options`
+ * In order to change the default icon, just change the properties of `L.Icon.Default.prototype.options`
  * (which is a set of `Icon options`).
  */
 
@@ -31,13 +31,20 @@ L.Icon.Default = L.Icon.extend({
 		// blue icon images. If you are placing these images in a non-standard
 		// way, set this option to point to the right absolute path.
 		if (!('imagePath' in this.options)) {
-			var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-			var path = L.DomUtil.getStyle(el, 'background-image') || L.DomUtil.getStyle(el, 'backgroundImage');
 
-			this.options.imagePath = path.indexOf('url') === 0 ?
-				path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';
+			if (L.Icon.Default.imagePath) {	// Deprecated, backwards-compatibility only
+				this.options.imagePath = L.Icon.Default.imagePath;
+			} else {
 
-			document.body.removeChild(el);
+				var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
+				var path = L.DomUtil.getStyle(el, 'background-image') ||
+				           L.DomUtil.getStyle(el, 'backgroundImage');	// IE8
+
+				this.options.imagePath = path.indexOf('url') === 0 ?
+					path.replace(/^url\([\"\']?/, '').replace(/[\"\']?\)$/, '') : '';
+
+				document.body.removeChild(el);
+			}
 		}
 
 		return this.options.imagePath + L.Icon.prototype._getIconUrl.call(this, name);

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -1,10 +1,22 @@
 /*
- * L.Icon.Default is the blue marker icon used by default in Leaflet.
+ * @miniclass Icon.Default (Icon)
+ * @aka L.Icon.Default
+ * @section
+ *
+ * A trivial subclass of `Icon`, represents the icon to use in `Marker`s when
+ * no icon is specified. Points to the blue marker image distributed with Leaflet
+ * releases.
+ *
+ * In order to change the default icon, just change the properties of `L.Icon.Default.options`
+ * (which is a set of `Icon options`).
  */
 
 L.Icon.Default = L.Icon.extend({
 
 	options: {
+		iconUrl:       'marker-icon.png',
+		iconRetinaUrl: 'marker-icon-2x.png',
+		shadowUrl:     'marker-shadow.png',
 		iconSize:    [25, 41],
 		iconAnchor:  [12, 41],
 		popupAnchor: [1, -34],
@@ -13,34 +25,21 @@ L.Icon.Default = L.Icon.extend({
 	},
 
 	_getIconUrl: function (name) {
-		var key = name + 'Url';
 
-		if (this.options[key]) {
-			return this.options[key];
+		// @option imagePath: String
+		// `L.Icon.Default` will try to auto-detect the absolute location of the
+		// blue icon images. If you are placing these images in a non-standard
+		// way, set this option to point to the right absolute path.
+		if (!('imagePath' in this.options)) {
+			var el = L.DomUtil.create('div',  'leaflet-default-icon-path', document.body);
+			this.options.imagePath = L.DomUtil.getStyle(el, 'background-image')
+				.replace(/^url\([\"\']?/, '')
+				.replace(/[\"\']?\)$/, '');
+
+			console.log(this.options.imagePath);
+			document.body.removeChild(el);
 		}
 
-		var path = L.Icon.Default.imagePath;
-
-		if (!path) {
-			throw new Error('Couldn\'t autodetect L.Icon.Default.imagePath, set it manually.');
-		}
-
-		return path + '/marker-' + name + (L.Browser.retina && name === 'icon' ? '-2x' : '') + '.png';
+		return this.options.imagePath + L.Icon.prototype._getIconUrl.call(this, name);
 	}
 });
-
-L.Icon.Default.imagePath = (function () {
-	var scripts = document.getElementsByTagName('script'),
-	    leafletRe = /[\/^]leaflet[\-\._]?([\w\-\._]*)\.js\??/;
-
-	var i, len, src, path;
-
-	for (i = 0, len = scripts.length; i < len; i++) {
-		src = scripts[i].src || '';
-
-		if (src.match(leafletRe)) {
-			path = src.split(leafletRe)[0];
-			return (path ? path + '/' : '') + 'images';
-		}
-	}
-}());

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -17,7 +17,7 @@ L.Marker = L.Layer.extend({
 	// @aka Marker options
 	options: {
 		// @option icon: Icon = *
-		// Icon class to use for rendering the marker. See [Icon documentation](#L.Icon) for details on how to customize the marker icon. Set to new `L.Icon.Default()` by default.
+		// Icon class to use for rendering the marker. See [Icon documentation](#L.Icon) for details on how to customize the marker icon. If not specified, a new `L.Icon.Default` is used.
 		icon: new L.Icon.Default(),
 
 		// Option inherited from "Interactive layer" abstract class


### PR DESCRIPTION
Takes some inspiration from #3559 (thanks,@sheppard!). This:

* Allows overriding the retina URLs for `L.Icon.Default` (#3696)
* Allows replacing the autodetected path for `L.Icon.Default` images (#4604)
* The CSS method from #3559 *should* make IE8 compute paths properly (#4579)
* Adds unit tests for the default images (just checking image size, which means default icon images are loaded)
* Removes the phantomJS hack in the unit tests (by adding `leaflet.css` to the Karma conf), as the CSS method enables phantomJS to autodetect the path!!
