### PR TITLE
Ensure zoom is within span when adding a layer with min/maxzoom, fixes #4915

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -281,6 +281,20 @@ describe("Map", function () {
 			expect(map.getMinZoom()).to.be(2);
 			expect(map.getMaxZoom()).to.be(20);
 		});
+
+		it("layer minZoom overrides map zoom if map has no minZoom set and layer minZoom is bigger than map zoom", function () {
+			var map = L.map(document.createElement("div"), {zoom: 10});
+			L.tileLayer("{z}{x}{y}", {minZoom: 15}).addTo(map);
+
+			expect(map.getMinZoom()).to.be(15);
+		});
+
+		it("layer maxZoom overrides map zoom if map has no maxZoom set and layer maxZoom is smaller than map zoom", function () {
+			var map = L.map(document.createElement("div"), {zoom: 20});
+			L.tileLayer("{z}{x}{y}", {maxZoom: 15}).addTo(map);
+
+			expect(map.getMaxZoom()).to.be(15);
+		});
 	});
 
 	describe("#hasLayer", function () {

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -295,6 +295,20 @@ describe("Map", function () {
 
 			expect(map.getMaxZoom()).to.be(15);
 		});
+
+		it("map's zoom is adjusted to layer's minZoom even if initialized with smaller value", function () {
+			var map = L.map(document.createElement("div"), {zoom: 10});
+			L.tileLayer("{z}{x}{y}", {minZoom: 15}).addTo(map);
+
+			expect(map.getZoom()).to.be(15);
+		});
+
+		it("map's zoom is adjusted to layer's maxZoom even if initialized with larger value", function () {
+			var map = L.map(document.createElement("div"), {zoom: 20});
+			L.tileLayer("{z}{x}{y}", {maxZoom: 15}).addTo(map);
+
+			expect(map.getZoom()).to.be(15);
+		});
 	});
 
 	describe("#hasLayer", function () {

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -250,5 +250,12 @@ L.Map.include({
 		if (oldZoomSpan !== this._getZoomSpan()) {
 			this.fire('zoomlevelschange');
 		}
+
+		if (this.options.maxZoom === undefined && this._layersMaxZoom && this.getZoom() > this._layersMaxZoom) {
+			this.setZoom(this._layersMaxZoom);
+		}
+		if (this.options.minZoom === undefined && this._layersMinZoom && this.getZoom() < this._layersMinZoom) {
+			this.setZoom(this._layersMinZoom);
+		}
 	}
 });


### PR DESCRIPTION
Fixes #4915, by running the same check from `L.Map.setMaxZoom` in `L.Map._updateZoomLevels`.

Could use a unit test, though.
