### PR TITLE
Use rollup-plugin-buble and use shorthand ES6 class methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "phantomjs-prebuilt": "^2.1.12",
     "prosthetic-hand": "^1.3.1",
     "rollup": "^0.36.1",
+    "rollup-plugin-buble": "^0.14.0",
     "source-map": "^0.5.6",
     "uglify-js": "~2.7.3"
   },
@@ -30,7 +31,7 @@
     "build": "jake build",
     "release": "./build/publish.sh",
     "lint": "node_modules/.bin/eslint --fix src/",
-    "rollup": "rollup src/Leaflet.js -f umd -n L > dist/leaflet-rollup.js"
+    "rollup": "rollup -c rollup-config.js -n L > dist/leaflet-rollup.js"
   },
   "eslintConfig": {
     "root": true,
@@ -44,8 +45,8 @@
     },
     "extends": "mourner",
     "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module"
+      "ecmaVersion": 6,
+      "sourceType": "module"
     },
     "rules": {
       "linebreak-style": [

--- a/rollup-config.js
+++ b/rollup-config.js
@@ -1,0 +1,7 @@
+import buble from 'rollup-plugin-buble';
+
+export default {
+  entry: 'src/Leaflet.js',
+  plugins: [ buble() ],
+  format: 'umd'
+};

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -35,7 +35,7 @@ export var Evented = Class.extend({
 	 * @method on(eventMap: Object): this
 	 * Adds a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
 	 */
-	on: function (types, fn, context) {
+	on(types, fn, context) {
 
 		// types can be a map of types/handlers
 		if (typeof types === 'object') {
@@ -68,7 +68,7 @@ export var Evented = Class.extend({
 	 * @method off: this
 	 * Removes all listeners to all events on the object.
 	 */
-	off: function (types, fn, context) {
+	off(types, fn, context) {
 
 		if (!types) {
 			// clear all listeners if called without arguments
@@ -91,7 +91,7 @@ export var Evented = Class.extend({
 	},
 
 	// attach listener (without syntactic sugar now)
-	_on: function (type, fn, context) {
+	_on(type, fn, context) {
 		this._events = this._events || {};
 
 		/* get/init listeners for type */
@@ -119,7 +119,7 @@ export var Evented = Class.extend({
 		typeListeners.count++;
 	},
 
-	_off: function (type, fn, context) {
+	_off(type, fn, context) {
 		var listeners,
 		    i,
 		    len;
@@ -173,7 +173,7 @@ export var Evented = Class.extend({
 	// Fires an event of the specified type. You can optionally provide an data
 	// object — the first argument of the listener function will contain its
 	// properties. The event might can optionally be propagated to event parents.
-	fire: function (type, data, propagate) {
+	fire(type, data, propagate) {
 		if (!this.listens(type, propagate)) { return this; }
 
 		var event = extend({}, data, {type: type, target: this});
@@ -202,7 +202,7 @@ export var Evented = Class.extend({
 
 	// @method listens(type: String): Boolean
 	// Returns `true` if a particular event type has any listeners attached to it.
-	listens: function (type, propagate) {
+	listens(type, propagate) {
 		var listeners = this._events && this._events[type];
 		if (listeners && listeners.length) { return true; }
 
@@ -217,7 +217,7 @@ export var Evented = Class.extend({
 
 	// @method once(…): this
 	// Behaves as [`on(…)`](#evented-on), except the listener will only get fired once and then removed.
-	once: function (types, fn, context) {
+	once(types, fn, context) {
 
 		if (typeof types === 'object') {
 			for (var type in types) {
@@ -240,7 +240,7 @@ export var Evented = Class.extend({
 
 	// @method addEventParent(obj: Evented): this
 	// Adds an event parent - an `Evented` that will receive propagated events
-	addEventParent: function (obj) {
+	addEventParent(obj) {
 		this._eventParents = this._eventParents || {};
 		this._eventParents[stamp(obj)] = obj;
 		return this;
@@ -248,14 +248,14 @@ export var Evented = Class.extend({
 
 	// @method removeEventParent(obj: Evented): this
 	// Removes an event parent, so it will stop receiving propagated events
-	removeEventParent: function (obj) {
+	removeEventParent(obj) {
 		if (this._eventParents) {
 			delete this._eventParents[stamp(obj)];
 		}
 		return this;
 	},
 
-	_propagateEvent: function (e) {
+	_propagateEvent(e) {
 		for (var id in this._eventParents) {
 			this._eventParents[id].fire(e.type, extend({layer: e.target}, e), true);
 		}

--- a/src/core/Handler.js
+++ b/src/core/Handler.js
@@ -10,13 +10,13 @@ import {Class} from './Class';
 // Abstract class for map interaction handlers
 
 export var Handler = Class.extend({
-	initialize: function (map) {
+	initialize(map) {
 		this._map = map;
 	},
 
 	// @method enable(): this
 	// Enables the handler
-	enable: function () {
+	enable() {
 		if (this._enabled) { return this; }
 
 		this._enabled = true;
@@ -26,7 +26,7 @@ export var Handler = Class.extend({
 
 	// @method disable(): this
 	// Disables the handler
-	disable: function () {
+	disable() {
 		if (!this._enabled) { return this; }
 
 		this._enabled = false;
@@ -36,7 +36,7 @@ export var Handler = Class.extend({
 
 	// @method enabled(): Boolean
 	// Returns `true` if the handler is enabled
-	enabled: function () {
+	enabled() {
 		return !!this._enabled;
 	}
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -41,7 +41,7 @@ L.Draggable = L.Evented.extend({
 
 	// @constructor L.Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline: Boolean)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).
-	initialize: function (element, dragStartTarget, preventOutline) {
+	initialize(element, dragStartTarget, preventOutline) {
 		this._element = element;
 		this._dragStartTarget = dragStartTarget || element;
 		this._preventOutline = preventOutline;
@@ -49,7 +49,7 @@ L.Draggable = L.Evented.extend({
 
 	// @method enable()
 	// Enables the dragging ability
-	enable: function () {
+	enable() {
 		if (this._enabled) { return; }
 
 		L.DomEvent.on(this._dragStartTarget, L.Draggable.START, this._onDown, this);
@@ -59,7 +59,7 @@ L.Draggable = L.Evented.extend({
 
 	// @method disable()
 	// Disables the dragging ability
-	disable: function () {
+	disable() {
 		if (!this._enabled) { return; }
 
 		L.DomEvent.off(this._dragStartTarget, L.Draggable.START, this._onDown, this);
@@ -68,7 +68,7 @@ L.Draggable = L.Evented.extend({
 		this._moved = false;
 	},
 
-	_onDown: function (e) {
+	_onDown(e) {
 		// Ignore simulated events, since we handle both touch and
 		// mouse explicitly; otherwise we risk getting duplicates of
 		// touch events, see #4315.
@@ -105,7 +105,7 @@ L.Draggable = L.Evented.extend({
 			.on(document, L.Draggable.END[e.type], this._onUp, this);
 	},
 
-	_onMove: function (e) {
+	_onMove(e) {
 		// Ignore simulated events, since we handle both touch and
 		// mouse explicitly; otherwise we risk getting duplicates of
 		// touch events, see #4315.
@@ -154,7 +154,7 @@ L.Draggable = L.Evented.extend({
 		this._animRequest = L.Util.requestAnimFrame(this._updatePosition, this, true);
 	},
 
-	_updatePosition: function () {
+	_updatePosition() {
 		var e = {originalEvent: this._lastEvent};
 
 		// @event predrag: Event
@@ -168,7 +168,7 @@ L.Draggable = L.Evented.extend({
 		this.fire('drag', e);
 	},
 
-	_onUp: function (e) {
+	_onUp(e) {
 		// Ignore simulated events, since we handle both touch and
 		// mouse explicitly; otherwise we risk getting duplicates of
 		// touch events, see #4315.

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -24,7 +24,7 @@ export var PosAnimation = L.Evented.extend({
 	// duration in seconds (`0.25` by default) and easing linearity factor (3rd
 	// argument of the [cubic bezier curve](http://cubic-bezier.com/#0,0,.5,1),
 	// `0.5` by default).
-	run: function (el, newPos, duration, easeLinearity) {
+	run(el, newPos, duration, easeLinearity) {
 		this.stop();
 
 		this._el = el;
@@ -45,20 +45,20 @@ export var PosAnimation = L.Evented.extend({
 
 	// @method stop()
 	// Stops the animation (if currently running).
-	stop: function () {
+	stop() {
 		if (!this._inProgress) { return; }
 
 		this._step(true);
 		this._complete();
 	},
 
-	_animate: function () {
+	_animate() {
 		// animation loop
 		this._animId = requestAnimFrame(this._animate, this);
 		this._step();
 	},
 
-	_step: function (round) {
+	_step(round) {
 		var elapsed = (+new Date()) - this._startTime,
 		    duration = this._duration * 1000;
 
@@ -70,7 +70,7 @@ export var PosAnimation = L.Evented.extend({
 		}
 	},
 
-	_runFrame: function (progress, round) {
+	_runFrame(progress, round) {
 		var pos = this._startPos.add(this._offset.multiplyBy(progress));
 		if (round) {
 			pos._round();
@@ -82,7 +82,7 @@ export var PosAnimation = L.Evented.extend({
 		this.fire('step');
 	},
 
-	_complete: function () {
+	_complete() {
 		cancelAnimFrame(this._animId);
 
 		this._inProgress = false;
@@ -91,7 +91,7 @@ export var PosAnimation = L.Evented.extend({
 		this.fire('end');
 	},
 
-	_easeOut: function (t) {
+	_easeOut(t) {
 		return 1 - Math.pow(1 - t, this._easeOutPower);
 	}
 });

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -46,7 +46,7 @@ export function LatLng(lat, lng, alt) {
 LatLng.prototype = {
 	// @method equals(otherLatLng: LatLng, maxMargin?: Number): Boolean
 	// Returns `true` if the given `LatLng` point is at the same position (within a small margin of error). The margin of error can be overriden by setting `maxMargin` to a small number.
-	equals: function (obj, maxMargin) {
+	equals(obj, maxMargin) {
 		if (!obj) { return false; }
 
 		obj = toLatLng(obj);
@@ -60,7 +60,7 @@ LatLng.prototype = {
 
 	// @method toString(): String
 	// Returns a string representation of the point (for debugging purposes).
-	toString: function (precision) {
+	toString(precision) {
 		return 'LatLng(' +
 		        formatNum(this.lat, precision) + ', ' +
 		        formatNum(this.lng, precision) + ')';
@@ -68,19 +68,19 @@ LatLng.prototype = {
 
 	// @method distanceTo(otherLatLng: LatLng): Number
 	// Returns the distance (in meters) to the given `LatLng` calculated using the [Haversine formula](http://en.wikipedia.org/wiki/Haversine_formula).
-	distanceTo: function (other) {
+	distanceTo(other) {
 		return Earth.distance(this, toLatLng(other));
 	},
 
 	// @method wrap(): LatLng
 	// Returns a new `LatLng` object with the longitude wrapped so it's always between -180 and +180 degrees.
-	wrap: function () {
+	wrap() {
 		return Earth.wrapLatLng(this);
 	},
 
 	// @method toBounds(sizeInMeters: Number): LatLngBounds
 	// Returns a new `LatLngBounds` object in which each boundary is `sizeInMeters` meters apart from the `LatLng`.
-	toBounds: function (sizeInMeters) {
+	toBounds(sizeInMeters) {
 		var latAccuracy = 180 * sizeInMeters / 40075017,
 		    lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * this.lat);
 
@@ -89,7 +89,7 @@ LatLng.prototype = {
 		        [this.lat + latAccuracy, this.lng + lngAccuracy]);
 	},
 
-	clone: function () {
+	clone() {
 		return new LatLng(this.lat, this.lng, this.alt);
 	}
 };

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -42,7 +42,7 @@ LatLngBounds.prototype = {
 	// @alternative
 	// @method extend(otherBounds: LatLngBounds): this
 	// Extend the bounds to contain the given bounds
-	extend: function (obj) {
+	extend(obj) {
 		var sw = this._southWest,
 		    ne = this._northEast,
 		    sw2, ne2;
@@ -76,7 +76,7 @@ LatLngBounds.prototype = {
 
 	// @method pad(bufferRatio: Number): LatLngBounds
 	// Returns bigger bounds created by extending the current bounds by a given percentage in each direction.
-	pad: function (bufferRatio) {
+	pad(bufferRatio) {
 		var sw = this._southWest,
 		    ne = this._northEast,
 		    heightBuffer = Math.abs(sw.lat - ne.lat) * bufferRatio,
@@ -89,7 +89,7 @@ LatLngBounds.prototype = {
 
 	// @method getCenter(): LatLng
 	// Returns the center point of the bounds.
-	getCenter: function () {
+	getCenter() {
 		return new LatLng(
 		        (this._southWest.lat + this._northEast.lat) / 2,
 		        (this._southWest.lng + this._northEast.lng) / 2);
@@ -97,49 +97,49 @@ LatLngBounds.prototype = {
 
 	// @method getSouthWest(): LatLng
 	// Returns the south-west point of the bounds.
-	getSouthWest: function () {
+	getSouthWest() {
 		return this._southWest;
 	},
 
 	// @method getNorthEast(): LatLng
 	// Returns the north-east point of the bounds.
-	getNorthEast: function () {
+	getNorthEast() {
 		return this._northEast;
 	},
 
 	// @method getNorthWest(): LatLng
 	// Returns the north-west point of the bounds.
-	getNorthWest: function () {
+	getNorthWest() {
 		return new LatLng(this.getNorth(), this.getWest());
 	},
 
 	// @method getSouthEast(): LatLng
 	// Returns the south-east point of the bounds.
-	getSouthEast: function () {
+	getSouthEast() {
 		return new LatLng(this.getSouth(), this.getEast());
 	},
 
 	// @method getWest(): Number
 	// Returns the west longitude of the bounds
-	getWest: function () {
+	getWest() {
 		return this._southWest.lng;
 	},
 
 	// @method getSouth(): Number
 	// Returns the south latitude of the bounds
-	getSouth: function () {
+	getSouth() {
 		return this._southWest.lat;
 	},
 
 	// @method getEast(): Number
 	// Returns the east longitude of the bounds
-	getEast: function () {
+	getEast() {
 		return this._northEast.lng;
 	},
 
 	// @method getNorth(): Number
 	// Returns the north latitude of the bounds
-	getNorth: function () {
+	getNorth() {
 		return this._northEast.lat;
 	},
 
@@ -149,7 +149,7 @@ LatLngBounds.prototype = {
 	// @alternative
 	// @method contains (latlng: LatLng): Boolean
 	// Returns `true` if the rectangle contains the given point.
-	contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean
+	contains(obj) { // (LatLngBounds) or (LatLng) -> Boolean
 		if (typeof obj[0] === 'number' || obj instanceof LatLng) {
 			obj = toLatLng(obj);
 		} else {
@@ -173,7 +173,7 @@ LatLngBounds.prototype = {
 
 	// @method intersects(otherBounds: LatLngBounds): Boolean
 	// Returns `true` if the rectangle intersects the given bounds. Two bounds intersect if they have at least one point in common.
-	intersects: function (bounds) {
+	intersects(bounds) {
 		bounds = toLatLngBounds(bounds);
 
 		var sw = this._southWest,
@@ -189,7 +189,7 @@ LatLngBounds.prototype = {
 
 	// @method overlaps(otherBounds: Bounds): Boolean
 	// Returns `true` if the rectangle overlaps the given bounds. Two bounds overlap if their intersection is an area.
-	overlaps: function (bounds) {
+	overlaps(bounds) {
 		bounds = toLatLngBounds(bounds);
 
 		var sw = this._southWest,
@@ -205,13 +205,13 @@ LatLngBounds.prototype = {
 
 	// @method toBBoxString(): String
 	// Returns a string with bounding box coordinates in a 'southwest_lng,southwest_lat,northeast_lng,northeast_lat' format. Useful for sending requests to web services that return geo data.
-	toBBoxString: function () {
+	toBBoxString() {
 		return [this.getWest(), this.getSouth(), this.getEast(), this.getNorth()].join(',');
 	},
 
 	// @method equals(otherBounds: LatLngBounds): Boolean
 	// Returns `true` if the rectangle is equivalent (within a small margin of error) to the given bounds.
-	equals: function (bounds) {
+	equals(bounds) {
 		if (!bounds) { return false; }
 
 		bounds = toLatLngBounds(bounds);
@@ -222,7 +222,7 @@ LatLngBounds.prototype = {
 
 	// @method isValid(): Boolean
 	// Returns `true` if the bounds are properly initialized.
-	isValid: function () {
+	isValid() {
 		return !!(this._southWest && this._northEast);
 	}
 };

--- a/src/geo/crs/CRS.Base.js
+++ b/src/geo/crs/CRS.Base.js
@@ -1,4 +1,4 @@
-import {Bounds} from '../../geometry/Bounds';
+import {toBounds} from '../../geometry/Bounds';
 import {LatLng} from '../LatLng';
 import {wrapNum, extend} from '../../core/Util';
 
@@ -18,7 +18,7 @@ import {wrapNum, extend} from '../../core/Util';
 export var Base = extend({}, {
 	// @method latLngToPoint(latlng: LatLng, zoom: Number): Point
 	// Projects geographical coordinates into pixel coordinates for a given zoom.
-	latLngToPoint: function (latlng, zoom) {
+	latLngToPoint(latlng, zoom) {
 		var projectedPoint = this.projection.project(latlng),
 		    scale = this.scale(zoom);
 
@@ -28,7 +28,7 @@ export var Base = extend({}, {
 	// @method pointToLatLng(point: Point, zoom: Number): LatLng
 	// The inverse of `latLngToPoint`. Projects pixel coordinates on a given
 	// zoom into geographical coordinates.
-	pointToLatLng: function (point, zoom) {
+	pointToLatLng(point, zoom) {
 		var scale = this.scale(zoom),
 		    untransformedPoint = this.transformation.untransform(point, scale);
 
@@ -38,14 +38,14 @@ export var Base = extend({}, {
 	// @method project(latlng: LatLng): Point
 	// Projects geographical coordinates into coordinates in units accepted for
 	// this CRS (e.g. meters for EPSG:3857, for passing it to WMS services).
-	project: function (latlng) {
+	project(latlng) {
 		return this.projection.project(latlng);
 	},
 
 	// @method unproject(point: Point): LatLng
 	// Given a projected coordinate returns the corresponding LatLng.
 	// The inverse of `project`.
-	unproject: function (point) {
+	unproject(point) {
 		return this.projection.unproject(point);
 	},
 
@@ -53,20 +53,20 @@ export var Base = extend({}, {
 	// Returns the scale used when transforming projected coordinates into
 	// pixel coordinates for a particular zoom. For example, it returns
 	// `256 * 2^zoom` for Mercator-based CRS.
-	scale: function (zoom) {
+	scale(zoom) {
 		return 256 * Math.pow(2, zoom);
 	},
 
 	// @method zoom(scale: Number): Number
 	// Inverse of `scale()`, returns the zoom level corresponding to a scale
 	// factor of `scale`.
-	zoom: function (scale) {
+	zoom(scale) {
 		return Math.log(scale / 256) / Math.LN2;
 	},
 
 	// @method getProjectedBounds(zoom: Number): Bounds
 	// Returns the projection's bounds scaled and transformed for the provided `zoom`.
-	getProjectedBounds: function (zoom) {
+	getProjectedBounds(zoom) {
 		if (this.infinite) { return null; }
 
 		var b = this.projection.bounds,
@@ -74,7 +74,7 @@ export var Base = extend({}, {
 		    min = this.transformation.transform(b.min, s),
 		    max = this.transformation.transform(b.max, s);
 
-		return new Bounds(min, max);
+		return toBounds(min, max);
 	},
 
 	// @method distance(latlng1: LatLng, latlng2: LatLng): Number
@@ -101,7 +101,7 @@ export var Base = extend({}, {
 	// @method wrapLatLng(latlng: LatLng): LatLng
 	// Returns a `LatLng` where lat and lng has been wrapped according to the
 	// CRS's `wrapLat` and `wrapLng` properties, if they are outside the CRS's bounds.
-	wrapLatLng: function (latlng) {
+	wrapLatLng(latlng) {
 		var lng = this.wrapLng ? wrapNum(latlng.lng, this.wrapLng, true) : latlng.lng,
 		    lat = this.wrapLat ? wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat,
 		    alt = latlng.alt;

--- a/src/geo/crs/CRS.Earth.js
+++ b/src/geo/crs/CRS.Earth.js
@@ -20,7 +20,7 @@ export var Earth = extend({}, Base, {
 	R: 6371000,
 
 	// distance between two geographical points using spherical law of cosines approximation
-	distance: function (latlng1, latlng2) {
+	distance(latlng1, latlng2) {
 		var rad = Math.PI / 180,
 		    lat1 = latlng1.lat * rad,
 		    lat2 = latlng2.lat * rad,

--- a/src/geo/crs/CRS.Simple.js
+++ b/src/geo/crs/CRS.Simple.js
@@ -17,15 +17,15 @@ export var Simple = extend({}, Base, {
 	projection: LonLat,
 	transformation: new Transformation(1, 0, -1, 0),
 
-	scale: function (zoom) {
+	scale(zoom) {
 		return Math.pow(2, zoom);
 	},
 
-	zoom: function (scale) {
+	zoom(scale) {
 		return Math.log(scale) / Math.LN2;
 	},
 
-	distance: function (latlng1, latlng2) {
+	distance(latlng1, latlng2) {
 		var dx = latlng2.lng - latlng1.lng,
 		    dy = latlng2.lat - latlng1.lat;
 

--- a/src/geo/projection/Projection.LonLat.js
+++ b/src/geo/projection/Projection.LonLat.js
@@ -16,11 +16,11 @@ import {Point} from '../../geometry/Point';
  */
 
 export var LonLat = {
-	project: function (latlng) {
+	project(latlng) {
 		return new Point(latlng.lng, latlng.lat);
 	},
 
-	unproject: function (point) {
+	unproject(point) {
 		return new LatLng(point.y, point.x);
 	},
 

--- a/src/geo/projection/Projection.Mercator.js
+++ b/src/geo/projection/Projection.Mercator.js
@@ -15,7 +15,7 @@ export var Mercator = {
 
 	bounds: new Bounds([-20037508.34279, -15496570.73972], [20037508.34279, 18764656.23138]),
 
-	project: function (latlng) {
+	project(latlng) {
 		var d = Math.PI / 180,
 		    r = this.R,
 		    y = latlng.lat * d,
@@ -29,7 +29,7 @@ export var Mercator = {
 		return new Point(latlng.lng * d * r, y);
 	},
 
-	unproject: function (point) {
+	unproject(point) {
 		var d = 180 / Math.PI,
 		    r = this.R,
 		    tmp = this.R_MINOR / r,

--- a/src/geo/projection/Projection.SphericalMercator.js
+++ b/src/geo/projection/Projection.SphericalMercator.js
@@ -16,7 +16,7 @@ export var SphericalMercator = {
 	R: 6378137,
 	MAX_LATITUDE: 85.0511287798,
 
-	project: function (latlng) {
+	project(latlng) {
 		var d = Math.PI / 180,
 		    max = this.MAX_LATITUDE,
 		    lat = Math.max(Math.min(max, latlng.lat), -max),
@@ -27,7 +27,7 @@ export var SphericalMercator = {
 				this.R * Math.log((1 + sin) / (1 - sin)) / 2);
 	},
 
-	unproject: function (point) {
+	unproject(point) {
 		var d = 180 / Math.PI;
 
 		return new LatLng(

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -34,7 +34,7 @@ export function Bounds(a, b) {
 Bounds.prototype = {
 	// @method extend(point: Point): this
 	// Extends the bounds to contain the given point.
-	extend: function (point) { // (Point)
+	extend(point) { // (Point)
 		point = toPoint(point);
 
 		// @property min: Point
@@ -55,7 +55,7 @@ Bounds.prototype = {
 
 	// @method getCenter(round?: Boolean): Point
 	// Returns the center point of the bounds.
-	getCenter: function (round) {
+	getCenter(round) {
 		return new Point(
 		        (this.min.x + this.max.x) / 2,
 		        (this.min.y + this.max.y) / 2, round);
@@ -63,19 +63,19 @@ Bounds.prototype = {
 
 	// @method getBottomLeft(): Point
 	// Returns the bottom-left point of the bounds.
-	getBottomLeft: function () {
+	getBottomLeft() {
 		return new Point(this.min.x, this.max.y);
 	},
 
 	// @method getTopRight(): Point
 	// Returns the top-right point of the bounds.
-	getTopRight: function () { // -> Point
+	getTopRight() { // -> Point
 		return new Point(this.max.x, this.min.y);
 	},
 
 	// @method getSize(): Point
 	// Returns the size of the given bounds
-	getSize: function () {
+	getSize() {
 		return this.max.subtract(this.min);
 	},
 
@@ -84,7 +84,7 @@ Bounds.prototype = {
 	// @alternative
 	// @method contains(point: Point): Boolean
 	// Returns `true` if the rectangle contains the given point.
-	contains: function (obj) {
+	contains(obj) {
 		var min, max;
 
 		if (typeof obj[0] === 'number' || obj instanceof Point) {
@@ -109,7 +109,7 @@ Bounds.prototype = {
 	// @method intersects(otherBounds: Bounds): Boolean
 	// Returns `true` if the rectangle intersects the given bounds. Two bounds
 	// intersect if they have at least one point in common.
-	intersects: function (bounds) { // (Bounds) -> Boolean
+	intersects(bounds) { // (Bounds) -> Boolean
 		bounds = toBounds(bounds);
 
 		var min = this.min,
@@ -125,7 +125,7 @@ Bounds.prototype = {
 	// @method overlaps(otherBounds: Bounds): Boolean
 	// Returns `true` if the rectangle overlaps the given bounds. Two bounds
 	// overlap if their intersection is an area.
-	overlaps: function (bounds) { // (Bounds) -> Boolean
+	overlaps(bounds) { // (Bounds) -> Boolean
 		bounds = toBounds(bounds);
 
 		var min = this.min,
@@ -138,7 +138,7 @@ Bounds.prototype = {
 		return xOverlaps && yOverlaps;
 	},
 
-	isValid: function () {
+	isValid() {
 		return !!(this.min && this.max);
 	}
 };

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -29,18 +29,18 @@ Point.prototype = {
 
 	// @method clone(): Point
 	// Returns a copy of the current point.
-	clone: function () {
+	clone() {
 		return new Point(this.x, this.y);
 	},
 
 	// @method add(otherPoint: Point): Point
 	// Returns the result of addition of the current and the given points.
-	add: function (point) {
+	add(point) {
 		// non-destructive, returns a new point
 		return this.clone()._add(toPoint(point));
 	},
 
-	_add: function (point) {
+	_add(point) {
 		// destructive, used directly for performance in situations where it's safe to modify existing point
 		this.x += point.x;
 		this.y += point.y;
@@ -49,11 +49,11 @@ Point.prototype = {
 
 	// @method subtract(otherPoint: Point): Point
 	// Returns the result of subtraction of the given point from the current.
-	subtract: function (point) {
+	subtract(point) {
 		return this.clone()._subtract(toPoint(point));
 	},
 
-	_subtract: function (point) {
+	_subtract(point) {
 		this.x -= point.x;
 		this.y -= point.y;
 		return this;
@@ -61,11 +61,11 @@ Point.prototype = {
 
 	// @method divideBy(num: Number): Point
 	// Returns the result of division of the current point by the given number.
-	divideBy: function (num) {
+	divideBy(num) {
 		return this.clone()._divideBy(num);
 	},
 
-	_divideBy: function (num) {
+	_divideBy(num) {
 		this.x /= num;
 		this.y /= num;
 		return this;
@@ -73,11 +73,11 @@ Point.prototype = {
 
 	// @method multiplyBy(num: Number): Point
 	// Returns the result of multiplication of the current point by the given number.
-	multiplyBy: function (num) {
+	multiplyBy(num) {
 		return this.clone()._multiplyBy(num);
 	},
 
-	_multiplyBy: function (num) {
+	_multiplyBy(num) {
 		this.x *= num;
 		this.y *= num;
 		return this;
@@ -88,24 +88,24 @@ Point.prototype = {
 	// `scale`. In linear algebra terms, multiply the point by the
 	// [scaling matrix](https://en.wikipedia.org/wiki/Scaling_%28geometry%29#Matrix_representation)
 	// defined by `scale`.
-	scaleBy: function (point) {
+	scaleBy(point) {
 		return new Point(this.x * point.x, this.y * point.y);
 	},
 
 	// @method unscaleBy(scale: Point): Point
 	// Inverse of `scaleBy`. Divide each coordinate of the current point by
 	// each coordinate of `scale`.
-	unscaleBy: function (point) {
+	unscaleBy(point) {
 		return new Point(this.x / point.x, this.y / point.y);
 	},
 
 	// @method round(): Point
 	// Returns a copy of the current point with rounded coordinates.
-	round: function () {
+	round() {
 		return this.clone()._round();
 	},
 
-	_round: function () {
+	_round() {
 		this.x = Math.round(this.x);
 		this.y = Math.round(this.y);
 		return this;
@@ -113,11 +113,11 @@ Point.prototype = {
 
 	// @method floor(): Point
 	// Returns a copy of the current point with floored coordinates (rounded down).
-	floor: function () {
+	floor() {
 		return this.clone()._floor();
 	},
 
-	_floor: function () {
+	_floor() {
 		this.x = Math.floor(this.x);
 		this.y = Math.floor(this.y);
 		return this;
@@ -125,11 +125,11 @@ Point.prototype = {
 
 	// @method ceil(): Point
 	// Returns a copy of the current point with ceiled coordinates (rounded up).
-	ceil: function () {
+	ceil() {
 		return this.clone()._ceil();
 	},
 
-	_ceil: function () {
+	_ceil() {
 		this.x = Math.ceil(this.x);
 		this.y = Math.ceil(this.y);
 		return this;
@@ -137,7 +137,7 @@ Point.prototype = {
 
 	// @method distanceTo(otherPoint: Point): Number
 	// Returns the cartesian distance between the current and the given points.
-	distanceTo: function (point) {
+	distanceTo(point) {
 		point = toPoint(point);
 
 		var x = point.x - this.x,
@@ -148,7 +148,7 @@ Point.prototype = {
 
 	// @method equals(otherPoint: Point): Boolean
 	// Returns `true` if the given point has the same coordinates.
-	equals: function (point) {
+	equals(point) {
 		point = toPoint(point);
 
 		return point.x === this.x &&
@@ -157,7 +157,7 @@ Point.prototype = {
 
 	// @method contains(otherPoint: Point): Boolean
 	// Returns `true` if both coordinates of the given point are less than the corresponding current point coordinates (in absolute values).
-	contains: function (point) {
+	contains(point) {
 		point = toPoint(point);
 
 		return Math.abs(point.x) <= Math.abs(this.x) &&
@@ -166,7 +166,7 @@ Point.prototype = {
 
 	// @method toString(): String
 	// Returns a string representation of the point for debugging purposes.
-	toString: function () {
+	toString() {
 		return 'Point(' +
 		        formatNum(this.x) + ', ' +
 		        formatNum(this.y) + ')';

--- a/src/geometry/Transformation.js
+++ b/src/geometry/Transformation.js
@@ -32,12 +32,12 @@ Transformation.prototype = {
 	// @method transform(point: Point, scale?: Number): Point
 	// Returns a transformed point, optionally multiplied by the given scale.
 	// Only accepts real `L.Point` instances, not arrays.
-	transform: function (point, scale) { // (Point, Number) -> Point
+	transform(point, scale) { // (Point, Number) -> Point
 		return this._transform(point.clone(), scale);
 	},
 
 	// destructive transform (faster)
-	_transform: function (point, scale) {
+	_transform(point, scale) {
 		scale = scale || 1;
 		point.x = scale * (this._a * point.x + this._b);
 		point.y = scale * (this._c * point.y + this._d);
@@ -47,7 +47,7 @@ Transformation.prototype = {
 	// @method untransform(point: Point, scale?: Number): Point
 	// Returns the reverse transformation of the given point, optionally divided
 	// by the given scale. Only accepts real `L.Point` instances, not arrays.
-	untransform: function (point, scale) {
+	untransform(point, scale) {
 		scale = scale || 1;
 		return new Point(
 		        (point.x / scale - this._b) / this._a,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -137,7 +137,7 @@ export var Map = Evented.extend({
 		trackResize: true
 	},
 
-	initialize: function (id, options) { // (HTMLElement or String, Object)
+	initialize(id, options) { // (HTMLElement or String, Object)
 		options = setOptions(this, options);
 
 		this._initContainer(id);
@@ -187,7 +187,7 @@ export var Map = Evented.extend({
 	// @method setView(center: LatLng, zoom: Number, options?: Zoom/pan options): this
 	// Sets the view of the map (geographical center and zoom) with the given
 	// animation options.
-	setView: function (center, zoom, options) {
+	setView(center, zoom, options) {
 
 		zoom = zoom === undefined ? this._zoom : this._limitZoom(zoom);
 		center = this._limitCenter(toLatLng(center), zoom, this.options.maxBounds);
@@ -222,7 +222,7 @@ export var Map = Evented.extend({
 
 	// @method setZoom(zoom: Number, options: Zoom/pan options): this
 	// Sets the zoom of the map.
-	setZoom: function (zoom, options) {
+	setZoom(zoom, options) {
 		if (!this._loaded) {
 			this._zoom = zoom;
 			return this;
@@ -232,14 +232,14 @@ export var Map = Evented.extend({
 
 	// @method zoomIn(delta?: Number, options?: Zoom options): this
 	// Increases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
-	zoomIn: function (delta, options) {
+	zoomIn(delta, options) {
 		delta = delta || (isAny3D ? this.options.zoomDelta : 1);
 		return this.setZoom(this._zoom + delta, options);
 	},
 
 	// @method zoomOut(delta?: Number, options?: Zoom options): this
 	// Decreases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
-	zoomOut: function (delta, options) {
+	zoomOut(delta, options) {
 		delta = delta || (isAny3D ? this.options.zoomDelta : 1);
 		return this.setZoom(this._zoom - delta, options);
 	},
@@ -250,7 +250,7 @@ export var Map = Evented.extend({
 	// @alternative
 	// @method setZoomAround(offset: Point, zoom: Number, options: Zoom options): this
 	// Zooms the map while keeping a specified pixel on the map (relative to the top-left corner) stationary.
-	setZoomAround: function (latlng, zoom, options) {
+	setZoomAround(latlng, zoom, options) {
 		var scale = this.getZoomScale(zoom),
 		    viewHalf = this.getSize().divideBy(2),
 		    containerPoint = latlng instanceof Point ? latlng : this.latLngToContainerPoint(latlng),
@@ -261,7 +261,7 @@ export var Map = Evented.extend({
 		return this.setView(newCenter, zoom, {zoom: options});
 	},
 
-	_getBoundsCenterZoom: function (bounds, options) {
+	_getBoundsCenterZoom(bounds, options) {
 
 		options = options || {};
 		bounds = bounds.getBounds ? bounds.getBounds() : toLatLngBounds(bounds);
@@ -288,7 +288,7 @@ export var Map = Evented.extend({
 	// @method fitBounds(bounds: LatLngBounds, options: fitBounds options): this
 	// Sets a map view that contains the given geographical bounds with the
 	// maximum zoom level possible.
-	fitBounds: function (bounds, options) {
+	fitBounds(bounds, options) {
 
 		bounds = toLatLngBounds(bounds);
 
@@ -303,19 +303,19 @@ export var Map = Evented.extend({
 	// @method fitWorld(options?: fitBounds options): this
 	// Sets a map view that mostly contains the whole world with the maximum
 	// zoom level possible.
-	fitWorld: function (options) {
+	fitWorld(options) {
 		return this.fitBounds([[-90, -180], [90, 180]], options);
 	},
 
 	// @method panTo(latlng: LatLng, options?: Pan options): this
 	// Pans the map to a given center.
-	panTo: function (center, options) { // (LatLng)
+	panTo(center, options) { // (LatLng)
 		return this.setView(center, this._zoom, {pan: options});
 	},
 
 	// @method panBy(offset: Point): this
 	// Pans the map by a given number of pixels (animated).
-	panBy: function (offset, options) {
+	panBy(offset, options) {
 		offset = toPoint(offset).round();
 		options = options || {};
 
@@ -360,7 +360,7 @@ export var Map = Evented.extend({
 	// @method flyTo(latlng: LatLng, zoom?: Number, options?: Zoom/pan options): this
 	// Sets the view of the map (geographical center and zoom) performing a smooth
 	// pan-zoom animation.
-	flyTo: function (targetCenter, targetZoom, options) {
+	flyTo(targetCenter, targetZoom, options) {
 
 		options = options || {};
 		if (options.animate === false || !isAny3D) {
@@ -441,14 +441,14 @@ export var Map = Evented.extend({
 	// @method flyToBounds(bounds: LatLngBounds, options?: fitBounds options): this
 	// Sets the view of the map with a smooth animation like [`flyTo`](#map-flyto),
 	// but takes a bounds parameter like [`fitBounds`](#map-fitbounds).
-	flyToBounds: function (bounds, options) {
+	flyToBounds(bounds, options) {
 		var target = this._getBoundsCenterZoom(bounds, options);
 		return this.flyTo(target.center, target.zoom, options);
 	},
 
 	// @method setMaxBounds(bounds: Bounds): this
 	// Restricts the map view to the given bounds (see the [maxBounds](#map-maxbounds) option).
-	setMaxBounds: function (bounds) {
+	setMaxBounds(bounds) {
 		bounds = toLatLngBounds(bounds);
 
 		if (!bounds.isValid()) {
@@ -469,7 +469,7 @@ export var Map = Evented.extend({
 
 	// @method setMinZoom(zoom: Number): this
 	// Sets the lower limit for the available zoom levels (see the [minZoom](#map-minzoom) option).
-	setMinZoom: function (zoom) {
+	setMinZoom(zoom) {
 		this.options.minZoom = zoom;
 
 		if (this._loaded && this.getZoom() < this.options.minZoom) {
@@ -481,7 +481,7 @@ export var Map = Evented.extend({
 
 	// @method setMaxZoom(zoom: Number): this
 	// Sets the upper limit for the available zoom levels (see the [maxZoom](#map-maxzoom) option).
-	setMaxZoom: function (zoom) {
+	setMaxZoom(zoom) {
 		this.options.maxZoom = zoom;
 
 		if (this._loaded && (this.getZoom() > this.options.maxZoom)) {
@@ -493,7 +493,7 @@ export var Map = Evented.extend({
 
 	// @method panInsideBounds(bounds: LatLngBounds, options?: Pan options): this
 	// Pans the map to the closest view that would lie inside the given bounds (if it's not already), controlling the animation using the options specific, if any.
-	panInsideBounds: function (bounds, options) {
+	panInsideBounds(bounds, options) {
 		this._enforcingBounds = true;
 		var center = this.getCenter(),
 		    newCenter = this._limitCenter(center, this._zoom, toLatLngBounds(bounds));
@@ -519,7 +519,7 @@ export var Map = Evented.extend({
 	// Checks if the map container size changed and updates the map if so —
 	// call it after you've changed the map size dynamically, also animating
 	// pan by default.
-	invalidateSize: function (options) {
+	invalidateSize(options) {
 		if (!this._loaded) { return this; }
 
 		options = extend({
@@ -568,7 +568,7 @@ export var Map = Evented.extend({
 	// @section Methods for modifying map state
 	// @method stop(): this
 	// Stops the currently running `panTo` or `flyTo` animation, if any.
-	stop: function () {
+	stop() {
 		this.setZoom(this._limitZoom(this._zoom));
 		if (!this.options.zoomSnap) {
 			this.fire('viewreset');
@@ -585,7 +585,7 @@ export var Map = Evented.extend({
 	// Note that, if your page doesn't use HTTPS, this method will fail in
 	// modern browsers ([Chrome 50 and newer](https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-powerful-features-on-insecure-origins))
 	// See `Locate options` for more details.
-	locate: function (options) {
+	locate(options) {
 
 		options = this._locateOptions = extend({
 			timeout: 10000,
@@ -620,7 +620,7 @@ export var Map = Evented.extend({
 	// Stops watching location previously initiated by `map.locate({watch: true})`
 	// and aborts resetting the map view if map.locate was called with
 	// `{setView: true}`.
-	stopLocate: function () {
+	stopLocate() {
 		if (navigator.geolocation && navigator.geolocation.clearWatch) {
 			navigator.geolocation.clearWatch(this._locationWatchId);
 		}
@@ -630,7 +630,7 @@ export var Map = Evented.extend({
 		return this;
 	},
 
-	_handleGeolocationError: function (error) {
+	_handleGeolocationError(error) {
 		var c = error.code,
 		    message = error.message ||
 		            (c === 1 ? 'permission denied' :
@@ -649,7 +649,7 @@ export var Map = Evented.extend({
 		});
 	},
 
-	_handleGeolocationResponse: function (pos) {
+	_handleGeolocationResponse(pos) {
 		var lat = pos.coords.latitude,
 		    lng = pos.coords.longitude,
 		    latlng = new LatLng(lat, lng),
@@ -684,7 +684,7 @@ export var Map = Evented.extend({
 	// @section Other Methods
 	// @method addHandler(name: String, HandlerClass: Function): this
 	// Adds a new `Handler` to the map, given its name and constructor function.
-	addHandler: function (name, HandlerClass) {
+	addHandler(name, HandlerClass) {
 		if (!HandlerClass) { return this; }
 
 		var handler = this[name] = new HandlerClass(this);
@@ -700,7 +700,7 @@ export var Map = Evented.extend({
 
 	// @method remove(): this
 	// Destroys the map and clears all related event listeners.
-	remove: function () {
+	remove() {
 
 		this._initEvents(true);
 
@@ -746,7 +746,7 @@ export var Map = Evented.extend({
 	// Creates a new [map pane](#map-pane) with the given name if it doesn't exist already,
 	// then returns it. The pane is created as a children of `container`, or
 	// as a children of the main map pane if not set.
-	createPane: function (name, container) {
+	createPane(name, container) {
 		var className = 'leaflet-pane' + (name ? ' leaflet-' + name.replace('Pane', '') + '-pane' : ''),
 		    pane = L.DomUtil.create('div', className, container || this._mapPane);
 
@@ -760,7 +760,7 @@ export var Map = Evented.extend({
 
 	// @method getCenter(): LatLng
 	// Returns the geographical center of the map view
-	getCenter: function () {
+	getCenter() {
 		this._checkIfLoaded();
 
 		if (this._lastCenter && !this._moved()) {
@@ -771,13 +771,13 @@ export var Map = Evented.extend({
 
 	// @method getZoom(): Number
 	// Returns the current zoom level of the map view
-	getZoom: function () {
+	getZoom() {
 		return this._zoom;
 	},
 
 	// @method getBounds(): LatLngBounds
 	// Returns the geographical bounds visible in the current map view
-	getBounds: function () {
+	getBounds() {
 		var bounds = this.getPixelBounds(),
 		    sw = this.unproject(bounds.getBottomLeft()),
 		    ne = this.unproject(bounds.getTopRight());
@@ -787,13 +787,13 @@ export var Map = Evented.extend({
 
 	// @method getMinZoom(): Number
 	// Returns the minimum zoom level of the map (if set in the `minZoom` option of the map or of any layers), or `0` by default.
-	getMinZoom: function () {
+	getMinZoom() {
 		return this.options.minZoom === undefined ? this._layersMinZoom || 0 : this.options.minZoom;
 	},
 
 	// @method getMaxZoom(): Number
 	// Returns the maximum zoom level of the map (if set in the `maxZoom` option of the map or of any layers).
-	getMaxZoom: function () {
+	getMaxZoom() {
 		return this.options.maxZoom === undefined ?
 			(this._layersMaxZoom === undefined ? Infinity : this._layersMaxZoom) :
 			this.options.maxZoom;
@@ -804,7 +804,7 @@ export var Map = Evented.extend({
 	// view in its entirety. If `inside` (optional) is set to `true`, the method
 	// instead returns the minimum zoom level on which the map view fits into
 	// the given bounds in its entirety.
-	getBoundsZoom: function (bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
+	getBoundsZoom(bounds, inside, padding) { // (LatLngBounds[, Boolean, Point]) -> Number
 		bounds = toLatLngBounds(bounds);
 		padding = toPoint(padding || [0, 0]);
 
@@ -830,7 +830,7 @@ export var Map = Evented.extend({
 
 	// @method getSize(): Point
 	// Returns the current size of the map container (in pixels).
-	getSize: function () {
+	getSize() {
 		if (!this._size || this._sizeChanged) {
 			this._size = new Point(
 				this._container.clientWidth,
@@ -844,7 +844,7 @@ export var Map = Evented.extend({
 	// @method getPixelBounds(): Bounds
 	// Returns the bounds of the current map view in projected pixel
 	// coordinates (sometimes useful in layer and overlay implementations).
-	getPixelBounds: function (center, zoom) {
+	getPixelBounds(center, zoom) {
 		var topLeftPoint = this._getTopLeftPoint(center, zoom);
 		return new Bounds(topLeftPoint, topLeftPoint.add(this.getSize()));
 	},
@@ -855,7 +855,7 @@ export var Map = Evented.extend({
 	// @method getPixelOrigin(): Point
 	// Returns the projected pixel coordinates of the top left point of
 	// the map layer (useful in custom layer and overlay implementations).
-	getPixelOrigin: function () {
+	getPixelOrigin() {
 		this._checkIfLoaded();
 		return this._pixelOrigin;
 	},
@@ -863,7 +863,7 @@ export var Map = Evented.extend({
 	// @method getPixelWorldBounds(zoom?: Number): Bounds
 	// Returns the world's bounds in pixel coordinates for zoom level `zoom`.
 	// If `zoom` is omitted, the map's current zoom level is used.
-	getPixelWorldBounds: function (zoom) {
+	getPixelWorldBounds(zoom) {
 		return this.options.crs.getProjectedBounds(zoom === undefined ? this.getZoom() : zoom);
 	},
 
@@ -871,20 +871,20 @@ export var Map = Evented.extend({
 
 	// @method getPane(pane: String|HTMLElement): HTMLElement
 	// Returns a [map pane](#map-pane), given its name or its HTML element (its identity).
-	getPane: function (pane) {
+	getPane(pane) {
 		return typeof pane === 'string' ? this._panes[pane] : pane;
 	},
 
 	// @method getPanes(): Object
 	// Returns a plain object containing the names of all [panes](#map-pane) as keys and
 	// the panes as values.
-	getPanes: function () {
+	getPanes() {
 		return this._panes;
 	},
 
 	// @method getContainer: HTMLElement
 	// Returns the HTML element that contains the map.
-	getContainer: function () {
+	getContainer() {
 		return this._container;
 	},
 
@@ -894,7 +894,7 @@ export var Map = Evented.extend({
 	// @method getZoomScale(toZoom: Number, fromZoom: Number): Number
 	// Returns the scale factor to be applied to a map transition from zoom level
 	// `fromZoom` to `toZoom`. Used internally to help with zoom animations.
-	getZoomScale: function (toZoom, fromZoom) {
+	getZoomScale(toZoom, fromZoom) {
 		// TODO replace with universal implementation after refactoring projections
 		var crs = this.options.crs;
 		fromZoom = fromZoom === undefined ? this._zoom : fromZoom;
@@ -905,7 +905,7 @@ export var Map = Evented.extend({
 	// Returns the zoom level that the map would end up at, if it is at `fromZoom`
 	// level and everything is scaled by a factor of `scale`. Inverse of
 	// [`getZoomScale`](#map-getZoomScale).
-	getScaleZoom: function (scale, fromZoom) {
+	getScaleZoom(scale, fromZoom) {
 		var crs = this.options.crs;
 		fromZoom = fromZoom === undefined ? this._zoom : fromZoom;
 		var zoom = crs.zoom(scale * crs.scale(fromZoom));
@@ -917,14 +917,14 @@ export var Map = Evented.extend({
 	// of the map's CRS, then scales it according to `zoom` and the CRS's
 	// `Transformation`. The result is pixel coordinate relative to
 	// the CRS origin.
-	project: function (latlng, zoom) {
+	project(latlng, zoom) {
 		zoom = zoom === undefined ? this._zoom : zoom;
 		return this.options.crs.latLngToPoint(toLatLng(latlng), zoom);
 	},
 
 	// @method unproject(point: Point, zoom: Number): LatLng
 	// Inverse of [`project`](#map-project).
-	unproject: function (point, zoom) {
+	unproject(point, zoom) {
 		zoom = zoom === undefined ? this._zoom : zoom;
 		return this.options.crs.pointToLatLng(toPoint(point), zoom);
 	},
@@ -932,7 +932,7 @@ export var Map = Evented.extend({
 	// @method layerPointToLatLng(point: Point): LatLng
 	// Given a pixel coordinate relative to the [origin pixel](#map-getpixelorigin),
 	// returns the corresponding geographical coordinate (for the current zoom level).
-	layerPointToLatLng: function (point) {
+	layerPointToLatLng(point) {
 		var projectedPoint = toPoint(point).add(this.getPixelOrigin());
 		return this.unproject(projectedPoint);
 	},
@@ -940,7 +940,7 @@ export var Map = Evented.extend({
 	// @method latLngToLayerPoint(latlng: LatLng): Point
 	// Given a geographical coordinate, returns the corresponding pixel coordinate
 	// relative to the [origin pixel](#map-getpixelorigin).
-	latLngToLayerPoint: function (latlng) {
+	latLngToLayerPoint(latlng) {
 		var projectedPoint = this.project(toLatLng(latlng))._round();
 		return projectedPoint._subtract(this.getPixelOrigin());
 	},
@@ -951,35 +951,35 @@ export var Map = Evented.extend({
 	// CRS's bounds.
 	// By default this means longitude is wrapped around the dateline so its
 	// value is between -180 and +180 degrees.
-	wrapLatLng: function (latlng) {
+	wrapLatLng(latlng) {
 		return this.options.crs.wrapLatLng(toLatLng(latlng));
 	},
 
 	// @method distance(latlng1: LatLng, latlng2: LatLng): Number
 	// Returns the distance between two geographical coordinates according to
 	// the map's CRS. By default this measures distance in meters.
-	distance: function (latlng1, latlng2) {
+	distance(latlng1, latlng2) {
 		return this.options.crs.distance(toLatLng(latlng1), toLatLng(latlng2));
 	},
 
 	// @method containerPointToLayerPoint(point: Point): Point
 	// Given a pixel coordinate relative to the map container, returns the corresponding
 	// pixel coordinate relative to the [origin pixel](#map-getpixelorigin).
-	containerPointToLayerPoint: function (point) { // (Point)
+	containerPointToLayerPoint(point) { // (Point)
 		return toPoint(point).subtract(this._getMapPanePos());
 	},
 
 	// @method layerPointToContainerPoint(point: Point): Point
 	// Given a pixel coordinate relative to the [origin pixel](#map-getpixelorigin),
 	// returns the corresponding pixel coordinate relative to the map container.
-	layerPointToContainerPoint: function (point) { // (Point)
+	layerPointToContainerPoint(point) { // (Point)
 		return toPoint(point).add(this._getMapPanePos());
 	},
 
 	// @method containerPointToLatLng(point: Point): Point
 	// Given a pixel coordinate relative to the map container, returns
 	// the corresponding geographical coordinate (for the current zoom level).
-	containerPointToLatLng: function (point) {
+	containerPointToLatLng(point) {
 		var layerPoint = this.containerPointToLayerPoint(toPoint(point));
 		return this.layerPointToLatLng(layerPoint);
 	},
@@ -987,35 +987,35 @@ export var Map = Evented.extend({
 	// @method latLngToContainerPoint(latlng: LatLng): Point
 	// Given a geographical coordinate, returns the corresponding pixel coordinate
 	// relative to the map container.
-	latLngToContainerPoint: function (latlng) {
+	latLngToContainerPoint(latlng) {
 		return this.layerPointToContainerPoint(this.latLngToLayerPoint(toLatLng(latlng)));
 	},
 
 	// @method mouseEventToContainerPoint(ev: MouseEvent): Point
 	// Given a MouseEvent object, returns the pixel coordinate relative to the
 	// map container where the event took place.
-	mouseEventToContainerPoint: function (e) {
+	mouseEventToContainerPoint(e) {
 		return getMousePosition(e, this._container);
 	},
 
 	// @method mouseEventToLayerPoint(ev: MouseEvent): Point
 	// Given a MouseEvent object, returns the pixel coordinate relative to
 	// the [origin pixel](#map-getpixelorigin) where the event took place.
-	mouseEventToLayerPoint: function (e) {
+	mouseEventToLayerPoint(e) {
 		return this.containerPointToLayerPoint(this.mouseEventToContainerPoint(e));
 	},
 
 	// @method mouseEventToLatLng(ev: MouseEvent): LatLng
 	// Given a MouseEvent object, returns geographical coordinate where the
 	// event took place.
-	mouseEventToLatLng: function (e) { // (MouseEvent)
+	mouseEventToLatLng(e) { // (MouseEvent)
 		return this.layerPointToLatLng(this.mouseEventToLayerPoint(e));
 	},
 
 
 	// map initialization methods
 
-	_initContainer: function (id) {
+	_initContainer(id) {
 		var container = this._container = L.DomUtil.get(id);
 
 		if (!container) {
@@ -1028,7 +1028,7 @@ export var Map = Evented.extend({
 		this._containerId = stamp(container);
 	},
 
-	_initLayout: function () {
+	_initLayout() {
 		var container = this._container;
 
 		this._fadeAnimated = this.options.fadeAnimation && isAny3D;
@@ -1053,7 +1053,7 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_initPanes: function () {
+	_initPanes() {
 		var panes = this._panes = {};
 		this._paneRenderers = {};
 
@@ -1101,7 +1101,7 @@ export var Map = Evented.extend({
 	// private methods that modify map state
 
 	// @section Map state change events
-	_resetView: function (center, zoom) {
+	_resetView(center, zoom) {
 		L.DomUtil.setPosition(this._mapPane, new Point(0, 0));
 
 		var loading = !this._loaded;
@@ -1129,7 +1129,7 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_moveStart: function (zoomChanged) {
+	_moveStart(zoomChanged) {
 		// @event zoomstart: Event
 		// Fired when the map zoom is about to change (e.g. before zoom animation).
 		// @event movestart: Event
@@ -1140,7 +1140,7 @@ export var Map = Evented.extend({
 		return this.fire('movestart');
 	},
 
-	_move: function (center, zoom, data) {
+	_move(center, zoom, data) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -1163,7 +1163,7 @@ export var Map = Evented.extend({
 		return this.fire('move', data);
 	},
 
-	_moveEnd: function (zoomChanged) {
+	_moveEnd(zoomChanged) {
 		// @event zoomend: Event
 		// Fired when the map has changed, after any animations.
 		if (zoomChanged) {
@@ -1176,7 +1176,7 @@ export var Map = Evented.extend({
 		return this.fire('moveend');
 	},
 
-	_stop: function () {
+	_stop() {
 		cancelAnimFrame(this._flyToFrame);
 		if (this._panAnim) {
 			this._panAnim.stop();
@@ -1184,21 +1184,21 @@ export var Map = Evented.extend({
 		return this;
 	},
 
-	_rawPanBy: function (offset) {
+	_rawPanBy(offset) {
 		L.DomUtil.setPosition(this._mapPane, this._getMapPanePos().subtract(offset));
 	},
 
-	_getZoomSpan: function () {
+	_getZoomSpan() {
 		return this.getMaxZoom() - this.getMinZoom();
 	},
 
-	_panInsideMaxBounds: function () {
+	_panInsideMaxBounds() {
 		if (!this._enforcingBounds) {
 			this.panInsideBounds(this.options.maxBounds);
 		}
 	},
 
-	_checkIfLoaded: function () {
+	_checkIfLoaded() {
 		if (!this._loaded) {
 			throw new Error('Set map center and zoom first.');
 		}
@@ -1207,7 +1207,7 @@ export var Map = Evented.extend({
 	// DOM event handling
 
 	// @section Interaction events
-	_initEvents: function (remove) {
+	_initEvents(remove) {
 		this._targets = {};
 		this._targets[stamp(this._container)] = this;
 
@@ -1246,18 +1246,18 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_onResize: function () {
+	_onResize() {
 		cancelAnimFrame(this._resizeRequest);
 		this._resizeRequest = requestAnimFrame(
 		        function () { this.invalidateSize({debounceMoveend: true}); }, this);
 	},
 
-	_onScroll: function () {
+	_onScroll() {
 		this._container.scrollTop  = 0;
 		this._container.scrollLeft = 0;
 	},
 
-	_onMoveEnd: function () {
+	_onMoveEnd() {
 		var pos = this._getMapPanePos();
 		if (Math.max(Math.abs(pos.x), Math.abs(pos.y)) >= this.options.transform3DLimit) {
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=1203873 but Webkit also have
@@ -1266,7 +1266,7 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_findEventTargets: function (e, type) {
+	_findEventTargets(e, type) {
 		var targets = [],
 		    target,
 		    isHover = type === 'mouseout' || type === 'mouseover',
@@ -1294,7 +1294,7 @@ export var Map = Evented.extend({
 		return targets;
 	},
 
-	_handleDOMEvent: function (e) {
+	_handleDOMEvent(e) {
 		if (!this._loaded || skippedDOMEvent(e)) { return; }
 
 		var type = e.type === 'keypress' && e.keyCode === 13 ? 'click' : e.type;
@@ -1307,7 +1307,7 @@ export var Map = Evented.extend({
 		this._fireDOMEvent(e, type);
 	},
 
-	_fireDOMEvent: function (e, type, targets) {
+	_fireDOMEvent(e, type, targets) {
 
 		if (e.type === 'click') {
 			// Fire a synthetic 'preclick' event which propagates up (mainly for closing popups).
@@ -1351,12 +1351,12 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_draggableMoved: function (obj) {
+	_draggableMoved(obj) {
 		obj = obj.dragging && obj.dragging.enabled() ? obj : this;
 		return (obj.dragging && obj.dragging.moved()) || (this.boxZoom && this.boxZoom.moved());
 	},
 
-	_clearHandlers: function () {
+	_clearHandlers() {
 		for (var i = 0, len = this._handlers.length; i < len; i++) {
 			this._handlers[i].disable();
 		}
@@ -1368,7 +1368,7 @@ export var Map = Evented.extend({
 	// Runs the given function `fn` when the map gets initialized with
 	// a view (center and zoom) and at least one layer, or immediately
 	// if it's already initialized, optionally passing a function context.
-	whenReady: function (callback, context) {
+	whenReady(callback, context) {
 		if (this._loaded) {
 			callback.call(context || this, {target: this});
 		} else {
@@ -1380,44 +1380,44 @@ export var Map = Evented.extend({
 
 	// private methods for getting map state
 
-	_getMapPanePos: function () {
+	_getMapPanePos() {
 		return L.DomUtil.getPosition(this._mapPane) || new Point(0, 0);
 	},
 
-	_moved: function () {
+	_moved() {
 		var pos = this._getMapPanePos();
 		return pos && !pos.equals([0, 0]);
 	},
 
-	_getTopLeftPoint: function (center, zoom) {
+	_getTopLeftPoint(center, zoom) {
 		var pixelOrigin = center && zoom !== undefined ?
 			this._getNewPixelOrigin(center, zoom) :
 			this.getPixelOrigin();
 		return pixelOrigin.subtract(this._getMapPanePos());
 	},
 
-	_getNewPixelOrigin: function (center, zoom) {
+	_getNewPixelOrigin(center, zoom) {
 		var viewHalf = this.getSize()._divideBy(2);
 		return this.project(center, zoom)._subtract(viewHalf)._add(this._getMapPanePos())._round();
 	},
 
-	_latLngToNewLayerPoint: function (latlng, zoom, center) {
+	_latLngToNewLayerPoint(latlng, zoom, center) {
 		var topLeft = this._getNewPixelOrigin(center, zoom);
 		return this.project(latlng, zoom)._subtract(topLeft);
 	},
 
 	// layer point of the current center
-	_getCenterLayerPoint: function () {
+	_getCenterLayerPoint() {
 		return this.containerPointToLayerPoint(this.getSize()._divideBy(2));
 	},
 
 	// offset of the specified place to the current center in pixels
-	_getCenterOffset: function (latlng) {
+	_getCenterOffset(latlng) {
 		return this.latLngToLayerPoint(latlng).subtract(this._getCenterLayerPoint());
 	},
 
 	// adjust center for view to get inside bounds
-	_limitCenter: function (center, zoom, bounds) {
+	_limitCenter(center, zoom, bounds) {
 
 		if (!bounds) { return center; }
 
@@ -1437,7 +1437,7 @@ export var Map = Evented.extend({
 	},
 
 	// adjust offset for view to get inside bounds
-	_limitOffset: function (offset, bounds) {
+	_limitOffset(offset, bounds) {
 		if (!bounds) { return offset; }
 
 		var viewBounds = this.getPixelBounds(),
@@ -1447,7 +1447,7 @@ export var Map = Evented.extend({
 	},
 
 	// returns offset needed for pxBounds to get inside maxBounds at a specified zoom
-	_getBoundsOffset: function (pxBounds, maxBounds, zoom) {
+	_getBoundsOffset(pxBounds, maxBounds, zoom) {
 		var projectedMaxBounds = toBounds(
 		        this.project(maxBounds.getNorthEast(), zoom),
 		        this.project(maxBounds.getSouthWest(), zoom)
@@ -1461,13 +1461,13 @@ export var Map = Evented.extend({
 		return new Point(dx, dy);
 	},
 
-	_rebound: function (left, right) {
+	_rebound(left, right) {
 		return left + right > 0 ?
 			Math.round(left - right) / 2 :
 			Math.max(0, Math.ceil(left)) - Math.max(0, Math.floor(right));
 	},
 
-	_limitZoom: function (zoom) {
+	_limitZoom(zoom) {
 		var min = this.getMinZoom(),
 		    max = this.getMaxZoom(),
 		    snap = isAny3D ? this.options.zoomSnap : 1;
@@ -1477,16 +1477,16 @@ export var Map = Evented.extend({
 		return Math.max(min, Math.min(max, zoom));
 	},
 
-	_onPanTransitionStep: function () {
+	_onPanTransitionStep() {
 		this.fire('move');
 	},
 
-	_onPanTransitionEnd: function () {
+	_onPanTransitionEnd() {
 		L.DomUtil.removeClass(this._mapPane, 'leaflet-pan-anim');
 		this.fire('moveend');
 	},
 
-	_tryAnimatedPan: function (center, options) {
+	_tryAnimatedPan(center, options) {
 		// difference between the new and current centers in pixels
 		var offset = this._getCenterOffset(center)._floor();
 
@@ -1498,7 +1498,7 @@ export var Map = Evented.extend({
 		return true;
 	},
 
-	_createAnimProxy: function () {
+	_createAnimProxy() {
 
 		var proxy = this._proxy = L.DomUtil.create('div', 'leaflet-proxy leaflet-zoom-animated');
 		this._panes.mapPane.appendChild(proxy);
@@ -1522,17 +1522,17 @@ export var Map = Evented.extend({
 		}, this);
 	},
 
-	_catchTransitionEnd: function (e) {
+	_catchTransitionEnd(e) {
 		if (this._animatingZoom && e.propertyName.indexOf('transform') >= 0) {
 			this._onZoomTransitionEnd();
 		}
 	},
 
-	_nothingToAnimate: function () {
+	_nothingToAnimate() {
 		return !this._container.getElementsByClassName('leaflet-zoom-animated').length;
 	},
 
-	_tryAnimatedZoom: function (center, zoom, options) {
+	_tryAnimatedZoom(center, zoom, options) {
 
 		if (this._animatingZoom) { return true; }
 
@@ -1558,7 +1558,7 @@ export var Map = Evented.extend({
 		return true;
 	},
 
-	_animateZoom: function (center, zoom, startAnim, noUpdate) {
+	_animateZoom(center, zoom, startAnim, noUpdate) {
 		if (startAnim) {
 			this._animatingZoom = true;
 
@@ -1581,7 +1581,7 @@ export var Map = Evented.extend({
 		setTimeout(bind(this._onZoomTransitionEnd, this), 250);
 	},
 
-	_onZoomTransitionEnd: function () {
+	_onZoomTransitionEnd() {
 		if (!this._animatingZoom) { return; }
 
 		L.DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');


### PR DESCRIPTION
This uses Rich Harris' [Bublé](https://buble.surge.sh/guide/) in order to use "Object shorthand methods and properties", so instead of

```
var foo = L.Class.extend({
    method: function(par1, par2) {
         ...
    }
});
```

One can write:

```
var foo = L.Class.extend({
    method(par1, par2) {
         ...
    }
});
```

...thus saving a few bytes on the ES6 code.

We might also want to use things like default values for function parameters, arrow functions, and other things that transpile well.

cc @mourner