### PR TITLE
Use same condition for adding as well as removing double tap listener

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -134,7 +134,8 @@ function removeOne(obj, type, fn, context) {
 	if (Browser.pointer && type.indexOf('touch') === 0) {
 		removePointerListener(obj, type, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && removeDoubleTapListener) {
+	} else if (Browser.touch && (type === 'dblclick') && removeDoubleTapListener &&
+	           !(Browser.pointer && Browser.chrome)) {
 		removeDoubleTapListener(obj, id);
 
 	} else if ('removeEventListener' in obj) {


### PR DESCRIPTION
Removal logic in `DomEvent` is missing part of the condition used when adding a listener, which can cause Leaflet to try to remove a listener that has not been added before.

Fixes #5588.