### PR TITLE
Fix #4039: Implement FIFO MRU list of tiles before pruning them

### DIFF
--- a/debug/map/tile-debug.html
+++ b/debug/map/tile-debug.html
@@ -157,12 +157,14 @@
         resetCounter();
 
         var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
+            maxOffScreenTiles: 3
         });
 
         var grid = L.gridLayer({
             attribution: 'Grid Layer',
-            tileSize: L.point(256, 256)
+            tileSize: L.point(256, 256),
+            maxOffScreenTiles: 3
         });
 
         grid.createTile = function (coords) {

--- a/debug/map/tile-debug.html
+++ b/debug/map/tile-debug.html
@@ -157,14 +157,12 @@
         resetCounter();
 
         var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>',
-            maxOffScreenTiles: 3
+            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
         });
 
         var grid = L.gridLayer({
             attribution: 'Grid Layer',
-            tileSize: L.point(256, 256),
-            maxOffScreenTiles: 3
+            tileSize: L.point(256, 256)
         });
 
         grid.createTile = function (coords) {


### PR DESCRIPTION
Implements a non-strictly-First-In-First-Out More-Recently-Used list of off-screen tiles, preventing them to be pruned.

In other words: when a tile goes off-screen, it is not immediately pruned. Instead, it goes into a most-recently-gone-offscreen tiles. When a tile is ejected from that list (due to another tile going into it), then it will get pruned.

As title says, fixes #4039.