### PR TITLE
Limit ESLint to project folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "./build/publish.sh"
   },
   "eslintConfig": {
+    "root": true,
     "globals": {
       "L": true
     },


### PR DESCRIPTION
From the [ESLint documentation](http://eslint.org/docs/user-guide/configuring):

> By default, ESLint will look for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place `"root": true` inside the `eslintConfig` field of the `package.json` file or in the `.eslintrc.*` file at your project’s root level. ESLint will stop looking in parent folders once it finds a configuration with `"root": true`.