### PR TITLE
BUGFIX - Cannot read property 'attributionControl' of null

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -105,8 +105,8 @@ L.Layer = L.Evented.extend({
 
 		this.onAdd(map);
 
-		if (this.getAttribution && this._map.attributionControl) {
-			this._map.attributionControl.addAttribution(this.getAttribution());
+		if (this.getAttribution && map.attributionControl) {
+			map.attributionControl.addAttribution(this.getAttribution());
 		}
 
 		this.fire('add');


### PR DESCRIPTION
I get this exception when tried to open & close a marker popup immediately:
TypeError: Cannot read property 'attributionControl' of null
    at NewClass._layerAdd (http://localhost:8100/build/main.js:20926:39)
    at NewClass.whenReady (http://localhost:8100/build/main.js:20566:13)
    at NewClass.addLayer (http://localhost:8100/build/main.js:20982:8)
    at NewClass.openPopup (http://localhost:8100/build/main.js:24186:15)
    at NewClass.openPopup (http://localhost:8100/build/main.js:24292:14)
    at NewClass._openPopup (http://localhost:8100/build/main.js:24367:9)
    at NewClass.fire (http://localhost:8100/build/main.js:17552:11)
    at NewClass._fireDOMEvent (http://localhost:8100/build/main.js:20541:15)
    at NewClass._handleDOMEvent (http://localhost:8100/build/main.js:20500:8)
    at HTMLDivElement.handler (http://localhost:8100/build/main.js:21164:14)

It runs the following code:
```
_layerAdd: function (e) {
 var map = e.target;

 // check in case layer gets added and then removed before the map is ready
 if (!map.hasLayer(this)) { return; }

 this._map = map;
 this._zoomAnimated = map._zoomAnimated;

 if (this.getEvents) {
  var events = this.getEvents();
  map.on(events, this);
  this.once('remove', function () {
   map.off(events, this);
  }, this);
 }

 this.onAdd(map);

 if (this.getAttribution && this._map.attributionControl) {
  this._map.attributionControl.addAttribution(this.getAttribution());
 }

 this.fire('add');
 map.fire('layeradd', {layer: this});
}
```

but the line:  this.onAdd(map); can make this._map be undefind, like in:
```
...
layer._map = layer._mapToAdd = null;
```

so I replaced it with map instead which must be defined because it is used afterwards as well.