### PR TITLE
Make sure path's pixel coords are up to date when updating

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -56,6 +56,7 @@ L.Canvas = L.Renderer.extend({
 		this._redrawBounds = null;
 		for (var id in this._layers) {
 			layer = this._layers[id];
+			layer._project();
 			layer._update();
 		}
 		this._redraw();


### PR DESCRIPTION
This is _yet another_ fix for #5170, I believe the simplest. From looking at the code, it seems to be an oversight that `_updatePaths()`, which is just an optimization for doing `_update(layer)` for all the canvas' layers, does not call `project(layer)`, which `_update(layer)` does.

Adding this fixes the provided example for #5170, and it's just a one line fix.
