### PR TITLE
Docstrings(Map/Grid+TileLayer): improve minZoom and maxZoom explanations

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -106,11 +106,11 @@ export var GridLayer = Layer.extend({
 		bounds: null,
 
 		// @option minZoom: Number = 0
-		// The minimum zoom level down to which this layer will be displayed (included).
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
 		minZoom: 0,
 
 		// @option maxZoom: Number = undefined
-		// The maximum zoom level up to which this layer will be displayed (included).
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
 		maxZoom: undefined,
 
 		// @option maxNativeZoom: Number = undefined

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -106,11 +106,11 @@ export var GridLayer = Layer.extend({
 		bounds: null,
 
 		// @option minZoom: Number = 0
-		// The minimum zoom level that tiles will be loaded at. By default the entire map.
+		// The minimum zoom level down to which this layer will be displayed (included).
 		minZoom: 0,
 
 		// @option maxZoom: Number = undefined
-		// The maximum zoom level that tiles will be loaded at.
+		// The maximum zoom level up to which this layer will be displayed (included).
 		maxZoom: undefined,
 
 		// @option maxNativeZoom: Number = undefined

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -42,11 +42,11 @@ export var TileLayer = GridLayer.extend({
 	// @aka TileLayer options
 	options: {
 		// @option minZoom: Number = 0
-		// Minimum zoom number.
+		// The minimum zoom level down to which this layer will be displayed (included).
 		minZoom: 0,
 
 		// @option maxZoom: Number = 18
-		// Maximum zoom number.
+		// The maximum zoom level up to which this layer will be displayed (included).
 		maxZoom: 18,
 
 		// @option subdomains: String|String[] = 'abc'

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -42,11 +42,11 @@ export var TileLayer = GridLayer.extend({
 	// @aka TileLayer options
 	options: {
 		// @option minZoom: Number = 0
-		// The minimum zoom level down to which this layer will be displayed (included).
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
 		minZoom: 0,
 
 		// @option maxZoom: Number = 18
-		// The maximum zoom level up to which this layer will be displayed (included).
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
 		maxZoom: 18,
 
 		// @option subdomains: String|String[] = 'abc'

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -46,12 +46,16 @@ export var Map = Evented.extend({
 		// Initial map zoom level
 		zoom: undefined,
 
-		// @option minZoom: Number = undefined
-		// Minimum zoom level of the map. Overrides any `minZoom` option set on map layers.
+		// @option minZoom: Number = *
+		// Minimum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the lowest of their `minZoom` options will be used instead.
 		minZoom: undefined,
 
-		// @option maxZoom: Number = undefined
-		// Maximum zoom level of the map. Overrides any `maxZoom` option set on map layers.
+		// @option maxZoom: Number = *
+		// Maximum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the highest of their `maxZoom` options will be used instead.
 		maxZoom: undefined,
 
 		// @option layers: Layer[] = []


### PR DESCRIPTION
so that it is more explicit how Map's options may get automatically computed from its Grid/Tile layers, and what is the exact effect of these options on Grid/Tile layers.

The explanations for Map `minZoom` and `maxZoom` options are taken from https://github.com/Leaflet/Leaflet/pull/4643#r66759552

Replaces / closes https://github.com/Leaflet/Leaflet/pull/4643
Fixes https://github.com/Leaflet/Leaflet/issues/4034

Note: the "By default the entire map." sentence on Grid Layer `minZoom` option looks misplaced. It might have been intended for the above `bounds` option. But in that case, I am not sure the wording is appropriate? I would have said that if not set, there is no horizontal limit to Tile Loading… which is what the current docstrings says anyway, by describing the opposite situation.