### PR TITLE
Blind attempt to fix Edge dblclicks (side effects of #5185)

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -17,7 +17,7 @@ L.extend(L.DomEvent, {
 			var count;
 
 			if (L.Browser.pointer) {
-				if (!L.Browser.edge && e.pointerType === 'mouse') {
+				if ((!L.Browser.edge) || e.pointerType === 'mouse') {
 					return;
 				}
 				count = L.DomEvent._pointersCount;


### PR DESCRIPTION
Based on my observations and on the feedback given by @dtapuska, I now think that the right behaviour is to rely on native `dblclick`s whenever we're on something other than Edge **or** the pointer type is a mouse.

The rationale is that Edge fires native `dblclick`s when using a mouse, but not when using a touchscreen. Chrome always fires native `dblclick`s. IEMobile (not edge) always fires native `dblclick`s.

This should fix #5180 (or at least make the code behave better in more browsers)