### PR TITLE
Docs(Marker): modify icon option description

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -24,7 +24,7 @@ export var Marker = Layer.extend({
 	// @aka Marker options
 	options: {
 		// @option icon: Icon = *
-		// Icon class to use for rendering the marker.
+		// Icon instance to use for rendering the marker.
 		// See [Icon documentation](#L.Icon) for details on how to customize the marker icon.
 		// If not specified, a common instance of `L.Icon.Default` is used.
 		icon: new IconDefault(),

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -24,7 +24,9 @@ export var Marker = Layer.extend({
 	// @aka Marker options
 	options: {
 		// @option icon: Icon = *
-		// Icon class to use for rendering the marker. See [Icon documentation](#L.Icon) for details on how to customize the marker icon. If not specified, a new `L.Icon.Default` is used.
+		// Icon class to use for rendering the marker.
+		// See [Icon documentation](#L.Icon) for details on how to customize the marker icon.
+		// If not specified, a common instance of `L.Icon.Default` is used.
 		icon: new IconDefault(),
 
 		// Option inherited from "Interactive layer" abstract class


### PR DESCRIPTION
To explain that a _common_ / generic instance of `L.Icon.Default` is used, instead of leaving room to think that a _new instance_ of `L.Icon.Default` is created for every Marker without specified `icon` option.

See https://github.com/Leaflet/Leaflet.markercluster/issues/786#issuecomment-302893446

The current behaviour is to re-use the same instance for all markers with default icon.

Also replaced "icon class" by "icon instance", since it needs an actual _instance_ of `L.Icon`, not the class.