### PR TITLE
Remove -rc.3 flags from example CDN URLs

### DIFF
--- a/docs/examples/choropleth-example.html
+++ b/docs/examples/choropleth-example.html
@@ -6,7 +6,7 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 
 	<style>
 		#map {
@@ -44,7 +44,7 @@
 <body>
 	<div id="map"></div>
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 
 	<script type="text/javascript" src="us-states.js"></script>
 	<script type="text/javascript">

--- a/docs/examples/custom-icons-example.html
+++ b/docs/examples/custom-icons-example.html
@@ -6,12 +6,12 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 </head>
 <body>
 	<div id="map" style="width: 600px; height: 400px"></div>
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 	<script>
 		var map = L.map('map').setView([51.5, -0.09], 13);
 

--- a/docs/examples/geojson-example.html
+++ b/docs/examples/geojson-example.html
@@ -6,13 +6,13 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 </head>
 <body>
 	<div id="map" style="width: 600px; height: 400px"></div>
 
 	<script src="sample-geojson.js" type="text/javascript"></script>
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 
 	<script>
 		var map = L.map('map').setView([39.74739, -105], 13);

--- a/docs/examples/layers-control-example.html
+++ b/docs/examples/layers-control-example.html
@@ -6,12 +6,12 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 </head>
 <body>
 	<div id="map" style="width: 600px; height: 400px"></div>
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 	<script>
 		var cities = new L.LayerGroup();
 

--- a/docs/examples/map-panes-example.html
+++ b/docs/examples/map-panes-example.html
@@ -6,13 +6,13 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 
 </head>
 <body>
 	<div id="map" style="width: 600px; height: 400px"></div>
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 	<script type="text/javascript" src="eu-countries.js"></script>
 
 	<script>

--- a/docs/examples/mobile-example.html
+++ b/docs/examples/mobile-example.html
@@ -5,9 +5,9 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 
 	<style>
 		body {

--- a/docs/examples/quick-start-example.html
+++ b/docs/examples/quick-start-example.html
@@ -6,12 +6,12 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 </head>
 <body>
 	<div id="mapid" style="width: 600px; height: 400px"></div>
 
-	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 	<script>
 
 		var mymap = L.map('mapid').setView([51.505, -0.09], 13);

--- a/docs/examples/quick-start.md
+++ b/docs/examples/quick-start.md
@@ -19,11 +19,11 @@ Before writing any code for the map, you need to do the following preparation st
 
  * Include Leaflet CSS file in the head section of your document:
 
-		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.css" />
+		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
 
  * Include Leaflet JavaScript file:
 
-		<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
+		<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
 
  * Put a `div` element with a certain `id` where you want your map to be:
 


### PR DESCRIPTION
This PR removes the `-rc.3` flag from all CDN URLs in the examples, so examples actually run using 1.0.0.