### PR TITLE
Be more defensive when using other layers pxBounds in L.Canvas._draw

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -151,7 +151,7 @@ L.Canvas = L.Renderer.extend({
 
 		for (var id in this._layers) {
 			layer = this._layers[id];
-			if (!bounds || layer._pxBounds.intersects(bounds)) {
+			if (!bounds || (layer._pxBounds && layer._pxBounds.intersects(bounds))) {
 				layer._updatePath();
 			}
 			if (clear && layer._removed) {


### PR DESCRIPTION
In some edge cases, `layer._pxBounds` will not be defined. For example if a poly
with no latlngs (or only one) is attached to the canvas renderer.

I've hit this in Leaflet.Editable in two [scenarios](https://github.com/Leaflet/Leaflet.Editable/issues/80) (because when drawing a new shape we must start with an invalid situation).
I've fixed the wrong pattern in Leaflet.Editable code, but it seems to me that it's better here to be a bit more defensive.