### PR TITLE
Always create L.Control.Layers as collapsed; expand if collapse option not set

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -128,4 +128,16 @@ describe("Control.Layers", function () {
 		});
 	});
 
+	describe("is created with an expand link", function ()  {
+		it("when collapsed", function () {
+			var layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			expect(map._container.querySelector('.leaflet-control-layers-toggle')).to.be.ok();
+		});
+
+		it("when not collapsed", function () {
+			var layersCtrl = L.control.layers(null, null, {collapsed: false}).addTo(map);
+			expect(map._container.querySelector('.leaflet-control-layers-toggle')).to.be.ok();
+		});
+	});
+
 });

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -153,34 +153,34 @@ L.Control.Layers = L.Control.extend({
 
 		var form = this._form = L.DomUtil.create('form', className + '-list');
 
-		if (this.options.collapsed) {
-			if (!L.Browser.android) {
-				L.DomEvent.on(container, {
-					mouseenter: this.expand,
-					mouseleave: this.collapse
-				}, this);
-			}
-
-			var link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
-			link.href = '#';
-			link.title = 'Layers';
-
-			if (L.Browser.touch) {
-				L.DomEvent
-				    .on(link, 'click', L.DomEvent.stop)
-				    .on(link, 'click', this.expand, this);
-			} else {
-				L.DomEvent.on(link, 'focus', this.expand, this);
-			}
-
-			// work around for Firefox Android issue https://github.com/Leaflet/Leaflet/issues/2033
-			L.DomEvent.on(form, 'click', function () {
-				setTimeout(L.bind(this._onInputClick, this), 0);
+		if (!L.Browser.android) {
+			L.DomEvent.on(container, {
+				mouseenter: this.expand,
+				mouseleave: this.collapse
 			}, this);
+		}
 
-			this._map.on('click', this.collapse, this);
-			// TODO keyboard accessibility
+		var link = this._layersLink = L.DomUtil.create('a', className + '-toggle', container);
+		link.href = '#';
+		link.title = 'Layers';
+
+		if (L.Browser.touch) {
+			L.DomEvent
+			    .on(link, 'click', L.DomEvent.stop)
+			    .on(link, 'click', this.expand, this);
 		} else {
+			L.DomEvent.on(link, 'focus', this.expand, this);
+		}
+
+		// work around for Firefox Android issue https://github.com/Leaflet/Leaflet/issues/2033
+		L.DomEvent.on(form, 'click', function () {
+			setTimeout(L.bind(this._onInputClick, this), 0);
+		}, this);
+
+		this._map.on('click', this.collapse, this);
+		// TODO keyboard accessibility
+
+		if (!this.options.collapsed) {
 			this.expand();
 		}
 


### PR DESCRIPTION
This is an alternative fix for #5073. @IvanSanchez's fix is in #5074. This is minor details, but it seemed a bit easier to me to avoid any state for fixing this.

I've tested both approaches with the example provided in #5073 and they both do their job.