### PR TITLE
Change dependencies to peerDependencies

### DIFF
--- a/PLUGIN-GUIDE.md
+++ b/PLUGIN-GUIDE.md
@@ -148,7 +148,7 @@ Here is an example of a `package.json` file for a Leaflet plugin.
   "main": "my-plugin.js",
   "author": "You",
   "license": "IST",
-  "dependencies": {
+  "peerDependencies": {
     "leaflet": "^1.0.0"
   }
 }


### PR DESCRIPTION
If I some plugin include leaflet to dependencies and I have local version leaflet, then I have two version - leaflet from plugin and my.