### PR TITLE
increase hit target instead of overriding box-shadow on touch enabled browsers

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -305,8 +305,8 @@
 	}
 
 .leaflet-touch .leaflet-bar a {
-	width: 30px;
-	height: 30px;
+	width: 34px;
+	height: 34px;
 	line-height: 30px;
 	}
 
@@ -436,17 +436,6 @@
 	}
 .leaflet-control-scale-line:not(:first-child):not(:last-child) {
 	border-bottom: 2px solid #777;
-	}
-
-.leaflet-touch .leaflet-control-attribution,
-.leaflet-touch .leaflet-control-layers,
-.leaflet-touch .leaflet-bar {
-	box-shadow: none;
-	}
-.leaflet-touch .leaflet-control-layers,
-.leaflet-touch .leaflet-bar {
-	border: 2px solid rgba(0,0,0,0.2);
-	background-clip: padding-box;
 	}
 
 


### PR DESCRIPTION
IE10/11/Edge (and now Chrome 55+) all support touch *and* CSS3 box-shadows, but the current rules force a fallback to a `2px` solid border whenever touch support is detected.

IE10/11/Edge and Chrome 55+ display:
![screenshot 2017-01-09 13 42 54](https://cloud.githubusercontent.com/assets/3011734/21784695/8ed56682-d671-11e6-8e47-a399b5f221ea.png)
instead of:
![screenshot 2017-01-09 13 29 30](https://cloud.githubusercontent.com/assets/3011734/21784287/b5a43538-d66f-11e6-9525-3492feda5a97.png)

Because box-shadow now enjoys wide support and a graceful fallback occurs automatically, it makes more sense to just increase the hit target slightly (ref: https://github.com/Leaflet/Leaflet/issues/1868#issuecomment-20994762) when touch support is detected instead of removing the box-shadow and substituting a border.