### PR TITLE
specify license on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: v2
 ---
 
-<p>Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps.
+<p>Leaflet is the leading open-source BSD-licensed JavaScript library for mobile-friendly interactive maps.
 Weighing just about <abbr title="33 KB gzipped &mdash; that's 123 KB minified and 218 KB in the source form, with 10 KB of CSS (2 KB gzipped) and 11 KB of images.">33 KB of JS</abbr>,
 it&nbsp;has all the mapping <a href="#features">features</a> most developers ever need.</p>
 


### PR DESCRIPTION
Not sure if the formulation is the best, but i think it's important to specify it on the home page as it was done before f3762cff39ed1739640c063c07ad4da816fc7182

Any thoughts about it ?