### PR TITLE
Remove layer from map before calling onRemove

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -173,6 +173,8 @@ L.Map.include({
 
 		if (!this._layers[id]) { return this; }
 
+		delete this._layers[id];
+
 		if (this._loaded) {
 			layer.onRemove(this);
 		}
@@ -180,8 +182,6 @@ L.Map.include({
 		if (layer.getAttribution && this.attributionControl) {
 			this.attributionControl.removeAttribution(layer.getAttribution());
 		}
-
-		delete this._layers[id];
 
 		if (this._loaded) {
 			this.fire('layerremove', {layer: layer});


### PR DESCRIPTION
This makes sure that the popupclose event fires with an actually closed popup.
function onPopupClose (e) {
  e.popup.isOpen(); // Previously, this would be true
}