### PR TITLE
Fix typo in touch-action CSS rules

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -56,7 +56,7 @@
 .leaflet-container.leaflet-touch-drag {
 	-ms-touch-action: pinch-zoom;
 	}
-.leaflet-container.leaflet-touch-drag.leaflet-touch-drag {
+.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
 	-ms-touch-action: none;
 	touch-action: none;
 }


### PR DESCRIPTION
Apparently @perliedman introduced a very-hard-to-spot typo in the `touch-action` CSS rules in #4552, and nobody noticed until #5180. :disappointed: 