### PR TITLE
Prevent canvas from firing multiple mouseover for same layer.

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -286,15 +286,19 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_handleMouseHover: function (e, point) {
-		var id, layer;
+		var id, layer, candidateHoveredLayer;
 
 		for (id in this._drawnLayers) {
 			layer = this._drawnLayers[id];
 			if (layer.options.interactive && layer._containsPoint(point)) {
-				L.DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
-				this._fireEvent([layer], e, 'mouseover');
-				this._hoveredLayer = layer;
+				candidateHoveredLayer = layer;
 			}
+		}
+
+		if (candidateHoveredLayer && candidateHoveredLayer !== this._hoveredLayer) {
+			L.DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
+			this._fireEvent([candidateHoveredLayer], e, 'mouseover');
+			this._hoveredLayer = candidateHoveredLayer;
 		}
 
 		if (this._hoveredLayer) {


### PR DESCRIPTION
Also, fire mouseover for at most one layer for every mousemove,
preventing overlapping features from firing multiple
mouseover/mouseout (#4495).

The only problem I can see is that there's no reliable order of which layer will fire mousover when layers overlap. Since `drawnLayers` is just a hash, it will just use the last one it finds when iterating. I think it's still a great improvement over the current situation.

Close #5028. Close #4495.