### PR TITLE
Add hook points to allow for a proper NoGap plugin

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -322,7 +322,11 @@ export var GridLayer = Layer.extend({
 			if (fade < 1) {
 				nextFrame = true;
 			} else {
-				if (tile.active) { willPrune = true; }
+				if (tile.active) {
+					willPrune = true;
+				} else {
+					this._onOpaqueTile(tile);
+				}
 				tile.active = true;
 			}
 		}
@@ -334,6 +338,8 @@ export var GridLayer = Layer.extend({
 			this._fadeFrame = Util.requestAnimFrame(this._updateOpacity, this);
 		}
 	},
+
+	_onOpaqueTile: Util.falseFn,
 
 	_initContainer: function () {
 		if (this._container) { return; }
@@ -358,9 +364,11 @@ export var GridLayer = Layer.extend({
 		for (var z in this._levels) {
 			if (this._levels[z].el.children.length || z === zoom) {
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
+				this._onUpdateLevel(z);
 			} else {
 				DomUtil.remove(this._levels[z].el);
 				this._removeTilesAtZoom(z);
+				this._onRemoveLevel(z);
 				delete this._levels[z];
 			}
 		}
@@ -381,12 +389,20 @@ export var GridLayer = Layer.extend({
 
 			// force the browser to consider the newly added element for transition
 			Util.falseFn(level.el.offsetWidth);
+
+			this._onCreateLevel(level);
 		}
 
 		this._level = level;
 
 		return level;
 	},
+
+	_onUpdateLevel: Util.falseFn,
+
+	_onRemoveLevel: Util.falseFn,
+
+	_onCreateLevel: Util.falseFn,
 
 	_pruneTiles: function () {
 		if (!this._map) {
@@ -442,6 +458,7 @@ export var GridLayer = Layer.extend({
 	_invalidateAll: function () {
 		for (var z in this._levels) {
 			DomUtil.remove(this._levels[z].el);
+			this._onRemoveLevel(z);
 			delete this._levels[z];
 		}
 		this._removeAllTiles();


### PR DESCRIPTION
This is just a subset of changes from #5290.

Motivation is @mourner's comments in https://github.com/Leaflet/Leaflet/pull/5290#issuecomment-286386260 , about the tile gap not being a core issue. This PR just allows plugin authors to run some code whenever a `GridLayer`  creates or deletes a tile zoom-level container, and whenever a tile becomes fully opaque. That, in turn, will allow much cleaner code for [L.TileLayer.NoGap](https://github.com/Leaflet/Leaflet.TileLayer.NoGap/blob/master/L.TileLayer.NoGap.js), since right now it reimplements the whole tile pruning logic.