### PR TITLE
Update bounds property in Projection.leafdoc

### DIFF
--- a/src/geo/projection/Projection.leafdoc
+++ b/src/geo/projection/Projection.leafdoc
@@ -5,7 +5,7 @@ An object with methods for projecting geographical coordinates of the world onto
 a flat surface (and back). See [Map projection](http://en.wikipedia.org/wiki/Map_projection).
 
 @property bounds: Bounds
-The bounds where the projection is valid
+The bounds (specified in CRS units) where the projection is valid
 
 @method project(latlng: LatLng): Point
 Projects geographical coordinates into a 2D point. Only accepts actual `L.LatLng` instances, not arrays.

--- a/src/geo/projection/Projection.leafdoc
+++ b/src/geo/projection/Projection.leafdoc
@@ -4,7 +4,7 @@
 An object with methods for projecting geographical coordinates of the world onto
 a flat surface (and back). See [Map projection](http://en.wikipedia.org/wiki/Map_projection).
 
-@property bounds: LatLngBounds
+@property bounds: Bounds
 The bounds where the projection is valid
 
 @method project(latlng: LatLng): Point


### PR DESCRIPTION
To me it appears that the property bounds is expected in the rest of the code to be 'Bounds' and not 'LatLngBounds'. All the included projections pass 'Bounds'. Giving the area where the projection is valid in latlng's did not work for me.