### PR TITLE
Fix #4592 by falling back to a legacy ScrollEvent property on Edge.

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -235,16 +235,16 @@ L.DomEvent = {
 	// Gets normalized wheel delta from a mousewheel DOM event, in vertical
 	// pixels scrolled (negative if scrolling down).
 	// Events from pointing devices without precise scrolling are mapped to
-	// a best guess of between 50-60 pixels.
+	// a best guess of 60 pixels.
 	getWheelDelta: function (e) {
 		return (L.Browser.edge) ? e.wheelDeltaY / 2 : // Don't trust window-geometry-based delta
 		       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels
-		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 : // Lines
-		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 : // Pages
+		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 20 : // Lines
+		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 60 : // Pages
 		       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events
 		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
-		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 18 : // Legacy Moz lines
-		       e.detail ? e.detail / -32765 * 52 : // Legacy Moz pages
+		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 20 : // Legacy Moz lines
+		       e.detail ? e.detail / -32765 * 60 : // Legacy Moz pages
 		       0;
 	},
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -228,7 +228,7 @@ L.DomEvent = {
 	// Chrome on Win scrolls double the pixels as in other platforms (see #4538),
 	// and Firefox scrolls device pixels, not CSS pixels
 	_wheelPxFactor: (L.Browser.win && L.Browser.chrome) ? 2 :
-	                (L.Browser.gecko) ? window.devicePixelRatio :
+	                L.Browser.gecko ? window.devicePixelRatio :
 	                1,
 
 	// @function getWheelDelta(ev: DOMEvent): Number
@@ -237,7 +237,8 @@ L.DomEvent = {
 	// Events from pointing devices without precise scrolling are mapped to
 	// a best guess of between 50-60 pixels.
 	getWheelDelta: function (e) {
-		return (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels
+		return (L.Browser.edge) ? e.wheelDeltaY / 2 : // Don't trust window-geometry-based delta
+		       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels
 		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 18 : // Lines
 		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 52 : // Pages
 		       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -20,7 +20,7 @@ L.Map.mergeOptions({
 	// How many scroll pixels (as reported by [L.DomEvent.getWheelDelta](#domevent-getwheeldelta))
 	// mean a change of one full zoom level. Smaller values will make wheel-zooming
 	// faster (and vice versa).
-	wheelPxPerZoomLevel: 50
+	wheelPxPerZoomLevel: 60
 });
 
 L.Map.ScrollWheelZoom = L.Handler.extend({


### PR DESCRIPTION
The `ScrollEvent`s in Edge are a pain in the a**. The `deltaY` amount depends on the window geometry (or the ratio between window height and window width), so it can have values as high as 130px or as low as 25, depending on how the user resizes a browser window.

The only way to work around this right now is to rely on the *legacy* `wheelDeltaY` event property, which Edge keeps at +/-120 per tick.

I have **not** tried Edge with a proper touchpad.

Furthermore, changed the values of the guessed deltas to be exactly 60 (this prevents FFX scrolling by 54px and others by 60, which causes problems with small `zoomSnap`s.