### PR TITLE
Allow to make screenshots in Phantomjs

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -193,7 +193,7 @@ exports.test = function(complete, fail) {
 	var karma = require('karma'),
 	    testConfig = {configFile : __dirname + '/../spec/karma.conf.js'};
 
-	testConfig.browsers = ['PhantomJS'];
+	testConfig.browsers = ['PhantomJSCustom'];
 
 	function isArgv(optName) {
 		return process.argv.indexOf(optName) !== -1;

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -14,6 +14,7 @@
     "expect": false,
     "sinon": false,
     "happen": false,
-    "Hand": false
+    "Hand": false,
+    "takeScreenshot"
   }
 }

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function (config) {
 		"node_modules/prosthetic-hand/dist/prosthetic-hand.js",
 		"spec/suites/SpecHelper.js",
 		"spec/suites/**/*.js",
+		"dist/*.css",
 		{pattern: "dist/images/*.png", included: false}
 	]);
 

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration
 module.exports = function (config) {
 
-	var libSources = require(__dirname+'/../build/build.js').getFiles();
+	var libSources = require(__dirname + '/../build/build.js').getFiles();
 
 	var files = [
 		"spec/sinon.js",
@@ -60,7 +60,21 @@ module.exports = function (config) {
 		// - Safari (only Mac)
 		// - PhantomJS
 		// - IE (only Windows)
-		browsers: ['PhantomJS'],
+		browsers: ['PhantomJSCustom'],
+
+		customLaunchers: {
+			'PhantomJSCustom': {
+				base: 'PhantomJS',
+				flags: ['--load-images=true'],
+				options: {
+					onCallback: function (data) {
+						if (data.render) {
+							page.render(data.render);
+						}
+					}
+				}
+			}
+		},
 
 		// If browser does not capture in given timeout [ms], kill it
 		captureTimeout: 5000,

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function (config) {
 		"spec/suites/SpecHelper.js",
 		"spec/suites/**/*.js",
 		"dist/*.css",
-		{pattern: "dist/images/*.png", included: false}
+		{pattern: "dist/images/*.png", included: false, serve: true}
 	]);
 
 	config.set({
@@ -33,6 +33,9 @@ module.exports = function (config) {
 
 		// list of files / patterns to load in the browser
 		files: files,
+		proxies: {
+			'/base/dist/images/': 'dist/images/'
+		},
 		exclude: [],
 
 		// test results reporter to use

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -60,3 +60,8 @@ it.skipIfNotTouch = window.TouchEvent ? it : it.skip;
 
 // A couple of tests need the browser to be pointer-capable
 it.skipIfNotEdge = window.PointerEvent ? it : it.skip;
+
+
+function takeScreenshot(path) {
+	window.top.callPhantom({'render': path || 'screenshot.png'});
+}

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -135,7 +135,7 @@ describe('GridLayer', function () {
 		});
 
 		// Passes on Firefox, but fails on phantomJS: done is never called.
-		it.skipInPhantom('only creates tiles for visible area on zoom in', function (done) {
+		it('only creates tiles for visible area on zoom in', function (done) {
 			map.remove();
 			map = L.map(div);
 			map.setView([0, 0], 10);

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -653,7 +653,7 @@ describe("Map", function () {
 			document.body.removeChild(div);
 		});
 
-		it.skipInPhantom('move to requested center and zoom, and call zoomend once', function (done) {
+		it('move to requested center and zoom, and call zoomend once', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
 			var spy = sinon.spy(),
@@ -670,7 +670,7 @@ describe("Map", function () {
 			map.on('zoomend', callback).flyTo(newCenter, newZoom);
 		});
 
-		it.skipInPhantom('flyTo start latlng == end latlng', function (done) {
+		it('flyTo start latlng == end latlng', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
 			var dc = new L.LatLng(38.91, -77.04);


### PR DESCRIPTION
For that, one needs to run this call:

    window.top.callPhantom({'render': 'screenshot.png'});


This PR also make PhantomJS load Leaflet CSS while running tests (separate commit).

Example of screenshot:

![screenshot](https://cloud.githubusercontent.com/assets/146023/16539856/c30a7306-404f-11e6-82fe-97c8f458534b.png)


Should I add a helper to make the screenshot command easier to remember (something like `takeScreenshot(optionalPath)` ?