### PR TITLE
Add opacity param to ImageOverlay.setOpacity jsdoc

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -72,7 +72,7 @@ L.ImageOverlay = L.Layer.extend({
 		}
 	},
 
-	// @method setOpacity(): this
+	// @method setOpacity(opacity: Number): this
 	// Sets the opacity of the overlay.
 	setOpacity: function (opacity) {
 		this.options.opacity = opacity;


### PR DESCRIPTION
`opacity: Number` param is missing from `ImageOverlay.setOpacity` jsdoc.