### PR TITLE
Removed type attribute in HTML5 files

### DIFF
--- a/debug/hacks/jitter.html
+++ b/debug/hacks/jitter.html
@@ -8,7 +8,7 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1 maximum-scale=1.0 user-scalable=0">
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -23,7 +23,7 @@
 		Bug tested to occur on: Safari on Mac (Tested in 5.1.7), iPad/iPhone 5.1.1., Android 4 Browser. Hack is in L.Browser.chrome and TileLayer._addTile
 
 </div>
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 		osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/canvas.html
+++ b/debug/map/canvas.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map" style="width: 600px; height: 600px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var tiles = new L.GridLayer();
 

--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -7,13 +7,13 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 		var geojson = {
 			"type": "Polygon",
 			"coordinates": [[

--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/geolocation.html
+++ b/debug/map/geolocation.html
@@ -8,14 +8,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <link rel="stylesheet" href="../css/screen.css" />
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
 
     <div id="map"></div>
 
-    <script type="text/javascript">
+    <script>
 
         var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/grid.html
+++ b/debug/map/grid.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var grid = L.gridLayer({
 			attribution: 'Grid Layer'

--- a/debug/map/image-overlay.html
+++ b/debug/map/image-overlay.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -17,7 +17,7 @@
 	<div id="map"></div>
 	<button id="populate">Populate with 10 markers</button>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/layer_remove_add.html
+++ b/debug/map/layer_remove_add.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -17,7 +17,7 @@
     <div id="map"></div>
     <button id="removeAdd">Remove and Add Layer</button>
 
-    <script type="text/javascript">
+    <script>
         map = L.map('map', { center: [0, 0], zoom: 3, maxZoom: 4 });
 
         var osm = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {

--- a/debug/map/map-mobile.html
+++ b/debug/map/map-mobile.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/map-popup.html
+++ b/debug/map/map-popup.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/map.html
+++ b/debug/map/map.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -17,7 +17,7 @@
 	<div id="map"></div>
 	<button id="populate">Populate with 10 markers</button>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/markers.html
+++ b/debug/map/markers.html
@@ -9,14 +9,14 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
 
     <div id="map"></div>
 
-    <script type="text/javascript">
+    <script>
         map = L.map('map', { center: [0, 0], zoom: 3, maxZoom: 4 });
 
         var markerStatic = new L.Marker([0, -10], {

--- a/debug/map/max-bounds-bouncy.html
+++ b/debug/map/max-bounds-bouncy.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -19,7 +19,7 @@
 	<div id="map1" style="float: left; width:45%; height: 80%;"></div>
 	<div id="map2" style="float: left; width:45%; height: 80%;"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/max-bounds-infinite.html
+++ b/debug/map/max-bounds-infinite.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/max-bounds.html
+++ b/debug/map/max-bounds.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/opacity.html
+++ b/debug/map/opacity.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 		.mapcontainer {
@@ -65,7 +65,7 @@
 		<div id="map6" class="map"></div>
 	</div>
 
-	<script type="text/javascript">
+	<script>
 		var mapopts =  {
 			center: [35, -122],
 			zoom : 5

--- a/debug/map/popup.html
+++ b/debug/map/popup.html
@@ -9,14 +9,14 @@
 
   <link rel="stylesheet" href="../css/screen.css" />
 
-  <script type="text/javascript" src="../../build/deps.js"></script>
+  <script src="../../build/deps.js"></script>
   <script src="../leaflet-include.js"></script>
 </head>
 <body>
 
   <div id="map"></div>
 
-  <script type="text/javascript">
+  <script>
 
     var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/rollup.html
+++ b/debug/map/rollup.html
@@ -9,8 +9,8 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-<!-- 	<script type="text/javascript" src="../../dist/leaflet-rollup-src.js"></script> -->
-	<script type="text/javascript" src="../leaflet-rollup-src.js"></script>
+<!-- 	<script src="../../dist/leaflet-rollup-src.js"></script> -->
+	<script src="../leaflet-rollup-src.js"></script>
 
 </head>
 <body>
@@ -21,7 +21,7 @@
 	<button id="populate-lines">Populate with lines</button>
 	<button id="populate-polygons">Populate with polygons</button>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/scroll.html
+++ b/debug/map/scroll.html
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -20,7 +20,7 @@
 		</div>
 	</div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/map/simple-proj.html
+++ b/debug/map/simple-proj.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var map = L.map('map', {
 			crs: L.CRS.Simple

--- a/debug/map/tile-debug.html
+++ b/debug/map/tile-debug.html
@@ -65,7 +65,7 @@
     }
     </style>
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -134,7 +134,7 @@
         <button id="reset">reset</button>
     </div>
 
-    <script type="text/javascript">
+    <script>
 
         var kyiv = [50.5, 30.5],
             lnd = [51.51, -0.12],

--- a/debug/map/tile-opacity.html
+++ b/debug/map/tile-opacity.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 		var map = new L.Map('map');
 		var nexrad = new L.TileLayer.WMS("http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi", {
 			layers: 'nexrad-n0r-900913',

--- a/debug/map/tooltip.html
+++ b/debug/map/tooltip.html
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style type="text/css">
 		.my-div-icon {
@@ -25,7 +25,7 @@
 	<div id="map"></div>
 
 
-	<script type="text/javascript">
+	<script>
 		var center = [41.2058, 9.4307];
 
 		var map = L.map('map').setView(center, 13);

--- a/debug/map/wms-marble.html
+++ b/debug/map/wms-marble.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map" style="width: 1024px; height: 440px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 		var map = new L.Map('map', {crs: L.CRS.EPSG4326});
 
 		var bluemarble = new L.TileLayer.WMS("http://maps.opengeo.org/geowebcache/service/wms", {

--- a/debug/map/wms.html
+++ b/debug/map/wms.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 		var map = new L.Map('map');
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/debug/map/zoom-delta.html
+++ b/debug/map/zoom-delta.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 	.container {
@@ -55,7 +55,7 @@
 		<span id="zoom2"></span>
 	</div>
 
-	<script type="text/javascript">
+	<script>
 
 		var sf = [37.77, -122.42],
 			trd = [63.41, 10.41];

--- a/debug/map/zoom-remain-centered.html
+++ b/debug/map/zoom-remain-centered.html
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -15,7 +15,7 @@
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 		// Check the 'center' setting of the scroll-wheel, double-click and touch-zoom
 		// handlers
 

--- a/debug/map/zoomlevels.html
+++ b/debug/map/zoomlevels.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 	    // Test that changing between layers with differing zoomlevels also updates
         // the zoomlevels in the map + also
 

--- a/debug/map/zoompan.html
+++ b/debug/map/zoompan.html
@@ -19,7 +19,7 @@
 	}
 	</style>
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -44,7 +44,7 @@
 		<tr><td>on grid load</td><td id='load'></td></tr>
 	</div>
 
-	<script type="text/javascript">
+	<script>
 
 		var kyiv = [50.5, 30.5],
 			lnd = [51.51, -0.12],

--- a/debug/tests/add_remove_layers.html
+++ b/debug/tests/add_remove_layers.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/tests/bringtoback.html
+++ b/debug/tests/bringtoback.html
@@ -8,7 +8,7 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -16,7 +16,7 @@
 	<div id="map"></div>
 	<button id="foo">Click to add layer, then zoom out or in</button>
 
-	<script type="text/javascript">
+	<script>
 
 	var map = new L.Map('map', { center: new L.LatLng(45.50144, -122.67599), zoom: 4 });
 

--- a/debug/tests/canvasloop.html
+++ b/debug/tests/canvasloop.html
@@ -3,7 +3,7 @@
     <link rel="stylesheet" href="../../dist/leaflet.css" />
     <link rel="stylesheet" href="../css/screen.css" />
 
-        <script type="text/javascript" src="../../build/deps.js"></script>
+        <script src="../../build/deps.js"></script>
 
         <script src="../leaflet-include.js"></script>
     </head>

--- a/debug/tests/click_on_canvas.html
+++ b/debug/tests/click_on_canvas.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/tests/custom-panes.html
+++ b/debug/tests/custom-panes.html
@@ -9,7 +9,7 @@
 	
 	<link rel="stylesheet" href="../css/screen.css" />
 	
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	
 	<style>
@@ -31,7 +31,7 @@
 		<div id="mapSvg"></div>
 	</div>
 
-	<script type="text/javascript">
+	<script>
 
 		function makeMap(container, options) {
 			var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/debug/tests/detached-dom-memory-leak.html
+++ b/debug/tests/detached-dom-memory-leak.html
@@ -5,7 +5,7 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<script>
 	var map,

--- a/debug/tests/doubleclick-events-slowdown.html
+++ b/debug/tests/doubleclick-events-slowdown.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -19,7 +19,7 @@
 	<div id="map"></div>
 	<button id="populate">Populate with 100 more markers</button><div id='perf'></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/tests/dragging_and_copyworldjump.html
+++ b/debug/tests/dragging_and_copyworldjump.html
@@ -9,7 +9,7 @@
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 		<link rel="stylesheet" href="../css/screen.css" />
-		<script type="text/javascript" src="../../build/deps.js"></script>
+		<script src="../../build/deps.js"></script>
 		<script src="../leaflet-include.js"></script>
 	</head>
 	<body>
@@ -25,7 +25,7 @@
 		<div style="clear:both"></div>
 
 
-		<script type="text/javascript">
+		<script>
 			function addLayerAndMarker(map) {
 				var layer = new L.TileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
 					maxZoom : 18

--- a/debug/tests/dragging_cursors.html
+++ b/debug/tests/dragging_cursors.html
@@ -9,7 +9,7 @@
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 		<link rel="stylesheet" href="../css/screen.css" />
-		<script type="text/javascript" src="../../build/deps.js"></script>
+		<script src="../../build/deps.js"></script>
 		<script src="../leaflet-include.js"></script>
 	</head>
 	<body>
@@ -25,7 +25,7 @@
 		<div>Map dragging disabled:</div>
 		<div id="map2" style="height: 300px;width: 400px; float:left;"></div>
 
-		<script type="text/javascript">
+		<script>
 			function addLayerAndMarkers(map) {
 				var layer = new L.TileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
 					maxZoom : 18

--- a/debug/tests/event-perf-2.html
+++ b/debug/tests/event-perf-2.html
@@ -9,14 +9,14 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
 
     <div id="map"></div>
 
-    <script type="text/javascript">
+    <script>
         /*
 
             Can be used to profile performance of event system.

--- a/debug/tests/event-perf.html
+++ b/debug/tests/event-perf.html
@@ -4,7 +4,7 @@
 <meta name="viewport" id="vp" content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width" />
 
     <link rel="stylesheet" href="../../dist/leaflet.css" />
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 
   <meta charset="utf-8">

--- a/debug/tests/mousemove_on_polygons.html
+++ b/debug/tests/mousemove_on_polygons.html
@@ -33,7 +33,7 @@
 			}
 		}
 	</style>
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<table>
 	<tr><td>           </td><td>Enter       </td><td>Move       </td><td>Exit       </td><td>Click       </td></tr>
@@ -46,7 +46,7 @@
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/tests/opacity.html
+++ b/debug/tests/opacity.html
@@ -14,14 +14,14 @@
 		}
 
 	</style>
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/tests/popup_offset.html
+++ b/debug/tests/popup_offset.html
@@ -9,14 +9,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/tests/popupcontextmenuclicks.html
+++ b/debug/tests/popupcontextmenuclicks.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="../css/screen.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
 </head>
 <body>
@@ -17,7 +17,7 @@
     <div id="map"></div>
     <button id="populate">Populate with 10 markers</button>
 
-    <script type="text/javascript">
+    <script>
 
 var map = L.map('map').setView([36.9, -95.4], 5);
 map.on('contextmenu', function (e) {

--- a/debug/tests/remove_while_dragging.html
+++ b/debug/tests/remove_while_dragging.html
@@ -7,14 +7,14 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 
 	<div id="map" style="width: 600px; height: 600px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 
 	var map = L.map('map').setView( [50, 50], 10);
 	var marker = L.marker([50, 50], {draggable: true}).addTo(map);

--- a/debug/tests/removetilewhilepan.html
+++ b/debug/tests/removetilewhilepan.html
@@ -8,15 +8,15 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
-	<script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+	<script src="http://code.jquery.com/jquery-1.8.0.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 	var map = new L.Map('map', { center: new L.LatLng(45.50144, -122.67599), zoom: 4 });
 

--- a/debug/tests/reuse_popups.html
+++ b/debug/tests/reuse_popups.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/tests/rtl.html
+++ b/debug/tests/rtl.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 	body {
@@ -22,7 +22,7 @@
 	<p>Click the map to place a popup at the mouse location</p>
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 		var osm = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/debug/tests/rtl2.html
+++ b/debug/tests/rtl2.html
@@ -7,7 +7,7 @@
 
     <link rel="stylesheet" href="../css/mobile.css" />
 
-    <script type="text/javascript" src="../../build/deps.js"></script>
+    <script src="../../build/deps.js"></script>
     <script src="../leaflet-include.js"></script>
     <style>
         #map { height: 100%; }

--- a/debug/tests/set_icon_reuse_dom.html
+++ b/debug/tests/set_icon_reuse_dom.html
@@ -5,13 +5,13 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>
 	<div id="map" style="width: 600px; height: 600px; border: 1px solid #ccc"></div>
 
-	<script type="text/javascript">
+	<script>
 
 	var blueIcon = new L.Icon({iconUrl: 'http://www.webatlas.no/webatlasapi/v/071009/media/interface/default/markers/flag_blue.gif'});
 	var redIcon = new L.Icon({iconUrl: 'http://www.webatlas.no/webatlasapi/v/071009/media/interface/default/markers/flag_red.gif'});

--- a/debug/tests/svg_clicks.html
+++ b/debug/tests/svg_clicks.html
@@ -8,15 +8,15 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
-	<script type='text/javascript' src='http://code.jquery.com/jquery-1.8.0.js'></script>
+	<script src="http://code.jquery.com/jquery-1.8.0.js"></script>
 </head>
 <body>
 
 	<div id="map"></div>
 
-	<script type="text/javascript">
+	<script>
 
 	var map;
 	var myLayerGroup = new L.LayerGroup();

--- a/debug/tests/tile-bounds.html
+++ b/debug/tests/tile-bounds.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 	#map {
@@ -28,7 +28,7 @@
 
 	<div id="map" class="map"></div>
 
-	<script type="text/javascript">
+	<script>
 		var mapopts =  {
 			center: [35, -122],
 			zoom: 5.7,

--- a/debug/tests/tile-events.html
+++ b/debug/tests/tile-events.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 	#map {
@@ -78,7 +78,7 @@
 	<div><button id="stop">stop</button></div>
 
 
-	<script type="text/javascript">
+	<script>
 		var mapopts =  {
 			center: [35, -122],
 			zoom: 5.75,

--- a/debug/tests/tile-opacity.html
+++ b/debug/tests/tile-opacity.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 	<style>
 	</style>
@@ -19,7 +19,7 @@
 	The opacity of the "toner" layer should pulse nicely, even when dragging/zooming the map around with new tiles.
 	<div id="map" class="map"></div>
 
-	<script type="text/javascript">
+	<script>
 		var mapopts =  {
 			center: [35, -122],
 			zoom : 5

--- a/debug/tests/touch-shake.html
+++ b/debug/tests/touch-shake.html
@@ -11,7 +11,7 @@
 
 
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 
 	<script src="../../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>

--- a/debug/tests/touch-zoom-bounce.html
+++ b/debug/tests/touch-zoom-bounce.html
@@ -11,7 +11,7 @@
 
 
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 
 	<script src="../../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>

--- a/debug/vector/vector-canvas.html
+++ b/debug/vector/vector-canvas.html
@@ -7,7 +7,7 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/vector/vector-mobile.html
+++ b/debug/vector/vector-mobile.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/vector/vector-simple.html
+++ b/debug/vector/vector-simple.html
@@ -9,7 +9,7 @@
 
 	<link rel="stylesheet" href="../css/mobile.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/vector/vector.html
+++ b/debug/vector/vector.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/debug/vector/vector2.html
+++ b/debug/vector/vector2.html
@@ -6,7 +6,7 @@
 	<link rel="stylesheet" href="../../dist/leaflet.css" />
 
 	<link rel="stylesheet" href="../css/screen.css" />
-	<script type="text/javascript" src="../../build/deps.js"></script>
+	<script src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -154,6 +154,6 @@
 	})();
 </script>
 
-<script type="text/javascript" src="{{ root }}docs/js/docs.js"></script>
+<script src="{{ root }}docs/js/docs.js"></script>
 </body>
 </html>

--- a/docs/examples/geojson/geojson-example.html
+++ b/docs/examples/geojson/geojson-example.html
@@ -11,7 +11,7 @@
 <body>
 	<div id="map" style="width: 600px; height: 400px"></div>
 
-	<script src="sample-geojson.js" type="text/javascript"></script>
+	<script src="sample-geojson.js"></script>
 	<script src="https://unpkg.com/leaflet@1.0.0-rc.3/dist/leaflet.js"></script>
 
 	<script>

--- a/docs/examples/geojson/geojson.html
+++ b/docs/examples/geojson/geojson.html
@@ -9,7 +9,7 @@ title: Using GeoJSON with Leaflet
 
 <div id="map" class="map" style="height: 250px"></div>
 
-<script src="sample-geojson.js" type="text/javascript"></script>
+<script src="sample-geojson.js"></script>
 <script>
 
 	var map = L.map('map').setView([39.74739, -105], 13);

--- a/spec/index.html
+++ b/spec/index.html
@@ -9,19 +9,19 @@
 <body>
 	<div id="mocha"></div>
 	<script src="expect.js"></script>
-	<script type="text/javascript" src="../node_modules/mocha/mocha.js"></script>
-	<script type="text/javascript" src="../node_modules/happen/happen.js"></script>
-	<script type="text/javascript" src="../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>
-	<script type="text/javascript" src="sinon.js"></script>
+	<script src="../node_modules/mocha/mocha.js"></script>
+	<script src="../node_modules/happen/happen.js"></script>
+	<script src="../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>
+	<script src="sinon.js"></script>
 
 	<!-- source files -->
 	<script>
 		// Trick Leaflet into believing we have a touchscreen (for Chrome)
 		if (window.Touch) { window.ontouchstart = function(){} };
 	</script>
-<!-- 	<script type="text/javascript" src="../build/deps.js"></script> -->
+<!-- 	<script src="../build/deps.js"></script> -->
 
-	<script type="text/javascript" src="../debug/leaflet-include.js"></script>
+	<script src="../debug/leaflet-include.js"></script>
 
 	<script>
 		mocha.setup({
@@ -32,69 +32,69 @@
 
 	<!-- spec files -->
 
-	<script type="text/javascript" src="suites/SpecHelper.js"></script>
+	<script src="suites/SpecHelper.js"></script>
 
 	<!-- /control -->
-	<script type="text/javascript" src="suites/control/ControlSpec.js"></script>
-	<script type="text/javascript" src="suites/control/Control.LayersSpec.js"></script>
-	<script type="text/javascript" src="suites/control/Control.ScaleSpec.js"></script>
-	<script type="text/javascript" src="suites/control/Control.AttributionSpec.js"></script>
+	<script src="suites/control/ControlSpec.js"></script>
+	<script src="suites/control/Control.LayersSpec.js"></script>
+	<script src="suites/control/Control.ScaleSpec.js"></script>
+	<script src="suites/control/Control.AttributionSpec.js"></script>
 
 	<!-- /core -->
-	<script type="text/javascript" src="suites/core/UtilSpec.js"></script>
-	<script type="text/javascript" src="suites/core/ClassSpec.js"></script>
-	<script type="text/javascript" src="suites/core/EventsSpec.js"></script>
+	<script src="suites/core/UtilSpec.js"></script>
+	<script src="suites/core/ClassSpec.js"></script>
+	<script src="suites/core/EventsSpec.js"></script>
 
 	<!-- /geometry -->
-	<script type="text/javascript" src="suites/geometry/PointSpec.js"></script>
-	<script type="text/javascript" src="suites/geometry/BoundsSpec.js"></script>
-	<script type="text/javascript" src="suites/geometry/TransformationSpec.js"></script>
-	<script type="text/javascript" src="suites/geometry/LineUtilSpec.js"></script>
-	<script type="text/javascript" src="suites/geometry/PolyUtilSpec.js"></script>
+	<script src="suites/geometry/PointSpec.js"></script>
+	<script src="suites/geometry/BoundsSpec.js"></script>
+	<script src="suites/geometry/TransformationSpec.js"></script>
+	<script src="suites/geometry/LineUtilSpec.js"></script>
+	<script src="suites/geometry/PolyUtilSpec.js"></script>
 
 	<!-- /geo -->
-	<script type="text/javascript" src="suites/geo/LatLngSpec.js"></script>
-	<script type="text/javascript" src="suites/geo/LatLngBoundsSpec.js"></script>
-	<script type="text/javascript" src="suites/geo/ProjectionSpec.js"></script>
+	<script src="suites/geo/LatLngSpec.js"></script>
+	<script src="suites/geo/LatLngBoundsSpec.js"></script>
+	<script src="suites/geo/ProjectionSpec.js"></script>
 
 	<!-- /dom -->
-	<script type="text/javascript" src="suites/dom/DomEventSpec.js"></script>
-	<script type="text/javascript" src="suites/dom/DomUtilSpec.js"></script>
+	<script src="suites/dom/DomEventSpec.js"></script>
+	<script src="suites/dom/DomUtilSpec.js"></script>
 
 	<!-- /layer -->
-	<script type="text/javascript" src="suites/layer/FeatureGroupSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/GeoJSONSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/ImageOverlaySpec.js"></script>
-	<script type="text/javascript" src="suites/layer/LayerGroupSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/PopupSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/TooltipSpec.js"></script>
+	<script src="suites/layer/FeatureGroupSpec.js"></script>
+	<script src="suites/layer/GeoJSONSpec.js"></script>
+	<script src="suites/layer/ImageOverlaySpec.js"></script>
+	<script src="suites/layer/LayerGroupSpec.js"></script>
+	<script src="suites/layer/PopupSpec.js"></script>
+	<script src="suites/layer/TooltipSpec.js"></script>
 
 	<!-- /layer/tile -->
-	<script type="text/javascript" src="suites/layer/tile/GridLayerSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/tile/TileLayerSpec.js"></script>
+	<script src="suites/layer/tile/GridLayerSpec.js"></script>
+	<script src="suites/layer/tile/TileLayerSpec.js"></script>
 
 	<!-- /layer/marker/ -->
-	<script type="text/javascript" src="suites/layer/marker/MarkerSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/marker/Icon.DefaultSpec.js"></script>
+	<script src="suites/layer/marker/MarkerSpec.js"></script>
+	<script src="suites/layer/marker/Icon.DefaultSpec.js"></script>
 
 	<!-- /layer/vector/ -->
-	<script type="text/javascript" src="suites/layer/vector/CircleSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/CircleMarkerSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/PathSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/PolygonSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/PolylineSpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/PolylineGeometrySpec.js"></script>
-	<script type="text/javascript" src="suites/layer/vector/CanvasSpec.js"></script>
+	<script src="suites/layer/vector/CircleSpec.js"></script>
+	<script src="suites/layer/vector/CircleMarkerSpec.js"></script>
+	<script src="suites/layer/vector/PathSpec.js"></script>
+	<script src="suites/layer/vector/PolygonSpec.js"></script>
+	<script src="suites/layer/vector/PolylineSpec.js"></script>
+	<script src="suites/layer/vector/PolylineGeometrySpec.js"></script>
+	<script src="suites/layer/vector/CanvasSpec.js"></script>
 
 	<!-- /map -->
-	<script type="text/javascript" src="suites/map/MapSpec.js"></script>
+	<script src="suites/map/MapSpec.js"></script>
 
 	<!-- /map/handler -->
-	<script type="text/javascript" src="suites/map/handler/Map.DragSpec.js"></script>
-	<script type="text/javascript" src="suites/map/handler/Map.TouchZoomSpec.js"></script>
+	<script src="suites/map/handler/Map.DragSpec.js"></script>
+	<script src="suites/map/handler/Map.TouchZoomSpec.js"></script>
 
 	<!-- /geo/crs -->
-	<script type="text/javascript" src="suites/geo/CRSSpec.js"></script>
+	<script src="suites/geo/CRSSpec.js"></script>
 
 	<script>
 		(window.mochaPhantomJS || window.mocha).run();


### PR DESCRIPTION
Removed unneeded type attribute in <script> form in .html files.

type attribute is not needed in HTML5 cos its default scripting language in html