### PR TITLE
Sanity check in LatLngBounds.contains (fixes #5132)

### DIFF
--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -138,9 +138,19 @@ describe('LatLngBounds', function () {
 	});
 
 	describe('#contains', function () {
-		it('returns true if contains latlng point', function () {
+		it('returns true if contains latlng point as array', function () {
 			expect(a.contains([16, 20])).to.eql(true);
 			expect(L.latLngBounds(a).contains([5, 20])).to.eql(false);
+		});
+
+		it('returns true if contains latlng point as {lat:, lng:} object', function () {
+			expect(a.contains({lat: 16, lng: 20})).to.eql(true);
+			expect(L.latLngBounds(a).contains({lat: 5, lng: 20})).to.eql(false);
+		});
+
+		it('returns true if contains latlng point as L.LatLng instance', function () {
+			expect(a.contains(L.latLng([16, 20]))).to.eql(true);
+			expect(L.latLngBounds(a).contains(L.latLng([5, 20]))).to.eql(false);
 		});
 
 		it('returns true if contains bounds', function () {

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -150,7 +150,7 @@ L.LatLngBounds.prototype = {
 	// @method contains (latlng: LatLng): Boolean
 	// Returns `true` if the rectangle contains the given point.
 	contains: function (obj) { // (LatLngBounds) or (LatLng) -> Boolean
-		if (typeof obj[0] === 'number' || obj instanceof L.LatLng) {
+		if (typeof obj[0] === 'number' || obj instanceof L.LatLng || 'lat' in obj) {
 			obj = L.latLng(obj);
 		} else {
 			obj = L.latLngBounds(obj);


### PR DESCRIPTION
Note that the new unit tests fail without the fix.