### PR TITLE
docstrings: L.GeoJSON filter and methods

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -78,7 +78,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 		}
 	},
 
-	// @function addData( <GeoJSON> data ): Layer
+	// @method addData( <GeoJSON> data ): Layer
 	// Adds a GeoJSON object to the layer.
 	addData: function (geojson) {
 		var features = L.Util.isArray(geojson) ? geojson : geojson.features,
@@ -115,7 +115,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 		return this.addLayer(layer);
 	},
 
-	// @function resetStyle( <Path> layer ): Layer
+	// @method resetStyle( <Path> layer ): Layer
 	// Resets the given vector layer's style to the original GeoJSON style, useful for resetting style after hover events.
 	resetStyle: function (layer) {
 		// reset any custom styles
@@ -124,7 +124,7 @@ L.GeoJSON = L.FeatureGroup.extend({
 		return this;
 	},
 
-	// @function setStyle( <Function> style ): Layer
+	// @method setStyle( <Function> style ): Layer
 	// Changes styles of GeoJSON vector layers with the given style function.
 	setStyle: function (style) {
 		return this.eachLayer(function (layer) {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -53,13 +53,15 @@ L.GeoJSON = L.FeatureGroup.extend({
 	 * ```
 	 *
 	 * @option filter: Function = *
-	 * A `Function` that will be used to decide whether to show a feature or not.
-	 * The default is to show all features:
+	 * A `Function` that will be used to decide whether to include a feature or not.
+	 * The default is to include all features:
 	 * ```js
 	 * function (geoJsonFeature) {
 	 * 	return true;
 	 * }
 	 * ```
+	 * Note: dynamically changing the `filter` option will have effect only on newly
+	 * added data. It will _not_ re-evaluate already included features.
 	 *
 	 * @option coordsToLatLng: Function = *
 	 * A `Function` that will be used for converting GeoJSON coordinates to `LatLng`s.


### PR DESCRIPTION
Following https://stackoverflow.com/questions/39776919/how-to-reference-the-data-of-an-existing-geojson-leaflet-object/39787583#39787583, sounds like the current definition "decide whether to show a feature or not" implies that the data is retained in memory, but just not shown.

Replaced "show" by "include" to try to make it clearer that the filtered out data is _lost_ (not retained at all within the group).

Also took the opportunity to add a note about changing the `filter` option dynamically (no re-evaluation of child layers, whether they meet the new filter conditions or not).

Corrected docstrings of L.GeoJSON for methods (addData, resetStyle, setStyle) to be really counted as "methods" instead of static "functions" (geometryToLayer, coordsToLatLng, coordsToLatLngs, latLngToCoords, latLngsToCoords, asFeature)
