### PR TITLE
add an option to L.Layer to prevent popup toggle on click

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -67,6 +67,25 @@ describe('Popup', function () {
 		expect(map.hasLayer(marker._popup)).to.be(false);
 	});
 
+	it("should not toggle its visibility when marker with togglePopupOnClick: false option is clicked", function () {
+		var marker = new L.Marker(new L.LatLng(55.8, 37.6), {togglePopupOnClick: false});
+		map.addLayer(marker);
+
+		marker.bindPopup('Popup1');
+		expect(map.hasLayer(marker._popup)).to.be(false);
+
+		// click marker
+		happen.click(marker._icon);
+		expect(map.hasLayer(marker._popup)).to.be(false);
+
+		// manually open popup
+		marker.openPopup();
+
+		// click marker
+		happen.click(marker._icon);
+		expect(map.hasLayer(marker._popup)).to.be(true);
+	});
+
 	it("it should use a popup with a function as content with a FeatureGroup", function () {
 		var marker1 = new L.Marker(new L.LatLng(55.8, 37.6));
 		var marker2 = new L.Marker(new L.LatLng(54.6, 38.2));

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -333,6 +333,16 @@ L.Map.include({
 	}
 });
 
+/* @namespace Layer
+ * @section Popup Options
+ * @option togglePopupOnClick: Boolean = true
+ * Set it to `false` if you don't want the popup to be toggled when user clicks the popup.
+ * If set to `false`, the only way to toggle the popup is by calling `openPopup()` or `closePopup()` manually
+ */
+L.Layer.mergeOptions({
+	togglePopupOnClick: true
+});
+
 /*
  * @namespace Layer
  * @section Popup methods example
@@ -495,8 +505,10 @@ L.Layer.include({
 		// otherwise treat it like a marker and figure out
 		// if we should toggle it open/closed
 		if (this._map.hasLayer(this._popup) && this._popup._source === layer) {
-			this.closePopup();
-		} else {
+			if ('togglePopupOnClick' in this.options && this.options.togglePopupOnClick) {
+				this.closePopup();
+			}
+		} else if ('togglePopupOnClick' in this.options && this.options.togglePopupOnClick) {
 			this.openPopup(layer, e.latlng);
 		}
 	},


### PR DESCRIPTION
There are different options to control the automatic behaviour of showing/hiding popups: 

* `closeOnClick` ( on `L.Popup`) / `closePopupOnClick` (on `L.Map`): Set to `false` to prevent auto-hiding of popups when map is clicked
* `autoClose` ( on `L.Popup`): Set to `false` to to prevent auto-hiding of a popup, if another popup is showed.

However, as far as I can tell, theres no way to prevent popup hiding/showing when clicking on the marker itself.

I need to control whether popups are displayed manually and don't want the user to interfere with that by clicking a marker. (Clicking the marker opens an Edit Dialog in my use case which is different from the popup). 

This PR adds a new option:

* `togglePopupOnClick` ( on `L.Layer`) with a default value of `true` (to preserve the current behaviour). If this option is set to `false`, the marker will not hide or show the popup on a click. The popup can still be hidden/shown by directly calling `openPopup()` / `closePopup()` directly on the marker.