### PR TITLE
Adding background-clip to .leaflet-bar

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -261,6 +261,7 @@
 .leaflet-bar {
 	box-shadow: 0 1px 5px rgba(0,0,0,0.65);
 	border-radius: 4px;
+	background-clip: padding-box;
 	}
 .leaflet-bar a,
 .leaflet-bar a:hover {


### PR DESCRIPTION
Issue #2012 covers mobile devices

Leaflet/Leaflet.draw#629 detected an issue with svg in .leaflet-bar for retina or 'zoomed in' on chrome that would ignore scaling when using negative background positions.