### PR TITLE
Fix box zoom race condition

### DIFF
--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -25,6 +25,7 @@ export var BoxZoom = Handler.extend({
 		this._map = map;
 		this._container = map._container;
 		this._pane = map._panes.overlayPane;
+		this._resetStateTimeout = 0;
 		map.on('unload', this._destroy, this);
 	},
 
@@ -46,11 +47,19 @@ export var BoxZoom = Handler.extend({
 	},
 
 	_resetState: function () {
+		this._resetStateTimeout = 0;
 		this._moved = false;
 	},
 
 	_onMouseDown: function (e) {
 		if (!e.shiftKey || ((e.which !== 1) && (e.button !== 1))) { return false; }
+
+		// Clear the deferred resetState if it hasn't executed yet, otherwise it
+		// will interrupt the interaction and orphan a box element in the container.
+		if (this._resetStateTimeout !== 0) {
+			clearTimeout(this._resetStateTimeout);
+			this._resetStateTimeout = 0;
+		}
 
 		this._resetState();
 
@@ -113,7 +122,10 @@ export var BoxZoom = Handler.extend({
 		if (!this._moved) { return; }
 		// Postpone to next JS tick so internal click event handling
 		// still see it as "moved".
-		setTimeout(Util.bind(this._resetState, this), 0);
+		if (this._resetStateTimeout !== 0) {
+			clearTimeout(this._resetStateTimeout);
+		}
+		this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
 
 		var bounds = new LatLngBounds(
 		        this._map.containerPointToLatLng(this._startPoint),

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -51,16 +51,19 @@ export var BoxZoom = Handler.extend({
 		this._moved = false;
 	},
 
+	_clearDeferredResetState: function () {
+		if (this._resetStateTimeout !== 0) {
+			clearTimeout(this._resetStateTimeout);
+			this._resetStateTimeout = 0;
+		}
+	},
+
 	_onMouseDown: function (e) {
 		if (!e.shiftKey || ((e.which !== 1) && (e.button !== 1))) { return false; }
 
 		// Clear the deferred resetState if it hasn't executed yet, otherwise it
 		// will interrupt the interaction and orphan a box element in the container.
-		if (this._resetStateTimeout !== 0) {
-			clearTimeout(this._resetStateTimeout);
-			this._resetStateTimeout = 0;
-		}
-
+		this._clearDeferredResetState();
 		this._resetState();
 
 		DomUtil.disableTextSelection();
@@ -122,9 +125,7 @@ export var BoxZoom = Handler.extend({
 		if (!this._moved) { return; }
 		// Postpone to next JS tick so internal click event handling
 		// still see it as "moved".
-		if (this._resetStateTimeout !== 0) {
-			clearTimeout(this._resetStateTimeout);
-		}
+		this._clearDeferredResetState();
 		this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
 
 		var bounds = new LatLngBounds(


### PR DESCRIPTION
The deferred call to `_resetState` can interrupt the next box zoom if
the user initiates it before the timeout fires. This causes the mouse
move handler to create a second box zoom element, orphaning the first
one and leaving it in the DOM.

It is possible to reproduce this issue in Chrome by using the Timeline
panel's CPU throttle (20x) and box zooming in rapid succession.