### PR TITLE
Use translate() in DomUtil.setTransform

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -188,9 +188,7 @@ L.DomUtil = {
 		var pos = offset || new L.Point(0, 0);
 
 		el.style[L.DomUtil.TRANSFORM] =
-			(L.Browser.ie3d ?
-				'translate(' + pos.x + 'px,' + pos.y + 'px)' :
-				'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
+			'translate(' + pos.x + 'px,' + pos.y + 'px)' +
 			(scale ? ' scale(' + scale + ')' : '');
 	},
 


### PR DESCRIPTION
Use translate() instead of translate3d() because the z transformation is 0 anyway, and browsers seem to better support the former transformation (i.e. the interpolation (e.g. when upscaling) remains cubic (in browsers that support it, e.g. Chromium)  instead of linear as noticeable (in Chromium) in https://jsfiddle.net/Lb6abxmu/).