### PR TITLE
Implement dump-tile-to-canvas functionality. Fixes #3575.

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -574,7 +574,7 @@ L.GridLayer = L.Layer.extend({
 		}
 	},
 
-	_setCanvasZoomTransform: function(level, center, zoom){
+	_setCanvasZoomTransform: function (level, center, zoom) {
 		if (!level.canvasOrigin) { return; }
 		var scale = this._map.getZoomScale(zoom, level.zoom),
 		    translate = level.canvasOrigin.multiplyBy(scale)
@@ -776,14 +776,14 @@ L.GridLayer = L.Layer.extend({
 		});
 	},
 
-	_resetCanvasSize: function(level) {
+	_resetCanvasSize: function (level) {
 		var buff = this.options.keepBuffer,
-		    pixelBounds = this._getTiledPixelBounds(map.getCenter()),
+		    pixelBounds = this._getTiledPixelBounds(this._map.getCenter()),
 		    tileRange = this._pxBoundsToTileRange(pixelBounds),
 		    tileSize = this.getTileSize();
 
 		tileRange.min = tileRange.min.subtract([buff, buff]);	// This adds the no-prune buffer
-		tileRange.max = tileRange.max.add([buff+1, buff+1]);
+		tileRange.max = tileRange.max.add([buff + 1, buff + 1]);
 
 		var pixelRange = L.bounds(
 		        tileRange.min.scaleBy(tileSize),
@@ -848,7 +848,7 @@ L.GridLayer = L.Layer.extend({
 		}
 	},
 
-	_dumpTileToCanvas: function(tile){
+	_dumpTileToCanvas: function (tile) {
 		var level = this._levels[tile.coords.z];
 		var tileSize = this.getTileSize();
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -74,7 +74,12 @@ L.TileLayer = L.GridLayer.extend({
 
 		// @option crossOrigin: Boolean = false
 		// If true, all tiles will have their crossOrigin attribute set to ''. This is needed if you want to access tile pixel data.
-		crossOrigin: false
+		crossOrigin: false,
+
+		// @option dumpToCanvas: Boolean = true
+		// Whether to dump loaded tiles to a `<canvas>` to prevent some rendering
+		// artifacts. (Disabled by default in IE)
+		dumpToCanvas: L.Browser.canvas && !L.Browser.ie
 	},
 
 	initialize: function (url, options) {


### PR DESCRIPTION
This is basically https://github.com/Leaflet/Leaflet.TileLayer.NoGap, but in the form of a pull request instead of a plugin.

So this adds a new option to `GridLayer` s (enabled by default on `TileLayer`s): instead of adding the tiles to a tile container, dump the tile contents into a `<canvas>`. That `<canvas>` will be inside the same map pane as the `GridLayer`, so it will perform the pan and zoom animations as expected. This is pretty much what OpenLayers 3 does.

The canvas will be as large as the map container (plus a bit of buffer). The whole content of that canvas will be shifted whenever the map is panned. This shift has decent performance (< 1 frame) in all browsers _except IE_. I should make a couple more tests in MS Edge anyway, just to make sure. It's a layer option that can be disabled, so any users hitting a performance problem can just disable this.

All the canvas operations are CORS-safe: even if the tiles come from an origin which does not allow cross-origin requests, everything will work. This is due to the code **not** using `ctx.getImageData`. The canvas will be tainted, but that's not a problem.

There are a few possible improvements, starting by clearing canvases from levels other than the active one when a tile from the active level is loaded - this will reduce artifacts on semitransparent tile sources. Further improvements to behave more like OL3 does are possible (loading lower zoom tiles with a fair buffer and using them when the canvas size is reset, for example).

A bit overkill for just fixing a bug, but I feel there's no other way around it. Plus, it will improve rendering of rotated tiles when time becomes to implementing that.
