### PR TITLE
Doc(LayerGroup): add hasLayer method call with id

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -67,6 +67,9 @@ export var LayerGroup = Layer.extend({
 
 	// @method hasLayer(layer: Layer): Boolean
 	// Returns `true` if the given layer is currently added to the group.
+	// @alternative
+	// @method hasLayer(id: Number): Boolean
+	// Returns `true` if the given internal ID is currently added to the group.
 	hasLayer: function (layer) {
 		return !!layer && (layer in this._layers || this.getLayerId(layer) in this._layers);
 	},


### PR DESCRIPTION
With the current `hasLayer` code, we can call this method by passing the `_leaflet_id` and get the same result as passing the corresponding layer object.
Added the alternative method call, as done for `removeLayer` method.