### PR TITLE
Prevent Travis from running twice on a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: node_js
 node_js: stable
+branches:
+  only:
+    - master
+    - stable
 addons:
   artifacts:
     paths:


### PR DESCRIPTION
Currently, when we open a PR, Travis run twice: once because it's a
PR and once for the last commit of the branch.

This change will make Travis run for *commits* only when
made directly on master (which should not happen that much, but still
happen).
Of course, Travis will still be run for a PR, but only once.