### PR TITLE
Implement wrapLatLngBounds (to fix #5149)

### DIFF
--- a/spec/suites/geo/CRSSpec.js
+++ b/spec/suites/geo/CRSSpec.js
@@ -70,6 +70,71 @@ describe("CRS.EPSG3857", function () {
 			expect(crs.wrapLatLng(new L.LatLng(0, 380, 1234)).lng).to.eql(20);
 			expect(crs.wrapLatLng(new L.LatLng(0, 380, 1234)).alt).to.eql(1234);
 		});
+	});
+
+	describe('#wrapLatLngBounds', function () {
+		it("does not wrap bounds between -180 and 180 longitude", function () {
+
+			var bounds1 = L.latLngBounds([-10, -10], [10, 10]);
+			var bounds2 = L.latLngBounds([-80, -180], [-70, -170]);
+			var bounds3 = L.latLngBounds([70, 170], [80, 180]);
+
+			bounds1 = crs.wrapLatLngBounds(bounds1);
+			bounds2 = crs.wrapLatLngBounds(bounds2);
+			bounds3 = crs.wrapLatLngBounds(bounds3);
+
+			expect(bounds1.getSouth()).to.eql(-10);
+			expect(bounds1.getWest()).to.eql(-10);
+			expect(bounds1.getNorth()).to.eql(10);
+			expect(bounds1.getEast()).to.eql(10);
+
+			expect(bounds2.getSouth()).to.eql(-80);
+			expect(bounds2.getWest()).to.eql(-180);
+			expect(bounds2.getNorth()).to.eql(-70);
+			expect(bounds2.getEast()).to.eql(-170);
+
+			expect(bounds3.getSouth()).to.eql(70);
+			expect(bounds3.getWest()).to.eql(170);
+			expect(bounds3.getNorth()).to.eql(80);
+			expect(bounds3.getEast()).to.eql(180);
+
+		});
+
+		it("wraps bounds when center longitude is less than -180", function () {
+			var bounds1 = L.latLngBounds([0, -185], [10, -170]);
+			var bounds2 = L.latLngBounds([0, -190], [10, -175]);
+
+			bounds1 = crs.wrapLatLngBounds(bounds1);
+			bounds2 = crs.wrapLatLngBounds(bounds2);
+
+			expect(bounds1.getSouth()).to.eql(0);
+			expect(bounds1.getWest()).to.eql(-185);
+			expect(bounds1.getNorth()).to.eql(10);
+			expect(bounds1.getEast()).to.eql(-170);
+
+			expect(bounds2.getSouth()).to.eql(0);
+			expect(bounds2.getWest()).to.eql(170);
+			expect(bounds2.getNorth()).to.eql(10);
+			expect(bounds2.getEast()).to.eql(185);
+		});
+
+		it("wraps bounds when center longitude is larger than +180", function () {
+			var bounds1 = L.latLngBounds([0, 185], [10, 170]);
+			var bounds2 = L.latLngBounds([0, 190], [10, 175]);
+
+			bounds1 = crs.wrapLatLngBounds(bounds1);
+			bounds2 = crs.wrapLatLngBounds(bounds2);
+
+			expect(bounds1.getSouth()).to.eql(0);
+			expect(bounds1.getWest()).to.eql(170);
+			expect(bounds1.getNorth()).to.eql(10);
+			expect(bounds1.getEast()).to.eql(185);
+
+			expect(bounds2.getSouth()).to.eql(0);
+			expect(bounds2.getWest()).to.eql(-185);
+			expect(bounds2.getNorth()).to.eql(10);
+			expect(bounds2.getEast()).to.eql(-170);
+		});
 
 	});
 

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -97,11 +97,34 @@ L.CRS = {
 	// @method wrapLatLng(latlng: LatLng): LatLng
 	// Returns a `LatLng` where lat and lng has been wrapped according to the
 	// CRS's `wrapLat` and `wrapLng` properties, if they are outside the CRS's bounds.
+	// Only accepts actual `L.LatLng` instances, not arrays.
 	wrapLatLng: function (latlng) {
 		var lng = this.wrapLng ? L.Util.wrapNum(latlng.lng, this.wrapLng, true) : latlng.lng,
 		    lat = this.wrapLat ? L.Util.wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat,
 		    alt = latlng.alt;
 
 		return L.latLng(lat, lng, alt);
+	}
+
+	// @method wrapLatLngBounds(bounds: LatLngBounds): LatLngBounds
+	// Returns a `LatLngBounds` with the same size as the given one, ensuring
+	// that its center is within the CRS's bounds.
+	// Only accepts actual `L.LatLngBounds` instances, not arrays.
+	wrapLatLngBounds: function (bounds) {
+		var center = bounds.getCenter(),
+		    newCenter = this.wrapLatLng(center),
+		    latShift = center.lat - newCenter.lat,
+		    lngShift = center.lng - newCenter.lng;
+
+		if (latShift === 0 && lngShift === 0) {
+			return bounds;
+		}
+
+		var sw = bounds.getSouthWest(),
+		    ne = bounds.getNorthEast(),
+		    newSw = L.latLng({lat: sw.lat - latShift, lng: sw.lng - lngShift}),
+		    newNe = L.latLng({lat: ne.lat - latShift, lng: ne.lng - lngShift});
+
+		return new L.LatLngBounds(newSw, newNe);
 	}
 };

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -104,7 +104,7 @@ L.CRS = {
 		    alt = latlng.alt;
 
 		return L.latLng(lat, lng, alt);
-	}
+	},
 
 	// @method wrapLatLngBounds(bounds: LatLngBounds): LatLngBounds
 	// Returns a `LatLngBounds` with the same size as the given one, ensuring

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -681,14 +681,14 @@ L.GridLayer = L.Layer.extend({
 		    sePoint = nwPoint.add(tileSize),
 
 		    nw = map.unproject(nwPoint, coords.z),
-		    se = map.unproject(sePoint, coords.z);
+		    se = map.unproject(sePoint, coords.z),
+		    bounds = new L.LatLngBounds(nw, se);
 
 		if (!this.options.noWrap) {
-			nw = map.wrapLatLng(nw);
-			se = map.wrapLatLng(se);
+			map.wrapLatLngBounds(bounds);
 		}
 
-		return new L.LatLngBounds(nw, se);
+		return bounds;
 	},
 
 	// converts tile coordinates to key for the tile cache

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -925,6 +925,16 @@ L.Map = L.Evented.extend({
 		return this.options.crs.wrapLatLng(L.latLng(latlng));
 	},
 
+	// @method wrapLatLngBounds(bounds: LatLngBounds): LatLngBounds
+	// Returns a `LatLngBounds` with the same size as the given one, ensuring that
+	// its center is within the CRS's bounds.
+	// By default this means the center longitude is wrapped around the dateline so its
+	// value is between -180 and +180 degrees, and the majority of the bounds
+	// overlaps the CRS's bounds.
+	wrapLatLngBounds: function (latlng) {
+		return this.options.crs.wrapLatLngBounds(L.latLngBounds(latlng));
+	},
+
 	// @method distance(latlng1: LatLng, latlng2: LatLng): Number
 	// Returns the distance between two geographical coordinates according to
 	// the map's CRS. By default this measures distance in meters.


### PR DESCRIPTION
This is an alternative to #5164 that should also fix #5149.

After looking at @DiogoMCampos 's PR, I think that it would be better to just wrap the center of the bounds. This would ensure that the shifted bounds overlaps as much of the CRS as possible in every scenario.

Also, I think that having this as a separate method would help in other scenarios - namely, preventing lines/polygons from wrapping across the antimeridian.

I'll whip up a few tests if I can find a bit of time.
