### PR TITLE
Fix doc: add clarification for projection; closes #4817

### DIFF
--- a/src/geo/projection/Projection.leafdoc
+++ b/src/geo/projection/Projection.leafdoc
@@ -8,9 +8,9 @@ a flat surface (and back). See [Map projection](http://en.wikipedia.org/wiki/Map
 The bounds where the projection is valid
 
 @method project(latlng: LatLng): Point
-Projects geographical coordinates into a 2D point.
+Projects geographical coordinates into a 2D point. Only accepts actual `L.LatLng` instances, not arrays.
 
 @method unproject(point: Point): LatLng
-The inverse of `project`. Projects a 2D point into a geographical location.
+The inverse of `project`. Projects a 2D point into a geographical location. Only accepts actual `L.Point` instances, not arrays.
 
 

--- a/src/geometry/Transformation.js
+++ b/src/geometry/Transformation.js
@@ -29,7 +29,7 @@ L.Transformation = function (a, b, c, d) {
 L.Transformation.prototype = {
 	// @method transform(point: Point, scale?: Number): Point
 	// Returns a transformed point, optionally multiplied by the given scale.
-	// Only accepts real `L.Point` instances, not arrays.
+	// Only accepts actual `L.Point` instances, not arrays.
 	transform: function (point, scale) { // (Point, Number) -> Point
 		return this._transform(point.clone(), scale);
 	},
@@ -44,7 +44,7 @@ L.Transformation.prototype = {
 
 	// @method untransform(point: Point, scale?: Number): Point
 	// Returns the reverse transformation of the given point, optionally divided
-	// by the given scale. Only accepts real `L.Point` instances, not arrays.
+	// by the given scale. Only accepts actual `L.Point` instances, not arrays.
 	untransform: function (point, scale) {
 		scale = scale || 1;
 		return new L.Point(


### PR DESCRIPTION
Adds clarification in the documentation that specifies that the`project` and `unproject` methods cannot take in arrays, but only real `L.point` instances.

This is my first time trying to add a fix to an open-source project, so I hope I got the workflow down okay. I have used Leaflet in the past, but never actually touched this specific method. I hope I didn't misunderstand the Issue.

Closes #4817 