### PR TITLE
Sanity check to prevent loading tiles when bounds are `Infinity`

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -631,6 +631,12 @@ export var GridLayer = Layer.extend({
 		    noPruneRange = new Bounds(tileRange.getBottomLeft().subtract([margin, -margin]),
 		                              tileRange.getTopRight().add([margin, -margin]));
 
+		// Sanity check: panic if the tile range contains Infinity somewhere.
+		if (tileRange.min.x === Infinity ||
+		    tileRange.min.y === Infinity ||
+		    tileRange.max.x === Infinity ||
+		    tileRange.max.y === Infinity ) { throw new Error('Attempted to load an infinite number of tiles'); }
+
 		for (var key in this._tiles) {
 			var c = this._tiles[key].coords;
 			if (c.z !== this._tileZoom || !noPruneRange.contains(new Point(c.x, c.y))) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -635,7 +635,7 @@ export var GridLayer = Layer.extend({
 		if (tileRange.min.x === Infinity ||
 		    tileRange.min.y === Infinity ||
 		    tileRange.max.x === Infinity ||
-		    tileRange.max.y === Infinity ) { throw new Error('Attempted to load an infinite number of tiles'); }
+		    tileRange.max.y === Infinity) { throw new Error('Attempted to load an infinite number of tiles'); }
 
 		for (var key in this._tiles) {
 			var c = this._tiles[key].coords;


### PR DESCRIPTION
Fixes #5477