### PR TITLE
DOCS GeoJSON update usage example to L.geoJSON

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -9,7 +9,7 @@
  * @example
  *
  * ```js
- * L.geoJson(data, {
+ * L.geoJSON(data, {
  * 	style: function (feature) {
  * 		return {color: feature.properties.color};
  * 	}


### PR DESCRIPTION
Replaced factory example `L.geoJson` (from Leaflet 0.7) by `L.geoJSON` for consistency with the new factory signature rendered just below in the generated docs.
http://leafletjs.com/reference-1.0.0.html#geojson-example