### PR TITLE
Explicitly stop propagation of wheel events in layers control

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -140,6 +140,7 @@ L.Control.Layers = L.Control.extend({
 		if (acceptableHeight < this._form.clientHeight) {
 			L.DomUtil.addClass(this._form, 'leaflet-control-layers-scrollbar');
 			this._form.style.height = acceptableHeight + 'px';
+			L.DomEvent.on(this._form, 'wheel', L.DomEvent.stopPropagation);
 		} else {
 			L.DomUtil.removeClass(this._form, 'leaflet-control-layers-scrollbar');
 		}
@@ -151,6 +152,7 @@ L.Control.Layers = L.Control.extend({
 	// Collapse the control container if expanded.
 	collapse: function () {
 		L.DomUtil.removeClass(this._container, 'leaflet-control-layers-expanded');
+		L.DomEvent.off(this._form, 'wheel', L.DomEvent.stopPropagation);
 		return this;
 	},
 


### PR DESCRIPTION
Fixes #5277.

I don't know why this change in the behaviour of Chrome, though.

Dunno if it's worth to submit a bug report upstream. According to this behaviour, event handlers in a parent element take precedence over the default action on children elements.