### PR TITLE
Added Leaflet.GeotagPhoto to list of plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1327,7 +1327,7 @@ These plugins provide new markers or news ways of converting abstract data into 
 			<a href="https://github.com/nypl-spacetime/Leaflet.GeotagPhoto">Leaflet.GeotagPhoto</a>
 		</td>
 		<td>
-			Leaflet plugin for photo geotagging, with two modes: camera and crosshair (<a href="http://spacetime.nypl.org/Leaflet.GeotagPhoto/examples/camera.html">Demo</a>).
+			Plugin for photo geotagging, with two modes: camera and crosshair (<a href="http://spacetime.nypl.org/Leaflet.GeotagPhoto/examples/camera.html">Demo</a>).
 		</td>
 		<td>
 			<a href="https://github.com/bertspaan">Bert Spaan</a>


### PR DESCRIPTION
Added Leaflet.GeotagPhoto to list of plugins: 

- Demo: http://spacetime.nypl.org/Leaflet.GeotagPhoto/examples/camera.html
- Repo: https://github.com/nypl-spacetime/Leaflet.GeotagPhoto