### PR TITLE
docstrings: Expanded FeatureGroup docs.

### DIFF
--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -3,14 +3,19 @@
  * @aka L.FeatureGroup
  * @inherits LayerGroup
  *
- * Extended `LayerGroup` that also has mouse events (propagated from members of the group) and a shared bindPopup method.
+ * Extended `LayerGroup` that makes it easier to do the same thing to all its member layers:
+ *  * [`bindPopup`](#layer-bindpopup) binds a popup to all of the layers at once (likewise with [`bindTooltip`](#layer-bindtooltip))
+ *  * Events are propagated to the `FeatureGroup`, so if the group has an event
+ * handler, it will handle events from any of the layers. This includes mouse events
+ * and custom events.
+ *  * Has `layeradd` and `layerremove` events
  *
  * @example
  *
  * ```js
  * L.featureGroup([marker1, marker2, polyline])
  * 	.bindPopup('Hello world!')
- * 	.on('click', function() { alert('Clicked on a group!'); })
+ * 	.on('click', function() { alert('Clicked on a member of the group!'); })
  * 	.addTo(map);
  * ```
  */
@@ -26,6 +31,8 @@ L.FeatureGroup = L.LayerGroup.extend({
 
 		L.LayerGroup.prototype.addLayer.call(this, layer);
 
+		// @event layeradd: LayerEvent
+		// Fired when a layer is added to this `FeatureGroup`
 		return this.fire('layeradd', {layer: layer});
 	},
 
@@ -41,6 +48,8 @@ L.FeatureGroup = L.LayerGroup.extend({
 
 		L.LayerGroup.prototype.removeLayer.call(this, layer);
 
+		// @event layerremove: LayerEvent
+		// Fired when a layer is removed from this `FeatureGroup`
 		return this.fire('layerremove', {layer: layer});
 	},
 


### PR DESCRIPTION
Expand the docstrings of `FeatureGroup` so things like #4861 won't happen again.