### PR TITLE
Adding setOpacity() as a method in paths (used by L.CircleMarker)

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -108,6 +108,17 @@ L.Path = L.Layer.extend({
 		}
 		return this;
 	},
+	
+	// @method setOpacity(opacity: Number): this
+	// Changes the opacity of a path based on the options in the 'Path options' object.
+	setOpacity: function(opacity) {
+		if (typeof opacity ===  "number") {
+			this.setStyle({'opacity' : opacity, 'fillOpacity': opacity });
+		} else {
+			this.setStyle(opacity);
+		}
+		return this;
+	},
 
 	// @method bringToFront(): this
 	// Brings the layer to the top of all path layers.


### PR DESCRIPTION
This pull request addresses #4683 to align the methods between Markers and circleMarkers. The new .setOpacity() method accepts either a single number to set the fill and stroke of the marker, or an object which can define each property separately. 

The pull request is designed to allow layer groups, feature groups, and geojson layers which contain a mixed types of markers to cycle through all of the markers regardless of whether they are circleMarkers or regular markers and adjust their opacity. 