### PR TITLE
Don't turn enter keypress into clicks on map

### DIFF
--- a/spec/suites/core/GeneralSpec.js
+++ b/spec/suites/core/GeneralSpec.js
@@ -1,0 +1,11 @@
+describe('General', function () {
+	describe('noConflict', function () {
+		var leaflet = L;
+
+		after(function () {
+			L = leaflet;
+		});
+
+		expect(L.noConflict()).to.eql(leaflet);
+	});
+});

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -248,6 +248,18 @@ describe('Popup', function () {
 		expect(map.hasLayer(layer._popup)).to.be(true);
 	});
 
+
+	it("can open a popup with enter keypress when marker has focus", function () {
+		var layer = new L.Marker([55.8, 37.6]).addTo(map);
+		layer.bindPopup("layer popup");
+
+		happen.keypress(layer._icon, {
+			keyCode: 13
+		});
+
+		expect(map.hasLayer(layer._popup)).to.be(true);
+	});
+
 });
 
 describe("L.Map#openPopup", function () {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -383,7 +383,7 @@ Layer.include({
 		if (!this._popupHandlersAdded) {
 			this.on({
 				click: this._openPopup,
-				keypress: this._popupKeypressHandler,
+				keypress: this._onKeyPress,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -399,7 +399,7 @@ Layer.include({
 		if (this._popup) {
 			this.off({
 				click: this._openPopup,
-				keypress: this._popupKeypressHandler,
+				keypress: this._onKeyPress,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -519,7 +519,7 @@ Layer.include({
 		this._popup.setLatLng(e.latlng);
 	},
 
-	_popupKeypressHandler: function (e) {
+	_onKeyPress: function (e) {
 		if (e.originalEvent.keyCode === 13) {
 			this._openPopup(e);
 		}

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -383,6 +383,7 @@ Layer.include({
 		if (!this._popupHandlersAdded) {
 			this.on({
 				click: this._openPopup,
+				keypress: this._popupKeypressHandler,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -398,6 +399,7 @@ Layer.include({
 		if (this._popup) {
 			this.off({
 				click: this._openPopup,
+				keypress: this._popupKeypressHandler,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -515,5 +517,11 @@ Layer.include({
 
 	_movePopup: function (e) {
 		this._popup.setLatLng(e.latlng);
+	},
+
+	_popupKeypressHandler: function (e) {
+		if (e.originalEvent.keyCode === 13) {
+			this._openPopup(e);
+		}
 	}
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1300,9 +1300,9 @@ export var Map = Evented.extend({
 	_handleDOMEvent: function (e) {
 		if (!this._loaded || DomEvent.skipped(e)) { return; }
 
-		var type = e.type === 'keypress' && e.keyCode === 13 ? 'click' : e.type;
+		var type = e.type;
 
-		if (type === 'mousedown') {
+		if (type === 'mousedown' || e.type === 'keypress') {
 			// prevents outline when clicking on keyboard-focusable element
 			DomUtil.preventOutline(e.target || e.srcElement);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1302,7 +1302,7 @@ export var Map = Evented.extend({
 
 		var type = e.type;
 
-		if (type === 'mousedown' || e.type === 'keypress') {
+		if (type === 'mousedown' || type === 'keypress') {
 			// prevents outline when clicking on keyboard-focusable element
 			DomUtil.preventOutline(e.target || e.srcElement);
 		}


### PR DESCRIPTION
Addresses #5499 by:

* removing the general transformation of enter `keypress` into `click`
* adding a `keypress` listener for markers with bound popups

Possible downside: popups or other `click` handlers that added without `bindPopup` will no longer fire when enter is pressed on a focused marker.

I first tried to fix this in a more general way, but it ends up more of a hack, where we can still end up with a `click` event without mouse coordinates and `latlng`, exactly like #5499 again.