### PR TITLE
Escape html elements inside code sample

### DIFF
--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -63,7 +63,7 @@ Also note that when using multiple base layers, only one of them should be added
 Finally, you can style the keys when you define the objects for the layers. For example, this code will make the label for the grayscale map gray:
 
 <pre><code>var baseMaps = {
-	"<span style='color: gray'>Grayscale</span>": grayscale,
+	"&lt;span style='color: gray'&gt;Grayscale&lt;/span&gt;": grayscale,
 	"Streets": streets
 };
 </code></pre>


### PR DESCRIPTION
The markup renderer will still literally render html tags inside "pre" and "code" unless they're escaped. The result was that the example code would be rendered as:
```
var baseMaps = {
	"Grayscale": grayscale,
	"Streets": streets
};
```
rather than
```
var baseMaps = {
	"<span style='color: gray'>Grayscale</span>": grayscale,
	"Streets": streets
};
```
because the "Grayscale" text would be literally styled as a span with gray color, and then recolored by the syntax highlighter.

Escaping the span tags fixes this.