### PR TITLE
Fix handling of NaN in getScaleZoom

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1088,11 +1088,20 @@ describe("Map", function () {
 	});
 
 	describe('#getScaleZoom && #getZoomScale', function () {
-		it("convert zoom to scale and viceversa and return the same values", function () {
+		it("converts zoom to scale and vice versa and returns the same values", function () {
 			var toZoom = 6.25;
 			var fromZoom = 8.5;
-			var scale = map.getScaleZoom(toZoom, fromZoom);
-			expect(Math.round(map.getZoomScale(scale, fromZoom) * 100) / 100).to.eql(toZoom);
+			var scale = map.getZoomScale(toZoom, fromZoom);
+			expect(Math.round(map.getScaleZoom(scale, fromZoom) * 100) / 100).to.eql(toZoom);
+		});
+
+		it("converts scale to zoom and returns Infinity if map crs.zoom returns NaN", function () {
+			var stub = sinon.stub(map.options.crs, "zoom");
+			stub.returns(NaN);
+			var scale = 0.25;
+			var fromZoom = 8.5;
+			expect(map.getScaleZoom(scale, fromZoom)).to.eql(Infinity);
+			map.options.crs.zoom.restore();
 		});
 	});
 

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -54,7 +54,7 @@ L.CRS = {
 	},
 
 	// @method zoom(scale: Number): Number
-	// Inverse of `scale()`, returns the zoom level correspondingto a scale
+	// Inverse of `scale()`, returns the zoom level corresponding to a scale
 	// factor of `scale`.
 	zoom: function (scale) {
 		return Math.log(scale / 256) / Math.LN2;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -852,14 +852,14 @@ L.Map = L.Evented.extend({
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
 		// @event zoom: Event
-		// Fired repeteadly during any change in zoom level, including zoom
+		// Fired repeatedly during any change in zoom level, including zoom
 		// and fly animations.
 		if (zoomChanged || (data && data.pinch)) {	// Always fire 'zoom' if pinching because #3530
 			this.fire('zoom', data);
 		}
 
 		// @event move: Event
-		// Fired repeteadly during any movement of the map, including pan and
+		// Fired repeatedly during any movement of the map, including pan and
 		// fly animations.
 		return this.fire('move', data);
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -609,7 +609,8 @@ L.Map = L.Evented.extend({
 	getScaleZoom: function (scale, fromZoom) {
 		var crs = this.options.crs;
 		fromZoom = fromZoom === undefined ? this._zoom : fromZoom;
-		return crs.zoom(scale * crs.scale(fromZoom));
+		var zoom = crs.zoom(scale * crs.scale(fromZoom));
+		return isNaN(zoom) ? Infinity : zoom;
 	},
 
 	// @method project(latlng: LatLng, zoom: Number): Point


### PR DESCRIPTION
Fixed the issue with `getScaleZoom` returning `NaN` when `L.CRS.zoom()` used with a scale factor of `Infinity` which could return `NaN` causing this. Discussed here https://github.com/Leaflet/Leaflet/issues/4566