### PR TITLE
build sets e in catch(e) to argument name

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -174,7 +174,7 @@ function _setOpacityIE(el, value) {
 	if (filter) {
 		filter.Enabled = (value !== 100);
 		filter.Opacity = value;
-	} else {
+	} else if (!el.name == 'Error') {
 		el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
 	}
 }

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -174,7 +174,7 @@ function _setOpacityIE(el, value) {
 	if (filter) {
 		filter.Enabled = (value !== 100);
 		filter.Opacity = value;
-	} else if (!el.name == 'Error') {
+	} else if (!el.name === 'Error') {
 		el.style.filter += ' progid:' + filterName + '(opacity=' + value + ')';
 	}
 }


### PR DESCRIPTION
The current uglify job generates the following code:

`_setOpacityIE:function(t,e){var i=!1,n="DXImageTransform.Microsoft.Alpha";try{i=t.filters.item(n)}catch(t){if(1===e)return}e=Math.round(100*e),i?(i.Enabled=100!==e,i.Opacity=e):t.style.filter+=" progid:"+n+"(opacity="+e+")"}`

The catch(t) statement might *not* return (if value != 1), which changes the argument t to the caught error. I tried alternatives to catch(e) eg. catch(me), catch(you) catch(acold), but only testing for the error to have happened helps.

I get this error when I click on a cluster from the markercluster module.