### PR TITLE
Different _reset methods for Canvas & SVG (fixes #5170)

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -92,6 +92,15 @@ L.Canvas = L.Renderer.extend({
 		this.fire('update');
 	},
 
+	_reset: function () {
+		for (var id in this._layers) {
+			this._layers[id]._reset();
+		}
+
+		this._updateTransform(this._center, this._zoom);
+		this._update();
+	},
+
 	_initPath: function (layer) {
 		this._updateDashArray(layer);
 		this._layers[L.stamp(layer)] = layer;

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -92,15 +92,6 @@ L.Renderer = L.Layer.extend({
 		}
 	},
 
-	_reset: function () {
-		this._update();
-		this._updateTransform(this._center, this._zoom);
-
-		for (var id in this._layers) {
-			this._layers[id]._reset();
-		}
-	},
-
 	_onZoomEnd: function () {
 		for (var id in this._layers) {
 			this._layers[id]._project();

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -82,6 +82,15 @@ L.SVG = L.Renderer.extend({
 		this.fire('update');
 	},
 
+	_reset: function () {
+		this._update();
+		this._updateTransform(this._center, this._zoom);
+
+		for (var id in this._layers) {
+			this._layers[id]._reset();
+		}
+	},
+
 	// methods below are called by vector layers implementations
 
 	_initPath: function (layer) {


### PR DESCRIPTION
An alternative to #5171, this also fixes #5170.

Rather than changing the order of the `L.Map` events, this changes the order of the calls in a `L.Canvas` reset/redraw, to trigger the reprojection of the paths' pixel coordinates **before** drawing them.

Adds a bit more code, but the impact in the rest of the code (with edge cases like the `GridLayer` pruning and so on) should be greatly reduced.