### PR TITLE
Remove trailing column in Object definition

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -35,7 +35,7 @@ L.Layer = L.Evented.extend({
 
 		// @option attribution: String = null
 		// String to be shown in the attribution control, describes the layer data, e.g. "© Mapbox".
-		attribution: null,
+		attribution: null
 	},
 
 	/* @section


### PR DESCRIPTION
The trailing column in the Layer default Options Object definition crashes IE8.