### PR TITLE
Events performance refactoring

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -3,6 +3,7 @@ var deps = {
 		src: ['Leaflet.js',
 		      'core/Util.js',
 		      'core/Class.js',
+          'core/ListenerCollection.js',
 		      'core/Events.js',
 		      'core/Browser.js',
 		      'geometry/Point.js',

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -603,5 +603,4 @@ describe('Events', function () {
 			expect(obj.listens('test')).to.be(false);
 		});
 	});
-
 });

--- a/spec/suites/core/ListenerCollectionSpec.js
+++ b/spec/suites/core/ListenerCollectionSpec.js
@@ -1,0 +1,525 @@
+describe('ListenerCollection', function () {
+
+	describe('#initialize', function () {
+		it('initializes the collection type to array', function () {
+			var obj = new L.ListenerCollection();
+			expect(obj._arrayMembers).to.be(true);
+		});
+
+		it('initializes the internal collection as an array', function () {
+			var obj = new L.ListenerCollection();
+			expect(Array.isArray(obj._members)).to.be(true);
+		});
+	});
+
+	describe('#_switchToArray', function () {
+		it('does nothing if _members is an array', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+
+			expect(Array.isArray(obj._members)).to.be(true);
+			expect(obj._switchToArray()).to.be(false);
+		});
+
+		it('returns true when called', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj._switchToObject();
+
+			expect(obj._switchToArray()).to.be(true);
+		});
+
+		it('switches _members to an array', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj._switchToObject();
+
+			expect(Array.isArray(obj._members)).to.be(false);
+			obj._switchToArray();
+			expect(Array.isArray(obj._members)).to.be(true);
+		});
+
+		it('deletes _count', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj._switchToObject();
+
+			expect(obj._count).to.be(1);
+			obj._switchToArray();
+			expect(obj._count).to.be(undefined);
+		});
+
+		it('changes _arrayMembers to true', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj._switchToObject();
+
+			expect(obj._arrayMembers).to.be(false);
+			obj._switchToArray();
+			expect(obj._arrayMembers).to.be(true);
+		});
+
+		it('keeps the right count()', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+			obj._switchToObject();
+
+			expect(obj.count()).to.be(3);
+			obj._switchToArray();
+			expect(obj.count()).to.be(3);
+		});
+
+		it('finds all the listeners before and after switching', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+			obj._switchToObject();
+
+			expect(obj.find(l1)).to.be(l1);
+			expect(obj.find(l2)).to.be(l2);
+			expect(obj.find(l3)).to.be(l3);
+			obj._switchToArray();
+			expect(obj.find(l1)).to.be(l1);
+			expect(obj.find(l2)).to.be(l2);
+			expect(obj.find(l3)).to.be(l3);
+		});
+	});
+
+	describe('#_switchToObject', function () {
+		it('does nothing if _members is an object', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj._switchToObject();
+			expect(Array.isArray(obj._members)).to.be(false);
+			expect(obj._switchToObject()).to.be(false);
+		});
+
+		it('returns true when called', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+
+			expect(obj._switchToObject()).to.be(true);
+		});
+
+		it('switches _members to an object', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+
+			expect(Array.isArray(obj._members)).to.be(true);
+			obj._switchToObject();
+			expect(Array.isArray(obj._members)).to.be(false);
+		});
+
+		it('creates the field _count', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+
+			expect(obj._count).to.be(undefined);
+			obj._switchToObject();
+			expect(obj._count).to.be(1);
+		});
+
+		it('changes _arrayMembers to false', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			obj.add(l1);
+
+			expect(obj._arrayMembers).to.be(true);
+			obj._switchToObject();
+			expect(obj._arrayMembers).to.be(false);
+		});
+
+		it('keeps the right count()', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+
+			expect(obj.count()).to.be(3);
+			obj._switchToObject();
+			expect(obj.count()).to.be(3);
+		});
+
+		it('finds all the listeners before and after switching', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+
+			expect(obj.find(l1)).to.be(l1);
+			expect(obj.find(l2)).to.be(l2);
+			expect(obj.find(l3)).to.be(l3);
+			obj._switchToObject();
+			expect(obj.find(l1)).to.be(l1);
+			expect(obj.find(l2)).to.be(l2);
+			expect(obj.find(l3)).to.be(l3);
+		});
+	});
+
+	describe('#_sameListener', function () {
+		it('is false if first fn different from second fn', function () {
+			var obj = new L.ListenerCollection(),
+			    spy1 = sinon.spy(),
+			    spy2 = sinon.spy(),
+			    l1 = {fn: spy1},
+			    l2 = {fn: spy2};
+			expect(obj._sameListener(l1, l2)).to.be(false);
+		});
+
+		it('is true if first fn equals second fn', function () {
+			var obj = new L.ListenerCollection(),
+			    spy1 = sinon.spy(),
+			    l1 = {fn: spy1},
+			    l2 = {fn: spy1};
+			expect(obj._sameListener(l1, l2)).to.be(true);
+		});
+
+		it('is false if same fn but different contexts', function () {
+			var obj = new L.ListenerCollection(),
+			    spy1 = sinon.spy(),
+			    l1 = {fn: spy1, ctx:{}},
+			    l2 = {fn: spy1, ctx:{}};
+			expect(obj._sameListener(l1, l2)).to.be(false);
+		});
+
+		it('is true if same fn and same context', function () {
+			var obj = new L.ListenerCollection(),
+			    spy1 = sinon.spy(),
+			    ctx = {},
+			    l1 = {fn: spy1, ctx:ctx},
+			    l2 = {fn: spy1, ctx:ctx};
+			expect(obj._sameListener(l1, l2)).to.be(true);
+		});
+	});
+
+	describe('#find', function () {
+
+		it('returns null if collection is empty', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()};
+			expect(obj.find(l1)).to.be(null);
+		});
+
+		it('returns null if no listener found', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()};
+			obj.add(l1);
+			expect(obj.find(l2)).to.be(null);
+		});
+
+		it('returns the listener object if found (with members as array)', function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+			expect(obj.find(l2)).to.be(l2);
+		});
+
+		it('returns the listener object if found (with _members as object)', function () {
+			var obj = new L.ListenerCollection();
+			for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until we are sure _members has switched to an object
+				obj.add({fn: sinon.spy()});
+			}
+			var l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()},
+			    l3 = {fn: sinon.spy()};
+			obj.add(l1);
+			obj.add(l2);
+			obj.add(l3);
+			expect(obj.find(l2)).to.be(l2);
+		});
+	});
+
+	describe('#add', function () {
+		describe('with _members as array', function () {
+			it('adds a new listener', function () {
+				var obj = new L.ListenerCollection();
+				var c = obj.count();
+				expect(obj.add({fn: sinon.spy()})).to.be(true);
+				expect(obj.count()).to.be(c + 1);
+			});
+
+			it('adds a listener with the same fn of another but different ctx', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx1 = {},
+				    ctx2 = {};
+				obj.add({fn: fn, ctx: ctx1});
+				var c = obj.count();
+				expect(obj.add({fn: fn, ctx: ctx2})).to.be(true);
+				expect(obj.count()).to.be(c + 1);
+			});
+
+			it('does not add a listener with the same fn of another one', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx1 = {},
+				    ctx2 = {};
+				obj.add({fn: fn});
+				var c = obj.count();
+				expect(obj.add({fn: fn})).to.be(false);
+				expect(obj.count()).to.be(c);
+			});
+
+			it('does not add a listener with the same fn and ctx of another one', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx = {};
+				obj.add({fn: fn, ctx: ctx});
+				var c = obj.count();
+				expect(obj.add({fn: fn, ctx: ctx})).to.be(false);
+				expect(obj.count()).to.be(c);
+			});
+
+			it('switches _members to object if needed', function () {
+				var obj = new L.ListenerCollection();
+				obj._switchToObject = sinon.spy();
+				for (var i = 0; i < L.ListenerCollection.MAX_ARRAY; i++) {
+					obj.add({fn: sinon.spy()});
+				}
+				expect(obj._switchToObject.called).to.be(false);
+				obj.add({fn: sinon.spy()});
+				expect(obj._switchToObject.calledOnce).to.be(true);
+			});
+		});
+
+		describe('with _members as object', function () {
+			it('adds a new listener', function () {
+				var obj = new L.ListenerCollection();
+				for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until _members becomes an object
+					obj.add({fn: sinon.spy()});
+				}
+				var c = obj.count();
+				expect(obj.add({fn: sinon.spy()})).to.be(true);
+				expect(obj.count()).to.be(c + 1);
+			});
+
+			it('adds a listener with the same fn of another but different ctx', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx1 = {},
+				    ctx2 = {};
+				for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until _members becomes an object
+					obj.add({fn: sinon.spy()});
+				}
+				obj.add({fn: fn, ctx: ctx1});
+				var c = obj.count();
+				expect(obj.add({fn: fn, ctx: ctx2})).to.be(true);
+				expect(obj.count()).to.be(c + 1);
+			});
+
+			it('does not add a listener with the same fn of another one', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx1 = {},
+				    ctx2 = {};
+				for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until _members becomes an object
+					obj.add({fn: sinon.spy()});
+				}
+				obj.add({fn: fn});
+				var c = obj.count();
+				expect(obj.add({fn: fn})).to.be(false);
+				expect(obj.count()).to.be(c);
+			});
+
+			it('does not add a listener with the same fn and ctx of another one', function () {
+				var obj = new L.ListenerCollection(),
+				    fn = sinon.spy(),
+				    ctx = {};
+				for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until _members becomes an object
+					obj.add({fn: sinon.spy()});
+				}
+				obj.add({fn: fn, ctx: ctx});
+				var c = obj.count();
+				expect(obj.add({fn: fn, ctx: ctx})).to.be(false);
+				expect(obj.count()).to.be(c);
+			});
+		});
+	});
+
+	describe('#count', function () {
+		it('returns 0 if empty', function () {
+			var obj = new L.ListenerCollection();
+			expect(obj.count()).to.be(0);
+		});
+
+		it('returns the number of listeners', function () {
+			var obj = new L.ListenerCollection();
+			obj.add({fn: sinon.spy()});
+			obj.add({fn: sinon.spy()});
+			obj.add({fn: sinon.spy()});
+			expect(obj.count()).to.be(3);
+		});
+
+		it('returns the number of listeners when _members is an array', function () {
+			var obj = new L.ListenerCollection();
+			for (var i = 0; i < L.ListenerCollection.MIN_OBJECT - 1; i++) { // add elements while we are sure _members remains an array
+				obj.add({fn: sinon.spy()});
+			}
+			expect(obj.count()).to.be(L.ListenerCollection.MIN_OBJECT - 1);
+		});
+
+		it('returns the number of listeners when using an object internally', function () {
+			var obj = new L.ListenerCollection();
+			for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until we are sure _members has switched to an object
+				obj.add({fn: sinon.spy()});
+			}
+			expect(obj.count()).to.be(L.ListenerCollection.MAX_ARRAY + 1);
+		});
+	});
+
+	describe('#remove', function () {
+		it('does not remove a listener if collection is empty', function () {
+			var obj = new L.ListenerCollection();
+			expect(obj.remove({fn: sinon.spy()})).to.be(false);
+			expect(obj.count()).to.be(0);
+		});
+
+		it('does not remove a listener if not found, with _members as array', function () {
+			var obj = new L.ListenerCollection();
+			obj.add({fn: sinon.spy()});
+			obj.add({fn: sinon.spy()});
+			obj.add({fn: sinon.spy()});
+			expect(obj.remove({fn: sinon.spy()})).to.be(false);
+			expect(obj.count()).to.be(3);
+		});
+
+		it('does not remove a listener if not found, with _members as object', function () {
+			var obj = new L.ListenerCollection();
+			for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until we are sure _members has switched to an object
+				obj.add({fn: sinon.spy()});
+			}
+			expect(obj.remove({fn: sinon.spy()})).to.be(false);
+			expect(obj.count()).to.be(L.ListenerCollection.MAX_ARRAY + 1);
+		});
+
+		it('removes a listener if found, with _members as array', function () {
+			var obj = new L.ListenerCollection(),
+			    lis1 = {fn: sinon.spy()},
+			    lis2 = {fn: sinon.spy()},
+			    lis3 = {fn: sinon.spy()};
+			obj.add(lis1);
+			obj.add(lis2);
+			obj.add(lis3);
+			var c = obj.count();
+			expect(obj.find(lis1)).to.be(lis1);
+			expect(obj.find(lis2)).to.be(lis2);
+			expect(obj.find(lis3)).to.be(lis3);
+			expect(obj.remove(lis2)).to.be(true);
+			expect(obj.count()).to.be(c - 1);
+			expect(obj.find(lis1)).to.be(lis1);
+			expect(obj.find(lis2)).to.be(null);
+			expect(obj.find(lis3)).to.be(lis3);
+		});
+
+		it('removes a listener if found, with _members as object', function () {
+			var obj = new L.ListenerCollection(),
+			    lis1 = {fn: sinon.spy()},
+			    lis2 = {fn: sinon.spy()},
+			    lis3 = {fn: sinon.spy()};
+			for (var i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) { // add elements until we are sure _members has switched to an object
+				obj.add({fn: sinon.spy()});
+			}
+			obj.add(lis1);
+			obj.add(lis2);
+			obj.add(lis3);
+			var c = obj.count();
+			expect(obj.find(lis1)).to.be(lis1);
+			expect(obj.find(lis2)).to.be(lis2);
+			expect(obj.find(lis3)).to.be(lis3);
+			expect(obj.remove(lis2)).to.be(true);
+			expect(obj.count()).to.be(c - 1);
+			expect(obj.find(lis1)).to.be(lis1);
+			expect(obj.find(lis2)).to.be(null);
+			expect(obj.find(lis3)).to.be(lis3);
+		});
+
+		it('switches back _members to an array if needed', function () {
+			var obj = new L.ListenerCollection(),
+			    lisArray = [],
+			    i = 0;
+			obj._switchToArray = sinon.spy();
+			for (i = 0; i < L.ListenerCollection.MAX_ARRAY + 1; i++) {
+				var lis = {fn: sinon.spy()};
+				lisArray.push(lis);
+				obj.add(lis);
+			}
+			for (i = 0; i < lisArray.length - L.ListenerCollection.MIN_OBJECT; i++) {
+				obj.remove(lisArray[i]);
+			}
+			expect(obj._switchToArray.called).to.be(false);
+			expect(obj.count()).to.be(L.ListenerCollection.MIN_OBJECT);
+			obj.remove(lisArray[i + 1]);
+			expect(obj._switchToArray.calledOnce).to.be(true);
+		});
+	});
+
+	describe('#_listenerId', function () {
+		it("returns a string id", function () {
+			var obj = new L.ListenerCollection(),
+			    lis = {fn: sinon.spy(), ctx: {}};
+			expect(typeof obj._listenerId(lis)).to.be("string");
+		});
+
+		it("returns different ids for listeners with different fn", function () {
+			var obj = new L.ListenerCollection(),
+			    l1 = {fn: sinon.spy()},
+			    l2 = {fn: sinon.spy()};
+			expect(obj._listenerId(l1)).to.not.be(obj._listenerId(l2));
+		});
+
+		it("returns different ids for listeners with same fn and different ctx", function () {
+			var obj = new L.ListenerCollection(),
+			    fn = sinon.spy(),
+			    l1 = {fn: fn, ctx: {}},
+			    l2 = {fn: fn, ctx: {}};
+			expect(obj._listenerId(l1)).to.not.be(obj._listenerId(l2));
+		});
+
+		it("returns the same id for listeners with same fn", function () {
+			var obj = new L.ListenerCollection(),
+			    fn = sinon.spy(),
+			    l1 = {fn: fn},
+			    l2 = {fn: fn};
+			expect(obj._listenerId(l1)).to.be(obj._listenerId(l2));
+		});
+
+		it("returns the same id for listeners with same fn and same ctx", function () {
+			var obj = new L.ListenerCollection(),
+			    fn = sinon.spy(),
+			    ctx = {},
+			    l1 = {fn: fn, ctx: ctx},
+			    l2 = {fn: fn, ctx: ctx};
+			expect(obj._listenerId(l1)).to.be(obj._listenerId(l2));
+		});
+	});
+
+});

