### PR TITLE
Added tileRecycleDelay option to GridLayer

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -384,10 +384,11 @@ L.GridLayer = L.Layer.extend({
 			this._removeAllTiles();
 			return;
 		}
-
+		
+		var now = +new Date();
 		for (key in this._tiles) {
 			tile = this._tiles[key];
-			tile.retain = tile.current;
+			tile.retain = tile.current || (this.options.tileRecycleDelay > 0 && (tile.loaded === undefined || (now - tile.loaded < this.options.tileRecycleDelay * 1000)));
 		}
 
 		for (key in this._tiles) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -384,7 +384,7 @@ L.GridLayer = L.Layer.extend({
 			this._removeAllTiles();
 			return;
 		}
-		
+
 		var now = +new Date();
 		for (key in this._tiles) {
 			tile = this._tiles[key];


### PR DESCRIPTION
Commit related to issue https://github.com/Leaflet/Leaflet/issues/4039
Tile is retained if it has been loaded in the last X seconds, which is configurable via the tileRecycleDelay option on any TileLayer/GridLayer (0 = disabled = default).