### PR TITLE
Docs: Make the latest leaflet version into a Jekyll variable

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,5 @@ markdown: kramdown
 
 kramdown:
   entity_output: as_input
+
+latest_leaflet_version: 1.0.0

--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -9,8 +9,8 @@
 	{% capture root %}{% if page.root %}{{ page.root }}{% else %}{{ layout.root }}{% endif %}{% endcapture %}
 	<link rel="shortcut icon" type="image/x-icon" href="{{ root }}docs/images/favicon.ico" />
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
-	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.js"></script>
 
 {% unless page.customMapContainer == "true" %}
 	<style>

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -34,8 +34,8 @@
 	<link rel="stylesheet" href="{{ root }}docs/highlight/styles/github-gist.css" />
 
 	<!-- Leaflet -->
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
-	<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.js"></script>
 
 	{% if page.css %}<style>{{ page.css }}</style>{% endif %}
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -35,8 +35,8 @@ so please read the changelog carefully when upgrading to it.
 The latest stable Leaflet release is hosted on a CDN &mdash; to start using
 it straight away, place this in the `head` of your HTML code:
 
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
-    <script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"></script>
 
 ### Using a Downloaded Version of Leaflet
 

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -15,11 +15,11 @@ Before writing any code for the map, you need to do the following preparation st
 
  * Include Leaflet CSS file in the head section of your document:
 
-		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.0/dist/leaflet.css" />
+		<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.css" />
 
  * Include Leaflet JavaScript file:
 
-		<script src="https://unpkg.com/leaflet@1.0.0/dist/leaflet.js"></script>
+		<script src="https://unpkg.com/leaflet@{{ site.leatest_leaflet_version }}/dist/leaflet.js"></script>
 
  * Put a `div` element with a certain `id` where you want your map to be:
 


### PR DESCRIPTION
This replaces all instances of `"1.0.0"` with a template using a variable in the jekyll config. Esentially this allows changing the Leaflet version in just one place, and it will be updated everywhere else.