### PR TITLE
Support for MinNativeZoom in TileLayer

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -378,4 +378,93 @@ describe('TileLayer', function () {
 			});
 		});
 	});
+
+	describe('minNativeZoom', function () {
+		before(function () {
+			div = document.createElement('div');
+			div.style.width = '400px';
+			div.style.height = '400px';
+			div.style.visibility = 'hidden';
+
+			document.body.appendChild(div);
+
+			map = L.map(div).setView([0, 0], 0);
+		});
+
+		it('returns downscaled tileSize when zoom is lower than minNativeZoom (zoom = 0, minNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				minNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 0);
+			expect(map.getZoom()).to.equal(0);
+			expect(layer.getTileSize().x).to.equal(128);
+			expect(layer.getTileSize().y).to.equal(128);
+		});
+
+		it('returns regular tileSize when zoom is equal to minNativeZoom (zoom = 1, minNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				minNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 1);
+			expect(map.getZoom()).to.equal(1);
+			expect(layer.getTileSize().x).to.equal(256);
+			expect(layer.getTileSize().y).to.equal(256);
+		});
+
+		it('returns regular tileSize when zoom is greater than minNativeZoom (zoom = 2, minNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				minNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 2);
+			expect(map.getZoom()).to.equal(2);
+			expect(layer.getTileSize().x).to.equal(256);
+			expect(layer.getTileSize().y).to.equal(256);
+		});
+	});
+
+	describe('maxNativeZoom', function () {
+		before(function () {
+			div = document.createElement('div');
+			div.style.width = '400px';
+			div.style.height = '400px';
+			div.style.visibility = 'hidden';
+
+			document.body.appendChild(div);
+
+			map = L.map(div).setView([0, 0], 0);
+		});
+
+		it('returns upscaled tileSize when zoom is higher than maxNativeZoom (zoom = 2, maxNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				maxNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 2);
+			expect(layer.getTileSize().x).to.equal(512);
+			expect(layer.getTileSize().y).to.equal(512);
+		});
+
+		it('returns regular tileSize when zoom is equal to minNativeZoom (zoom = 1, maxNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				maxNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 1);
+			expect(layer.getTileSize().x).to.equal(256);
+			expect(layer.getTileSize().y).to.equal(256);
+		});
+
+		it('returns regular tileSize when zoom is lower than minNativeZoom (zoom = 0, maxNativeZoom = 1)', function () {
+			var layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+				maxNativeZoom: 1,
+				tileSize: 256
+			}).addTo(map);
+			map.setView([0, 0], 0);
+			expect(layer.getTileSize().x).to.equal(256);
+			expect(layer.getTileSize().y).to.equal(256);
+		});
+	});
 });

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -235,7 +235,6 @@ L.TileLayer = L.GridLayer.extend({
 			return minNativeZoom;
 		}
 
-		// increase tile size when scaling above maxNativeZoom
 		if (maxNativeZoom !== null && zoom > maxNativeZoom) {
 			return maxNativeZoom;
 		}

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -48,6 +48,12 @@ L.TileLayer = L.GridLayer.extend({
 		// from `maxNativeZoom` level and auto-scaled.
 		maxNativeZoom: null,
 
+		// @option minNativeZoom: Number = null
+		// Minimum zoom number the tile source has available. If it is specified,
+		// the tiles on all zoom levels lower than `minNativeZoom` will be loaded
+		// from `minNativeZoom` level and auto-scaled.
+		minNativeZoom: null,
+
 		// @option subdomains: String|String[] = 'abc'
 		// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.
 		subdomains: 'abc',
@@ -191,12 +197,20 @@ L.TileLayer = L.GridLayer.extend({
 		var map = this._map,
 		    tileSize = L.GridLayer.prototype.getTileSize.call(this),
 		    zoom = this._tileZoom + this.options.zoomOffset,
-		    zoomN = this.options.maxNativeZoom;
+			minNativeZoom = this.options.minNativeZoom,
+		    maxNativeZoom = this.options.maxNativeZoom;
 
-		// increase tile size when overscaling
-		return zoomN !== null && zoom > zoomN ?
-				tileSize.divideBy(map.getZoomScale(zoomN, zoom)).round() :
-				tileSize;
+		// decrease tile size when scaling below minNativeZoom
+		if (minNativeZoom !== null && zoom < minNativeZoom) {
+			return tileSize.divideBy(map.getZoomScale(minNativeZoom, zoom)).round();
+		}
+
+		// increase tile size when scaling above maxNativeZoom
+		if(maxNativeZoom !== null && zoom > maxNativeZoom){
+			return tileSize.divideBy(map.getZoomScale(maxNativeZoom, zoom)).round();
+		}
+
+		return tileSize;
 	},
 
 	_onTileRemove: function (e) {
@@ -204,17 +218,29 @@ L.TileLayer = L.GridLayer.extend({
 	},
 
 	_getZoomForUrl: function () {
+		var zoom = this._tileZoom,
+			maxZoom = this.options.maxZoom,
+			zoomReverse = this.options.zoomReverse,
+			zoomOffset = this.options.zoomOffset,
+			minNativeZoom = this.options.minNativeZoom,
+			maxNativeZoom = this.options.maxNativeZoom;
 
-		var options = this.options,
-		    zoom = this._tileZoom;
-
-		if (options.zoomReverse) {
-			zoom = options.maxZoom - zoom;
+		if (zoomReverse) {
+			zoom = maxZoom - zoom;
 		}
 
-		zoom += options.zoomOffset;
+		zoom += zoomOffset;
 
-		return options.maxNativeZoom !== null ? Math.min(zoom, options.maxNativeZoom) : zoom;
+		if (minNativeZoom !== null && zoom < minNativeZoom) {
+			return minNativeZoom;
+		}
+
+		// increase tile size when scaling above maxNativeZoom
+		if(maxNativeZoom !== null && zoom > maxNativeZoom) {
+			return maxNativeZoom;
+		}
+
+		return zoom;
 	},
 
 	_getSubdomain: function (tilePoint) {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -195,10 +195,10 @@ L.TileLayer = L.GridLayer.extend({
 
 	getTileSize: function () {
 		var map = this._map,
-		    tileSize = L.GridLayer.prototype.getTileSize.call(this),
-		    zoom = this._tileZoom + this.options.zoomOffset,
-			minNativeZoom = this.options.minNativeZoom,
-		    maxNativeZoom = this.options.maxNativeZoom;
+		tileSize = L.GridLayer.prototype.getTileSize.call(this),
+		zoom = this._tileZoom + this.options.zoomOffset,
+		minNativeZoom = this.options.minNativeZoom,
+		maxNativeZoom = this.options.maxNativeZoom;
 
 		// decrease tile size when scaling below minNativeZoom
 		if (minNativeZoom !== null && zoom < minNativeZoom) {
@@ -206,7 +206,7 @@ L.TileLayer = L.GridLayer.extend({
 		}
 
 		// increase tile size when scaling above maxNativeZoom
-		if(maxNativeZoom !== null && zoom > maxNativeZoom){
+		if (maxNativeZoom !== null && zoom > maxNativeZoom) {
 			return tileSize.divideBy(map.getZoomScale(maxNativeZoom, zoom)).round();
 		}
 
@@ -219,11 +219,11 @@ L.TileLayer = L.GridLayer.extend({
 
 	_getZoomForUrl: function () {
 		var zoom = this._tileZoom,
-			maxZoom = this.options.maxZoom,
-			zoomReverse = this.options.zoomReverse,
-			zoomOffset = this.options.zoomOffset,
-			minNativeZoom = this.options.minNativeZoom,
-			maxNativeZoom = this.options.maxNativeZoom;
+		maxZoom = this.options.maxZoom,
+		zoomReverse = this.options.zoomReverse,
+		zoomOffset = this.options.zoomOffset,
+		minNativeZoom = this.options.minNativeZoom,
+		maxNativeZoom = this.options.maxNativeZoom;
 
 		if (zoomReverse) {
 			zoom = maxZoom - zoom;
@@ -236,7 +236,7 @@ L.TileLayer = L.GridLayer.extend({
 		}
 
 		// increase tile size when scaling above maxNativeZoom
-		if(maxNativeZoom !== null && zoom > maxNativeZoom) {
+		if (maxNativeZoom !== null && zoom > maxNativeZoom) {
 			return maxNativeZoom;
 		}
 


### PR DESCRIPTION
Since we shared a similar use case to Mapbox, I went ahead and implemented minNativeZoom in the TileLayer. The idea is the same as described in: https://github.com/Leaflet/Leaflet/issues/3165 and it's linked mapbox issue at https://github.com/mapbox/mapbox.js/pull/1182.

I've also added unit tests for minNativeZoom as well as maxNativeZoom.