### PR TITLE
Icon size x can now be initialised with a number

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -56,21 +56,6 @@ describe("Marker", function () {
 			expect(icon.style.width).to.be(expectedXY + 'px');
 			expect(icon.style.height).to.be(expectedXY + 'px');
 		});
-	});
-
-	describe("#setIcon", function () {
-
-		it("changes the icon to another image", function () {
-			var marker = new L.Marker([0, 0], {icon: icon1});
-			map.addLayer(marker);
-
-			var beforeIcon = marker._icon;
-			marker.setIcon(icon2);
-			var afterIcon = marker._icon;
-
-			expect(beforeIcon).to.be(afterIcon);
-			expect(afterIcon.src).to.contain(icon2._getIconUrl('icon'));
-		});
 
 		it("changes the icon to another image", function () {
 			var marker = new L.Marker([0, 0], {icon: icon1});

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -23,6 +23,55 @@ describe("Marker", function () {
 	});
 
 	describe("#setIcon", function () {
+
+		it("set the correct x and y size attributes", function () {
+			var expectedX = 96;
+			var expectedY = 100;
+			var sizedIcon = new L.Icon.Default({
+				iconUrl: icon1._getIconUrl('icon') + '?3',
+				iconSize: [expectedX, expectedY]
+			});
+
+			var marker = new L.Marker([0, 0], {icon: sizedIcon});
+			map.addLayer(marker);
+
+			var icon = marker._icon;
+
+			expect(icon.style.width).to.be(expectedX + 'px');
+			expect(icon.style.height).to.be(expectedY + 'px');
+		});
+
+		it("set the correct x and y size attributes passing only one value", function () {
+			var expectedXY = 96;
+			var sizedIcon = new L.Icon.Default({
+				iconUrl: icon1._getIconUrl('icon') + '?3',
+				iconSize: expectedXY
+			});
+
+			var marker = new L.Marker([0, 0], {icon: sizedIcon});
+			map.addLayer(marker);
+
+			var icon = marker._icon;
+
+			expect(icon.style.width).to.be(expectedXY + 'px');
+			expect(icon.style.height).to.be(expectedXY + 'px');
+		});
+	});
+
+	describe("#setIcon", function () {
+
+		it("changes the icon to another image", function () {
+			var marker = new L.Marker([0, 0], {icon: icon1});
+			map.addLayer(marker);
+
+			var beforeIcon = marker._icon;
+			marker.setIcon(icon2);
+			var afterIcon = marker._icon;
+
+			expect(beforeIcon).to.be(afterIcon);
+			expect(afterIcon.src).to.contain(icon2._getIconUrl('icon'));
+		});
+
 		it("changes the icon to another image", function () {
 			var marker = new L.Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -47,8 +47,14 @@ L.Icon = L.Class.extend({
 	},
 
 	_setIconStyles: function (img, name) {
-		var options = this.options,
-		    size = L.point(options[name + 'Size']),
+		var options = this.options;
+		var sizeOption = options[name + 'Size'];
+
+		if (!L.Util.isArray(sizeOption)) {
+			options[name + 'Size'] = [options[name + 'Size'], options[name + 'Size']];
+		}
+
+		var size = L.point(options[name + 'Size']),
 		    anchor = L.point(name === 'shadow' && options.shadowAnchor || options.iconAnchor ||
 		            size && size.divideBy(2, true));
 

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -51,10 +51,10 @@ L.Icon = L.Class.extend({
 		var sizeOption = options[name + 'Size'];
 
 		if (!L.Util.isArray(sizeOption)) {
-			options[name + 'Size'] = [options[name + 'Size'], options[name + 'Size']];
+			sizeOption = [sizeOption, sizeOption];
 		}
 
-		var size = L.point(options[name + 'Size']),
+		var size = L.point(sizeOption),
 		    anchor = L.point(name === 'shadow' && options.shadowAnchor || options.iconAnchor ||
 		            size && size.divideBy(2, true));
 


### PR DESCRIPTION
Icon size can now be passed as a single numeric as well as the [x, y].  Additional tests added to cover new parameter option.

Fixes #3185