### PR TITLE
docstring: grid layer use bounds with noWrap

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -108,7 +108,9 @@ L.GridLayer = L.Layer.extend({
 		// @option noWrap: Boolean = false
 		// Whether the layer is wrapped around the antimeridian. If `true`, the
 		// GridLayer will only be displayed once at low zoom levels. Has no
-		// effect when the [map CRS](#map-crs) doesn't wrap around.
+		// effect when the [map CRS](#map-crs) doesn't wrap around. Can be used
+		// in combination with [`bounds`](#gridlayer-bounds) to prevent requesting
+		// tiles outside the CRS limits.
 		noWrap: false,
 
 		// @option pane: String = 'tilePane'


### PR DESCRIPTION
Following #5154, added mention about using `bounds` on Grid Layer when `noWrap` is used (i.e. set to `true`), in order to prevent requesting tiles outside the main world (CRS limits).

Looks like behaviour changed compared to Leaflet 0.7, where the CRS limits were still effective.

In order to restore that behaviour, application developer must now specify `bounds`.

Especially visible with CartoDB tiles which do serve tiles outside the main world.