### PR TITLE
[zoom-control] Use `touchstart` event if in Mobile devices

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control';
 import {Map} from '../map/Map';
+import * as Browser from '../core/Browser';
 import * as DomUtil from '../dom/DomUtil';
 import * as DomEvent from '../dom/DomEvent';
 
@@ -91,10 +92,12 @@ export var Zoom = Control.extend({
 		link.setAttribute('role', 'button');
 		link.setAttribute('aria-label', title);
 
+		var eventName = Browser.touch ? 'touchstart' : 'click';
+
 		DomEvent.disableClickPropagation(link);
-		DomEvent.on(link, 'click', DomEvent.stop);
-		DomEvent.on(link, 'click', fn, this);
-		DomEvent.on(link, 'click', this._refocusOnMap, this);
+		DomEvent.on(link, eventName, DomEvent.stop);
+		DomEvent.on(link, eventName, fn, this);
+		DomEvent.on(link, eventName, this._refocusOnMap, this);
 
 		return link;
 	},


### PR DESCRIPTION
### Description
Instead of always listening to `click` event, we should actually listen to `touchstart` event if in mobile devices as it's more reliable way to see if the button is being clicked. 

We are seeing a bug on mobile devices (iOS with Chrome and Safari) where the first mouse click on zoom buttons is always ignored, and have to click twice to trigger the correct action. After digging into the issue, we found out that the `click` event will not be called in some scenarios, as documented here https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent. And changing to `touchstart` event seems fixed the issue. 

I think in other cases, we may need to have better solution instead of use `touchstart` to replace `click`, but since the target here is just a button with no other complicated interactions, so I think it's okay here. 