### PR TITLE
Refactor(fitBounds): move sanity check into _getBoundsCenterZoom

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -248,6 +248,10 @@ export var Map = Evented.extend({
 		options = options || {};
 		bounds = bounds.getBounds ? bounds.getBounds() : toLatLngBounds(bounds);
 
+		if (!bounds.isValid()) {
+			throw new Error('Bounds are not valid.');
+		}
+
 		var paddingTL = toPoint(options.paddingTopLeft || options.padding || [0, 0]),
 		    paddingBR = toPoint(options.paddingBottomRight || options.padding || [0, 0]),
 
@@ -278,13 +282,6 @@ export var Map = Evented.extend({
 	// Sets a map view that contains the given geographical bounds with the
 	// maximum zoom level possible.
 	fitBounds: function (bounds, options) {
-
-		bounds = toLatLngBounds(bounds);
-
-		if (!bounds.isValid()) {
-			throw new Error('Bounds are not valid.');
-		}
-
 		var target = this._getBoundsCenterZoom(bounds, options);
 		return this.setView(target.center, target.zoom, options);
 	},


### PR DESCRIPTION
after conversion of `bounds` argument into LatLngBounds, so that we avoid duplicating the conversion and inconsistency in several public API's that use this private method (namely [`flyToBounds`](http://leafletjs.com/reference-1.0.3.html#map-flytobounds)).

This PR tries to address https://github.com/Leaflet/Leaflet/issues/4345#issuecomment-308301449.

However I am not exactly sure if the remaining `isValid` sanity check is not totally redundant with `LatLng` conversion own checks.