### PR TITLE
Always export window.L; fixes #5489

### DIFF
--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -30,3 +30,6 @@ export function noConflict() {
 	window.L = oldL;
 	return this;
 }
+
+// Always export us to window global (see #2364)
+window.L = exports;


### PR DESCRIPTION
I ended up fixing this in `Leaflet.js`, but there might be some Rollup trickery that would be a cleaner solution. I'm not familiar enough with Rollup to find it, in that case.