### PR TITLE
Stop map on drag start instead of pointer down

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -61,7 +61,6 @@ export var Drag = Handler.extend({
 			this._draggable = new Draggable(map._mapPane, map._container);
 
 			this._draggable.on({
-				down: this._onDown,
 				dragstart: this._onDragStart,
 				drag: this._onDrag,
 				dragend: this._onDragEnd
@@ -93,9 +92,6 @@ export var Drag = Handler.extend({
 
 	moving: function () {
 		return this._draggable && this._draggable._moving;
-	},
-
-	_onDown: function () {
 	},
 
 	_onDragStart: function () {

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -96,12 +96,12 @@ export var Drag = Handler.extend({
 	},
 
 	_onDown: function () {
-		this._map._stop();
 	},
 
 	_onDragStart: function () {
 		var map = this._map;
 
+		map._stop();
 		if (this._map.options.maxBounds && this._map.options.maxBoundsViscosity) {
 			var bounds = latLngBounds(this._map.options.maxBounds);
 


### PR DESCRIPTION
Looking at #5350, I found out that `Map.Drag` stops an ongoing `flyTo` animation once a pointer down event is received, and not when the user actually starts dragging the map. This leaves the possibility that the user only taps the map, without starting to drag. In this situation, the animation will be aborted, but no map movement will be registered by `Map.Drag`, so no `moveend` event will be fired, neither for the `flyTo` animation or the drag.

This in turn becomes a problem since it's reasonable to assume a `flyTo` call will be succeeded by a `moveend` at some point, either when the animation finishes or when it's aborted - clearly the map has moved by then.

I looked through other usages of `Map._stop`, and it appears it is otherwise only used where a `moveend` will be fired, so `Map.Drag` is an exception, which is not guaranteed to fire a `moveend`.

An alternative to this fix would be to make `Map._stop` fire a `moveend` if an animation is interrupted - this would also make sense to me, but at the same time seems to be a potentially more intrusive fix: we would sometimes fire multiple `moveend` events where we today only fire one, potentially causing problems for existing apps.