### PR TITLE
Polygon contains

### DIFF
--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -87,33 +87,38 @@ L.Polygon = L.Polyline.extend({
 	// @method contains (latlng: LatLng): Boolean
 	// Returns `true` if the polygon contains the given point.
 	contains: function (obj) {
-		if (!this.getBounds().contains(obj)) {
-			return false;
-		} else {
-			// check based on the winding number method
-			var wn = 0,
-			    nodes = this.getLatLngs()[0];
+		var contained = !this.isEmpty() &&
+				this.getBounds().contains(obj) &&
+				this._ringContains(this._latlngs[0], obj);
 
-			for (var i = 0, len = nodes.length; i < len; ++i) {
-				// through all edges of the polygon, with last edge linked to
-				// the first node
-				var next = (i < len - 1) ? i + 1 : 0;
-				if (nodes[i].lat <= obj.lat) {
-					if ((nodes[next].lat > obj.lat) &&
-							(this._checkLeft(obj, nodes[i], nodes[next]) > 0)) {
-						// upward crossing with obj on the left of current polygon
-						// edge
-						++wn;
-					}
-				}	else if ((nodes[next].lat <= obj.lat) &&
-									 (this._checkLeft(obj, nodes[i], nodes[next]) < 0)) {
-					// downward crossing with obj on the right of current
-					// polygon edge
-					--wn;
-				}
-			}
-			return (wn !== 0);
+		for (var i = 1, len = this._latlngs.length; contained && i < len; ++i) {
+			contained = contained && !this._ringContains(this._latlngs[i], obj);
 		}
+		return contained;
+	},
+
+	_ringContains: function (latLngs, obj) {
+		// check based on the wind number method
+		var wn = 0;
+
+		for (var i = 0, len = latLngs.length; i < len; ++i) {
+			// through all edges of the ring, with last edge linked to the
+			// first node
+			var next = (i < len - 1) ? i + 1 : 0;
+			if (latLngs[i].lat <= obj.lat) {
+				if ((latLngs[next].lat > obj.lat) &&
+						(this._checkLeft(obj, latLngs[i], latLngs[next]) > 0)) {
+					// upward crossing with obj on the left of current ring edge
+					++wn;
+				}
+			}	else if ((latLngs[next].lat <= obj.lat) &&
+								 (this._checkLeft(obj, latLngs[i], latLngs[next]) < 0)) {
+				// downward crossing with obj on the right of current ring
+				// edge
+				--wn;
+			}
+		}
+		return (wn !== 0);
 	},
 
 	_checkLeft: function (obj, latlng1, latlng2) {

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -84,6 +84,50 @@ L.Polygon = L.Polyline.extend({
 		return this._map.layerPointToLatLng(center);
 	},
 
+	// @method contains (latlng: LatLng): Boolean
+	// Returns `true` if the polygon contains the given point.
+	contains: function (obj) {
+		if (!this.getBounds().contains(obj)) {
+			return false;
+		} else {
+			// check based on the winding number method
+			var wn = 0,
+			    nodes = this.getLatLngs()[0];
+
+			for (var i = 0, len = nodes.length; i < len; ++i) {
+				// through all edges of the polygon, with last edge linked to
+				// the first node
+				var next = (i < len - 1) ? i + 1 : 0;
+				if (nodes[i].lat <= obj.lat) {
+					if ((nodes[next].lat > obj.lat) &&
+							(this._checkLeft(obj, nodes[i], nodes[next]) > 0)) {
+						// upward crossing with obj on the left of current polygon
+						// edge
+						++wn;
+					}
+				}	else if ((nodes[next].lat <= obj.lat) &&
+									 (this._checkLeft(obj, nodes[i], nodes[next]) < 0)) {
+					// downward crossing with obj on the right of current
+					// polygon edge
+					--wn;
+				}
+			}
+			return (wn !== 0);
+		}
+	},
+
+	_checkLeft: function (obj, latlng1, latlng2) {
+		// Return a positive (resp. negative) value if obj is left
+		// (resp. right) of the oriented line defined by latlng1 and
+		// latlng2 (using the (latlng1 latlng2)x(latlng1 obj) cross
+		// product z-component to check).
+		var u1 = latlng2.lng - latlng1.lng,
+		    u2 = latlng2.lat - latlng1.lat,
+		    v1 = obj.lng - latlng1.lng,
+		    v2 = obj.lat - latlng1.lat;
+		return u1 * v2 - u2 * v1;
+	},
+
 	_convertLatLngs: function (latlngs) {
 		var result = L.Polyline.prototype._convertLatLngs.call(this, latlngs),
 		    len = result.length;


### PR DESCRIPTION
Implementation of a `contains` method for polygons, as proposed at [uservoice](https://leaflet.uservoice.com/forums/150880-ideas-and-suggestions-for-leaflet/suggestions/6154146-add-method-to-determine-if-a-point-is-contained-by).

This doesn't add much to the codebase (+45 LOC) while providing a nice feature.

The different behaviour of `polygon.getBounds().contains(obj)` and `polygon.contains(obj)` can be viewed at  http://plnkr.co/FMWoraRGZPzXbKCdaxoL?p=preview, where the polygon bounding box is drawn for convenience.

Notes: 
- so far this method is OK for single-ring polygons and polygons with holes. To make it work for multipolygons, I would need more insight into how these should be handled;
- the _checkLeft function would probably fit better somewhere else in the code...