### PR TITLE
Docstring(GridLayer): more explicit updateWhenIdle option

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -88,7 +88,8 @@ export var GridLayer = Layer.extend({
 		// @option updateWhenIdle: Boolean = (depends)
 		// Load new tiles only when panning ends.
 		// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
-		// `false` otherwise in order to display new tiles during panning, which can be extensive on desktop browsers.
+		// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
+		// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
 		updateWhenIdle: Browser.mobile,
 
 		// @option updateWhenZooming: Boolean = true

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -85,8 +85,10 @@ export var GridLayer = Layer.extend({
 		// Opacity of the tiles. Can be used in the `createTile()` function.
 		opacity: 1,
 
-		// @option updateWhenIdle: Boolean = depends
-		// If `false`, new tiles are loaded during panning, otherwise only after it (for better performance). `true` by default on mobile browsers, otherwise `false`.
+		// @option updateWhenIdle: Boolean = (depends)
+		// Load new tiles only when panning ends.
+		// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
+		// `false` otherwise in order to display new tiles during panning, which can be extensive on desktop browsers.
 		updateWhenIdle: Browser.mobile,
 
 		// @option updateWhenZooming: Boolean = true


### PR DESCRIPTION
Made the GridLayer [`updateWhenIdle`](http://leafletjs.com/reference-1.0.3.html#tilelayer-updatewhenidle) option description more explicit, because "for better performance" is quite generic and might be understood in very different manners depending on the reader's point of view.

Maybe we could also find a way to make it clearer that although Leaflet does not fetch new tiles, there is little probability the user reaches a grey area thanks to the `keepBuffer` option at value `2` by default?
And with default tile size of 256px (hence 2 tiles => 512px) and most [common smartphones](https://www.mydevice.io/devices/) biggest CSS dimension being 736px, most of the map is still covered (assuming user can hardly pan more than 1 screen / viewport at a time without having to release his/her finger).

That is no longer true for tablets however… (1366px on iPad Pro)