### PR TITLE
Fire 'zoomlevelschange' when calling setMinZoom & setMaxZoom.

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -444,10 +444,10 @@ L.Map = L.Evented.extend({
 		this.options.minZoom = zoom;
 
 		if (this._loaded && oldZoom !== zoom) {
+			this.fire('zoomlevelschange');
+			
 			if (this.getZoom() < this.options.minZoom) {
 				return this.setZoom(zoom);
-			} else {
-				this.fire('zoomlevelschange');
 			}
 		}
 
@@ -461,10 +461,10 @@ L.Map = L.Evented.extend({
 		this.options.maxZoom = zoom;
 
 		if (this._loaded && oldZoom !== zoom) {
+			this.fire('zoomlevelschange');
+			
 			if (this.getZoom() > this.options.maxZoom) {
 				return this.setZoom(zoom);
-			} else {
-				this.fire('zoomlevelschange');
 			}
 		}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -440,12 +440,12 @@ L.Map = L.Evented.extend({
 	// @method setMinZoom(zoom: Number): this
 	// Sets the lower limit for the available zoom levels (see the [minZoom](#map-minzoom) option).
 	setMinZoom: function (zoom) {
-		var pZoom = this.options.minZoom;
+		var oldZoom = this.options.minZoom;
 
 		this.options.minZoom = zoom;
 
 		if (this._loaded) {
-			if (pZoom !== zoom) {
+			if (oldZoom !== zoom) {
 				this.fire('zoomlevelschange');
 			}
 
@@ -460,12 +460,12 @@ L.Map = L.Evented.extend({
 	// @method setMaxZoom(zoom: Number): this
 	// Sets the upper limit for the available zoom levels (see the [maxZoom](#map-maxzoom) option).
 	setMaxZoom: function (zoom) {
-		var pZoom = this.options.maxZoom;
+		var oldZoom = this.options.maxZoom;
 
 		this.options.maxZoom = zoom;
 
 		if (this._loaded) {
-			if (pZoom !== zoom) {
+			if (oldZoom !== zoom) {
 				this.fire('zoomlevelschange');
 			}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -445,7 +445,7 @@ L.Map = L.Evented.extend({
 
 		if (this._loaded && oldZoom !== zoom) {
 			this.fire('zoomlevelschange');
-			
+
 			if (this.getZoom() < this.options.minZoom) {
 				return this.setZoom(zoom);
 			}
@@ -462,7 +462,7 @@ L.Map = L.Evented.extend({
 
 		if (this._loaded && oldZoom !== zoom) {
 			this.fire('zoomlevelschange');
-			
+
 			if (this.getZoom() > this.options.maxZoom) {
 				return this.setZoom(zoom);
 			}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -440,10 +440,18 @@ L.Map = L.Evented.extend({
 	// @method setMinZoom(zoom: Number): this
 	// Sets the lower limit for the available zoom levels (see the [minZoom](#map-minzoom) option).
 	setMinZoom: function (zoom) {
+		var pZoom = this.options.minZoom;
+
 		this.options.minZoom = zoom;
 
-		if (this._loaded && this.getZoom() < this.options.minZoom) {
-			return this.setZoom(zoom);
+		if (this._loaded) {
+			if (pZoom !== zoom) {
+				this.fire('zoomlevelschange');
+			}
+
+			if (this.getZoom() < this.options.minZoom) {
+				return this.setZoom(zoom);
+			}
 		}
 
 		return this;
@@ -452,10 +460,18 @@ L.Map = L.Evented.extend({
 	// @method setMaxZoom(zoom: Number): this
 	// Sets the upper limit for the available zoom levels (see the [maxZoom](#map-maxzoom) option).
 	setMaxZoom: function (zoom) {
+		var pZoom = this.options.maxZoom;
+
 		this.options.maxZoom = zoom;
 
-		if (this._loaded && (this.getZoom() > this.options.maxZoom)) {
-			return this.setZoom(zoom);
+		if (this._loaded) {
+			if (pZoom !== zoom) {
+				this.fire('zoomlevelschange');
+			}
+
+			if (this.getZoom() > this.options.maxZoom) {
+				return this.setZoom(zoom);
+			}
 		}
 
 		return this;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -445,7 +445,7 @@ L.Map = L.Evented.extend({
 		this.options.minZoom = zoom;
 
 		if (this._loaded) {
-			if (oldZoom !== zoom) {
+			if (oldZoom !== zoom && zoom === this.getZoom()) {
 				this.fire('zoomlevelschange');
 			}
 
@@ -465,7 +465,7 @@ L.Map = L.Evented.extend({
 		this.options.maxZoom = zoom;
 
 		if (this._loaded) {
-			if (oldZoom !== zoom) {
+			if (oldZoom !== zoom && zoom === this.getZoom()) {
 				this.fire('zoomlevelschange');
 			}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -441,16 +441,13 @@ L.Map = L.Evented.extend({
 	// Sets the lower limit for the available zoom levels (see the [minZoom](#map-minzoom) option).
 	setMinZoom: function (zoom) {
 		var oldZoom = this.options.minZoom;
-
 		this.options.minZoom = zoom;
 
-		if (this._loaded) {
-			if (oldZoom !== zoom && zoom === this.getZoom()) {
-				this.fire('zoomlevelschange');
-			}
-
+		if (this._loaded && oldZoom !== zoom) {
 			if (this.getZoom() < this.options.minZoom) {
 				return this.setZoom(zoom);
+			} else {
+				this.fire('zoomlevelschange');
 			}
 		}
 
@@ -461,16 +458,13 @@ L.Map = L.Evented.extend({
 	// Sets the upper limit for the available zoom levels (see the [maxZoom](#map-maxzoom) option).
 	setMaxZoom: function (zoom) {
 		var oldZoom = this.options.maxZoom;
-
 		this.options.maxZoom = zoom;
 
-		if (this._loaded) {
-			if (oldZoom !== zoom && zoom === this.getZoom()) {
-				this.fire('zoomlevelschange');
-			}
-
+		if (this._loaded && oldZoom !== zoom) {
 			if (this.getZoom() > this.options.maxZoom) {
 				return this.setZoom(zoom);
+			} else {
+				this.fire('zoomlevelschange');
 			}
 		}
 


### PR DESCRIPTION
Allows Control.Zoom to enable/disable controls in response to min and max zoom level changes.