### PR TITLE
Implemented polyline wrapping

### DIFF
--- a/debug/vector/polyline.html
+++ b/debug/vector/polyline.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Leaflet debug page</title>
+
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+
+    <link rel="stylesheet" href="../css/screen.css" />
+    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../dist/leaflet-src.js"></script>
+</head>
+
+<body>
+    <div id="mapid" style="width: 1000px; height: 700px; border: 1px solid #ccc"></div>
+
+    <script src="route.js"></script>
+    <script>
+        var mymap = L.map('mapid').setView([51.505, -0.09], 1);
+
+        L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpandmbXliNDBjZWd2M2x6bDk3c2ZtOTkifQ._QA7i5Mpkd_m30IGElHziw', {
+            maxZoom: 18,
+            attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
+                '<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
+                'Imagery Â© <a href="http://mapbox.com">Mapbox</a>',
+            id: 'mapbox.streets',
+            noWrap:false
+        }).addTo(mymap);
+
+        var pointA = new L.LatLng(20.00, 140.0);
+        var pointB = new L.LatLng(50.00, -120.0);
+        var pointC = new L.LatLng(70.50, 170.0);
+        var pointList = [pointA, pointB, pointC];
+
+        var firstpolyline = new L.polyline(pointList, {
+            color: 'red',
+            weight: 3,
+            opacity: 0.5,
+            smoothFactor: 1,
+            noWrap:true
+        });
+        firstpolyline.addTo(mymap);
+
+        var pointA = new L.LatLng(90, 180.0);
+        var pointB = new L.LatLng(-90, 180.0);
+        var pointList = [pointA, pointB];
+
+        var idl = new L.polyline(pointList, {
+            color: 'red',
+            weight: 3,
+            opacity: 0.5,
+            smoothFactor: 1,
+            noWrap:false
+        });
+        idl.addTo(mymap);
+
+        var pointA = new L.LatLng(90, -180.0);
+        var pointB = new L.LatLng(-90, -180.0);
+        var pointList = [pointA, pointB];
+        var idl2 = new L.polyline(pointList, {
+            color: 'red',
+            weight: 3,
+            opacity: 0.5,
+            smoothFactor: 1,
+            noWrap:false
+        });
+        idl2.addTo(mymap);
+
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
As discussed on issue  #2645, we have developed an implementation for Polylines that allow for two points to link using the shorter path around the international date line instead of the direct path when the difference between the longitudes of each point is higher than half the size of the CRS bounds (180). This is activated by setting the noWrap variable of the L.polyline object to true. 
However, this is based on hard-coded values of the range. We aren't sure if it is possible to use the wrapLng values of the CRS.Earth file on the geo/crs folder.