### PR TITLE
Add alternative text to marker shadows

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -209,6 +209,7 @@ L.Marker = L.Layer.extend({
 
 		if (newShadow) {
 			L.DomUtil.addClass(newShadow, classToAdd);
+			newShadow.alt = '';
 		}
 		this._shadow = newShadow;
 


### PR DESCRIPTION
Fixes #5258 

Set alternative text for marker shadows by copying from its icon. 

Acceptance criteria
--------------------
- [ ] If an alternative text is set for a maker then should be also applied to his shadow too.