### PR TITLE
fix invalid GeoJSON produced by nested LayerGroups

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -356,4 +356,17 @@ describe("L.LayerGroup#toGeoJSON", function () {
 			features: []
 		});
 	});
+
+	it('should return only one FeatureCollection for nested LayerGroups', function () {
+		var layerGroup = new L.LayerGroup([
+			new L.LayerGroup([new L.Marker([-41.3330287, 173.2008273])]),
+			new L.Marker([-41.273356, 173.287278])
+		]);
+
+		var geoJSON = layerGroup.toGeoJSON();
+
+		expect(geoJSON.features.length).to.eql(2);
+		expect(geoJSON.features[0].type).to.eql("Feature");
+		expect(geoJSON.features[1].type).to.eql("Feature");
+	});
 });

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -362,7 +362,7 @@ LayerGroup.include({
 	},
 
 	// @method toGeoJSON(): Object
-	// Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the layer group (as a GeoJSON `GeometryCollection`).
+	// Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the layer group (as a GeoJSON `FeatureCollection`, `GeometryCollection`, or `MultiPoint`).
 	toGeoJSON: function () {
 
 		var type = this.feature && this.feature.geometry && this.feature.geometry.type;
@@ -377,7 +377,17 @@ LayerGroup.include({
 		this.eachLayer(function (layer) {
 			if (layer.toGeoJSON) {
 				var json = layer.toGeoJSON();
-				jsons.push(isGeometryCollection ? json.geometry : asFeature(json));
+				if (isGeometryCollection) {
+					jsons.push(json.geometry);
+				} else {
+					var feature = asFeature(json);
+					// Squash nested feature collections
+					if (feature.type === 'FeatureCollection') {
+						jsons.push.apply(jsons, feature.features);
+					} else {
+						jsons.push(feature);
+					}
+				}
 			}
 		});
 


### PR DESCRIPTION
When a LayerGroup contains another LayerGroup .toGeoJSON returns an invalid GeoJSON object as it will return nested FeatureCollection objects.

This fix squashes nested FeatureCollections by concatenating their features array with the parent FeatureCollection's features array.

The GeoJSON spec states that a FeatureCollection's features property contains an array of Feature objects.

http://geojson.org/geojson-spec.html#feature-collection-objects
> The value corresponding to "features" is an array. Each element in the array is a feature object as defined above.

Currently LayerGroup.toGeoJSON will return a FeatureCollection where the features array may contain one or more FeatureCollection objects.

Example:
https://playground-leaflet.rhcloud.com/pin/2/edit?html,console