### PR TITLE
Add other h2 headers to ToC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,11 @@ Contributing to Leaflet
  1. [Getting Involved](#getting-involved)
  2. [Reporting Bugs](#reporting-bugs)
  3. [Contributing Code](#contributing-code)
- 4. [Improving Documentation](#improving-documentation)
- 5. [Code of Conduct](#code-of-conduct)
+ 4. [Running the Tests](#running-the-tests)
+ 5. [Code Coverage](#code-coverage)
+ 6. [Improving Documentation](#improving-documentation)
+ 7. [Code of Conduct](#code-of-conduct)
+ 8. [Thank You](#thank-you)
 
 ## Getting Involved
 


### PR DESCRIPTION
This adds the other secondary headers in the Contributing document to the Table of Contents at the top. I have kept the depth at what it was - this just adjusts the oversight of other sections.