### PR TITLE
Only set the original popup offset once

### DIFF
--- a/src/layer/Layer.Popup.js
+++ b/src/layer/Layer.Popup.js
@@ -42,9 +42,10 @@ L.Layer.include({
 			this._popupHandlersAdded = true;
 		}
 
-		// save the originally passed offset
-		this._originalPopupOffset = this._popup.options.offset;
-
+		if (!this._originalPopupOffset) {
+			// save the originally passed offset
+			this._originalPopupOffset = this._popup.options.offset;
+		}
 		return this;
 	},
 


### PR DESCRIPTION
It doesn't seem to make sense to set `_originalPopupOffset` more than once.

One way to illustrate the issue is to do a quick change in reuse_popups.html:
```
var marker=... 
var icon = new L.Icon.Default();
map.on('zoomend', function(event) {
	marker.setIcon(icon);
});
```

After opening reuse_popups.html, click on the bottom marker. The popup looks good. Close the popup.
Zoom out one level, click on the bottom marker again, the popup offset is now incorrect (twice the custom offset).
This is due to `setIcon` calling `bind_popup` after `_popup.options.offset` was already changed in `openPopup`.