--- a/src/core/ListenerCollection.js
+++ b/src/core/ListenerCollection.js
@@ -1,0 +1,128 @@
+/*
+ * @class ListenerCollection
+ * @aka L.ListenerCollection
+ * @inherits Class
+ *
+ * A collection of listener, each one defined as an object with a function 'fn' and an optional context 'ctx'
+ *
+ * All collection members are considered equal by reference equality between their 'fn' and 'ctx' fields
+ */
+
+
+L.ListenerCollection = L.Class.extend({
+
+	statics: {
+		MAX_ARRAY: 30, // Maximum number of listeners before switching _members to object
+		MIN_OBJECT: 20 // Minimum number of listeners before switching back _members to array
+	},
+
+	// @constructor L.ListenerCollection()
+	initialize: function () {
+		this._arrayMembers = true;
+		this._members = [];
+	},
+
+	// @method count(): Number
+	// Returns the number of members inside the collection
+	count: function () {
+		if (this._arrayMembers) { return this._members.length; }
+		return this._count;
+	},
+
+	// @method add(listener: Object): Boolean
+	// Add a listener object to the collection if it doesn't exist.
+	// Returns true if the listener was added; returns false otherwise.
+	add: function (listener) {
+		if (this.find(listener) === null) {
+			if (this._arrayMembers) {
+				this._members.push(listener);
+			} else {
+				this._members[this._listenerId(listener)] = listener;
+				this._count++;
+			}
+			if (this.count() > L.ListenerCollection.MAX_ARRAY) {
+				this._switchToObject();
+			}
+			return true;
+		}
+		return false;
+	},
+
+	// @method remove(listener: Object): Boolean
+	// Remove a listener object to the collection if it exists.
+	// Returns true if the listener was removed; returns false otherwise.
+	remove: function (listener) {
+		if (this._arrayMembers) {
+			for (var i = 0; i < this._members.length; i++) {
+				if (this._sameListener(this._members[i], listener)) {
+					this._members.splice(i, 1);
+					return true;
+				}
+			}
+		} else {
+			var lid = this._listenerId(listener);
+			if (this._members[lid]) {
+				delete this._members[lid];
+				this._count--;
+				if (this.count() < L.ListenerCollection.MIN_OBJECT) {
+					this._switchToArray();
+				}
+				return true;
+			}
+		}
+		return false;
+	},
+
+	// @method find(listener: Object): Object
+	// Find and return a listener object from the collection if it exists, otherwise return null.
+	find: function (listener) {
+		if (this._arrayMembers) {
+			for (var i = 0; i < this._members.length; i++) {
+				if (this._sameListener(this._members[i], listener)) {
+					return this._members[i];
+				}
+			}
+		} else {
+			return this._members[this._listenerId(listener)] || null;
+		}
+		return null;
+	},
+
+	// Switches the internal data structure used to store the members to an object
+	_switchToObject: function () {
+		if (!this._arrayMembers) { return false; }
+		var tmp = this._members;
+		this._members = {};
+		this._count = tmp.length;
+		for (var i = 0; i < tmp.length; i++) {
+			this._members[this._listenerId(tmp[i])] = tmp[i];
+		}
+		this._arrayMembers = false;
+		return true;
+	},
+
+	// Switches the internal data structure used to store the members to an array
+	_switchToArray: function () {
+		if (this._arrayMembers) { return false; }
+		var tmp = this._members;
+		this._members = [];
+		delete this._count;
+		for (var k in tmp) {
+			if (tmp.hasOwnProperty(k)) {
+				this._members.push(tmp[k]);
+			}
+		}
+		this._arrayMembers = true;
+		return true;
+	},
+
+	// Returns an id for a listener
+	_listenerId: function (listener) {
+		return 'id_' + L.stamp(listener.fn) + (listener.ctx && ('_' + L.stamp(listener.ctx)) || '');
+	},
+
+	// Returns `true` if two listeners have the same fn and ctx.
+	_sameListener: function (l1, l2) {
+		return l1.fn === l2.fn && l1.ctx === l2.ctx;
+	},
+});

