### PR TITLE
Add synthetic dblclick for MS Edge with mouse

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -17,7 +17,7 @@ L.extend(L.DomEvent, {
 			var count;
 
 			if (L.Browser.pointer) {
-				if ((!L.Browser.edge) || e.pointerType === 'mouse') {
+				if (!L.Browser.edge) {
 					return;
 				}
 				count = L.DomEvent._pointersCount;
@@ -51,6 +51,7 @@ L.extend(L.DomEvent, {
 				touch.type = 'dblclick';
 				handler(touch);
 				last = null;
+				doubleTap = false;
 			}
 		}
 


### PR DESCRIPTION
As I understand it, MS Edge never fires `dblclick`, neither for mouse or touch, so the fix in Edge is to always fire synthetic `dblclick`, no matter the source of the `PointerEvent`s.

Also, we had an issue where a previous double tap would set the `DoubleTap` handlers internal state as if in a double tap, but it where never reset, so mouse events would later fire synthetic `dblclick`s. This PR resets the `doubleTap` status after firing a `dblclick` to avoid keeping an old state around.

I've verified this in with mouse and touch in Edge 14, Chrome 55 and Firefox 41 on Win10.