### PR TITLE
Prevent from adding twice the same event listener without context

### DIFF
--- a/debug/tests/event-perf.html
+++ b/debug/tests/event-perf.html
@@ -13,37 +13,80 @@
 <body>
   <script>
 
-  var obj = new L.Evented();
+  function benchmark(name, fn, setup) {
+    //warmup
+    for (var i = 0; i < 100; i++) {
+      if (setup) {
+        setup();
+      }
+      fn();
+    }
+
+    var t = 0;
+    for (var i = 0; i < 100; i++) {
+      if (setup) {
+        setup();
+      }
+      var t0 = performance.now();
+      fn();
+      t += performance.now() - t0;
+    }
+    console.log(name, (t / 100) + ' ms/run');
+  }
+
   var fn = function (e) {called += e.count;},
     fns = [],
     called = 0;
   for (var p = 0; p < 1000; p++) {
-    fns.push(function(e) { called += e.count;});
+    fns.push((function(p) { return function(e) { called += p;}; }));
   }
-  console.time('Overall');
-  console.time('Adding same function x1000');
+  benchmark('Adding same fn', function() {
+    var obj = new L.Evented();
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      obj.on('test', fn);
+    }
+  });
+
+  benchmark('Adding different fn', function() {
+    var obj = new L.Evented();
+    var fn = function () {};
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      obj.on('test', fns[p]);
+    }
+  });
+
+  var obj = new L.Evented();
+  var fn = function () {};
+  var t0 = performance.now();
   for (var p = 0; p < 1000; p++) {
-    obj.on('test', fn);
+    obj.on('test', (function(p) { return function() { var x = 2 + p; }})(p));
   }
-  console.timeEnd('Adding same function x1000');
-  console.time('Adding same function x1000');
-  for (var p = 0; p < 1000; p++) {
-    obj.on('test', fns[p]);
-  }
-  console.timeEnd('Adding different functions x1000');
-  console.time('Firing');
-  for (var p = 0; p < 1000; p++) {
-    obj.fire('test', {count: 1});
-  }
-  console.timeEnd('Firing');
-  console.time('Removing');
-  for (var p = 0; p < 1000; p++) {
-    obj.off('test', fn);
-  }
-  obj.off('test');  // Remove all listeners.
-  console.timeEnd('Removing');
-  console.timeEnd('Overall');
-  console.log('Total call count', called);
+  benchmark('Fire', function() {
+    for (var p = 0; p < 1000; p++) {
+      obj.fire('test');
+    }
+  });
+
+  benchmark('Off', function() {
+    var obj = new L.Evented();
+    var fn = function () {};
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      obj.on('test', fns[p]);
+    }
+  }, function() {
+    fns = [];
+    var obj = new L.Evented();
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      var fn = (function(p) { return function() { var x = 2 + p; }})(p);
+      fns.push(fn);
+      obj.on('test', fn);
+    }
+  });
+
   </script>
 </body>
 </html>

--- a/debug/tests/event-perf.html
+++ b/debug/tests/event-perf.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" id="vp" content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" />
+
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../leaflet-include.js"></script>
+
+  <meta charset="utf-8">
+  <title>Leaflet test for event adding/firing/removing performance</title>
+</head>
+<body>
+  <script>
+
+  var obj = new L.Evented();
+  var fn = function (e) {called += e.count;},
+    fns = [],
+    called = 0;
+  for (var p = 0; p < 1000; p++) {
+    fns.push(function(e) { called += e.count;});
+  }
+  console.time('Overall');
+  console.time('Adding same function x1000');
+  for (var p = 0; p < 1000; p++) {
+    obj.on('test', fn);
+  }
+  console.timeEnd('Adding same function x1000');
+  console.time('Adding same function x1000');
+  for (var p = 0; p < 1000; p++) {
+    obj.on('test', fns[p]);
+  }
+  console.timeEnd('Adding different functions x1000');
+  console.time('Firing');
+  for (var p = 0; p < 1000; p++) {
+    obj.fire('test', {count: 1});
+  }
+  console.timeEnd('Firing');
+  console.time('Removing');
+  for (var p = 0; p < 1000; p++) {
+    obj.off('test', fn);
+  }
+  obj.off('test');  // Remove all listeners.
+  console.timeEnd('Removing');
+  console.timeEnd('Overall');
+  console.log('Total call count', called);
+  </script>
+</body>
+</html>

