### PR TITLE
Avoid getBoundsZoom return Infinity when using CRS with flipped axis

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -200,6 +200,26 @@ describe("Map", function () {
 			map.options.zoomSnap = 0;
 			expect(map.getBoundsZoom(bounds, false, padding)).to.be.within(19.6864560, 19.6864561);
 		});
+
+		it("getBoundsZoom does not return Infinity when projected SE - NW has negative components", function () {
+			var container = map.getContainer();
+			container.style.height = 369;
+			container.style.width = 1048;
+			document.body.appendChild(container);
+			var bounds = L.latLngBounds(L.latLng([62.18475569507688, 6.926335173954951]), L.latLng([62.140483526511694, 6.923933370740089]));
+
+			// The following coordinates are bounds projected with proj4leaflet crs = EPSG:25833', '+proj=utm +zone=33 +ellps=GRS80 +units=m +no_defs
+			var projectedSE = L.point(7800503.059925064, 6440062.353052008);
+			var projectedNW = L.point(7801987.203481699, 6425186.447901004);
+			var crsMock = sinon.mock(map.options.crs);
+			crsMock.expects("latLngToPoint").withArgs(bounds.getNorthWest()).returns(projectedNW);
+			crsMock.expects("latLngToPoint").withArgs(bounds.getSouthEast()).returns(projectedSE);
+
+
+			var padding = L.point(-50, -50);
+			map.setZoom(16);
+			expect(map.getBoundsZoom(bounds, false, padding)).to.eql(7);
+		});
 	});
 
 	describe('#setMaxBounds', function () {

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -212,9 +212,8 @@ describe("Map", function () {
 			var projectedSE = L.point(7800503.059925064, 6440062.353052008);
 			var projectedNW = L.point(7801987.203481699, 6425186.447901004);
 			var crsMock = sinon.mock(map.options.crs);
-			crsMock.expects("latLngToPoint").withArgs(bounds.getNorthWest()).returns(projectedNW);
-			crsMock.expects("latLngToPoint").withArgs(bounds.getSouthEast()).returns(projectedSE);
-
+			crsMock.expects("project").withArgs(bounds.getNorthWest()).returns(projectedNW);
+			crsMock.expects("project").withArgs(bounds.getSouthEast()).returns(projectedSE);
 
 			var padding = L.point(-50, -50);
 			map.setZoom(16);

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -217,7 +217,7 @@ describe("Map", function () {
 
 			var padding = L.point(-50, -50);
 			map.setZoom(16);
-			expect(map.getBoundsZoom(bounds, false, padding)).to.eql(7);
+			expect(map.getBoundsZoom(bounds, false, padding)).to.eql(9);
 		});
 	});
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -784,7 +784,7 @@ L.Map = L.Evented.extend({
 		    nw = bounds.getNorthWest(),
 		    se = bounds.getSouthEast(),
 		    size = this.getSize().subtract(padding),
-		    boundsSize = this.project(se, zoom).subtract(this.project(nw, zoom)),
+		    boundsSize = L.bounds(this.project(se, zoom), this.project(nw, zoom)).getSize(),
 		    snap = L.Browser.any3d ? this.options.zoomSnap : 1;
 
 		var scale = Math.min(size.x / boundsSize.x, size.y / boundsSize.y);


### PR DESCRIPTION
Create new bounds from projected coordinates rather than subtract in getBoundsZoom to avoid negative scale. Fixes #5195