### PR TITLE
Fix #5011 (canvas remove+add)

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -157,4 +157,36 @@ describe('Canvas', function () {
 		});
 	});
 
+	it('removes vector on next animation frame', function (done) {
+		var layer = L.circle([0, 0]).addTo(map),
+		    layerId = L.stamp(layer),
+		    canvas = map.getRenderer(layer);
+
+		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+
+		map.removeLayer(layer);
+		// Defer check due to how Canvas renderer manages layer removal.
+		L.Util.requestAnimFrame(function () {
+			expect(canvas._layers.hasOwnProperty(layerId)).to.be(false);
+			done();
+		}, this);
+	});
+
+	it('adds vectors even if they have been removed just before', function (done) {
+		var layer = L.circle([0, 0]).addTo(map),
+		    layerId = L.stamp(layer),
+		    canvas = map.getRenderer(layer);
+
+		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+
+		map.removeLayer(layer);
+		map.addLayer(layer);
+		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+		// Re-perform a deferred check due to how Canvas renderer manages layer removal.
+		L.Util.requestAnimFrame(function () {
+			expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+			done();
+		}, this);
+	});
+
 });

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -89,7 +89,9 @@ L.Canvas = L.Renderer.extend({
 		this._layers[L.stamp(layer)] = layer;
 	},
 
-	_addPath: L.Util.falseFn,
+	_addPath: function (layer) {
+		layer._removed = false;
+	},
 
 	_removePath: function (layer) {
 		layer._removed = true;


### PR DESCRIPTION
Bug when using map option `preferCanvas: true` (canvas renderer for paths) and removing then adding back a vector within the same animation frame (typically in the same sequence, as done by Leaflet.markercluster at `"zoomend"` event, to remove layers and clusters outside visible bounds).

This commit clears the `_removed` flag from paths when they are added to the canvas.

Also added corresponding test suites.

Note: Leaflet #5011 was moved to https://github.com/Leaflet/Leaflet.markercluster/issues/727 due to bug being initially visible only with MCG plugin.

Demo of result: http://playground-leaflet.rhcloud.com/waw/1/edit?html,output