### PR TITLE
Fix canvas redraw when style updates fill and/or weight

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -229,7 +229,7 @@ L.Canvas = L.Renderer.extend({
 
 		ctx.globalCompositeOperation = clear ? 'destination-out' : 'source-over';
 
-		if (options.fill) {
+		if (options.fill || clear) {
 			ctx.globalAlpha = clear ? 1 : options.fillOpacity;
 			ctx.fillStyle = options.fillColor || options.color;
 			ctx.fill(options.fillRule || 'evenodd');


### PR DESCRIPTION
Close #5031.

This treats all features as if they had `fill: true` when clearing. I'm not that familiar with this piece of the code, but it seems clear that in this particular issue (#5031) the problem is that it's just the outline that is cleared, not the area inside.