### PR TITLE
Adds missing GeoJSON functions to API docs

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -76,6 +76,8 @@ L.GeoJSON = L.FeatureGroup.extend({
 		}
 	},
 
+	// @function addData( <GeoJSON> data ): Layer
+	// Adds a GeoJSON object to the layer.
 	addData: function (geojson) {
 		var features = L.Util.isArray(geojson) ? geojson : geojson.features,
 		    i, len, feature;
@@ -111,6 +113,8 @@ L.GeoJSON = L.FeatureGroup.extend({
 		return this.addLayer(layer);
 	},
 
+	// @function resetStyle( <Path> layer ): Layer
+	// Resets the given vector layer's style to the original GeoJSON style, useful for resetting style after hover events.
 	resetStyle: function (layer) {
 		// reset any custom styles
 		layer.options = L.Util.extend({}, layer.defaultOptions);
@@ -118,6 +122,8 @@ L.GeoJSON = L.FeatureGroup.extend({
 		return this;
 	},
 
+	// @function setStyle( <Function> style ): Layer
+	// Changes styles of GeoJSON vector layers with the given style function.
 	setStyle: function (style) {
 		return this.eachLayer(function (layer) {
 			this._setLayerStyle(layer, style);


### PR DESCRIPTION
Add leafdoc mark-up for addData, setStyle and resetStyle methods.

Fixes #4630 