### PR TITLE
Class name option for layer control items

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -215,12 +215,15 @@ L.Control.Layers = L.Control.extend({
 		}
 	},
 
-	_addLayer: function (layer, name, overlay) {
+	_addLayer: function (obj, name, overlay) {
+		var layer = obj instanceof L.Layer ? obj : obj.layer;
+
 		layer.on('add remove', this._onLayerChange, this);
 
 		this._layers.push({
 			layer: layer,
 			name: name,
+			className: obj.className,
 			overlay: overlay
 		});
 
@@ -304,6 +307,10 @@ L.Control.Layers = L.Control.extend({
 		var label = document.createElement('label'),
 		    checked = this._map.hasLayer(obj.layer),
 		    input;
+
+		if (obj.className) {
+			label.className = obj.className;
+		}
 
 		if (obj.overlay) {
 			input = document.createElement('input');


### PR DESCRIPTION
I ran into an issue where I had to indent some of the layers in the layer control. This PR makes it possible to pass a class name for every item added to the layer control. The class name will be set on the label for the item in the list of layers.

With this PR the layer passed to the layer control can be replaced by an object with the following structure:
`{ layer: layer, className: className }`
