### PR TITLE
Add quotes to css attribute value because of colon

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -522,7 +522,7 @@
 	margin: 0 auto;
 
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
-	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	}
 .leaflet-oldie .leaflet-popup-tip-container {
 	margin-top: -1px;


### PR DESCRIPTION
Fix minor issue in css file. The quotes are consistent with the line above.