### PR TITLE
New PixelGrid class. Implements #4844, fixes #4637 and #3575.

### DIFF
--- a/build/docs-index.leafdoc
+++ b/build/docs-index.leafdoc
@@ -9,6 +9,7 @@ This file just defines the order of the classes in the docs.
 @class Popup
 @class Tooltip
 
+@class PixelGrid
 @class TileLayer
 @class TileLayer.WMS
 @class ImageOverlay

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -47,6 +47,7 @@
 			</ul>
 			<h4>Raster Layers</h4>
 			<ul>
+				<li><a href="#pixelgrid">PixelGrid</a></li>
 				<li><a href="#tilelayer">TileLayer</a></li>
 				<li><a href="#tilelayer-wms">TileLayer.WMS</a></li>
 				<li><a href="#imageoverlay">ImageOverlay</a></li>

--- a/debug/map/pixelgrid.html
+++ b/debug/map/pixelgrid.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script src="../leaflet-include.js"></script>
+	<style>
+		#map {
+			position: absolute;
+			width: 100vw;
+			height: calc( 100vh - 5em );
+			bottom: 0px;
+
+			background: cyan;
+		}
+		body {margin: 0}
+	</style>
+</head>
+<body>
+	There should be no gaps between the tiles.
+
+	<div id="map" class="map"></div>
+
+	<script type="text/javascript">
+		var mapopts =  {
+			center: [35, -122],
+			zoom : 5.5,
+			zoomSnap: 0.1,
+			zoomDelta: 0.1,
+		};
+
+		var map = L.map('map', mapopts);
+
+		var cartoAttrib = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, &copy;        <a href="https://carto.com/attribution">CARTO</a>';
+
+		var darkMatter1 = L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
+			attribution: cartoAttrib,
+		}).addTo(map);
+
+		var darkMatter2 = L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
+			attribution: cartoAttrib,
+			dumpToCanvas: false	// Disable the PixelGrid logic
+		});
+
+		var darkMatter3 = L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/dark_all/{z}/{x}/{y}.png', {
+			attribution: cartoAttrib,
+			opacity: 0.5
+		});
+
+		L.control.layers({
+			'PixelGrid': darkMatter1,
+			'Legacy TileLayer': darkMatter2,
+			'PixelGrid 50% opacity': darkMatter3
+		}, {}, {
+			collapsed: false
+		}).addTo(map);
+
+	</script>
+</body>
+</html>

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -322,7 +322,11 @@ export var GridLayer = Layer.extend({
 			if (fade < 1) {
 				nextFrame = true;
 			} else {
-				if (tile.active) { willPrune = true; }
+				if (tile.active) {
+					willPrune = true;
+				} else {
+					this._onOpaqueTile(tile);
+				}
 				tile.active = true;
 			}
 		}
@@ -334,6 +338,8 @@ export var GridLayer = Layer.extend({
 			this._fadeFrame = Util.requestAnimFrame(this._updateOpacity, this);
 		}
 	},
+
+	_onOpaqueTile: Util.falseFn,
 
 	_initContainer: function () {
 		if (this._container) { return; }
@@ -358,9 +364,11 @@ export var GridLayer = Layer.extend({
 		for (var z in this._levels) {
 			if (this._levels[z].el.children.length || z === zoom) {
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
+				this._onUpdateLevel(z);
 			} else {
 				DomUtil.remove(this._levels[z].el);
 				this._removeTilesAtZoom(z);
+				this._onRemoveLevel(z);
 				delete this._levels[z];
 			}
 		}
@@ -381,12 +389,20 @@ export var GridLayer = Layer.extend({
 
 			// force the browser to consider the newly added element for transition
 			Util.falseFn(level.el.offsetWidth);
+
+			this._onCreateLevel(level);
 		}
 
 		this._level = level;
 
 		return level;
 	},
+
+	_onUpdateLevel: Util.falseFn,
+
+	_onRemoveLevel: Util.falseFn,
+
+	_onCreateLevel: Util.falseFn,
 
 	_pruneTiles: function () {
 		if (!this._map) {
@@ -442,6 +458,7 @@ export var GridLayer = Layer.extend({
 	_invalidateAll: function () {
 		for (var z in this._levels) {
 			DomUtil.remove(this._levels[z].el);
+			this._onRemoveLevel(z);
 			delete this._levels[z];
 		}
 		this._removeAllTiles();

--- a/src/layer/tile/PixelGrid.js
+++ b/src/layer/tile/PixelGrid.js
@@ -283,9 +283,6 @@ export var PixelGrid = GridLayer.extend({
 		// Where in the canvas should this tile go?
 		var offset = toPoint(coords.x, coords.y).subtract(level.canvasRange.min).scaleBy(this.getTileSize());
 
-// 		console.log('Should dump tile to canvas:', tile);
-// 		console.log('Dumping:', coords, "at", offset );
-
 		level.ctx.drawImage(imageSource, offset.x, offset.y, tileSize.x, tileSize.y);
 
 		// TODO: Clear the pixels of other levels' canvases where they overlap

--- a/src/layer/tile/PixelGrid.js
+++ b/src/layer/tile/PixelGrid.js
@@ -1,0 +1,304 @@
+
+import {GridLayer} from './GridLayer';
+import * as Browser from '../../core/Browser';
+import * as Util from '../../core/Util';
+import * as DomUtil from '../../dom/DomUtil';
+import {toPoint} from '../../geometry/Point';
+import {toBounds} from '../../geometry/Bounds';
+
+
+/*
+ * @class PixelGrid
+ * @inherits GridLayer
+ * @aka PixelGrid
+ *
+ * A specific type of `GridLayer` where each tile must be either a `HTMLImageElement`
+ * or a `HTMLCanvasElement` (an `<img>` or a `<canvas>`).
+ *
+ * Image tiles will be stitched together into a `<canvas>` to avoid rendering
+ * artifacts in some browsers. If the `dumpToCanvas` option is set to `false`,
+ * then this class behaves exactly as a `GridLayer` where each tile is its own
+ * `<img>` element.
+ *
+ */
+
+export var PixelGrid = GridLayer.extend({
+	options: {
+		// @option dumpToCanvas: Boolean = true
+		// Whether to dump loaded tile images to a `<canvas>` or not
+		// (Disabled by default in IE)
+		dumpToCanvas: Browser.canvas && !Browser.ie
+	},
+
+	// Full rewrite of GridLayer._updateLevels to support dumpToCanvas
+	_updateLevels: function () {
+		var zoom = this._tileZoom,
+		    maxZoom = this.options.maxZoom,
+		    dump = this.options.dumpToCanvas;
+
+		if (zoom === undefined) { return undefined; }
+
+		for (var z in this._levels) {
+			if (this._levels[z].el.children.length || z === zoom) {
+				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
+				if (dump) {
+					this._levels[z].canvas.style.zIndex = maxZoom - Math.abs(zoom - z);
+				}
+			} else {
+				DomUtil.remove(this._levels[z].el);
+				if (dump) {
+					DomUtil.remove(this._levels[z].canvas);
+				}
+				this._removeTilesAtZoom(z);
+				delete this._levels[z];
+			}
+		}
+
+		var level = this._levels[zoom],
+		    map = this._map;
+
+		if (!level) {
+			level = this._levels[zoom] = {};
+
+			level.el = DomUtil.create('div', 'leaflet-tile-container leaflet-zoom-animated', this._container);
+			level.el.style.zIndex = maxZoom;
+
+			level.origin = map.project(map.unproject(map.getPixelOrigin()), zoom).round();
+			level.zoom = zoom;
+
+			this._setZoomTransform(level, map.getCenter(), map.getZoom());
+
+			// force the browser to consider the newly added element for transition
+			Util.falseFn(level.el.offsetWidth);
+
+			if (dump) {
+				level.canvas = DomUtil.create('canvas', 'leaflet-tile-container leaflet-zoom-animated', this._container);
+				level.ctx = level.canvas.getContext('2d');
+				this._resetCanvasSize(level);
+			}
+		}
+
+		this._level = level;
+		return level;
+	},
+
+	_removeTile: function (key) {
+		if (this.options.dumpToCanvas) {
+			var tile = this._tiles[key],
+			    level = this._levels[tile.coords.z],
+			    tileSize = this.getTileSize();
+
+			if (level) {
+				// Where in the canvas should this tile go?
+				var offset = toPoint(tile.coords.x, tile.coords.y).subtract(level.canvasRange.min).scaleBy(this.getTileSize());
+
+				level.ctx.clearRect(offset.x, offset.y, tileSize.x, tileSize.y);
+			}
+		}
+
+		GridLayer.prototype._removeTile.call(this, key);
+	},
+
+	// Full rewrite of GridLayer._invalidateAll to support dumpToCanvas
+	_invalidateAll: function () {
+		for (var z in this._levels) {
+			DomUtil.remove(this._levels[z].el);
+			if (this.options.dumpToCanvas) {
+				DomUtil.remove(this._levels[z].canvas);
+			}
+			delete this._levels[z];
+		}
+		this._removeAllTiles();
+
+		this._tileZoom = null;
+	},
+
+	_resetCanvasSize: function (level) {
+		var buff = this.options.keepBuffer,
+		    pixelBounds = this._getTiledPixelBounds(this._map.getCenter()),
+		    tileRange = this._pxBoundsToTileRange(pixelBounds),
+		    tileSize = this.getTileSize();
+
+		tileRange.min = tileRange.min.subtract([buff, buff]);	// This adds the no-prune buffer
+		tileRange.max = tileRange.max.add([buff + 1, buff + 1]);
+
+		var pixelRange = toBounds(
+		        tileRange.min.scaleBy(tileSize),
+		        tileRange.max.add([1, 1]).scaleBy(tileSize)	// This prevents an off-by-one when checking if tiles are inside
+		    ),
+		    mustRepositionCanvas = false,
+		    neededSize = pixelRange.max.subtract(pixelRange.min);
+
+		// Resize the canvas, if needed, and only to make it bigger.
+		if (neededSize.x > level.canvas.width || neededSize.y > level.canvas.height) {
+			// Resizing canvases erases the currently drawn content, I'm afraid.
+			// To keep it, dump the pixels to another canvas, then display it on
+			// top. This could be done with getImageData/putImageData, but that
+			// would break for tainted canvases (in non-CORS tilesets)
+			var oldSize = {x: level.canvas.width, y: level.canvas.height},
+			    tmpCanvas = DomUtil.create('canvas');
+
+			tmpCanvas.style.width  = (tmpCanvas.width  = oldSize.x) + 'px';
+			tmpCanvas.style.height = (tmpCanvas.height = oldSize.y) + 'px';
+			tmpCanvas.getContext('2d').drawImage(level.canvas, 0, 0);
+
+			level.canvas.style.width  = (level.canvas.width  = neededSize.x) + 'px';
+			level.canvas.style.height = (level.canvas.height = neededSize.y) + 'px';
+			level.ctx.drawImage(tmpCanvas, 0, 0);
+		}
+
+		// Translate the canvas contents if it's moved around
+		if (level.canvasRange) {
+			var offset = level.canvasRange.min.subtract(tileRange.min).scaleBy(this.getTileSize());
+
+			if (!Browser.safari) {
+				// By default, canvases copy things "on top of" existing pixels, but we want
+				// this to *replace* the existing pixels when doing a drawImage() call.
+				// This will also clear the sides, so no clearRect() calls are needed to make room
+				// for the new tiles.
+				level.ctx.globalCompositeOperation = 'copy';
+				level.ctx.drawImage(level.canvas, offset.x, offset.y);
+				level.ctx.globalCompositeOperation = 'source-over';
+			} else {
+				// Safari clears the canvas when copying from itself :-(
+				if (!this._tmpCanvas) {
+					var t = this._tmpCanvas = DomUtil.create('canvas');
+					t.width  = level.canvas.width;
+					t.height = level.canvas.height;
+					this._tmpContext = t.getContext('2d');
+				}
+				this._tmpContext.clearRect(0, 0, level.canvas.width, level.canvas.height);
+				this._tmpContext.drawImage(level.canvas, 0, 0);
+				level.ctx.clearRect(0, 0, level.canvas.width, level.canvas.height);
+				level.ctx.drawImage(this._tmpCanvas, offset.x, offset.y);
+			}
+
+			mustRepositionCanvas = true;	// Wait until new props are set
+		}
+
+		level.canvasRange = tileRange;
+		level.canvasPxRange = pixelRange;
+		level.canvasOrigin = pixelRange.min;
+
+		if (mustRepositionCanvas) {
+			this._setCanvasZoomTransform(level, this._map.getCenter(), this._map.getZoom());
+		}
+	},
+
+	// set transform/position of canvas, in addition to the transform/position of the individual tile container
+	_setZoomTransform: function (level, center, zoom) {
+		GridLayer.prototype._setZoomTransform.call(this, level, center, zoom);
+		if (this.options.dumpToCanvas) {
+			this._setCanvasZoomTransform(level, center, zoom);
+		}
+	},
+
+	// This will get called twice:
+	// * From _setZoomTransform
+	// * When the canvas has shifted due to a new tile being loaded
+	_setCanvasZoomTransform: function (level, center, zoom) {
+		if (!level.canvasOrigin) { return; }
+		var scale = this._map.getZoomScale(zoom, level.zoom),
+		    translate = level.canvasOrigin.multiplyBy(scale)
+		        .subtract(this._map._getNewPixelOrigin(center, zoom)).round();
+
+		if (Browser.any3d) {
+			DomUtil.setTransform(level.canvas, translate, scale);
+		} else {
+			DomUtil.setPosition(level.canvas, translate);
+		}
+	},
+
+	_updateOpacity: function () {
+		if (!this._map) { return; }
+
+		// IE doesn't inherit filter opacity properly, so we're forced to set it on tiles
+		if (Browser.ielt9) { return; }
+
+		DomUtil.setOpacity(this._container, this.options.opacity);
+
+		var now = +new Date(),
+		    nextFrame = false,
+		    willPrune = false;
+
+		for (var key in this._tiles) {
+			var tile = this._tiles[key];
+			if (!tile.current || !tile.loaded) { continue; }
+
+			var fade = Math.min(1, (now - tile.loaded) / 200);
+
+			DomUtil.setOpacity(tile.el, fade);
+			if (fade < 1) {
+				nextFrame = true;
+			} else {
+				if (tile.active) {
+					willPrune = true;
+				} else if (this.options.dumpToCanvas) {
+					// Tile is dumped into the canvas when it's fully opaque
+					this._dumpTileToCanvas(tile);
+				}
+				tile.active = true;
+			}
+		}
+
+		if (willPrune && !this._noPrune) { this._pruneTiles(); }
+
+		if (nextFrame) {
+			Util.cancelAnimFrame(this._fadeFrame);
+			this._fadeFrame = Util.requestAnimFrame(this._updateOpacity, this);
+		}
+	},
+
+	_dumpTileToCanvas: function (tile) {
+		this.dumpPixels(tile.coords, tile.el);
+
+		// Do not remove the tile itself, as it is needed to check if the whole
+		// level (and its canvas) should be removed (via level.el.children.length)
+		tile.el.style.display = 'none';
+	},
+
+	// @section Extension methods
+	// @uninheritable
+	// Layers extending `PixelGrid` might call the following method.
+
+	// @method dumpPixels(coords: Object, imageSource: CanvasImageSource): this
+	// Dumps pixels from the given `CanvasImageSource` into the layer, into
+	// the space for the tile represented by the `coords` tile coordinates (an object
+	// like `{x: Number, y: Number, z: Number}`; the image source must have the
+	// same size as the `tileSize` option for the layer. Has no effect if `dumpToCanvas`
+	// is `false`.
+	dumpPixels: function (coords, imageSource) {
+		var level = this._levels[coords.z],
+		    tileSize = this.getTileSize();
+
+		if (!level.canvasRange) { return; }
+
+		// Check if the tile is inside the currently visible map bounds
+		// There is a possible race condition when tiles are loaded after they
+		// have been panned outside of the map.
+		if (!level.canvasRange.contains(coords)) {
+			this._resetCanvasSize(level);
+		}
+
+		// Where in the canvas should this tile go?
+		var offset = toPoint(coords.x, coords.y).subtract(level.canvasRange.min).scaleBy(this.getTileSize());
+
+// 		console.log('Should dump tile to canvas:', tile);
+// 		console.log('Dumping:', coords, "at", offset );
+
+		level.ctx.drawImage(imageSource, offset.x, offset.y, tileSize.x, tileSize.y);
+
+		// TODO: Clear the pixels of other levels' canvases where they overlap
+		// this newly dumped tile.
+		return this;
+	}
+
+});
+
+
+// @factory pixelGrid(options?: PixelGrid options)
+// Instantiates an empty pixel grid.
+export function pixelGrid(url, options) {
+	return new PixelGrid(url, options);
+}
+

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -1,4 +1,4 @@
-import {GridLayer} from './GridLayer';
+import {PixelGrid} from './PixelGrid';
 import * as Browser from '../../core/Browser';
 import * as Util from '../../core/Util';
 import * as DomEvent from '../../dom/DomEvent';
@@ -7,9 +7,9 @@ import * as DomUtil from '../../dom/DomUtil';
 
 /*
  * @class TileLayer
- * @inherits GridLayer
+ * @inherits PixelGrid
  * @aka L.TileLayer
- * Used to load and display tile layers on the map. Extends `GridLayer`.
+ * Used to load and display tile layers on the map. Extends `PixelGrid`.
  *
  * @example
  *
@@ -36,7 +36,7 @@ import * as DomUtil from '../../dom/DomUtil';
  */
 
 
-export var TileLayer = GridLayer.extend({
+export var TileLayer = PixelGrid.extend({
 
 	// @section
 	// @aka TileLayer options

--- a/src/layer/tile/index.js
+++ b/src/layer/tile/index.js
@@ -1,4 +1,5 @@
 export {GridLayer, gridLayer} from './GridLayer';
+export {PixelGrid, pixelGrid} from './PixelGrid';
 import {TileLayer, tileLayer} from './TileLayer';
 import {TileLayerWMS, tileLayerWMS} from './TileLayer.WMS';
 TileLayer.WMS = TileLayerWMS;


### PR DESCRIPTION
Fixes the dreaded "half-pixel gap between tiles at fractional zoom" bug from #4637 / #3575 by adding a new class which sits between `GridLayer` and `TileLayer`, as described by #4844.

Code is basically https://github.com/Leaflet/Leaflet.TileLayer.NoGap , refactored as ES6 modules. Comments from #4941 apply to this PR.

The downside is that this new class adds about ~6 KiB~ 4KiB of unminified code / ~4 KiB~ 3KiB of minified code / ~0.5 KiB~ 0.45 KiB of gzipped code. ~I don't like rewriting the `GridLayer` methods just to add one more line of code inside a loop, but I see no other alternative right now (or should the `GridLayer` make a check for `dumpToCanvas`?)~