### PR TITLE
Remove marker.dragging when not on the map

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -108,28 +108,18 @@ describe("Marker", function () {
 			map.removeLayer(marker);
 			// Dragging is still enabled, we should be able to disable it,
 			// even if marker is off the map.
-			marker.dragging.disable();
+			expect(marker.dragging).to.be(undefined);
+			marker.options.draggable = false;
 			map.addLayer(marker);
 
 			map.removeLayer(marker);
 
 			// We should also be able to enable dragging while off the map
-			marker.dragging.enable();
-			expect(marker.dragging.enabled()).to.be(true);
+			expect(marker.dragging).to.be(undefined);
+			marker.options.draggable = true;
 
 			map.addLayer(marker);
 			expect(marker.dragging.enabled()).to.be(true);
-		});
-
-		it("doesn't break when enabling dragging while off the map", function () {
-			// This causes a different error to the similar test above
-			var marker = new L.Marker([0, 0]);
-			map.addLayer(marker);
-			marker.dragging.enable();
-			marker.dragging.disable();
-			map.removeLayer(marker);
-
-			marker.dragging.enable();
 		});
 
 		it("changes the icon to another DivIcon", function () {

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -110,6 +110,26 @@ describe("Marker", function () {
 			// even if marker is off the map.
 			marker.dragging.disable();
 			map.addLayer(marker);
+
+			map.removeLayer(marker);
+
+			// We should also be able to enable dragging while off the map
+			marker.dragging.enable();
+			expect(marker.dragging.enabled()).to.be(true);
+
+			map.addLayer(marker);
+			expect(marker.dragging.enabled()).to.be(true);
+		});
+
+		it("doesn't break when enabling dragging while off the map", function () {
+			// This causes a different error to the similar test above
+			var marker = new L.Marker([0, 0]);
+			map.addLayer(marker);
+			marker.dragging.enable();
+			marker.dragging.disable();
+			map.removeLayer(marker);
+
+			marker.dragging.enable();
 		});
 
 		it("changes the icon to another DivIcon", function () {

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -17,7 +17,7 @@ import {Draggable} from '../../dom/Draggable';
  * ```
  *
  * @property dragging: Handler
- * Marker dragging handler (by both mouse and touch).
+ * Marker dragging handler (by both mouse and touch). Only valid when the marker is on the map (Otherwise set [`marker.options.draggable`](#marker-draggable)).
  */
 
 export var MarkerDrag = Handler.extend({

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -96,6 +96,7 @@ export var Marker = Layer.extend({
 			this.options.draggable = true;
 			this.dragging.removeHooks();
 		}
+		delete this.dragging;
 
 		if (this._zoomAnimated) {
 			map.off('zoomanim', this._animateZoom, this);


### PR DESCRIPTION
Fix for #5293 
Not 100% sure this is the right way to do this, but it is probably the easiest ;)

An issue we have now is that interacting with the dragging object while the marker is not on the map is not really valid as the dragging handler depends on the icon, which doesn't exist while not on the map.

This is probably a breaking change, although I don't expect it to actually affect many users.