### PR TITLE
Turn nonBubblingEvents into a documented boolean option

### DIFF
--- a/src/layer/Layer.Interactive.leafdoc
+++ b/src/layer/Layer.Interactive.leafdoc
@@ -8,6 +8,10 @@ Use the [event handling methods](#evented-method) to handle these events.
 @option interactive: Boolean = true
 If `false`, the layer will not emit mouse events and will act as a part of the underlying map.
 
+@option bubblingMouseEvents: Boolean = true
+When `true`, a mouse event on this layer will trigger the same event on the map
+(unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+
 @section Mouse events
 
 @event click: MouseEvent

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -34,11 +34,12 @@ export var Layer = Evented.extend({
 		// @option pane: String = 'overlayPane'
 		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
 		pane: 'overlayPane',
-		nonBubblingEvents: [],  // Array of events that should not be bubbled to DOM parents (like the map),
 
 		// @option attribution: String = null
 		// String to be shown in the attribution control, describes the layer data, e.g. "© Mapbox".
-		attribution: null
+		attribution: null,
+
+		bubblingMouseEvents: true
 	},
 
 	/* @section

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -66,8 +66,10 @@ export var Marker = Layer.extend({
 		// `Map pane` where the markers icon will be added.
 		pane: 'markerPane',
 
-		// FIXME: shadowPane is no longer a valid option
-		nonBubblingEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu']
+		// @option bubblingEvents: Boolean = false
+		// When `true`, a mouse event on this marker will trigger the same event on the map
+		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingEvents: false
 	},
 
 	/* @section

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -66,10 +66,10 @@ export var Marker = Layer.extend({
 		// `Map pane` where the markers icon will be added.
 		pane: 'markerPane',
 
-		// @option bubblingEvents: Boolean = false
+		// @option bubblingMouseEvents: Boolean = false
 		// When `true`, a mouse event on this marker will trigger the same event on the map
 		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-		bubblingEvents: false
+		bubblingMouseEvents: false
 	},
 
 	/* @section

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -67,7 +67,12 @@ export var Path = Layer.extend({
 		// className: '',
 
 		// Option inherited from "Interactive layer" abstract class
-		interactive: true
+		interactive: true,
+
+		// @option bubblingEvents: Boolean = true
+		// When `true`, a mouse event on this path will trigger the same event on the map
+		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingEvents: true
 	},
 
 	beforeAdd: function (map) {

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -69,10 +69,10 @@ export var Path = Layer.extend({
 		// Option inherited from "Interactive layer" abstract class
 		interactive: true,
 
-		// @option bubblingEvents: Boolean = true
+		// @option bubblingMouseEvents: Boolean = true
 		// When `true`, a mouse event on this path will trigger the same event on the map
 		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-		bubblingEvents: true
+		bubblingMouseEvents: true
 	},
 
 	beforeAdd: function (map) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1317,6 +1317,8 @@ export var Map = Evented.extend({
 		this._fireDOMEvent(e, type);
 	},
 
+	_mouseEvents: ['click', 'dblclick', 'mouseover', 'mouseout', 'contextmenu'],
+
 	_fireDOMEvent: function (e, type, targets) {
 
 		if (e.type === 'click') {
@@ -1357,7 +1359,7 @@ export var Map = Evented.extend({
 		for (var i = 0; i < targets.length; i++) {
 			targets[i].fire(type, data, true);
 			if (data.originalEvent._stopped ||
-				(targets[i].options.nonBubblingEvents && Util.indexOf(targets[i].options.nonBubblingEvents, type) !== -1)) { return; }
+				(targets[i].options.bubblingMouseEvents === false && Util.indexOf(this._mouseEvents, type) !== -1)) { return; }
 		}
 	},
 


### PR DESCRIPTION
Derived from conversation in #4882, this turns the (hidden) `nonBubblingEvents` layer option into a new documented (boolean) option, `bubblingEvents`, with explicit different defaults for markers and paths.

This should keep behaviour the same as now, while documenting why markers don't bubble mouse events to the map (by default).

cc @yohanboniface 
