### PR TITLE
Fixing quick start link in docs root

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@ L.marker([51.5, -0.09]).addTo(map)
     .bindPopup('A pretty CSS3 popup.&lt;br&gt; Easily customizable.')
     .openPopup();</code></pre>
 
-<p>Learn more with the <a href="examples/quick-start.html">quick start guide</a>, check out <a href="examples.html">other tutorials</a>,
+<p>Learn more with the <a href="examples/quick-start/">quick start guide</a>, check out <a href="examples.html">other tutorials</a>,
 or head straight to the <a href="reference.html">API documentation</a>.
 If you have any questions, take a look at the <a href="https://github.com/Leaflet/Leaflet/blob/master/FAQ.md">FAQ</a> first.</p>
 


### PR DESCRIPTION
`examples/quick-start.html` redirects to a 404, `examples/quick-start/` seems to be the correct link.