### PR TITLE
add source to moveend and zoomend events

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -63,13 +63,13 @@ L.Control.Zoom = L.Control.extend({
 
 	_zoomIn: function (e) {
 		if (!this._disabled && this._map._zoom < this._map.getMaxZoom()) {
-			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1), {}, 'user');
 		}
 	},
 
 	_zoomOut: function (e) {
 		if (!this._disabled && this._map._zoom > this._map.getMinZoom()) {
-			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1), {}, 'user');
 		}
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1135,7 +1135,7 @@ L.Map = L.Evented.extend({
 	},
 
 	_moveEnd: function (zoomChanged, source) {
-		param = {source: source || 'leaflet'};
+		var param = {source: source || 'leaflet'};
 		// @event zoomend: Event
 		// Fired when the map has changed, after any animations.
 		if (zoomChanged) {

--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -30,9 +30,9 @@ L.Map.DoubleClickZoom = L.Handler.extend({
 		    zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
 
 		if (map.options.doubleClickZoom === 'center') {
-			map.setZoom(zoom);
+			map.setZoom(zoom, {}, 'user');
 		} else {
-			map.setZoomAround(e.containerPoint, zoom);
+			map.setZoomAround(e.containerPoint, zoom, {}, 'user');
 		}
 	}
 });

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -184,7 +184,7 @@ L.Map.Drag = L.Handler.extend({
 		map.fire('dragend', e);
 
 		if (noInertia) {
-			map.fire('moveend');
+			map.fire('moveend', {source: 'user'});
 
 		} else {
 
@@ -202,7 +202,7 @@ L.Map.Drag = L.Handler.extend({
 			    offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2).round();
 
 			if (!offset.x && !offset.y) {
-				map.fire('moveend');
+				map.fire('moveend', {source: 'user'});
 
 			} else {
 				offset = map._limitOffset(offset, map.options.maxBounds);
@@ -213,7 +213,7 @@ L.Map.Drag = L.Handler.extend({
 						easeLinearity: ease,
 						noMoveStart: true,
 						animate: true
-					});
+					}, 'user');
 				});
 			}
 		}

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -147,14 +147,14 @@ L.Map.Keyboard = L.Handler.extend({
 				offset = L.point(offset).multiplyBy(3);
 			}
 
-			map.panBy(offset);
+			map.panBy(offset, 'user');
 
 			if (map.options.maxBounds) {
-				map.panInsideBounds(map.options.maxBounds);
+				map.panInsideBounds(map.options.maxBounds, {}, 'user');
 			}
 
 		} else if (key in this._zoomKeys) {
-			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key]);
+			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key], {}, 'user');
 
 		} else if (key === 27) {
 			map.closePopup();

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -73,9 +73,9 @@ L.Map.ScrollWheelZoom = L.Handler.extend({
 		if (!delta) { return; }
 
 		if (map.options.scrollWheelZoom === 'center') {
-			map.setZoom(zoom + delta);
+			map.setZoom(zoom + delta, {}, 'user');
 		} else {
-			map.setZoomAround(this._lastMousePos, zoom + delta);
+			map.setZoomAround(this._lastMousePos, zoom + delta, {}, 'user');
 		}
 	}
 });

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -113,9 +113,9 @@ L.Map.TouchZoom = L.Handler.extend({
 
 		// Pinch updates GridLayers' levels only when zoomSnap is off, so zoomSnap becomes noUpdate.
 		if (this._map.options.zoomAnimation) {
-			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.zoomSnap);
+			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.zoomSnap, 'user');
 		} else {
-			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
+			this._map._resetView(this._center, this._map._limitZoom(this._zoom), 'user');
 		}
 	}
 });


### PR DESCRIPTION
As [described on leaflet.uservoice.com](https://leaflet.uservoice.com/forums/150880-ideas-and-suggestions-for-leaflet/suggestions/17371396-adding-origin-to-events), we need to refresh some markers when the map has moved or zoomed but only if it’s coming from user interaction, not from our code calling leaflet API.

Here‘s a pull request which adds a 'source' param to moveend and zoomend events.
The source can be either 'user' or 'leaflet', depending on the action that triggered the event.
To illustrate:
- The user drags the map, 'moveend' is triggered with source=user.
- Calling 'fitbounds' on a list of markers will trigger 'moveend'' with source=leaflet

The commit may not be clean enough to integrate but it should give you an idea of the problem we trying to solve and so, hopefully, start a discussion.

So what do you think ?