### PR TITLE
On update set current tiles active to avoid pruning (#5381)

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -653,6 +653,7 @@ export var GridLayer = Layer.extend({
 				var tile = this._tiles[this._tileCoordsToKey(coords)];
 				if (tile) {
 					tile.current = true;
+					tile.active = true;
 				} else {
 					queue.push(coords);
 				}

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -650,11 +650,7 @@ export var GridLayer = Layer.extend({
 
 				if (!this._isValidTile(coords)) { continue; }
 
-				var tile = this._tiles[this._tileCoordsToKey(coords)];
-				if (tile) {
-					tile.current = true;
-					tile.active = true;
-				} else {
+				if (!this._tiles[this._tileCoordsToKey(coords)]) {
 					queue.push(coords);
 				}
 			}


### PR DESCRIPTION
The missing tiles after fast zoom in/out seems to be a race condition. 

When the tiles of the level have been loaded before they are re-used. But it can occur that this tile is not marked as active (maybe the opacity animation wasn't completed before), and this removes the current tile at the purging function.

Forcing the current tile to active solves this problem.