### PR TITLE
Only stop "preclick" on popup open for markers

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -102,7 +102,11 @@ L.Popup = L.DivOverlay.extend({
 			// @event popupopen: PopupEvent
 			// Fired when a popup bound to this layer is opened
 			this._source.fire('popupopen', {popup: this}, true);
-			this._source.on('preclick', L.DomEvent.stopPropagation);
+			// For non-path layers, we toggle the popup when clicking
+			// again the layer, so prevent the map to reopen it.
+			if (!(this._source instanceof L.Path)) {
+				this._source.on('preclick', L.DomEvent.stopPropagation);
+			}
 		}
 	},
 
@@ -121,7 +125,9 @@ L.Popup = L.DivOverlay.extend({
 			// @event popupclose: PopupEvent
 			// Fired when a popup bound to this layer is closed
 			this._source.fire('popupclose', {popup: this}, true);
-			this._source.off('preclick', L.DomEvent.stopPropagation);
+			if (!(this._source instanceof L.Path)) {
+				this._source.off('preclick', L.DomEvent.stopPropagation);
+			}
 		}
 	},
 


### PR DESCRIPTION
We actually do not toggle the popup on click for L.Path.

Fixing what is described here https://github.com/Leaflet/Leaflet/issues/3992#issuecomment-236885662

Side note: I'm not a big fan of having the "toggling" only for Marker and not for Path. It's not consistent as a UX and it introduce ugly `if` in the code.
What about instead having it by default for all layers, and adding an option (`toggleOnClick`) to opt-out?