### PR TITLE
docs: Fix path of Code Coverage report page on CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ To generate a detailed report about test coverage (which helps tremendously when
 jake test --cov
 ```
 
-After that, open `spec/coverage/<environment>/index.html` in a browser to see the report.
+After that, open `coverage/<environment>/index.html` in a browser to see the report.
 From there you can click through folders/files to get details on their individual coverage.
 
 ## Improving Documentation


### PR DESCRIPTION
Hello,

When I run

`jake test --cov`

command, the coverage folder is created on the Leaflet folder. Also on .gitignore file it is written as belonging to Leaflet folder, not to spec folder. However, on CONTRIBUTING.md the path of the report page is `spec/coverage/<environment>/index.html`. This pull request attempts to fix this documentation problem. 



