### PR TITLE
Fix popup "autoClose" and "closeOnClick" options documentation, fixes #5040

### DIFF
--- a/docs/reference-1.0.0.html
+++ b/docs/reference-1.0.0.html
@@ -2916,13 +2916,19 @@ off of the screen while it is open.</td>
 		<td><code>true</code></td>
 		<td>Controls the presence of a close button in the popup.</td>
 	</tr>
+	<tr id='popup-closeonclick'>
+		<td><code><b>closeOnClick</b></code></td>
+		<td><code>Boolean</code>
+		<td><code>*</code></td>
+		<td>Set it if you want to override the default behavior of the popup closing when user clicks
+on the map. Defaults to the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option.</td>
+	</tr>
 	<tr id='popup-autoclose'>
 		<td><code><b>autoClose</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>true</code></td>
 		<td>Set it to <code>false</code> if you want to override the default behavior of
-the popup closing when user clicks the map (set globally by
-the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option).</td>
+the popup closing when another popup is opened.</td>
 	</tr>
 	<tr id='popup-classname'>
 		<td><code><b>className</b></code></td>

--- a/docs/reference-1.0.2.html
+++ b/docs/reference-1.0.2.html
@@ -2958,13 +2958,19 @@ off of the screen while it is open.</td>
 		<td><code>true</code></td>
 		<td>Controls the presence of a close button in the popup.</td>
 	</tr>
+	<tr id='popup-closeonclick'>
+		<td><code><b>closeOnClick</b></code></td>
+		<td><code>Boolean</code>
+		<td><code>*</code></td>
+		<td>Set it if you want to override the default behavior of the popup closing when user clicks
+on the map. Defaults to the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option.</td>
+	</tr>
 	<tr id='popup-autoclose'>
 		<td><code><b>autoClose</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>true</code></td>
 		<td>Set it to <code>false</code> if you want to override the default behavior of
-the popup closing when user clicks the map (set globally by
-the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option).</td>
+the popup closing when another popup is opened.</td>
 	</tr>
 	<tr id='popup-classname'>
 		<td><code><b>className</b></code></td>

--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -2967,13 +2967,19 @@ off of the screen while it is open.</td>
 		<td><code>true</code></td>
 		<td>Controls the presence of a close button in the popup.</td>
 	</tr>
+	<tr id='popup-closeonclick'>
+		<td><code><b>closeOnClick</b></code></td>
+		<td><code>Boolean</code>
+		<td><code>*</code></td>
+		<td>Set it if you want to override the default behavior of the popup closing when user clicks
+on the map. Defaults to the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option.</td>
+	</tr>
 	<tr id='popup-autoclose'>
 		<td><code><b>autoClose</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>true</code></td>
 		<td>Set it to <code>false</code> if you want to override the default behavior of
-the popup closing when user clicks the map (set globally by
-the Map&#39;s <a href="#map-closepopuponclick">closePopupOnClick</a> option).</td>
+the popup closing when another popup is opened.</td>
 	</tr>
 	<tr id='popup-classname'>
 		<td><code><b>className</b></code></td>

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -84,8 +84,7 @@ export var Popup = DivOverlay.extend({
 
 		// @option autoClose: Boolean = true
 		// Set it to `false` if you want to override the default behavior of
-		// the popup closing when user clicks the map (set globally by
-		// the Map's [closePopupOnClick](#map-closepopuponclick) option).
+		// the popup closing when another popup is opened.
 		autoClose: true,
 
 		// @option className: String = ''

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -89,7 +89,7 @@ export var Popup = DivOverlay.extend({
 
 		// @option closeOnClick: Boolean = *
 		// Set it if you want to override the default behavior of the popup closing when user clicks
-		// on the map. Defaults to the Map's [closePopupOnClick](#map-closepopuponclick) option.
+		// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
 
 		// @option className: String = ''
 		// A custom CSS class name to assign to the popup.

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -87,6 +87,10 @@ export var Popup = DivOverlay.extend({
 		// the popup closing when another popup is opened.
 		autoClose: true,
 
+		// @option closeOnClick: Boolean = *
+		// Set it if you want to override the default behavior of the popup closing when user clicks
+		// on the map. Defaults to the Map's [closePopupOnClick](#map-closepopuponclick) option.
+
 		// @option className: String = ''
 		// A custom CSS class name to assign to the popup.
 		className: ''
@@ -147,7 +151,7 @@ export var Popup = DivOverlay.extend({
 	getEvents: function () {
 		var events = DivOverlay.prototype.getEvents.call(this);
 
-		if ('closeOnClick' in this.options ? this.options.closeOnClick : this._map.options.closePopupOnClick) {
+		if (this.options.closeOnClick !== undefined ? this.options.closeOnClick : this._map.options.closePopupOnClick) {
 			events.preclick = this._close;
 		}
 


### PR DESCRIPTION
"autoClose" documentation was actually about "closeOnClick" and "autoClose" documentation was missing.