### PR TITLE
Use pointer-events: visiblePainted as fallback for IE <11

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -95,6 +95,7 @@
 .leaflet-control {
 	position: relative;
 	z-index: 800;
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
 	pointer-events: auto;
 	}
 .leaflet-top,
@@ -215,6 +216,7 @@
 .leaflet-marker-icon.leaflet-interactive,
 .leaflet-image-layer.leaflet-interactive,
 .leaflet-pane > svg path.leaflet-interactive {
+	pointer-events: visiblePainted; /* IE 9-10 doesn't have auto */
 	pointer-events: auto;
 	}
 


### PR DESCRIPTION
Close #4674.

I've verified this fix in a IE10 VM