### PR TITLE
Relative path for images in CSS

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -345,12 +345,12 @@
 	border-radius: 5px;
 	}
 .leaflet-control-layers-toggle {
-	background-image: url(images/layers.png);
+	background-image: url(./images/layers.png);
 	width: 36px;
 	height: 36px;
 	}
 .leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
+	background-image: url(./images/layers-2x.png);
 	background-size: 26px 26px;
 	}
 .leaflet-touch .leaflet-control-layers-toggle {
@@ -390,7 +390,7 @@
 
 /* Default icon URLs */
 .leaflet-default-icon-path {
-	background-image: url(images/marker-icon.png);
+	background-image: url(./images/marker-icon.png);
 	}
 
 


### PR DESCRIPTION
It is necessary when styles are imported using webpack