### PR TITLE
Allow to call bindTooltip on a layer not yet added to a map (fix #4778)

### DIFF
--- a/debug/map/tooltip.html
+++ b/debug/map/tooltip.html
@@ -61,7 +61,7 @@
 		}, {opacity: 0.7});
 		L.marker([41.18, 9.35]).addTo(map).bindTooltip('Top tooltip is top', {permanent: true, direction: 'top'});
 		L.marker([41.173, 9.37]).addTo(map).bindTooltip('Bottom tooltip is weird but ok', {permanent: true, direction: 'bottom'});
-		L.polyline([[41.20, 9.36], [41.205, 9.35], [41.19, 9.34]]).addTo(map).bindTooltip('Polyline tooltip', {permanent: true, direction: 'top'});
+		L.polyline([[41.20, 9.36], [41.205, 9.35], [41.19, 9.34]]).bindTooltip('Polyline tooltip', {permanent: true, direction: 'top'}).addTo(map);
 		L.polygon([[41.21, 9.36], [41.24, 9.35], [41.23, 9.34]]).addTo(map).bindTooltip('Top tooltip following mouse', {sticky: true, direction: 'top'});
 
 	</script>

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -43,6 +43,15 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
 	});
 
+	it("can be added with bindTooltip before added to the map", function () {
+		var layer = new L.Marker(center);
+
+		layer.bindTooltip('Tooltip', {permanent: true});
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+		layer.addTo(map);
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+	});
+
 	it("is removed when removing marker", function () {
 		var layer = new L.Marker(center).addTo(map);
 
@@ -160,6 +169,19 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
 	});
 
+	it("can be added on polygon with bindTooltip before beind added to the map", function () {
+		var layer = new L.Polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
+
+		layer.bindTooltip('Tooltip', {permanent: true});
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+		layer.addTo(map);
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+		layer.remove();
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+		layer.addTo(map);
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+	});
+
 	it("opens on polyline mouseover and close on mouseout", function () {
 		var layer = new L.Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
@@ -173,10 +195,23 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(false);
 	});
 
-	it("stays open on marker when permanent", function () {
+	it("stays open on polyline when permanent", function () {
 		var layer = new L.Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+	});
+
+	it("can be added on polyline with bindTooltip before added to the map", function () {
+		var layer = new L.Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
+
+		layer.bindTooltip('Tooltip', {permanent: true});
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+		layer.addTo(map);
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+		layer.remove();
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+		layer.addTo(map);
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
 	});
 

--- a/src/layer/Layer.Tooltip.js
+++ b/src/layer/Layer.Tooltip.js
@@ -34,7 +34,9 @@ L.Layer.include({
 
 		this._initTooltipInteractions();
 
-		if (this._tooltip.options.permanent) { this.openTooltip(); }
+		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this)) {
+			this.openTooltip();
+		}
 
 		return this;
 	},
@@ -66,6 +68,8 @@ L.Layer.include({
 			if (L.Browser.touch) {
 				events.click = this._openTooltip;
 			}
+		} else {
+			events.add = this._openTooltip;
 		}
 		this[onOff](events);
 		this._tooltipHandlersAdded = !remove;


### PR DESCRIPTION
Fix #4778 