### PR TITLE
Added in-browser print map plugin with print modes and custom print background.

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -305,7 +305,7 @@ Plugins for loading basemaps or GIS raster layers in common (albeit non-default)
 			<a href="https://github.com/IHCantabria/Leaflet.CanvasLayer.Field">Leaflet.CanvasLayer.Field</a>
 		</td><td>
 			Loads and styles raster files (geotiff & asciigrid formats).
-            It includes a <code>ScalarField</code> layer (for DTM, temperature...) and 
+            It includes a <code>ScalarField</code> layer (for DTM, temperature...) and
 			<code>VectorFieldAnim</code> (an animated layer for wind, currents...). See the <a href="https://ihcantabria.github.io/Leaflet.CanvasLayer.Field/">examples</a>
 		</td><td>
 			<a href="https://github.com/VictorVelarde">Víctor Velarde</a>
@@ -3176,6 +3176,15 @@ Print or export your map.
 			A simple plugin which adds an icon to print your Leaflet map.
 		</td><td>
 			<a href="https://github.com/rowanwins">Rowan Winsemius</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Igor-Vladyka/leaflet.browser.print">leaflet.browser.print</a>
+		</td><td>
+			Allows users to print full page map directly from the browser.
+		</td><td>
+			<a href="https://github.com/Igor-Vladyka">Igor Vladyka</a>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Added a link to an in-browser print plugin that allows you to choose one of 4 different modes for printing, and use custom tiles layer as print background. 

Supported v0.7.7 and v1.0.3 with all basic leaflet layers.

[Demo with text and custom print tiles layer](https://igor-vladyka.github.io/leaflet.browser.print/)