### PR TITLE
Allow to create and open a tooltip without source (fix #4827)

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -278,5 +278,14 @@ describe('Tooltip', function () {
 		L.Browser.touch = oldTouch;
 	});
 
+
+	it("opens with map.openTooltip", function (done) {
+		map.on('tooltipopen', function (e) {
+			expect(map.hasLayer(e.tooltip)).to.be(true);
+			done();
+		});
+		map.openTooltip('Tooltip', center);
+	});
+
 });
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -174,7 +174,7 @@ L.Tooltip = L.DivOverlay.extend({
 
 	_getAnchor: function () {
 		// Where should we anchor the tooltip on the source layer?
-		return L.point(this._source._getTooltipAnchor && !this.options.sticky ? this._source._getTooltipAnchor() : [0, 0]);
+		return L.point(this._source && this._source._getTooltipAnchor && !this.options.sticky ? this._source._getTooltipAnchor() : [0, 0]);
 	}
 
 });


### PR DESCRIPTION
Fix #4827 