### PR TITLE
Remove MapQuest from leaflet-providers description

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,7 +107,7 @@ Ready-to-go basemaps, with little or no configuration at all.
 		<td>
 			<a href="https://github.com/leaflet-extras/leaflet-providers">leaflet-providers</a>
 		</td><td>
-			Contains configurations for various free tile providers &mdash; OSM, OpenCycleMap, MapQuest, Stamen, Esri, etc.
+			Contains configurations for various free tile providers &mdash; OSM, OpenCycleMap, Stamen, Esri, etc.
 		</td><td>
 			<a href="https://github.com/leaflet-extras">leaflet-extras members</a>
 		</td>


### PR DESCRIPTION
[leaflet-providers](http://leaflet-extras.github.io/leaflet-providers/preview/) doesn't include MapQuest anymore.