### PR TITLE
Update CONTRIBUTING.md: Use "yarn global add"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ npm install
 ```
 or, if you prefer [`yarn`](https://yarnpkg.com/) over `npm`:
 ```
-yarn install -g jake
+yarn global add jake
 yarn install
 ```
 


### PR DESCRIPTION
Use "yarn global add" instead of "yarn install -g". Because "yarn install" is used to install all dependencies for a project [1]. "yarn global"  install packages globally on your operating system [2].

[1] https://yarnpkg.com/en/docs/cli/install
[2] https://yarnpkg.com/en/docs/cli/global