### PR TITLE
Refactor L.Path _update and _project into L.Renderer so that no event handling is needed

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -35,8 +35,6 @@ L.Canvas = L.Renderer.extend({
 	onAdd: function () {
 		L.Renderer.prototype.onAdd.call(this);
 
-		this._layers = this._layers || {};
-
 		// Redraw vectors since canvas is cleared upon removal,
 		// in case of removing the renderer itself from the map.
 		this._draw();

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -76,12 +76,10 @@ L.Path = L.Layer.extend({
 		this._renderer._initPath(this);
 		this._reset();
 		this._renderer._addPath(this);
-		this._renderer.on('update', this._update, this);
 	},
 
 	onRemove: function () {
 		this._renderer._removePath(this);
-		this._renderer.off('update', this._update, this);
 	},
 
 	// @method redraw(): this

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -84,13 +84,6 @@ L.Path = L.Layer.extend({
 		this._renderer.off('update', this._update, this);
 	},
 
-	getEvents: function () {
-		return {
-			zoomend: this._project,
-			viewreset: this._reset
-		};
-	},
-
 	// @method redraw(): this
 	// Redraws the layer. Sometimes useful after you changed the coordinates that the path uses.
 	redraw: function () {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -32,6 +32,7 @@ L.Renderer = L.Layer.extend({
 	initialize: function (options) {
 		L.setOptions(this, options);
 		L.stamp(this);
+		this._layers = this._layers || {};
 	},
 
 	onAdd: function () {
@@ -55,7 +56,8 @@ L.Renderer = L.Layer.extend({
 		var events = {
 			viewreset: this._reset,
 			zoom: this._onZoom,
-			moveend: this._update
+			moveend: this._update,
+			zoomend: this._onZoomEnd
 		};
 		if (this._zoomAnimated) {
 			events.zoomanim = this._onAnimZoom;
@@ -91,6 +93,16 @@ L.Renderer = L.Layer.extend({
 	_reset: function () {
 		this._update();
 		this._updateTransform(this._center, this._zoom);
+
+		for (var id in this._layers) {
+			this._layers[id]._reset();
+		}
+	},
+
+	_onZoomEnd: function () {
+		for (var id in this._layers) {
+			this._layers[id]._project();
+		}
 	},
 
 	_update: function () {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -46,10 +46,12 @@ L.Renderer = L.Layer.extend({
 
 		this.getPane().appendChild(this._container);
 		this._update();
+		this.on('update', this._updatePaths, this);
 	},
 
 	onRemove: function () {
 		L.DomUtil.remove(this._container);
+		this.off('update', this._updatePaths, this);
 	},
 
 	getEvents: function () {
@@ -102,6 +104,12 @@ L.Renderer = L.Layer.extend({
 	_onZoomEnd: function () {
 		for (var id in this._layers) {
 			this._layers[id]._project();
+		}
+	},
+
+	_updatePaths: function () {
+		for (var id in this._layers) {
+			this._layers[id]._update();
 		}
 	},
 

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -99,6 +99,7 @@ L.SVG = L.Renderer.extend({
 		}
 
 		this._updateStyle(layer);
+		this._layers[L.stamp(layer)] = layer;
 	},
 
 	_addPath: function (layer) {
@@ -109,6 +110,7 @@ L.SVG = L.Renderer.extend({
 	_removePath: function (layer) {
 		L.DomUtil.remove(layer._path);
 		layer.removeInteractiveTarget(layer._path);
+		delete this._layers[L.stamp(layer)];
 	},
 
 	_updatePath: function (layer) {


### PR DESCRIPTION
An alternative approach to #5044 - if the problem is that every path hooks up two events, then simply remove the event logic altogether.