### PR TITLE
Fixes control incompatibility with PrimeFaces

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -316,7 +316,7 @@ L.Control.Layers = L.Control.extend({
 	},
 
 	_onInputClick: function () {
-		var inputs = this._form.getElementsByTagName('input'),
+		var inputs = this._form.getElementsByClassName('leaflet-control-layers-selector'),
 		    input, layer, hasLayer;
 		var addedLayers = [],
 		    removedLayers = [];
@@ -350,7 +350,7 @@ L.Control.Layers = L.Control.extend({
 	},
 
 	_checkDisabledLayers: function () {
-		var inputs = this._form.getElementsByTagName('input'),
+		var inputs = this._form.getElementsByClassName('leaflet-control-layers-selector'),
 		    input,
 		    layer,
 		    zoom = this._map.getZoom();


### PR DESCRIPTION
PrimeFaces inserts a hidden input field with the id "javax.faces.ViewState" into each form tag on the page.
As this input was not created by the control, it has no layerId and causes these functions to crash.
Test case: Manually insert an input element into the control's form and watch the console while switching layers.