### PR TITLE
Canvas improvements

### DIFF
--- a/debug/vector/moving-canvas.html
+++ b/debug/vector/moving-canvas.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script type="text/javascript">
+
+		var osmUrl = 'http://api.tiles.mapbox.com/v4/mapbox.light/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibGllZG1hbiIsImEiOiI3ZGFmOGI2ZWY0MTAyYzUyMjAxNjcxYjQzZjRkYzM3MSJ9.XoFXhnx2eXp0DJwL3aEzZg',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var map = L.map('map', {preferCanvas: true})
+				.setView([50.5, 30.51], 15)
+				.addLayer(osm);
+
+		var markers = [];
+		var colors = ['red', 'green', 'blue', 'purple', 'cyan', 'yellow'];
+		for (var i = 0; i < 20; i++) {
+			markers.push(L.circleMarker([50.5, 30.51], {color: colors[i % colors.length]}).addTo(map));
+		}
+
+		function update() {
+			var t = new Date().getTime() / 1000;
+			markers.forEach(function(marker, i) {
+				var v = t * (1 + i / 10) + (12.5 * i) / 180 * Math.PI;
+				marker.setLatLng([
+					50.5 + (i % 2 ? 1 : -1) * Math.sin(v) * 0.005,
+					30.51 + (i % 3 ? 1 : -1) * Math.cos(v) * 0.005,
+					]);
+			});
+
+			L.Util.requestAnimFrame(update);
+		}
+
+		update();
+	</script>
+</body>
+</html>

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -145,7 +145,8 @@ L.Canvas = L.Renderer.extend({
 	_clear: function() {
 		var bounds = this._redrawBounds;
 		if (bounds) {
-			this._ctx.clearRect(bounds.min.x, bounds.min.y, bounds.max.x - bounds.min.x, bounds.max.y - bounds.min.y);
+			var size = bounds.getSize();
+			this._ctx.clearRect(bounds.min.x, bounds.min.y, size.x, size.y);
 		} else {
 			this._ctx.clearRect(0, 0, this._container.width, this._container.height);
 		}
@@ -155,8 +156,9 @@ L.Canvas = L.Renderer.extend({
 		var layer, bounds = this._redrawBounds;
 		this._ctx.save();
 		if (bounds) {
+			var size = bounds.getSize();
 			this._ctx.beginPath();
-			this._ctx.rect(bounds.min.x, bounds.min.y, bounds.max.x - bounds.min.x, bounds.max.y - bounds.min.y);
+			this._ctx.rect(bounds.min.x, bounds.min.y, size.x - 1, size.y);
 			this._ctx.clip();
 		}
 
@@ -230,7 +232,7 @@ L.Canvas = L.Renderer.extend({
 	_fillStroke: function (ctx, layer) {
 		var options = layer.options;
 
-		ctx.globalCompositeOperation = 'source-over';
+		//ctx.globalCompositeOperation = 'source-over';
 
 		if (options.fill) {
 			ctx.globalAlpha = options.fillOpacity;
@@ -240,10 +242,7 @@ L.Canvas = L.Renderer.extend({
 
 		if (options.stroke && options.weight !== 0) {
 			ctx.globalAlpha = options.opacity;
-
-			// if clearing shape, do it with the previously drawn line width
-			layer._prevWeight = ctx.lineWidth = options.weight;
-
+			ctx.lineWidth = options.weight;
 			ctx.strokeStyle = options.color;
 			ctx.lineCap = options.lineCap;
 			ctx.lineJoin = options.lineJoin;

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -152,7 +152,7 @@ L.Canvas = L.Renderer.extend({
 		this._redrawBounds = null;
 	},
 
-	_clear: function() {
+	_clear: function () {
 		var bounds = this._redrawBounds;
 		if (bounds) {
 			var size = bounds.getSize();
@@ -187,7 +187,7 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_updatePoly: function (layer, closed) {
-		if (!this._drawing) return;
+		if (!this._drawing) { return; }
 
 		var i, j, len2, p,
 		    parts = layer._parts,

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -53,11 +53,12 @@ L.Canvas = L.Renderer.extend({
 
 	_updatePaths: function () {
 		var layer;
+		this._redrawBounds = null;
 		for (var id in this._layers) {
 			layer = this._layers[id];
 			layer._update();
-			this._requestRedraw(layer);
 		}
+		this._redraw();
 	},
 
 	_update: function () {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -115,8 +115,16 @@ L.Canvas = L.Renderer.extend({
 		var next = order.next;
 		var prev = order.prev;
 
-		if (next) { next.prev = prev; }
-		if (prev) { prev.next = next; }
+		if (next) {
+			next.prev = prev;
+		} else {
+			this._drawLast = prev;
+		}
+		if (prev) {
+			prev.next = next;
+		} else {
+			this._drawFirst = next;
+		}
 
 		delete layer._order;
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -160,7 +160,7 @@ L.Canvas = L.Renderer.extend({
 		this._redrawRequest = this._redrawRequest || L.Util.requestAnimFrame(this._redraw, this);
 	},
 
-	_extendRedrawBounds(layer) {
+	_extendRedrawBounds: function (layer) {
 		var padding = (layer.options.weight || 0) + 1;
 		this._redrawBounds = this._redrawBounds || new L.Bounds();
 		this._redrawBounds.extend(layer._pxBounds.min.subtract([padding, padding]));
@@ -353,7 +353,7 @@ L.Canvas = L.Renderer.extend({
 		this._map._fireDOMEvent(e, type || e.type, layers);
 	},
 
-	_bringToFront: function(layer) {
+	_bringToFront: function (layer) {
 		var order = layer._order;
 		var next = order.next;
 		var prev = order.prev;
@@ -367,7 +367,7 @@ L.Canvas = L.Renderer.extend({
 		if (prev) {
 			prev.next = next;
 		} else if (next) {
-			// Update first entry unless this is the 
+			// Update first entry unless this is the
 			// signle entry
 			this._drawFirst = next;
 		}
@@ -381,7 +381,7 @@ L.Canvas = L.Renderer.extend({
 		this._requestRedraw(layer);
 	},
 
-	_bringToBack: function(layer) {
+	_bringToBack: function (layer) {
 		var order = layer._order;
 		var next = order.next;
 		var prev = order.prev;
@@ -395,7 +395,7 @@ L.Canvas = L.Renderer.extend({
 		if (next) {
 			next.prev = prev;
 		} else if (prev) {
-			// Update last entry unless this is the 
+			// Update last entry unless this is the
 			// signle entry
 			this._drawLast = prev;
 		}

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -294,8 +294,8 @@ L.Canvas = L.Renderer.extend({
 	_onClick: function (e) {
 		var point = this._map.mouseEventToLayerPoint(e), layer, clickedLayer;
 
-		for (var id in this._drawnLayers) {
-			layer = this._layers[id];
+		for (var order = this._drawFirst; order; order = order.next) {
+			layer = order.layer;
 			if (layer.options.interactive && layer._containsPoint(point) && !this._map._draggableMoved(layer)) {
 				clickedLayer = layer;
 			}
@@ -325,10 +325,10 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_handleMouseHover: function (e, point) {
-		var id, layer, candidateHoveredLayer;
+		var layer, candidateHoveredLayer;
 
-		for (id in this._drawnLayers) {
-			layer = this._drawnLayers[id];
+		for (var order = this._drawFirst; order; order = order.next) {
+			layer = order.layer;
 			if (layer.options.interactive && layer._containsPoint(point)) {
 				candidateHoveredLayer = layer;
 			}

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -93,38 +93,23 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_reset: function () {
-		var layer;
-
 		this._update();
 		this._updateTransform(this._center, this._zoom);
 
 		for (var id in this._layers) {
-			layer = this._layers[id];
-			if (!layer._removed) {
-				layer._reset();
-			}
+			this._layers[id]._reset();
 		}
 	},
 
 	_onZoomEnd: function () {
-		var layer;
-
 		for (var id in this._layers) {
-			layer = this._layers[id];
-			if (!layer._removed) {
-				layer._project();
-			}
+			this._layers[id]._project();
 		}
 	},
 
 	_updatePaths: function () {
-		var layer;
-
 		for (var id in this._layers) {
-			layer = this._layers[id];
-			if (!layer._removed) {
-				layer._update();
-			}
+			this._layers[id]._update();
 		}
 	},
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -93,23 +93,38 @@ L.Renderer = L.Layer.extend({
 	},
 
 	_reset: function () {
+		var layer;
+
 		this._update();
 		this._updateTransform(this._center, this._zoom);
 
 		for (var id in this._layers) {
-			this._layers[id]._reset();
+			layer = this._layers[id];
+			if (!layer._removed) {
+				layer._reset();
+			}
 		}
 	},
 
 	_onZoomEnd: function () {
+		var layer;
+
 		for (var id in this._layers) {
-			this._layers[id]._project();
+			layer = this._layers[id];
+			if (!layer._removed) {
+				layer._project();
+			}
 		}
 	},
 
 	_updatePaths: function () {
+		var layer;
+
 		for (var id in this._layers) {
-			this._layers[id]._update();
+			layer = this._layers[id];
+			if (!layer._removed) {
+				layer._update();
+			}
 		}
 	},
 


### PR DESCRIPTION
This makes a lot of changes to how canvas is handled. Primarily:

* Adds canvas support for `bringToFront` and `bringToBack` (close #974)
* Fixes canvas sometimes now redrawing properly (close #5093)
* Fixes canvas calling `_project` on a layer that is no longer on the map (close #5097)
* Fixes canvas not rendering layers which moves significantly (close #5114)
* Theoretically improves performance when redrawing layers on canvas, by using `clearRect` instead of drawing all layers in the paint region twice

This makes some pretty significant changes to how canvas is handled internally, so a thorough review would be good.