### PR TITLE
Take devicePixelRatio into account for scrollwheel zoom in win10+chrome

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -231,7 +231,7 @@ export function getMousePosition(e, container) {
 // Chrome on Win scrolls double the pixels as in other platforms (see #4538),
 // and Firefox scrolls device pixels, not CSS pixels
 var wheelPxFactor =
-	(Browser.win && Browser.chrome) ? 2 :
+	(Browser.win && Browser.chrome) ? 2 * window.devicePixelRatio :
 	Browser.gecko ? window.devicePixelRatio : 1;
 
 // @function getWheelDelta(ev: DOMEvent): Number


### PR DESCRIPTION
Should fix #4538 as reported by @HarelM