### PR TITLE
Docs(Bounds): change topLeft/bottomRight to corner1/2

### DIFF
--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -144,11 +144,11 @@ Bounds.prototype = {
 };
 
 
-// @factory L.bounds(topLeft: Point, bottomRight: Point)
-// Creates a Bounds object from two coordinates (usually top-left and bottom-right corners).
+// @factory L.bounds(corner1: Point, corner2: Point)
+// Creates a Bounds object from two corners coordinate pairs.
 // @alternative
 // @factory L.bounds(points: Point[])
-// Creates a Bounds object from the points it contains
+// Creates a Bounds object from the given array of points.
 export function toBounds(a, b) {
 	if (!a || a instanceof Bounds) {
 		return a;


### PR DESCRIPTION
as suggested in issue #5475, and for consistency with https://github.com/Leaflet/Leaflet/pull/5059 (for `LatLngBounds`).

The actual relative position of the given corners do not matter for the factory / constructor current functionality: it just determines the min/max coordinate values.