### PR TITLE
Whitelist the jekyll-redirect-from

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,6 +9,9 @@ latest_leaflet_version: 1.1.0
 
 gems:
   - jekyll-redirect-from
+  
+whitelist:
+  - jekyll-redirect-from
 
 # Integrity hashes for both leaflet.js and leaflet-src.js
 # These will be shown in the downloads page
@@ -16,4 +19,3 @@ gems:
 integrity_hash_css: "sha512-wcw6ts8Anuw10Mzh9Ytw4pylW8+NAD4ch3lqm9lzAsTxg0GFeJgoAtxuCLREZSC5lUXdVyo/7yfsqFjQ4S+aKw=="
 integrity_hash_source: "sha512-sIPSXEX730B6EcdQyVPmIGp7f7ZrxIuECnkwYtPpEltG6NqOVtmBNoxHkMamNsAOHLMnDFaUoJYA4PWtzNZDuA=="
 integrity_hash_uglified: "sha512-mNqn2Wg7tSToJhvHcqfzLMU6J4mkOImSPTxVZAdo+lcPlk+GhZmYgACEe0x35K7YzW1zJ7XyJV/TT1MrdXvMcA=="
-


### PR DESCRIPTION
Since this [commit](https://github.com/Leaflet/Leaflet/commit/b6d21653faf8894f1db05e10958f55305767c27d) the `reference.html` links on the homepage don't work anymore: **well-documented API** or **API documentation**

Based on the [installation](https://github.com/jekyll/jekyll-redirect-from#installation) procedures of this plugin it's recommended to whitelist it if Jekyll use the safe mode (which I guess you're using as it's hosted on Github Pages).

I didn't try locally (so maybe double check) but hopefully it will solve this issue. :sparkles: 