### PR TITLE
Docstrings: recover lost docstring for L.Util.lastId

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -45,6 +45,8 @@ export function bind(fn, obj) {
 	};
 }
 
+// @property lastId: Number
+// Last unique ID used by [`stamp()`](#util-stamp)
 export var lastId = 0;
 
 // @function stamp(obj: Object): Number


### PR DESCRIPTION
Related to #5349. It seems that the docstrings for `L.Util.lastId` was lost in the big rollupJS commit, [over here](https://github.com/Leaflet/Leaflet/commit/703ae02aa8cbd0b87be5b01e77754b83ad732267?w=1#diff-4b892233603abc3c8825cfb5905b7453L59).