### PR TITLE
Take the popup container margin-bottom into account to compute autopan

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -211,7 +211,8 @@ L.Popup = L.DivOverlay.extend({
 		if (!this.options.autoPan || (this._map._panAnim && this._map._panAnim._inProgress)) { return; }
 
 		var map = this._map,
-		    containerHeight = this._container.offsetHeight,
+		    marginBottom = parseInt(L.DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
+		    containerHeight = this._container.offsetHeight + marginBottom,
 		    containerWidth = this._containerWidth,
 		    layerPos = new L.Point(this._containerLeft, -containerHeight - this._containerBottom);
 


### PR DESCRIPTION
Fix #4759 

Since https://github.com/Leaflet/Leaflet/commit/3ecd4273f3aab07736fdf0679c0874c273a85a0b the popup tip is in absolute positioning, thus not taken into account in the popup container offsetHeight.