### PR TITLE
fix the coding contradiction in the function of preventOutline.

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -297,7 +297,7 @@ export function preventOutline(element) {
 	while (element.tabIndex === -1) {
 		element = element.parentNode;
 	}
-	if (!element || !element.style) { return; }
+	if (!element.style) { return; }
 	restoreOutline();
 	_outlineElement = element;
 	_outlineStyle = element.style.outline;


### PR DESCRIPTION
The codes first execute "element.tabIndex"(show that element is not
NULL), then execute "!element" in the condition of if stmt(check whether
the element is NULL or not). It is a contradiction.
Since the element must not be NULL(otherwise the execution of
"element.tabIndex" would be wrong) when the while stmt finishes, the
next if stmt doesn't need to check the element like "!element" again.
Checking the element.style is already enough. So remove the "!element".