### PR TITLE
Fix L.Browser.pointer for chrome, Edge

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -30,7 +30,7 @@
 
 	    mobile = typeof orientation !== 'undefined' || ua.indexOf('mobile') !== -1,
 	    msPointer = !window.PointerEvent && window.MSPointerEvent,
-	    pointer = window.PointerEvent || msPointer,
+	    pointer = (window.PointerEvent && navigator.maxTouchPoints) || msPointer,
 
 	    ie3d = ie && ('transition' in doc.style),
 	    webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23,


### PR DESCRIPTION
window.PointerEvent is available on chrome, Edge, this makes
L.Browser.pointer true even if there is no pointer.

Keeping navigator.maxTouchPoints as one of the checks does well
across all the browsers.