### PR TITLE
Fix for wrapping inside the antimeridian (issue #5149)

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -684,8 +684,18 @@ L.GridLayer = L.Layer.extend({
 		    se = map.unproject(sePoint, coords.z);
 
 		if (!this.options.noWrap) {
-			nw = map.wrapLatLng(nw);
-			se = map.wrapLatLng(se);
+			var newNw = map.wrapLatLng(nw);
+			var newSe = map.wrapLatLng(se);
+
+			if (!newNw.equals(nw)) {
+				se.lat += (newNw.lat - nw.lat);
+				se.lng += (newNw.lng - nw.lng);
+				nw = newNw;
+			} else if (!newSe.equals(se)) {
+				nw.lat += (newSe.lat - se.lat);
+				nw.lng += (newSe.lng - se.lng);
+				se = newSe;
+			}
 		}
 
 		return new L.LatLngBounds(nw, se);


### PR DESCRIPTION
Related to issue #5149, check my comment there.

I believe the problem was that, when calling the ```wrapLatLng()``` function, sometimes one of the coordinates was outside the range while the other one was inside (as explained in my last edit in the aforementioned comment). This possible solution would force both points (```nw``` and ```se```) to be moved by the same amount.

This still wouldn't move the blue rectangle in the issue #5149 example to the place of the red rectangle, but that is due to the ```noWrap``` option being set to false by default. If the user wants to select something outside the [-180, 180] longitude range, that option should be set to true.

I am not sure if the code fits the project guidelines in terms of coding practices, so please do correct me if anything is wrong.

Hopefully this is a valid solution. If not, I am definitely available to keep working on it.