### PR TITLE
Remove incrementation of uninitialized typeListeners attribute 'count'

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -114,7 +114,6 @@ L.Evented = L.Class.extend({
 		}
 
 		listeners.push(newListener);
-		typeListeners.count++;
 	},
 
 	_off: function (type, fn, context) {


### PR DESCRIPTION
`typeListeners.count` was removed in an earlier update to event handling, but was still being referenced and producing an error when incremented.

Fixes #5159 