### PR TITLE
Do not round the point in latLngToLayerPoint

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -911,7 +911,7 @@ L.Map = L.Evented.extend({
 	// Given a geographical coordinate, returns the corresponding pixel coordinate
 	// relative to the [origin pixel](#map-getpixelorigin).
 	latLngToLayerPoint: function (latlng) {
-		var projectedPoint = this.project(L.latLng(latlng))._round();
+		var projectedPoint = this.project(L.latLng(latlng));
 		return projectedPoint._subtract(this.getPixelOrigin());
 	},
 


### PR DESCRIPTION
When moving the something like a marker a very small amount, subpixel `x` and `y` values makes the move more accurate.

This is going to make code [like this](https://github.com/mohsen1/leaflet-moving-marker/blob/master/index.ts#L89-L92) unnecessary: 

```js
            this.setLatLng({lat, lng});
            const rawPoint = this.map.project({lat,lng});
            const point = rawPoint._subtract(this.map.getPixelOrigin());
            L.DomUtil.setPosition(this.getElement(), point);
```

There I had to set marker position again to get subpixed translate values so the animation looks smooth.