### PR TITLE
Improve docs for keypress events, local refs from leafdoc templates

### DIFF
--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -4,12 +4,12 @@
 	<title>{{ title }}</title>
 	<meta charset="utf-8">
 
-	<link rel="stylesheet" href="http://leafletjs.com/docs/css/normalize.css" />
-	<link rel="stylesheet" href="http://leafletjs.com/docs/css/main.css" />
-	<script src="https://www.leafletjs.com/docs/highlight/highlight.pack.js"></script>
-	<link rel="stylesheet" href="http://leafletjs.com/docs/highlight/styles/github-gist.css" />
-	<link rel="stylesheet" href="http://leafletjs.com/dist/leaflet.css" />
-	<script src="https://www.leafletjs.com/dist/leaflet.js"></script>
+	<link rel="stylesheet" href="../docs/docs/css/normalize.css" />
+	<link rel="stylesheet" href="../docs/docs/css/main.css" />
+	<script src="../docs/docs/highlight/highlight.pack.js"></script>
+	<link rel="stylesheet" href="../docs/docs/highlight/styles/github-gist.css" />
+	<link rel="stylesheet" href="leaflet.css" />
+	<script src="leaflet.js"></script>
 </head>
 <body class='api-page'>
 	<div class='container'>

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -24,6 +24,11 @@ The event type (e.g. `'click'`).
 The object that fired the event.
 
 
+@miniclass KeyboardEvent (Event objects)
+@inherits Event
+@property originalEvent: DOMEvent
+The original [DOM `KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) that triggered this Leaflet event.
+
 @miniclass MouseEvent (Event objects)
 @inherits Event
 @property latlng: LatLng
@@ -32,10 +37,8 @@ The geographical point where the mouse event occured.
 Pixel coordinates of the point where the mouse event occured relative to the map layer.
 @property containerPoint: Point
 Pixel coordinates of the point where the mouse event occured relative to the map сontainer.
-@property originalEvent: DOM MouseEvent
-The original [DOM mouse event](https://developer.mozilla.org/docs/Web/API/MouseEvent) fired by the browser.
-
-
+@property originalEvent: DOMEvent
+The original [DOM `MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) or [DOM `TouchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent) that triggered this Leaflet event.
 
 @miniclass LocationEvent (Event objects)
 @inherits Event

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -934,7 +934,7 @@ L.Map = L.Evented.extend({
 		// default browser context menu from showing if there are listeners on
 		// this event. Also fired on mobile when the user holds a single touch
 		// for a second (also called long press).
-		// @event keypress: Event
+		// @event keypress: KeyboardEvent
 		// Fired when the user presses a key from the keyboard while the map is focused.
 		L.DomEvent[onOff](this._container, 'click dblclick mousedown mouseup ' +
 			'mouseover mouseout mousemove contextmenu keypress', this._handleDOMEvent, this);


### PR DESCRIPTION
* Minor change to the docstrings so that the docs for map's `keypress` event show the `originalevent` property.
* Change CSS and JS links from leafdoc template to relative URLs - this allows `highlight.js` to work locally since github pages won't serve it without a referrer. This doesn't affect the final docs, as the headers are re-copy-pasted manually on every release.