### PR TITLE
Feat(Bounds): add new methods for 2 missing corners

### DIFF
--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -3,12 +3,12 @@ describe('Bounds', function () {
 
 	beforeEach(function () {
 		a = new L.Bounds(
-			new L.Point(14, 12),
-			new L.Point(30, 40));
+			new L.Point(14, 12), // left, top
+			new L.Point(30, 40)); // right, bottom
 		b = new L.Bounds([
-			new L.Point(20, 12),
-			new L.Point(14, 20),
-			new L.Point(30, 40)
+			new L.Point(20, 12), // center, top
+			new L.Point(14, 20), // left, middle
+			new L.Point(30, 40) // right, bottom
 		]);
 		c = new L.Bounds();
 	});

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -90,6 +90,18 @@ describe('Bounds', function () {
 		});
 	});
 
+	describe('#getTopLeft', function () {
+		it('returns the proper bounds top-left value', function () {
+			expect(a.getTopLeft()).to.eql(new L.Point(14, 12)); // left, top
+		});
+	});
+
+	describe('#getBottomRight', function () {
+		it('returns the proper bounds bottom-right value', function () {
+			expect(a.getBottomRight()).to.eql(new L.Point(30, 40)); // left, bottom
+		});
+	});
+
 	describe('L.bounds factory', function () {
 		it('creates bounds from array of number arrays', function () {
 			var bounds = L.bounds([[14, 12], [30, 40]]);

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -78,6 +78,18 @@ describe('Bounds', function () {
 		});
 	});
 
+	describe('#getBottomLeft', function () {
+		it('returns the proper bounds bottom-left value', function () {
+			expect(a.getBottomLeft()).to.eql(new L.Point(14, 40)); // left, bottom
+		});
+	});
+
+	describe('#getTopRight', function () {
+		it('returns the proper bounds top-right value', function () {
+			expect(a.getTopRight()).to.eql(new L.Point(30, 12)); // right, top
+		});
+	});
+
 	describe('L.bounds factory', function () {
 		it('creates bounds from array of number arrays', function () {
 			var bounds = L.bounds([[14, 12], [30, 40]]);

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -74,13 +74,13 @@ Bounds.prototype = {
 	},
 
 	// @method getTopLeft(): Point
-	// Returns the top-left point of the bounds.
+	// Returns the top-left point of the bounds (i.e. [`this.min`](#bounds-min)).
 	getTopLeft: function () {
 		return this.min; // left, top
 	},
 
 	// @method getBottomRight(): Point
-	// Returns the bottom-right point of the bounds.
+	// Returns the bottom-right point of the bounds (i.e. [`this.max`](#bounds-max)).
 	getBottomRight: function () {
 		return this.max; // right, bottom
 	},

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -73,6 +73,18 @@ Bounds.prototype = {
 		return new Point(this.max.x, this.min.y);
 	},
 
+	// @method getTopLeft(): Point
+	// Returns the top-left point of the bounds.
+	getTopLeft: function () {
+		return new Point(this.min.x, this.min.y); // left, top
+	},
+
+	// @method getBottomRight(): Point
+	// Returns the bottom-right point of the bounds.
+	getBottomRight: function () {
+		return new Point(this.max.x, this.max.y); // right, bottom
+	},
+
 	// @method getSize(): Point
 	// Returns the size of the given bounds
 	getSize: function () {

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -76,13 +76,13 @@ Bounds.prototype = {
 	// @method getTopLeft(): Point
 	// Returns the top-left point of the bounds.
 	getTopLeft: function () {
-		return new Point(this.min.x, this.min.y); // left, top
+		return this.min; // left, top
 	},
 
 	// @method getBottomRight(): Point
 	// Returns the bottom-right point of the bounds.
 	getBottomRight: function () {
-		return new Point(this.max.x, this.max.y); // right, bottom
+		return this.max; // right, bottom
 	},
 
 	// @method getSize(): Point


### PR DESCRIPTION
As suggested in https://github.com/Leaflet/Leaflet/issues/5475, this PR adds `getTopLeft()` and `getBottomRight()` methods to `Bounds` to retrieve the 2 missing corners (besides `getBottomLeft()` and `getTopRight()` already existing).

Having now the 4 corners make `Bounds` more in line with `LatLngBounds`.

Also added 4 tests (for each of the corner retrieval methods).

Closes https://github.com/Leaflet/Leaflet/issues/5475 together with the previous PR https://github.com/Leaflet/Leaflet/pull/5487