### PR TITLE
Add new "corner" direction to tooltips

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -138,6 +138,8 @@ L.Tooltip = L.DivOverlay.extend({
 			pos = pos.subtract(L.point(tooltipWidth / 2 - offset.x, -offset.y));
 		} else if (direction === 'center') {
 			pos = pos.subtract(L.point(tooltipWidth / 2 + offset.x, tooltipHeight / 2 - anchor.y + offset.y));
+		} else if (direction === 'corner') {
+			pos = pos.add(L.point(offset.x + anchor.x, offset.y + anchor.y));
 		} else if (direction === 'right' || direction === 'auto' && tooltipPoint.x < centerPoint.x) {
 			direction = 'right';
 			pos = pos.add([offset.x + anchor.x, anchor.y - tooltipHeight / 2 + offset.y]);


### PR DESCRIPTION
This allows for a fixed positioning of the tooltip that is not dependant on the height or width of the DOM element.

My use case for this is that I have on my map many markers, that all look the same but have different permanent tooltips (some longer, some shorter, some multiline, some not).

Now, the equal positioning of these tooltips proves difficult with the available directions, because in my case, I do not want the tooltips vertically or horizontally centered, but want its upper left corner in the same place (relative to their markers) for all of them.

Thus I need a "direction", that does not include its height or width in its position calculation.

PS: The naming of the direction is debatable, I also thought about naming it `"fix(ed)"`.