### PR TITLE
maxbounds example fixes

### DIFF
--- a/debug/map/max-bounds-bouncy.html
+++ b/debug/map/max-bounds-bouncy.html
@@ -44,8 +44,8 @@
 		});
 
 		var latlngs = L.rectangle(bounds).getLatLngs();
-		L.polyline(latlngs.concat([latlngs[0]])).addTo(map1);
-		L.polyline(latlngs.concat([latlngs[0]])).addTo(map2);
+		L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map1);
+		L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map2);
 
 	</script>
 </body>

--- a/debug/map/max-bounds-infinite.html
+++ b/debug/map/max-bounds-infinite.html
@@ -30,9 +30,6 @@
 			maxBounds: bounds
 		});
 
-		var latlngs = L.rectangle(bounds).getLatLngs();
-		L.polyline(latlngs.concat([latlngs[0]])).addTo(map);
-
 		map.setMaxBounds(bounds);	// Should not enter infinite recursion
 
 	</script>

--- a/debug/map/max-bounds.html
+++ b/debug/map/max-bounds.html
@@ -30,8 +30,10 @@
 			maxBounds: bounds
 		});
 
+
+
 		var latlngs = L.rectangle(bounds).getLatLngs();
-		L.polyline(latlngs.concat([latlngs[0]])).addTo(map);
+		L.polyline(latlngs[0].concat(latlngs[0][0])).addTo(map);
 
 		map.setMaxBounds(bounds);	// Should not enter infinite recursion
 


### PR DESCRIPTION
Small fixes for maxbounds examples.
1. Drawing rectangle was broken.
2. Should not try to draw an infinite rectangle.