### PR TITLE
Use minus character instead of hyphen in the zoom control

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -325,15 +325,9 @@
 	font: bold 18px 'Lucida Console', Monaco, monospace;
 	text-indent: 1px;
 	}
-.leaflet-control-zoom-out {
-	font-size: 20px;
-	}
 
-.leaflet-touch .leaflet-control-zoom-in {
+.leaflet-touch .leaflet-control-zoom-in, .leaflet-touch .leaflet-control-zoom-out  {
 	font-size: 22px;
-	}
-.leaflet-touch .leaflet-control-zoom-out {
-	font-size: 24px;
 	}
 
 

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -26,9 +26,9 @@ export var Zoom = Control.extend({
 		// The title set on the 'zoom in' button.
 		zoomInTitle: 'Zoom in',
 
-		// @option zoomOutText: String = '-'
+		// @option zoomOutText: String = '−'
 		// The text set on the 'zoom out' button.
-		zoomOutText: '-',
+		zoomOutText: '−',
 
 		// @option zoomOutTitle: String = 'Zoom out'
 		// The title set on the 'zoom out' button.

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -26,9 +26,9 @@ export var Zoom = Control.extend({
 		// The title set on the 'zoom in' button.
 		zoomInTitle: 'Zoom in',
 
-		// @option zoomOutText: String = '−'
+		// @option zoomOutText: String = '&#x2212;'
 		// The text set on the 'zoom out' button.
-		zoomOutText: '−',
+		zoomOutText: '&#x2212;',
 
 		// @option zoomOutTitle: String = 'Zoom out'
 		// The title set on the 'zoom out' button.


### PR DESCRIPTION
I noticed that the minus sign in the zoom control was probably just a normal hyphen as it was narrow. The proper minus character is the exact same with as the plus character and has consistent vertical alignment. More info here: https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes

After replacing the hyphen with the minus from Wikipedia I checked a zoomed in screenshot of it in GIMP. The minus sign was wider than the plus because the font size had been enlarged - presumably because someone thought it looked too small in comparison. Now they can be the same font size which saves a bit of CSS too.