### PR TITLE
Ensure renderer's container is init'ed when a path is added to map

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -119,6 +119,7 @@ export var SVG = Renderer.extend({
 	},
 
 	_addPath: function (layer) {
+		if (!this._rootGroup) { this._initContainer(); }
 		this._rootGroup.appendChild(layer._path);
 		layer.addInteractiveTarget(layer._path);
 	},


### PR DESCRIPTION
Fixes #5401. Calling the renderer's `_initContainer()` before the renderer is added to the map has no ill effects.

Haven't tried with a `Canvas` renderer, but I expect no problems, as the DOM is not involved in that case.