### PR TITLE
util is now exported as a plain object

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -236,3 +236,27 @@ export function cancelAnimFrame(id) {
 		cancelFn.call(window, id);
 	}
 }
+
+export default {
+	cancelAnimFrame: cancelAnimFrame,
+	requestAnimFrame: requestAnimFrame,
+	cancelFn: cancelFn,
+	requestFn: requestFn,
+	emptyImageUrl: emptyImageUrl,
+	isArray: isArray,
+	indexOf: indexOf,
+	template: template,
+	getParamString: getParamString,
+	setOptions: setOptions,
+	splitWords: splitWords,
+	trim: trim,
+	formatNum: formatNum,
+	falseFn: falseFn,
+	wrapNum: wrapNum,
+	throttle: throttle,
+	lastId: lastId,
+	stamp: stamp,
+	bind: bind,
+	create: create,
+	extend: extend
+};

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -10,6 +10,6 @@ export var Mixin = {Events: Events};
 
 export {Handler} from './Handler';
 
-import * as Util from './Util';
+import Util from './Util';
 export {Util};
 export {extend, bind, stamp, setOptions} from './Util';


### PR DESCRIPTION
This changes the method of exporting the methods of util so that it's an extendable object

fixes #5589 and calvinmetcalf/leaflet-ajax#49