### PR TITLE
Be more picky about pointer events (blind attempt to fix #5180)

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -17,6 +17,9 @@ L.extend(L.DomEvent, {
 			var count;
 
 			if (L.Browser.pointer) {
+				if (!L.Browser.edge && e.pointerType === 'mouse') {
+					return;
+				}
 				count = L.DomEvent._pointersCount;
 			} else {
 				count = e.touches.length;

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -50,7 +50,7 @@ L.extend(L.DomEvent, {
 
 	_addPointerStart: function (obj, handler, id) {
 		var onDown = L.bind(function (e) {
-			if (e.pointerType !== 'mouse' && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
+			if (e.pointerType !== 'mouse' && e.MSPOINTER_TYPE_MOUSE && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
 				// In IE11, some touch events needs to fire for form controls, or
 				// the controls will stop working. We keep a whitelist of tag names that
 				// need these events. For other target tags, we prevent default on the event.


### PR DESCRIPTION
This PR aborts the handling of `PointerEvent`s in two cases:

* In `DomEvent.DoubleTap`, do not check for double taps if the event is a pointer event of type `mouse` when not in Edge.
  This gets rid of the synthetic doubleclicks in Chrome >=55. Chrome still needs that code so that Leaflet fires `dblblick`s when using a finger.
  This also means that mouse `dblclick`s in Chrome >=55 are handled by the OS **only**, and touch `dblclick`s are handled by the Leaflet code.

* In `DomEvent.Pointer.js`, skip handling the event if the `pointerType` is a `mouse`. There is an extra check for IE (IE11???) which uses the `e.MSPOINTER_TYPE_MOUSE` constant, which doesn't exist in Chrome. That's what's causing the spurious touch events.

This should fix #5180, hopefully. Testing this PR would help.