### PR TITLE
Include L.Mixin.Events again; add deprecation notice

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -604,4 +604,20 @@ describe('Events', function () {
 		});
 	});
 
+	describe('#L.Mixin.Events', function () {
+		it('can be used from includes', function () {
+			var EventClass = L.Class.extend({
+				includes: L.Mixin.Events
+			});
+			var obj = new EventClass();
+			var spy = sinon.spy();
+
+			obj.on('test', spy);
+
+			obj.fire('test');
+
+			expect(spy.called).to.be(true);
+		});
+	});
+
 });

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -48,6 +48,7 @@ Class.extend = function (props) {
 
 	// mix includes into the prototype
 	if (props.includes) {
+		checkDeprecatedMixinEvents(props.includes);
 		Util.extend.apply(null, [proto].concat(props.includes));
 		delete props.includes;
 	}
@@ -109,3 +110,17 @@ Class.addInitHook = function (fn) { // (Function) || (String, args...)
 	this.prototype._initHooks.push(init);
 	return this;
 };
+
+function checkDeprecatedMixinEvents(includes) {
+	if (!L || !L.Mixin) { return; }
+
+	includes = L.Util.isArray(includes) ? includes : [includes];
+
+	for (var i = 0; i < includes.length; i++) {
+		if (includes[i] === L.Mixin.Events) {
+			console.warn('Deprecated include of L.Mixin.Events: ' +
+				'this property will be removed in future releases, ' +
+				'please inherit from L.Evented instead.', new Error().stack);
+		}
+	}
+}

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -3,8 +3,9 @@ export {Browser};
 
 export {Class} from './Class';
 
-export {Evented} from './Events';
-// export var Mixin = {Events: Evented.prototype};
+import {Evented} from './Events';
+export {Evented};
+export var Mixin = {Events: Evented.prototype};
 
 export {Handler} from './Handler';
 


### PR DESCRIPTION
This addresses #5358 by including `L.Mixin.Events` in the exported namespace again. It also adds a deprecation warning in the log.