### PR TITLE
Avoid multiple canvas updatePaths/redraws during viewreset

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -31,6 +31,15 @@
  */
 
 L.Canvas = L.Renderer.extend({
+	getEvents: function () {
+		var events = L.Renderer.prototype.getEvents.call(this);
+		events.viewprereset = this._onViewPreReset;
+		return events;
+	},
+
+	_onViewPreReset: function() {
+		this._postponeUpdatePaths = true;
+	},
 
 	onAdd: function () {
 		L.Renderer.prototype.onAdd.call(this);
@@ -52,6 +61,8 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_updatePaths: function () {
+		if (this._postponeUpdatePaths) { return; }
+
 		var layer;
 		this._redrawBounds = null;
 		for (var id in this._layers) {
@@ -90,6 +101,15 @@ L.Canvas = L.Renderer.extend({
 
 		// Tell paths to redraw themselves
 		this.fire('update');
+	},
+
+	_reset: function() {
+		L.Renderer.prototype._reset.call(this);
+
+		if (this._postponeUpdatePaths) {
+			this._postponeUpdatePaths = false;
+			this._updatePaths();
+		}
 	},
 
 	_initPath: function (layer) {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -38,6 +38,7 @@ L.Canvas = L.Renderer.extend({
 	},
 
 	_onViewPreReset: function () {
+		// Set a flag so that a viewprereset+moveend+viewreset only updates&redraws once
 		this._postponeUpdatePaths = true;
 	},
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -37,7 +37,7 @@ L.Canvas = L.Renderer.extend({
 		return events;
 	},
 
-	_onViewPreReset: function() {
+	_onViewPreReset: function () {
 		this._postponeUpdatePaths = true;
 	},
 
@@ -103,7 +103,7 @@ L.Canvas = L.Renderer.extend({
 		this.fire('update');
 	},
 
-	_reset: function() {
+	_reset: function () {
 		L.Renderer.prototype._reset.call(this);
 
 		if (this._postponeUpdatePaths) {


### PR DESCRIPTION
During a `viewreset`, a `moveend` is also fired, which both cause `Canvas` to redraw. This is of course unnecessary and bad for performance.

This PR addresses this by listening to the `viewprereset` event, and postpones any calls to `_updatePaths` until the view reset finishes, so that it's only called once.

I'm not too fond of how I actually implemented this, so any feedback on how it could be improved is welcome.

And, oh, this _also_ fixes #5170, making it the fifth PR that fixes this issue, if I counted correctly.