### PR TITLE
Move attribution option and getAttribution to L.Layer

### DIFF
--- a/debug/map/image-overlay.html
+++ b/debug/map/image-overlay.html
@@ -35,7 +35,8 @@
 
 		var overlay = new L.ImageOverlay("https://www.lib.utexas.edu/maps/historical/newark_nj_1922.jpg", bounds, {
 			opacity: 0.5,
-			interactive: true
+			interactive: true,
+			attribution: '&copy; A.B.B Corp.'
 		});
 		map.addLayer(overlay);
 

--- a/debug/vector/geojson.html
+++ b/debug/vector/geojson.html
@@ -136,10 +136,10 @@
 
 		geojson = L.geoJson(statesData, {
 			style: style,
-			onEachFeature: onEachFeature
+			onEachFeature: onEachFeature,
+			attribution: 'Population data &copy; <a href="http://census.gov/">US Census Bureau</a>'
 		});
 
-		geojson.getAttribution = function() { return 'Population data &copy; <a href="http://census.gov/">US Census Bureau</a>' };
 		geojson.addTo(map);
 
 

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -31,10 +31,6 @@ L.ImageOverlay = L.Layer.extend({
 		// If `true`, the image overlay will emit [mouse events](#interactive-layer) when clicked or hovered.
 		interactive: false,
 
-		// @option attribution: String = null
-		// An optional string containing HTML to be shown on the `Attribution control`
-		attribution: null,
-
 		// @option crossOrigin: Boolean = false
 		// If true, the image will have its crossOrigin attribute set to ''. This is needed if you want to access image pixel data.
 		crossOrigin: false
@@ -126,10 +122,6 @@ L.ImageOverlay = L.Layer.extend({
 			this._reset();
 		}
 		return this;
-	},
-
-	getAttribution: function () {
-		return this.options.attribution;
 	},
 
 	getEvents: function () {

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -31,7 +31,11 @@ L.Layer = L.Evented.extend({
 		// @option pane: String = 'overlayPane'
 		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
 		pane: 'overlayPane',
-		nonBubblingEvents: []  // Array of events that should not be bubbled to DOM parents (like the map)
+		nonBubblingEvents: [],  // Array of events that should not be bubbled to DOM parents (like the map),
+
+		// @option attribution: String = null
+		// String to be shown in the attribution control, describes the layer data, e.g. "© Mapbox".
+		attribution: null,
 	},
 
 	/* @section
@@ -74,6 +78,12 @@ L.Layer = L.Evented.extend({
 	removeInteractiveTarget: function (targetEl) {
 		delete this._map._targets[L.stamp(targetEl)];
 		return this;
+	},
+
+	// @method getAttribution: String
+	// Used by the `attribution control`, returns the [attribution option](#gridlayer-attribution).
+	getAttribution: function () {
+		return this.options.attribution;
 	},
 
 	_layerAdd: function (e) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -89,10 +89,6 @@ L.GridLayer = L.Layer.extend({
 		// Tiles will not update more than once every `updateInterval` milliseconds when panning.
 		updateInterval: 200,
 
-		// @option attribution: String = null
-		// String to be shown in the attribution control, describes the layer data, e.g. "© Mapbox".
-		attribution: null,
-
 		// @option zIndex: Number = 1
 		// The explicit zIndex of the tile layer.
 		zIndex: 1,
@@ -172,12 +168,6 @@ L.GridLayer = L.Layer.extend({
 			this._setAutoZIndex(Math.min);
 		}
 		return this;
-	},
-
-	// @method getAttribution: String
-	// Used by the `attribution control`, returns the [attribution option](#gridlayer-attribution).
-	getAttribution: function () {
-		return this.options.attribution;
 	},
 
 	// @method getContainer: HTMLElement


### PR DESCRIPTION
Since we now have a common base class for all layers, we can easily allow all layers to add attribution, not just `GridLayer` and `ImageOverlay`. This fixes #5051, since also `L.GeoJSON` can add attribution.

This PR moves the `attribution` option and the `getAttribution` method to `L.Layer`. I also updated some of the debug pages to reflect this change.