--- a/debug/tests/event-perf.html
+++ b/debug/tests/event-perf.html
@@ -12,6 +12,45 @@
 </head>
 <body>
   <script>
+  function benchmark(name, fn, setup) {
+    //warmup
+    for (var i = 0; i < 100; i++) {
+      if (setup) {
+        setup();
+      }
+      fn();
+    }
+
+    var t = 0;
+    for (var i = 0; i < 100; i++) {
+      if (setup) {
+        setup();
+      }
+      var t0 = performance.now();
+      fn();
+      t += performance.now() - t0;
+    }
+    console.log(name, (t / 100) + ' ms/run');
+  }
+
+
+  benchmark('Adding same fn', function() {
+    var obj = new L.Evented();
+    var fn = function () {};
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      obj.on('test', fn);
+    }
+  });
+
+  benchmark('Adding different fn', function() {
+    var obj = new L.Evented();
+    var fn = function () {};
+    var t0 = performance.now();
+    for (var p = 0; p < 1000; p++) {
+      obj.on('test', (function(p) { return function() { var x = 2 + p; }})(p));
+    }
+  });
 
   function benchmark(name, fn, setup) {
     //warmup

--- a/debug/tests/event-perf.html
+++ b/debug/tests/event-perf.html
@@ -12,45 +12,6 @@
 </head>
 <body>
   <script>
-  function benchmark(name, fn, setup) {
-    //warmup
-    for (var i = 0; i < 100; i++) {
-      if (setup) {
-        setup();
-      }
-      fn();
-    }
-
-    var t = 0;
-    for (var i = 0; i < 100; i++) {
-      if (setup) {
-        setup();
-      }
-      var t0 = performance.now();
-      fn();
-      t += performance.now() - t0;
-    }
-    console.log(name, (t / 100) + ' ms/run');
-  }
-
-
-  benchmark('Adding same fn', function() {
-    var obj = new L.Evented();
-    var fn = function () {};
-    var t0 = performance.now();
-    for (var p = 0; p < 1000; p++) {
-      obj.on('test', fn);
-    }
-  });
-
-  benchmark('Adding different fn', function() {
-    var obj = new L.Evented();
-    var fn = function () {};
-    var t0 = performance.now();
-    for (var p = 0; p < 1000; p++) {
-      obj.on('test', (function(p) { return function() { var x = 2 + p; }})(p));
-    }
-  });
 
   function benchmark(name, fn, setup) {
     //warmup

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -311,6 +311,22 @@ describe('Events', function () {
 			obj.fire();
 			expect(spy3.called).to.be(true);
 		});
+
+
+		it('does not add twice the same function', function () {
+			var obj = new L.Evented(),
+			    spy = sinon.spy();
+
+			/* register without context */
+			obj.on("test", spy);
+			obj.on("test", spy);
+
+			/* Should be called once */
+			obj.fire("test");
+
+			expect(spy.callCount).to.eql(1);
+		});
+
 	});
 
 	describe("#clearEventListeners", function () {

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -115,6 +115,12 @@ L.Evented = L.Class.extend({
 			// so simple array makes the memory footprint better while not degrading performance
 
 			events[type] = events[type] || [];
+			for (var i = 0, len = events[type].length; i < len; i++) {
+				if (events[type][i].fn === fn) {
+					// This given callback has yet been registered.
+					return;
+				}
+			}
 			events[type].push({fn: fn});
 		}
 	},


### PR DESCRIPTION
Fix #4477 

Because we are storing events as objects `{fn: fn}`, and because of Javascript checking objects equality by reference, I see no elegant options, either:

- refactoring so we can store directly the `fn` in the array: needs more work, ends with `events` being inconsistent, probability of breaking something bigger
- store somewhere else the `fn` reference (for example is some `this._listeners_refs`): bad footprint, denormalized event storage, thus more fragile
- loop over existing registered listeners to see: bad performance in theory

Given that we are only talking about listeners registered without context or `this` as context, I think the list of already registered listeners will always be small, so I've chosen the last option.

If someone has a better pattern, I'm open! :)

Also, I've added a `console.warn` in the case we receive a listener already registered, trying to be smart with the developer. That's not in the usual Leaflet patterns, so I'll understand if we prefer remove it.
