### PR TITLE
Get / Each single layers recursively

### DIFF
--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -54,6 +54,25 @@
 		});
 	});
 
+	describe("#getSingleLayersRecursive", function () {
+		it('gets all non-group layers recursively', function () {
+			var lg1 = L.layerGroup(),
+			    marker1 = L.marker([0, 0]),
+			    lg2 = L.layerGroup(),
+			    marker2 = L.marker([0, 0]),
+			    lg3 = L.layerGroup(),
+			    marker3 = L.marker([0, 0]);
+
+			lg1.addLayer(marker1);
+			lg1.addLayer(lg2);
+			lg2.addLayer(marker2);
+			lg2.addLayer(lg3);
+			lg3.addLayer(marker3);
+
+			expect(lg1.getSingleLayersRecursive()).to.eql([marker1, marker2, marker3]);
+		});
+	});
+
 	describe("#eachLayer", function () {
 		it('iterates over all layers', function () {
 			var lg = L.layerGroup(),
@@ -66,6 +85,32 @@
 				expect(layer).to.eql(marker);
 				expect(this).to.eql(ctx);
 			}, ctx);
+		});
+	});
+
+	describe("#eachSingleLayerRecursive", function () {
+		it('iterates over all non-group layers recursively', function () {
+			var lg1 = L.layerGroup(),
+			    marker1 = L.marker([0, 0]),
+			    lg2 = L.layerGroup(),
+			    marker2 = L.marker([0, 0]),
+			    lg3 = L.layerGroup(),
+			    marker3 = L.marker([0, 0]),
+			    ctx = {foo: 'bar'},
+			    result = [];
+
+			lg1.addLayer(marker1);
+			lg1.addLayer(lg2);
+			lg2.addLayer(marker2);
+			lg2.addLayer(lg3);
+			lg3.addLayer(marker3);
+
+			lg1.eachSingleLayerRecursive(function (layer) {
+				result.push(layer);
+				expect(this).to.eql(ctx);
+			}, ctx);
+
+			expect(result).to.eql([marker1, marker2, marker3]);
 		});
 	});
 });

--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -73,6 +73,25 @@
 		});
 	});
 
+	describe("#toSingleLayersArray", function () {
+		it('gets all non-group layers recursively', function () {
+			var lg1 = L.layerGroup(),
+			    marker1 = L.marker([0, 0]),
+			    lg2 = L.layerGroup(),
+			    marker2 = L.marker([0, 0]),
+			    lg3 = L.layerGroup(),
+			    marker3 = L.marker([0, 0]);
+
+			lg1.addLayer(marker1);
+			lg1.addLayer(lg2);
+			lg2.addLayer(marker2);
+			lg2.addLayer(lg3);
+			lg3.addLayer(marker3);
+
+			expect(lg1.getSingleLayersRecursive()).to.eql([marker1, marker2, marker3]);
+		});
+	});
+
 	describe("#eachLayer", function () {
 		it('iterates over all layers', function () {
 			var lg = L.layerGroup(),

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -305,4 +305,12 @@ describe("Marker", function () {
 		});
 
 	});
+
+	describe("#toSingleLayersArray", function () {
+		it('returns an array with this marker only', function () {
+			var marker = L.marker([0, 0]);
+
+			expect(marker.toSingleLayersArray()).to.eql([marker]);
+		});
+	});
 });

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -101,6 +101,15 @@ L.Layer = L.Evented.extend({
 
 		this.fire('add');
 		map.fire('layeradd', {layer: this});
+	},
+
+	// @method toSingleLayersArray(): Layer[]
+	// Returns an array of child **non-group** layers recursively.
+	// If this is a non-group layer, returns an array if this only.
+	toSingleLayersArray: function () {
+		var getSingle = this.getSingleLayersRecursive;
+
+		return getSingle ? getSingle() : [this];
 	}
 });
 

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -121,6 +121,23 @@ L.LayerGroup = L.Layer.extend({
 		return this;
 	},
 
+	// @method eachSingleLayerRecursive(fn: Function, context?: Object): this
+	// Iterates over child **non-group** layers, recursively through child layer groups (if any).
+	eachSingleLayerRecursive: function (method, context) {
+		var thisLayers = this._layers,
+		    layer;
+
+		for (var i in thisLayers) {
+			layer = thisLayers[i];
+			if (layer.eachSingleLayerRecursive) {
+				layer.eachSingleLayerRecursive(method, context);
+			} else {
+				method.call(context, layer);
+			}
+		}
+		return this;
+	},
+
 	// @method getLayer(id: Number): Layer
 	// Returns the layer with the given internal ID.
 	getLayer: function (id) {
@@ -136,6 +153,30 @@ L.LayerGroup = L.Layer.extend({
 			layers.push(this._layers[i]);
 		}
 		return layers;
+	},
+
+	// @method getSingleLayersRecursive(): Layer[]
+	// Returns an array of all **non-group** child layers, recursively through child layer groups (if any).
+	getSingleLayersRecursive: function () {
+		var layers = [];
+
+		this._getSingleLayersIntoArrayRecursive(layers);
+
+		return layers;
+	},
+
+	_getSingleLayersIntoArrayRecursive: function (outputArray) {
+		var thisLayers = this._layers,
+		    layer;
+
+		for (var i in thisLayers) {
+			layer = thisLayers[i];
+			if (layer._getSingleLayersIntoArrayRecursive) {
+				layer._getSingleLayersIntoArrayRecursive(outputArray);
+			} else {
+				outputArray.push(layer);
+			}
+		}
 	},
 
 	// @method setZIndex(zIndex: Number): this


### PR DESCRIPTION
Following discussion in #4461, added the 2 methods to Layer Group that seem the most useful:
- `getSingleLayersRecursive()`: extract all **non-group** (i.e. single) layers from this Layer Group and from all its child Layer Groups recursively. When the method encounters a Layer Group, it re-applies itself on it and appends the result in place in the resulting array, instead of the Layer Group. However the final layers order is not necessarily guaranteed as it loops through child layers according to the ascending order of `_leaflet_id`, not to insertion order. This could replace [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster) internal `_extractNonGroupLayers()` method (if ready to loop twice).
- `eachSingleLayerRecursive()`: similar but applying a method and optionally a context. This should be directly usable by [leaflet-search](https://github.com/stefanocudini/leaflet-search) and [leaflet-pip](https://github.com/mapbox/leaflet-pip) to replace `eachLayer()`.

I added corresponding test cases.

I also took the liberty to add an extra method `toSingleLayersArray()` to the `L.Layer` base class. The idea is to provide a mean to easily convert whatever layer into an array of single layers, without having to re-implement a Layer Group detection and having to call `getSingleLayersRecursive()` in case it is a group.

For example, [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster) could now implement its `addLayer()` method (for single layer) through:
```javascript
addLayer: function (layer) {
    return this.addLayers(layer.toSingleLayersArray());
}
```
(it currently checks the Layer Group condition itself and acts accordingly)

I added corresponding test cases in Layer Group and Marker specs.