### PR TITLE
Docs(ref-103): attempt to fix GitHub 404 error

### DIFF
--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -8,6 +8,7 @@ bodyclass: api-page
 
 <p>This reference reflects <strong>Leaflet 1.0.3</strong>. Check <a href='reference-versions.html'>this list</a> if you are using a different version of Leaflet.</p>
 
+
 	<div id="toc" class="clearfix">
 		<div class="toc-col map-col">
 			<h4>Map</h4>


### PR DESCRIPTION
on `reference-1.0.3.html` page, for unknown reason?
See https://github.com/Leaflet/Leaflet/issues/5585
Using a dummy modification on the page, hopefully it might re-trigger a proper Jekyll build on that page?