### PR TITLE
Remove reference to deps.js in L.VideoOverlay debug example

### DIFF
--- a/debug/map/videooverlay.html
+++ b/debug/map/videooverlay.html
@@ -10,7 +10,6 @@
 
 	<link rel="stylesheet" href="../css/screen.css" />
 
-	<script type="text/javascript" src="../../build/deps.js"></script>
 	<script src="../leaflet-include.js"></script>
 </head>
 <body>


### PR DESCRIPTION
This fix is similar to #5417. The L.VideoOverlay example was added shortly after so it missed out.