### PR TITLE
Fix unexpected values returned when passing [x, y] arrays to functions in LineUtil

### DIFF
--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -26,6 +26,16 @@ describe('LineUtil', function () {
 			expect(segment2[1]).to.eql(new L.Point(15, 5));
 		});
 
+		it('clips a segment by bounds when a and b are point tuples', function () {
+			var a = [0, 0];
+			var b = [15, 15];
+
+			var segment = L.LineUtil.clipSegment(a, b, bounds);
+
+			expect(segment[0]).to.eql(new L.Point(5, 5));
+			expect(segment[1]).to.eql(new L.Point(10, 10));
+		});
+
 		it('uses last bit code and reject segments out of bounds', function () {
 			var a = new L.Point(15, 15);
 			var b = new L.Point(25, 20);
@@ -53,6 +63,7 @@ describe('LineUtil', function () {
 	describe('#pointToSegmentDistance & #closestPointOnSegment', function () {
 
 		var p1 = new L.Point(0, 10);
+		var p1Tuple = [0, 10];
 		var p2 = new L.Point(10, 0);
 		var p = new L.Point(0, 0);
 
@@ -60,8 +71,16 @@ describe('LineUtil', function () {
 			expect(L.LineUtil.pointToSegmentDistance(p, p1, p2)).to.eql(Math.sqrt(200) / 2);
 		});
 
+		it('calculates a non NaN distance from point to segment when p1 is a tuple', function () {
+			expect(L.LineUtil.pointToSegmentDistance(p, p1Tuple, p2)).to.eql(Math.sqrt(200) / 2);
+		});
+
 		it('calculates point closest to segment', function () {
 			expect(L.LineUtil.closestPointOnSegment(p, p1, p2)).to.eql(new L.Point(5, 5));
+		});
+
+		it('calculates point closest to segment with x and y not set to undefined when p1 is a tuple', function () {
+			expect(L.LineUtil.closestPointOnSegment(p, p1Tuple, p2)).to.eql(new L.Point(5, 5));
 		});
 	});
 
@@ -75,6 +94,26 @@ describe('LineUtil', function () {
 				new L.Point(1, 0),
 				new L.Point(1.999, 0.999),
 				new L.Point(2, 1)
+			];
+
+			var simplified = L.LineUtil.simplify(points, 0.1);
+
+			expect(simplified).to.eql([
+				new L.Point(0, 0),
+				new L.Point(1, 0),
+				new L.Point(2, 1)
+			]);
+		});
+
+		it('simplifies polylines built with point tuples and returns array of leaflet points', function () {
+			var points = [
+				[0, 0],
+				[0.01, 0],
+				[0.5, 0.01],
+				[0.7, 0],
+				[1, 0],
+				[1.999, 0.999],
+				[2, 1]
 			];
 
 			var simplified = L.LineUtil.simplify(points, 0.1);

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -39,7 +39,7 @@ L.LineUtil = {
 		return Math.sqrt(this._sqClosestPointOnSegment(p, p1, p2, true));
 	},
 
-	// @function closestPointOnSegment(p: Point, p1: Point, p2: Point): Number
+	// @function closestPointOnSegment(p: Point, p1: Point, p2: Point): Point
 	// Returns the closest point from a point `p` on a segment `p1` to `p2`.
 	closestPointOnSegment: function (p, p1, p2) {
 		return this._sqClosestPointOnSegment(p, p1, p2);
@@ -61,7 +61,7 @@ L.LineUtil = {
 
 		for (i = 0; i < len; i++) {
 			if (markers[i]) {
-				newPoints.push(points[i]);
+				newPoints.push(L.point(points[i]));
 			}
 		}
 
@@ -113,6 +113,9 @@ L.LineUtil = {
 	// (modifying the segment points directly!). Used by Leaflet to only show polyline
 	// points that are on the screen or near, increasing performance.
 	clipSegment: function (a, b, bounds, useLastCode, round) {
+		a = L.point(a);
+		b = L.point(b);
+
 		var codeA = useLastCode ? this._lastCode : this._getBitCode(a, bounds),
 		    codeB = this._getBitCode(b, bounds),
 
@@ -194,6 +197,9 @@ L.LineUtil = {
 
 	// square distance (to avoid unnecessary Math.sqrt calls)
 	_sqDist: function (p1, p2) {
+		p1 = L.point(p1);
+		p2 = L.point(p2);
+
 		var dx = p2.x - p1.x,
 		    dy = p2.y - p1.y;
 		return dx * dx + dy * dy;
@@ -201,6 +207,10 @@ L.LineUtil = {
 
 	// return closest point on segment or distance to that point
 	_sqClosestPointOnSegment: function (p, p1, p2, sqDist) {
+		p = L.point(p);
+		p1 = L.point(p1);
+		p2 = L.point(p2);
+
 		var x = p1.x,
 		    y = p1.y,
 		    dx = p2.x - x,


### PR DESCRIPTION
According to documentation, functions that accept `Point` will also accept a literal and an array with two numeric values unless otherwise noted. `LineUtil` functions return unexpected results when passing arrays. This commit fixes that and the leafdoc for the return type of `closesPointOnSegment`, which is currently `Number` but should really be `Point`.