### PR TITLE
add Leaflet.Pin plugin to Edit geometries section

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -1594,6 +1594,15 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 			<a href="https://github.com/manleyjster">Justin Manley</a>
 		</td>
 	</tr>
+<tr>
+		<td>
+			<a href="https://github.com/kklimczak/Leaflet.Pin">Leaflet.Pin</a>
+		</td><td>
+			Enable attaching of markers to other layers during draw or edit features with Leaflet.Draw.
+		</td><td>
+			<a href="https://github.com/kklimczak">Konrad Klimczak</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Plugin based on Leaflet.Snap for attaching markers to others layers, auto enabled during draw and edit features.