### PR TITLE
Add a "membersPane" option to groups

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -63,7 +63,9 @@ L.Layer = L.Evented.extend({
 	// @method getPane(name? : String): HTMLElement
 	// Returns the `HTMLElement` representing the named pane on the map. If `name` is omitted, returns the pane for this layer.
 	getPane: function (name) {
-		return this._map.getPane(name ? (this.options[name] || name) : this.options.pane);
+		return this._map.getPane(name ?
+			(this.options[name] || name) :
+			('_groupPane' in this.options ? this.options._groupPane : this.options.pane));
 	},
 
 	addInteractiveTarget: function (targetEl) {

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -35,6 +35,13 @@ L.LayerGroup = L.Layer.extend({
 	addLayer: function (layer) {
 		var id = this.getLayerId(layer);
 
+		// @option membersPane: String = undefined
+		// When set, forces members of this group to belong to the given [map pane](#map-pane).
+		// This overrides the `pane` option of the individual layers
+		if ('membersPane' in this.options) {
+			layer.options._groupPane = this.options.membersPane;
+		}
+
 		this._layers[id] = layer;
 
 		if (this._map) {


### PR DESCRIPTION
My attempt at providing a solution for #4277 / #4279. Haven't really tested it, but should work. *crosses fingers*

Now the question is the precedence we want for the `pane` options. We might want to push the `pane` option into a hidden `_defaultPane` option, so that explicit `pane`s from layers would override the group's `membersPane` which would override the `_defaultPane`. Or something like that.

