### PR TITLE
Do not call GridLayer.resetView on moveEnd (fix #4702)

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -529,9 +529,7 @@ L.GridLayer = L.Layer.extend({
 			this._noPrune = !!noPrune;
 		}
 
-		if (tileZoomChanged) {
-			this._setZoomTransforms(center, zoom);
-		}
+		this._setZoomTransforms(center, zoom);
 	},
 
 	_setZoomTransforms: function (center, zoom) {
@@ -576,7 +574,7 @@ L.GridLayer = L.Layer.extend({
 	_onMoveEnd: function () {
 		if (!this._map || this._map._animatingZoom) { return; }
 
-		this._resetView();
+		this._update();
 	},
 
 	_getTiledPixelBounds: function (center) {


### PR DESCRIPTION
Round 2 ;)

Fix #4702 

See https://github.com/Leaflet/Leaflet/issues/4702#issuecomment-230089565 for the rationale.