### PR TITLE
Prevent using functions from the global scope with es6

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -245,7 +245,7 @@ export var Layers = Control.extend({
 		});
 
 		if (this.options.sortLayers) {
-			this._layers.sort(L.bind(function (a, b) {
+			this._layers.sort(Util.bind(function (a, b) {
 				return this.options.sortFunction(a.layer, b.layer, a.name, b.name);
 			}, this));
 		}

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -75,7 +75,7 @@ export var Draggable = Evented.extend({
 
 		// If we're currently dragging this draggable,
 		// disabling it counts as first ending the drag.
-		if (this._dragging === this) {
+		if (_dragging === this) {
 			this.finishDrag();
 		}
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -75,7 +75,7 @@ export var Draggable = Evented.extend({
 
 		// If we're currently dragging this draggable,
 		// disabling it counts as first ending the drag.
-		if (L.Draggable._dragging === this) {
+		if (this._dragging === this) {
 			this.finishDrag();
 		}
 


### PR DESCRIPTION
I got the following error while using leaflet as a submodule in our [angular2 implementation of Leaflet](https://github.com/yagajs/leaflet-ng2/issues/243).

```
ReferenceError: L is not defined
      at NewClass.disable (node_modules/leaflet/dist/leaflet-src.js:5659:7)
      at NewClass.removeHooks (node_modules/leaflet/dist/leaflet-src.js:12824:19)
      at NewClass.disable (node_modules/leaflet/dist/leaflet-src.js:5569:8)
      at MapComponent.set [as draggingEnabled] (lib/map.component.js:9:20941)
      <...>
```

I think this is because of the use of Leaflet functions from the global scope. I also try to find other occurrences and fix them, too.

After the fix everything seems to work fine for me.