### PR TITLE
Docs(Popup+Tooltip): fix typo in bindPopup & bindTooltip

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -365,7 +365,7 @@ Layer.include({
 
 	// @method bindPopup(content: String|HTMLElement|Function|Popup, options?: Popup options): this
 	// Binds a popup to the layer with the passed `content` and sets up the
-	// neccessary event listeners. If a `Function` is passed it will receive
+	// necessary event listeners. If a `Function` is passed it will receive
 	// the layer as the first argument and should return a `String` or `HTMLElement`.
 	bindPopup: function (content, options) {
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -250,7 +250,7 @@ Layer.include({
 
 	// @method bindTooltip(content: String|HTMLElement|Function|Tooltip, options?: Tooltip options): this
 	// Binds a tooltip to the layer with the passed `content` and sets up the
-	// neccessary event listeners. If a `Function` is passed it will receive
+	// necessary event listeners. If a `Function` is passed it will receive
 	// the layer as the first argument and should return a `String` or `HTMLElement`.
 	bindTooltip: function (content, options) {
 


### PR DESCRIPTION
Fixed typo in [`bindPopup`](http://leafletjs.com/reference-1.0.3.html#layer-bindpopup) & [`bindTooltip`](http://leafletjs.com/reference-1.0.3.html#layer-bindtooltip) methods description.

Looks like I do not have `push` permission directly to `master` branch (which might be a good thing).
And that I cannot review my own PR (which is natural as well).