### PR TITLE
Add className option for ImageOverlay

### DIFF
--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -30,7 +30,8 @@ describe('ImageOverlay', function () {
 			map.setView(new L.LatLng(55.8, 37.6), 6);	// view needs to be set so when layer is added it is initilized
 
 			overlay = L.imageOverlay(blankUrl, [[40.712216, -74.22655], [40.773941, -74.12544]], {
-				errorOverlayUrl: errorUrl
+				errorOverlayUrl: errorUrl,
+				className: 'my-custom-image-class'
 			});
 			map.addLayer(overlay);
 
@@ -74,6 +75,12 @@ describe('ImageOverlay', function () {
 				raiseImageEvent('error');
 				expect(overlay._url).to.be(errorUrl);
 				expect(overlay._image.src).to.be(errorUrl);
+			});
+		});
+
+		describe('className', function () {
+			it('should set image\'s class', function () {
+				expect(L.DomUtil.hasClass(overlay._image, 'my-custom-image-class')).to.be(true);
 			});
 		});
 	});

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -47,7 +47,11 @@ export var ImageOverlay = Layer.extend({
 
 		// @option zIndex: Number = 1
 		// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the tile layer.
-		zIndex: 1
+		zIndex: 1,
+
+		// @option className: String = ''
+		// A custom class name to assign to the image. Empty by default.
+		className: '',
 	},
 
 	initialize: function (url, bounds, options) { // (String, LatLngBounds, Object)
@@ -176,7 +180,8 @@ export var ImageOverlay = Layer.extend({
 
 	_initImage: function () {
 		var img = this._image = DomUtil.create('img',
-				'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : ''));
+				'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : '') +
+				 (this.options.className || ''));
 
 		img.onselectstart = Util.falseFn;
 		img.onmousemove = Util.falseFn;


### PR DESCRIPTION
While reviewing #5515, it occured to me that a much more general approach would be to allow users to add any CSS class to an `ImageOverlay` using the `className` option, instead of adding custom options for details like rendering options.

This also has the advantage that it works exactly like a lot of other classes, for example `GridLayer`, which already have the `className` option.