--- a/src/core/ListenerCollection.js
+++ b/src/core/ListenerCollection.js
@@ -33,11 +33,12 @@ L.ListenerCollection = L.Class.extend({
 	// Add a listener object to the collection if it doesn't exist.
 	// Returns true if the listener was added; returns false otherwise.
 	add: function (listener) {
+		var mbr = this._members;
 		if (this.find(listener) === null) {
 			if (this._arrayMembers) {
-				this._members.push(listener);
+				mbr.push(listener);
 			} else {
-				this._members[this._listenerId(listener)] = listener;
+				mbr[this._listenerId(listener)] = listener;
 				this._count++;
 			}
 			if (this.count() > L.ListenerCollection.MAX_ARRAY) {
@@ -52,17 +53,20 @@ L.ListenerCollection = L.Class.extend({
 	// Remove a listener object to the collection if it exists.
 	// Returns true if the listener was removed; returns false otherwise.
 	remove: function (listener) {
+		var mbr = this._members;
 		if (this._arrayMembers) {
-			for (var i = 0; i < this._members.length; i++) {
-				if (this._sameListener(this._members[i], listener)) {
-					this._members.splice(i, 1);
+			for (var i = 0; i < mbr.length; i++) {
+				if (this._sameListener(mbr[i], listener)) {
+					mbr[i].fn = L.Util.falseFn; // Set fn to noop so that's not called if remove happens in fire
+					mbr.splice(i, 1);
 					return true;
 				}
 			}
 		} else {
 			var lid = this._listenerId(listener);
-			if (this._members[lid]) {
-				delete this._members[lid];
+			if (mbr[lid]) {
+				mbr[lid].fn = L.Util.falseFn; // Set fn to noop so that's not called if remove happens in fire
+				delete mbr[lid];
 				this._count--;
 				if (this.count() < L.ListenerCollection.MIN_OBJECT) {
 					this._switchToArray();
@@ -73,19 +77,66 @@ L.ListenerCollection = L.Class.extend({
 		return false;
 	},
 
+	// @method removeAll(): Boolean
+	// Remove all the listener objects from the collection.
+	// Returns true if the listeners were removed, false if the collection was empty
+	removeAll: function () {
+		if (this.count() === 0) { return false; }
+		this.each(function (listener) {
+			listener.fn = L.Util.falseFn;
+		});
+		delete this._count;
+		this.initialize();
+		return true;
+	},
+
+	// @method cloneMembers()
+	// Copy the _members data structure, keeping the same members
+	copyMembers: function () {
+		if (this._arrayMembers) {
+			this._members = this._members.slice();
+		} else {
+			var tmp = this._members;
+			this._members = {};
+			for (var key in tmp) {
+				if (tmp.hasOwnProperty(key)) {
+					this._members[key] = tmp[key];
+				}
+			}
+		}
+	},
+
 	// @method find(listener: Object): Object
 	// Find and return a listener object from the collection if it exists, otherwise return null.
 	find: function (listener) {
+		var mbr = this._members;
 		if (this._arrayMembers) {
-			for (var i = 0; i < this._members.length; i++) {
-				if (this._sameListener(this._members[i], listener)) {
-					return this._members[i];
+			for (var i = 0; i < mbr.length; i++) {
+				if (this._sameListener(mbr[i], listener)) {
+					return mbr[i];
 				}
 			}
 		} else {
-			return this._members[this._listenerId(listener)] || null;
+			return mbr[this._listenerId(listener)] || null;
 		}
 		return null;
+	},
+
+	// @method each(fn: Function)
+	// Iterates over all the listeners, invoking fn at each step, with the current listener passed as a parameter
+	each: function (fn) {
+		var mbr = this._members;
+		if (this._arrayMembers) {
+			for (var i = 0; i < mbr.length; i++) {
+				fn(mbr[i]);
+			}
+		} else {
+			for (var id in mbr) {
+				if (mbr.hasOwnProperty(id)) {
+					fn(mbr[id]);
+				}
+			}
+		}
 	},
 
 	// Switches the internal data structure used to store the members to an object


### PR DESCRIPTION
This pull request should fix the #5044, solving the optimization issue with many event listeners.

To to this I created a ListenerCollection class, which aggregates and manages event listeners, and replaced  each `this._event[type]` array with an object of type `L.ListenerCollection` 

While adding less than  L.ListenerCollection.MAX_ARRAY listeners, the ListenerCollection acts as a normal array. When adding more listeners, the behaviour is switched to an hash with constant access time (but more memory is used).

In a similar way, when removing elements down to L.ListenerCollection.MIN_OBJECT listeners, the ListenerCollection switches its behaviour back to an array.

I kept MAX_ARRAY and MIN_OBJECT values separated to avoid an obscillating switching effect between array an hash behaviours.

The class is tested with 100% coverage. I didn't remove any test (just added them) and I tried to keep the behaviour exactly as it was before.

It should work but in a single day I didn't have the time to test it in production, or to benchmark the performances, so it may be not production-ready yet.

Tomorrow I will test performances in a production environment and I will benchmark everything.

In the meantime, I'll appreciate any feedback.

I'm open to see this get rejected: there aren't breaking changes but it's a big refactoring, and I'm not sure you want to keep it.