### PR TITLE
Provide missing SVG static methods.

### DIFF
--- a/src/layer/vector/index.js
+++ b/src/layer/vector/index.js
@@ -1,6 +1,9 @@
 export {Renderer} from './Renderer';
 export {Canvas, canvas} from './Canvas';
-export {SVG, svg} from './SVG';
+import {SVG, create, pointsToPath, svg} from './SVG';
+SVG.create = create;
+SVG.pointsToPath = pointsToPath;
+export {SVG, svg};
 import './Renderer.getRenderer';	// This is a bit of a hack, but needed because circular dependencies
 
 export {Path} from './Path';


### PR DESCRIPTION
Currently, `SVG.create()` and `SVG.pointsToPath()` are unavailable when imported as a module.