### PR TITLE
Flip the order of the 'moveend' and 'viewreset' events in map (fixes #5170)

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1084,12 +1084,12 @@ L.Map = L.Evented.extend({
 		this
 			._moveStart(zoomChanged)
 			._move(center, zoom)
-			._moveEnd(zoomChanged);
 
 		// @event viewreset: Event
 		// Fired when the map needs to redraw its content (this usually happens
 		// on map zoom or load). Very useful for creating custom overlays.
-		this.fire('viewreset');
+			.fire('viewreset')
+			._moveEnd(zoomChanged);
 
 		// @event load: Event
 		// Fired when the map is initialized (when its center and zoom are set


### PR DESCRIPTION
Flipping the order of the `moveend` and `viewreset` events in the map fixes #5170, but I'm not sure if this might have any side effects.

In particular, I don't know if this will be a regression of https://github.com/Leaflet/Leaflet/pull/4193