### PR TITLE
Move latitude clamping out of Projection.project and into CRS.latLngToPoint

### DIFF
--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -15,8 +15,13 @@ L.CRS = {
 	// @method latLngToPoint(latlng: LatLng, zoom: Number): Point
 	// Projects geographical coordinates into pixel coordinates for a given zoom.
 	latLngToPoint: function (latlng, zoom) {
-		var projectedPoint = this.projection.project(latlng),
-		    scale = this.scale(zoom);
+		var projectedPoint = this.projection.project(latlng);
+
+		if (!this.infinite) {
+			projectedPoint = this.projection.bounds.clampPoint(projectedPoint);
+		}
+
+		var scale = this.scale(zoom);
 
 		return this.transformation._transform(projectedPoint, scale);
 	},

--- a/src/geo/projection/Projection.SphericalMercator.js
+++ b/src/geo/projection/Projection.SphericalMercator.js
@@ -14,9 +14,7 @@ L.Projection.SphericalMercator = {
 
 	project: function (latlng) {
 		var d = Math.PI / 180,
-		    max = this.MAX_LATITUDE,
-		    lat = Math.max(Math.min(max, latlng.lat), -max),
-		    sin = Math.sin(lat * d);
+		    sin = Math.sin(latlng.lat * d);
 
 		return new L.Point(
 				this.R * latlng.lng * d,

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -136,8 +136,20 @@ L.Bounds.prototype = {
 		return xOverlaps && yOverlaps;
 	},
 
+	// @method isValid(): Boolean
+	// Returns `true` if the bounds are properly initialized.
 	isValid: function () {
 		return !!(this.min && this.max);
+	},
+
+	// @method clampPoint(point: Point): Boolean
+	// Returns a point guaranteed to be within the bounds, as close as possible
+	// to the given one.
+	clampPoint: function (point) {
+		return new L.Point(
+			Math.min(Math.max(this.min.x, point.x), this.max.x),
+			Math.min(Math.max(this.min.y, point.y), this.max.y)
+		);
 	}
 };
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -198,10 +198,10 @@ L.Map = L.Evented.extend({
 		zoom = (typeof options.maxZoom === 'number') ? Math.min(options.maxZoom, zoom) : zoom;
 
 		var paddingOffset = paddingBR.subtract(paddingTL).divideBy(2),
-
 		    swPoint = this.project(bounds.getSouthWest(), zoom),
-		    nePoint = this.project(bounds.getNorthEast(), zoom),
-		    center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom);
+		    nePoint = this.project(bounds.getNorthEast(), zoom);
+
+		var center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom);
 
 		return {
 			center: center,


### PR DESCRIPTION
This moves the clamping of latitude (to keep it between -85/+85) out of `Projection.project` and into `CRS.latLngToPoint`. This means that `Projection.SphericalMercator.project` (which returns CRS coordinates) will return values "outside" the valid bounds, but `latLngToPoint` (which returns pixel coordinates) will still clamp pixel coordinates to the CRS bounds.

I made these changes because the way `Projection.SphericalMercator.project` works now was impacting some Leaflet.GL code (when calculating the CRS coord of the map center when it's past -85/+85 - the symptoms were the same as #4617, but the root cause is not).

The values for two unit tests change, so they need to be manually checked for sanity.