### PR TITLE
PLUGINS fix Leaflet.Marker.Stack demo link

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1139,7 +1139,7 @@ These plugins provide new markers or news ways of converting abstract data into 
 			<a href="https://github.com/IvanSanchez/Leaflet.Marker.Stack">Leaflet.Marker.Stack</a>
 		</td>
 		<td>
-			A pure Leaflet implementation of CartoDB's "<a href="http://blog.cartodb.com/stacking-chips-a-map-hack/">stacked chips</a>" symbolizer. <a href="http://ivansanchez.github.io/Leaflet.Marker.Stack/demo.html">Demo</a>.
+			A pure Leaflet implementation of CartoDB's "<a href="http://blog.cartodb.com/stacking-chips-a-map-hack/">stacked chips</a>" symbolizer. <a href="http://ivansanchez.github.io/Leaflet.Marker.Stack/demos/color_ramps.html">Demo</a>.
 		</td>
 		<td>
 			<a href="https://github.com/IvanSanchez">Iván Sánchez</a>


### PR DESCRIPTION
Link to demo page was broken, replaced by the "color ramps" demo.