### PR TITLE
Just store array of listeners, count is no longer needed.

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -377,11 +377,11 @@ describe('Events', function () {
 
 			obj.removeEventListener('test', removeSpy);
 
-			// expect(obj.listens('test', L.Util.falseFn)).to.be(false);
+			expect(obj.listens('test')).to.be(false);
 			// Remove the expect below and comment out the one above, once we've
 			// gotten rid of _events.count (which makes the expect above pass).
-			var listeners = obj._events['test'];
-			expect(listeners.count === listeners.listeners.length).to.be(true);
+			// var listeners = obj._events['test'];
+			// expect(listeners.count === listeners.listeners.length).to.be(true);
 		});
 	});
 

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -378,10 +378,6 @@ describe('Events', function () {
 			obj.removeEventListener('test', removeSpy);
 
 			expect(obj.listens('test')).to.be(false);
-			// Remove the expect below and comment out the one above, once we've
-			// gotten rid of _events.count (which makes the expect above pass).
-			// var listeners = obj._events['test'];
-			// expect(listeners.count === listeners.listeners.length).to.be(true);
 		});
 	});
 

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -95,10 +95,7 @@ L.Evented = L.Class.extend({
 		/* get/init listeners for type */
 		var typeListeners = this._events[type];
 		if (!typeListeners) {
-			typeListeners = {
-				listeners: [],
-				count: 0
-			};
+			typeListeners = [];
 			this._events[type] = typeListeners;
 		}
 
@@ -107,7 +104,7 @@ L.Evented = L.Class.extend({
 			context = undefined;
 		}
 		var newListener = {fn: fn, ctx: context},
-		    listeners = typeListeners.listeners;
+		    listeners = typeListeners;
 
 		// check if fn already there
 		for (var i = 0, len = listeners.length; i < len; i++) {
@@ -121,20 +118,17 @@ L.Evented = L.Class.extend({
 	},
 
 	_off: function (type, fn, context) {
-		var typeListeners,
-		    listeners,
+		var listeners,
 		    i,
 		    len;
 
 		if (!this._events) { return; }
 
-		typeListeners = this._events[type];
+		listeners = this._events[type];
 
-		if (!typeListeners) {
+		if (!listeners) {
 			return;
 		}
-
-		listeners = typeListeners.listeners;
 
 		if (!fn) {
 			// Set all removed listeners to noop so they are not called if remove happens in fire
@@ -145,7 +139,6 @@ L.Evented = L.Class.extend({
 			delete this._events[type];
 			return;
 		}
-
 
 		if (context === this) {
 			context = undefined;
@@ -161,11 +154,10 @@ L.Evented = L.Class.extend({
 
 					// set the removed listener to noop so that's not called if remove happens in fire
 					l.fn = L.Util.falseFn;
-					typeListeners.count--;
 
 					if (this._firingCount) {
 						/* copy array in case events are being fired */
-						typeListeners.listeners = listeners = listeners.slice();
+						this._events[type] = listeners = listeners.slice();
 					}
 					listeners.splice(i, 1);
 
@@ -185,11 +177,10 @@ L.Evented = L.Class.extend({
 		var event = L.Util.extend({}, data, {type: type, target: this});
 
 		if (this._events) {
-			var typeListeners = this._events[type];
+			var listeners = this._events[type];
 
-			if (typeListeners) {
+			if (listeners) {
 				this._firingCount = (this._firingCount + 1) || 1;
-				var listeners = typeListeners.listeners;
 				for (var i = 0, len = listeners.length; i < len; i++) {
 					var l = listeners[i];
 					l.fn.call(l.ctx || this, event);
@@ -210,8 +201,8 @@ L.Evented = L.Class.extend({
 	// @method listens(type: String): Boolean
 	// Returns `true` if a particular event type has any listeners attached to it.
 	listens: function (type, propagate) {
-		var typeListeners = this._events && this._events[type];
-		if (typeListeners && typeListeners.count) { return true; }
+		var listeners = this._events && this._events[type];
+		if (listeners && listeners.length) { return true; }
 
 		if (propagate) {
 			// also check parents for listeners if event propagates


### PR DESCRIPTION
Discovered that `count` is no longer needed per event type, so this removes it, cleaning up the code as well as one of the tests that had to rely on the event system's internals before.