### PR TITLE
Add the 'bufferSize' option to GridLayer to increase tiles kept (#4039)

### DIFF
--- a/debug/map/grid.html
+++ b/debug/map/grid.html
@@ -19,7 +19,8 @@
 	<script type="text/javascript">
 
 		var grid = L.gridLayer({
-			attribution: 'Grid Layer'
+			attribution: 'Grid Layer',
+			bufferSize: 0
 		});
 
 		grid.createTile = function (coords, done) {

--- a/debug/map/tile-debug.html
+++ b/debug/map/tile-debug.html
@@ -157,12 +157,14 @@
         resetCounter();
 
         var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+            bufferSize: 0
         });
 
         var grid = L.gridLayer({
             attribution: 'Grid Layer',
-            tileSize: L.point(256, 256)
+            tileSize: L.point(256, 256),
+            bufferSize: 0
         });
 
         grid.createTile = function (coords) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -120,7 +120,15 @@ L.GridLayer = L.Layer.extend({
 
 		// @option className: String = ''
 		// A custom class name to assign to the tile layer. Empty by default.
-		className: ''
+		className: '',
+
+		// @option bufferSize: Number|Point = [256, 256]
+		// How many pixels this grid extends out of the visible map container.
+		// This increases the amount of tiles to be loaded and kept. Lower values
+		// will decrease network usage, and higher values will prevent grey areas
+		// when dragging or zooming quickly. Use a number if the top/bottom and
+		// left/right buffer sizes are equal, or `L.point(leftRight, topBottom)` otherwise.
+		bufferSize: 256
 	},
 
 	initialize: function (options) {
@@ -253,6 +261,11 @@ L.GridLayer = L.Layer.extend({
 	// Normalizes the [tileSize option](#gridlayer-tilesize) into a point. Used by the `createTile()` method.
 	getTileSize: function () {
 		var s = this.options.tileSize;
+		return s instanceof L.Point ? s : new L.Point(s, s);
+	},
+
+	_getBufferSize: function () {
+		var s = this.options.bufferSize;
 		return s instanceof L.Point ? s : new L.Point(s, s);
 	},
 
@@ -578,7 +591,7 @@ L.GridLayer = L.Layer.extend({
 		    mapZoom = map._animatingZoom ? Math.max(map._animateToZoom, map.getZoom()) : map.getZoom(),
 		    scale = map.getZoomScale(mapZoom, this._tileZoom),
 		    pixelCenter = map.project(center, this._tileZoom).floor(),
-		    halfSize = map.getSize().divideBy(scale * 2);
+		    halfSize = map.getSize().divideBy(scale * 2).add(this._getBufferSize());
 
 		return new L.Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
 	},


### PR DESCRIPTION
Basically reuses some of the ideas from #3551 and the square-by-default tileSize option.