### PR TITLE
Trying to fix issue #2795

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -826,8 +826,8 @@ export var Map = Evented.extend({
 	getSize: function () {
 		if (!this._size || this._sizeChanged) {
 			this._size = new Point(
-				this._container.clientWidth || 0,
-				this._container.clientHeight || 0);
+				this._container.getBoundingClientRect().width || 0,
+				this._container.getBoundingClientRect().height || 0);
 
 			this._sizeChanged = false;
 		}


### PR DESCRIPTION
I tried to fix #2795 issue following @IvanSanchez 's [suggestion](https://github.com/Leaflet/Leaflet/issues/2795#issuecomment-284674984) .
Yeap, `getBoundingClientRect` really returns scaled pixel size, but in doesn't fix anything at all. I tried to debug some map methods, which are used to change map's zoom, but I didn't find a reason (I'm newbie in Leaflet source code and in open-source generally).

One more interesting thing is, that `getBoundingClientRect`'s `width` and `height` properties also contain element's `borderWidth`, So it's not the proper element's size.
E.g. if element's width is 400px and it has a 1px border, `getBoundingClientRect().width` will return `402`. We can calculate element's borderWidth using `getComputedStyle` method. But if map's container will be scaled using css transform (e.g. `scale(2, 2)`), `getBoundingClientRect().width` will return `804`  (border is also doubled), but `getComputedStyle.borderWidth` will still be `1px`. In this case `getComputedStyle.transform` probably should be also checked to calculate borderWidth properly.

I'm not sure, if this issue really needs that size calculation changes, since it doesn't fix the bug. But if so, it should be done careful.

Does anyone can help me with that issue?