### PR TITLE
Proof of concept of named classes

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -10,21 +10,31 @@ import * as Util from './Util';
 
 export function Class() {}
 
-Class.extend = function (props) {
+// @function extend(className: String, props: Object): Function
+// [Extends the current class](#class-inheritance) given the properties to be included.
+// Returns a Javascript function that is a class constructor (to be called with `new`).
+// The given name is shown in the stack traces when debugging.
 
-	// @function extend(props: Object): Function
-	// [Extends the current class](#class-inheritance) given the properties to be included.
-	// Returns a Javascript function that is a class constructor (to be called with `new`).
-	var NewClass = function () {
+// @alternative extend(props: Object): Function
+// Extends the current class. The resulting constructor is unnamed, and will
+// show up as `NewClass` in the stack traces when debugging.
+Class.extend = function (className, props) {
 
+	if (props === undefined) {
+		props = className;
+		className = '';
+	}
+
+	className = className.replace(/\W/, '');	// Remove spaces and non-letters
+
+	var NewClass = eval('var NewClass = function ' + className + '() {' +
 		// call the constructor
-		if (this.initialize) {
-			this.initialize.apply(this, arguments);
-		}
+		'if (this.initialize){ this.initialize.apply(this, arguments);}' +
 
 		// call all constructor hooks
-		this.callInitHooks();
-	};
+		'this.callInitHooks();' +
+
+		'};NewClass;'); //
 
 	var parentProto = NewClass.__super__ = this.prototype;
 

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -45,7 +45,7 @@ import {Point} from '../../geometry/Point';
  */
 
 
-export var Polyline = Path.extend({
+export var Polyline = Path.extend('Polyline', {
 
 	// @section
 	// @aka Polyline options

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -43,7 +43,7 @@ export var create = Browser.vml ? vmlCreate : svgCreate;
  * ```
  */
 
-export var SVG = Renderer.extend({
+export var SVG = Renderer.extend('SVG', {
 
 	getEvents: function () {
 		var events = Renderer.prototype.getEvents.call(this);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -29,7 +29,7 @@ import {PosAnimation} from '../dom/PosAnimation';
  *
  */
 
-export var Map = Evented.extend({
+export var Map = Evented.extend('Map', {
 
 	options: {
 		// @section Map State Options


### PR DESCRIPTION
This is just a proof of concept of named class inheritance.

I've been looking at ES6 `class`es, and the only real nice thing is the classes are named. This PR is just a proof of concept, to see if we like the idea.

Before: all classes are named `NewClass` because of how `L.Class.Extend` works:

![screenshot_20170126_113427](https://cloud.githubusercontent.com/assets/1125786/22328271/ac5e0946-e3bb-11e6-832e-1ec197949dd0.png)

After: An `eval()` trick allows to give each subclass its own name:

![screenshot_20170126_113204](https://cloud.githubusercontent.com/assets/1125786/22328285/baab860e-e3bb-11e6-8fcd-dcd1e782a6e7.png)

I think this would be quite useful to devs while developing.