### PR TITLE
Fix return type of GridLayer.getContainer in leafdoc

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -180,7 +180,7 @@ L.GridLayer = L.Layer.extend({
 		return this.options.attribution;
 	},
 
-	// @method getContainer: String
+	// @method getContainer: HTMLElement
 	// Returns the HTML element that contains the tiles for this layer.
 	getContainer: function () {
 		return this._container;


### PR DESCRIPTION
Return type of `GridLayer.getContainer` is currently listed as `String` when it should be `HTMLElement` in leafdoc.