### PR TITLE
Fix typo in the description of getWheelDelta

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -234,7 +234,7 @@ L.DomEvent = {
 	// @function getWheelDelta(ev: DOMEvent): Number
 	// Gets normalized wheel delta from a mousewheel DOM event, in vertical
 	// pixels scrolled (negative if scrolling down).
-	// Events from pointing devices without precise scrolling are mapped to
+	// The delta from pointing devices without precise scrolling are mapped to
 	// a best guess of between 50-60 pixels.
 	getWheelDelta: function (e) {
 		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels


### PR DESCRIPTION
The event doesn't map itself, but value of delta does.