### PR TITLE
A11y fixes from #3210

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -79,6 +79,12 @@ L.Control.Zoom = L.Control.extend({
 		link.href = '#';
 		link.title = title;
 
+		/*
+		 * Will force screen readers like VoiceOver to read this as "Zoom in - button"
+		 */
+		link.setAttribute('role', 'button');
+		link.setAttribute('aria-label', title);
+
 		L.DomEvent
 		    .on(link, 'mousedown dblclick', L.DomEvent.stopPropagation)
 		    .on(link, 'click', L.DomEvent.stop)

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -140,6 +140,12 @@ L.TileLayer = L.GridLayer.extend({
 		*/
 		tile.alt = '';
 
+		/*
+		 Set role="presentation" to force screen readers to ignore this
+		 https://www.w3.org/TR/wai-aria/roles#textalternativecomputation
+		*/
+		tile.setAttribute('role', 'presentation');
+
 		tile.src = this.getTileUrl(coords);
 
 		return tile;


### PR DESCRIPTION
This implements a few basic fixes I suggested in https://github.com/Leaflet/Leaflet/issues/3210#issuecomment-258918073.

This should do 2 things:

1. Add the standards based way to force screen readers to ignore images with `role="presenation"` in addition to an empty `alt` tag.
2. Add proper ARIA role and label to Zoom buttons. This makes VoiceOver read them as "Zoom in - button" as opposed to "+ - link". I an not sure if this will improve JAWs as well but it should.