### PR TITLE
Fire update event from VML renderer

### DIFF
--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -38,6 +38,7 @@ L.SVG.include(!L.Browser.vml ? {} : {
 	_update: function () {
 		if (this._map._animatingZoom) { return; }
 		L.Renderer.prototype._update.call(this);
+		this.fire('update');
 	},
 
 	_initPath: function (layer) {


### PR DESCRIPTION
When refactoring updates, we accidentally created #4950, so vector drawing is currently broken for VML (IE8).

This adds firing the `update` event from the VML renderer, which is required since it _doesn't use it's parents `_update` method_, but rather `L.Renderer`'s `_update`, which doesn't fire this event.

I have verified that the GeoJSON debug page works again in IE8 after this fix.