### PR TITLE
adds graceful fallback to clientWidth & clinetHeight in getSize

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -803,8 +803,8 @@ L.Map = L.Evented.extend({
 	getSize: function () {
 		if (!this._size || this._sizeChanged) {
 			this._size = new L.Point(
-				this._container.clientWidth,
-				this._container.clientHeight);
+				this._container.clientWidth || 0,
+				this._container.clientHeight || 0);
 
 			this._sizeChanged = false;
 		}


### PR DESCRIPTION
Per #4823 

If `clientWidth` or `clientHeight` are undefined (as might be the case in an environment like jsdom), `L.Point` will return a point with `undefined` or `NaN` coordinates. Since `L.Point` always expects a number to be passed in as an argument, clientWidth and clientHeight can fallback to 0 in case they are undefined.

For further background, check the issue linked above.