### PR TITLE
Shift+scroll wheel zoom

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -63,13 +63,13 @@ L.Control.Zoom = L.Control.extend({
 
 	_zoomIn: function (e) {
 		if (!this._disabled && this._map._zoom < this._map.getMaxZoom()) {
-			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? this._map.options.zoomDeltaFactor : 1));
 		}
 	},
 
 	_zoomOut: function (e) {
 		if (!this._disabled && this._map._zoom > this._map.getMinZoom()) {
-			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? this._map.options.zoomDeltaFactor : 1));
 		}
 	},
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -237,12 +237,11 @@ L.DomEvent = {
 	// Events from pointing devices without precise scrolling are mapped to
 	// a best guess of 60 pixels.
 	getWheelDelta: function (e) {
-		return (L.Browser.edge) ? e.wheelDeltaY / 2 : // Don't trust window-geometry-based delta
-		       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / L.DomEvent._wheelPxFactor : // Pixels
-		       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 20 : // Lines
-		       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 60 : // Pages
-		       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events
-		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDelta) / 2 : // Legacy IE pixels
+		return (L.Browser.edge) ? (e.wheelDeltaY || e.wheelDeltaX || e.wheelDelta) / 2 : // Don't trust window-geometry-based delta
+		       ((e.deltaY || e.deltaX) && e.deltaMode === 0) ? -(e.deltaY || e.deltaX) / L.DomEvent._wheelPxFactor : // Pixels
+		       ((e.deltaY || e.deltaX) && e.deltaMode === 1) ? -(e.deltaY || e.deltaX) * 20 : // Lines
+		       ((e.deltaY || e.deltaX) && e.deltaMode === 2) ? -(e.deltaY || e.deltaX) * 60 : // Pages
+		       e.wheelDelta ? (e.wheelDeltaY || e.wheelDeltaX || e.wheelDelta) / 2 : // Legacy IE pixels
 		       (e.detail && Math.abs(e.detail) < 32765) ? -e.detail * 20 : // Legacy Moz lines
 		       e.detail ? e.detail / -32765 * 60 : // Legacy Moz pages
 		       0;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -102,6 +102,10 @@ L.Map = L.Evented.extend({
 		// Values smaller than `1` (e.g. `0.5`) allow for greater granularity.
 		zoomDelta: 1,
 
+		// @option zoomDeltaFactor: Number = 3
+		// Defines a multiplier for a zoomDelta option when zooming is being done with a pressed SHIFT key
+		zoomDeltaFactor: 3,
+
 		// @option trackResize: Boolean = true
 		// Whether the map automatically handles browser window resize to update itself.
 		trackResize: true

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -154,7 +154,7 @@ L.Map.Keyboard = L.Handler.extend({
 			}
 
 		} else if (key in this._zoomKeys) {
-			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key]);
+			map.setZoom(map.getZoom() + (e.shiftKey ? this._map.options.zoomDeltaFactor : 1) * this._zoomKeys[key]);
 
 		} else if (key === 27) {
 			map.closePopup();

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -39,7 +39,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		var debounce = this._map.options.wheelDebounceTime;
 
-		this._delta += delta * (e.shiftKey ? 3 : 1);
+		this._delta += delta * (e.shiftKey ? this._map.options.zoomDeltaFactor : 1);
 		this._lastMousePos = this._map.mouseEventToContainerPoint(e);
 
 		if (!this._startTime) {

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -39,7 +39,7 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 
 		var debounce = this._map.options.wheelDebounceTime;
 
-		this._delta += delta;
+		this._delta += delta * (e.shiftKey ? 3 : 1);
 		this._lastMousePos = this._map.mouseEventToContainerPoint(e);
 
 		if (!this._startTime) {


### PR DESCRIPTION
This pull request is supposed to resolve the "Shift + scroll wheel zoom" issue (fixes #3521).

When I started resolving it I found out that in the current version of Leaflet holding the SHIFT key and scrolling the mouse wheel produces no effect and does not zoom a map. Strange thing was that it was working in Firefox and was not in Chrome and Opera. After some research I found out that Chrome and Opera have a feature  - holding the SHIFT key pressed transforms vertical scrolling into horizontal. And horizontal scrolling was explicitly ignored by Leaflet. So, I thought it would be a good idea to treat vertical and horizontal wheel scrolling in a similar manner for the sake of resolving this issue and for the sake of consistency as well.

The current version of Leaflet already provides the SHIFT + zoom feature for zoom buttons and key presses (+/-). However, the zoomDetlata multiplier is hard-coded and I don't think it is a really good idea.
My proposal is to extend the API and implement it as a separate map option (I came up with the name "zoomDeltaFactor"). Implementing it as a separate map option makes it flexible (the default value is 3 but developers can change it depending on situation) and explicit.

So, the summary of this PR:
- The getWheelDelta method of the L.DomEvent object has been changed to treat horizontal and vertical scrolling similarly,
- Holding the Shift key while scrollwheel-zooming now multiplies the zoom delta by 3 (by default),
- The API has been extended and provides an option to change the zoom delta multiplier.

_PS. This is my first attempt to contribute to an open source project. So, if I am doing it wrong, please, be kind and guide me to the right path.
Thanks ;)_
