### PR TITLE
Change Util.formatNum default to 6 decimals

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -84,7 +84,8 @@ describe('Util', function () {
 	describe('#formatNum', function () {
 		it('formats numbers with a given precision', function () {
 			expect(L.Util.formatNum(13.12325555, 3)).to.eql(13.123);
-			expect(L.Util.formatNum(13.12325555)).to.eql(13.12326);
+			expect(L.Util.formatNum(13.12325555)).to.eql(13.123256);
+			expect(L.Util.formatNum(13.12325555, 0)).to.eql(13);
 		});
 	});
 

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -54,6 +54,7 @@ describe('LatLng', function () {
 		it('formats a string', function () {
 			var a = new L.LatLng(10.333333333, 20.2222222);
 			expect(a.toString(3)).to.eql('LatLng(10.333, 20.222)');
+			expect(a.toString()).to.eql('LatLng(10.333333, 20.222222)');
 		});
 	});
 

--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -82,6 +82,7 @@ describe("Point", function () {
 	describe('#toString', function () {
 		it('formats a string out of point coordinates', function () {
 			expect(new L.Point(50, 30) + '').to.eql('Point(50, 30)');
+			expect(new L.Point(50.1234567, 30.1234567) + '').to.eql('Point(50.123457, 30.123457)');
 		});
 	});
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -109,7 +109,7 @@ export function wrapNum(x, range, includeMax) {
 export function falseFn() { return false; }
 
 // @function formatNum(num: Number, digits?: Number): Number
-// Returns the number `num` rounded to `digits` decimals, or to 5 decimals by default.
+// Returns the number `num` rounded to `digits` decimals, or to 6 decimals by default.
 export function formatNum(num, digits) {
 	var pow = Math.pow(10, (digits === undefined ? 6 : digits));
 	return Math.round(num * pow) / pow;

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -111,7 +111,7 @@ export function falseFn() { return false; }
 // @function formatNum(num: Number, digits?: Number): Number
 // Returns the number `num` rounded to `digits` decimals, or to 5 decimals by default.
 export function formatNum(num, digits) {
-	var pow = Math.pow(10, digits || 5);
+	var pow = Math.pow(10, (digits === undefined ? 6 : digits));
 	return Math.round(num * pow) / pow;
 }
 


### PR DESCRIPTION
Changed Util.formaNum default to 6 decimails.
Solved 0 decimals bug.
Added tests.
Can be useful for PR #5444