### PR TITLE
Export lastId in Util

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -45,7 +45,7 @@ export function bind(fn, obj) {
 	};
 }
 
-var lastId = 0;
+export var lastId = 0;
 
 // @function stamp(obj: Object): Number
 // Returns the unique ID of an object, assiging it one if it doesn't have it.


### PR DESCRIPTION
Looking over at the documentation I noticed that `lastId` was an available property however it wasn't exported.

http://leafletjs.com/reference-1.0.3.html#util-lastid