### PR TITLE
Disable click propagation on zoom control buttons

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -91,7 +91,7 @@ export var Zoom = Control.extend({
 		link.setAttribute('role', 'button');
 		link.setAttribute('aria-label', title);
 
-		DomEvent.on(link, 'mousedown dblclick', DomEvent.stopPropagation);
+		DomEvent.disableClickPropagation(link);
 		DomEvent.on(link, 'click', DomEvent.stop);
 		DomEvent.on(link, 'click', fn, this);
 		DomEvent.on(link, 'click', this._refocusOnMap, this);


### PR DESCRIPTION
We used some old, incomplete logic to disable click propagation from zoom control buttons, switch to use `L.DomEvent.disableClickPropagation` instead. Should fix the #5308, except for the things that relate to controls in other plugins (that we can't do much about).