### PR TITLE
docstrings: update L.circle example to match new syntax

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -10,7 +10,7 @@
  * @example
  *
  * ```js
- * L.circle([50.5, 30.5], 200).addTo(map);
+ * L.circle([50.5, 30.5], {radius: 200}).addTo(map);
  * ```
  */
 


### PR DESCRIPTION
New [recommended signature](http://leafletjs.com/reference-1.0.0.html#circle-l-circle) (shown just below the [usage example](http://leafletjs.com/reference-1.0.0.html#circle-example) in the generated docs) is with `options` as 2nd argument, and `radius` is one the available options.

The current example still uses the legacy signature (`radius` as 2nd argument, `options` as 3rd).