### PR TITLE
Fix(DomEvent): DomEvent.off should return this

### DIFF
--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -60,6 +60,11 @@ describe('DomEvent', function () {
 
 			expect(type).to.eql('click');
 		});
+
+		it('is chainable', function () {
+			var res = L.DomEvent.addListener(el, 'click', function () {});
+			expect(res.addListener).to.be.a('function');
+		});
 	});
 
 	describe('#removeListener', function () {
@@ -72,6 +77,11 @@ describe('DomEvent', function () {
 			simulateClick(el);
 
 			expect(listener.called).to.not.be.ok();
+		});
+
+		it('is chainable', function () {
+			var res = L.DomEvent.removeListener(el, 'click', function () {});
+			expect(res.removeListener).to.be.a('function');
 		});
 	});
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -70,6 +70,8 @@ export function off(obj, types, fn, context) {
 		}
 		delete obj[eventsKey];
 	}
+
+	return this;
 }
 
 function addOne(obj, type, fn, context) {


### PR DESCRIPTION
Following docs `DomEvent.off()` should return `this` but it was broken in 14c5f1602cdd337df14c37ea8df777578219f744. Leaflet 1.1.0 is affected by this but.