### PR TITLE
Fixes documentation for Map#containerPointToLatLng

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -946,7 +946,7 @@ L.Map = L.Evented.extend({
 		return L.point(point).add(this._getMapPanePos());
 	},
 
-	// @method containerPointToLatLng(point: Point): Point
+	// @method containerPointToLatLng(point: Point): LatLng
 	// Given a pixel coordinate relative to the map container, returns
 	// the corresponding geographical coordinate (for the current zoom level).
 	containerPointToLatLng: function (point) {


### PR DESCRIPTION
`Map#containerPointToLatLng` returns a `LatLng` and not a `Point`. This PR fixes the documentation for that method. Thanks!