### PR TITLE
Fix(DivIcon): revert #5517 to avoid appending a single node instead of generating content

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -122,20 +122,6 @@ describe("Marker", function () {
 			expect(marker.dragging.enabled()).to.be(true);
 		});
 
-		it("changes the icon to another DivIcon which is a DOM element", function () {
-			var marker = new L.Marker([0, 0], {icon: new L.DivIcon({html: 'Inner1Text'})});
-			var customElement = document.createElement('p');
-			customElement.innerHTML = 'InnerTextFromCustomNode';
-			map.addLayer(marker);
-
-			var beforeIcon = marker._icon;
-			marker.setIcon(new L.DivIcon({html: customElement}));
-			var afterIcon = marker._icon;
-
-			expect(beforeIcon).to.be(afterIcon);
-			expect(afterIcon.innerHTML).to.contain('<p>InnerTextFromCustomNode</p>');
-		});
-
 		it("changes the DivIcon to another DivIcon, while re-using the DIV element", function () {
 			var marker = new L.Marker([0, 0], {icon: new L.DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -73,7 +73,7 @@ describe("Marker", function () {
 			expect(icon.style.height).to.be(expectedXY + 'px');
 		});
 
-		it("changes the icon to another image", function () {
+		it("changes the icon to another image while re-using the IMG element", function () {
 			var marker = new L.Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 
@@ -81,7 +81,7 @@ describe("Marker", function () {
 			marker.setIcon(icon2);
 			var afterIcon = marker._icon;
 
-			expect(beforeIcon).to.be(afterIcon);
+			expect(beforeIcon).to.be(afterIcon); // Check that the <IMG> element is re-used
 			expect(afterIcon.src).to.contain(icon2._getIconUrl('icon'));
 		});
 
@@ -136,7 +136,7 @@ describe("Marker", function () {
 			expect(afterIcon.innerHTML).to.contain('<p>InnerTextFromCustomNode</p>');
 		});
 
-		it("changes the icon to another DivIcon", function () {
+		it("changes the DivIcon to another DivIcon, while re-using the DIV element", function () {
 			var marker = new L.Marker([0, 0], {icon: new L.DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);
 
@@ -144,7 +144,7 @@ describe("Marker", function () {
 			marker.setIcon(new L.DivIcon({html: 'Inner2Text'}));
 			var afterIcon = marker._icon;
 
-			expect(beforeIcon).to.be(afterIcon);
+			expect(beforeIcon).to.be(afterIcon); // Check that the <DIV> element is re-used
 			expect(afterIcon.innerHTML).to.contain('Inner2Text');
 		});
 
@@ -165,7 +165,7 @@ describe("Marker", function () {
 
 			marker.setIcon(icon1);
 
-			expect(oldIcon).to.not.be(marker._icon);
+			expect(oldIcon).to.not.be(marker._icon); // Check that the _icon is NOT re-used
 			expect(oldIcon.parentNode).to.be(null);
 
 			if (L.Browser.retina) {
@@ -183,7 +183,7 @@ describe("Marker", function () {
 
 			marker.setIcon(new L.DivIcon({html: 'Inner1Text'}));
 
-			expect(oldIcon).to.not.be(marker._icon);
+			expect(oldIcon).to.not.be(marker._icon); // Check that the _icon is NOT re-used
 			expect(oldIcon.parentNode).to.be(null);
 
 			expect(marker._icon.innerHTML).to.contain('Inner1Text');

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -29,7 +29,7 @@ export var DivIcon = Icon.extend({
 		// iconAnchor: (Point),
 		// popupAnchor: (Point),
 
-		// @option html: String|HTMLElement = ''
+		// @option html: String = ''
 		// Custom HTML code to put inside the div element, empty by default.
 		html: false,
 
@@ -44,13 +44,7 @@ export var DivIcon = Icon.extend({
 		var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
 		    options = this.options;
 
-		if (options.html === false) {
-			div.innerHTML = '';
-		} else if (typeof options.html === 'object' && options.html.nodeType === 1) {
-			div.appendChild(options.html);
-		} else {
-			div.innerHTML = options.html;
-		}
+		div.innerHTML = options.html !== false ? options.html : '';
 
 		if (options.bgPos) {
 			var bgPos = point(options.bgPos);


### PR DESCRIPTION
Following https://github.com/Leaflet/Leaflet/pull/5517#issuecomment-303825019, this reverts the effect of that PR in order to avoid a situation where Leaflet could accept an input that leads to a strange behaviour compared to how `Icon` and `DivIcon` currently work (i.e. re-using the `DivIcon` could lead to empty icons except for the last added one).

Hopefully this could clear the way to a Leaflet release.

Regarding @perliedman's [proposal](https://github.com/Leaflet/Leaflet/pull/5517#issuecomment-307566642) to accept a _function_ (similarly to `Popup` and `Tooltip`), this could indeed be interesting in order to re-use the `DivIcon` for different markers and customizing the content based on that marker (e.g. this could be used to simplify Leaflet.markercluster [`iconCreateFunction`](https://github.com/Leaflet/Leaflet.markercluster/blob/v1.0.6/src/MarkerClusterGroup.js#L803-L817), which could just re-use a single `DivIcon` instead of creating a new one for each cluster).

_However_ in order for such a functionality to be really useful, the `DivIcon`'s `createIcon` method would need to be aware of the `Marker` it is applied to. `Popup` and `Tooltip` read their internal `_source` reference to retrieve their associated `Marker` instance, but that does not work for an `Icon` because it is not bound to a particular `Marker`…

We could workaround this issue by passing the current `Marker` to the [`createIcon`](http://leafletjs.com/reference-1.0.3.html#icon-createicon) function, therefore changing its API.

But I feel this would need more thinking, especially given the fact that actually, even `Popup` and `Tooltip` may not be bound to a particular `Marker`… opening a different issue for that point.