### PR TITLE
Load retina after touch

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -343,13 +343,13 @@
 	width: 36px;
 	height: 36px;
 	}
-.leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
-	background-size: 26px 26px;
-	}
 .leaflet-touch .leaflet-control-layers-toggle {
 	width: 44px;
 	height: 44px;
+	}
+.leaflet-retina .leaflet-control-layers-toggle {
+	background-image: url(images/layers-2x.png);
+	background-size: 26px 26px;
 	}
 .leaflet-control-layers .leaflet-control-layers-list,
 .leaflet-control-layers-expanded .leaflet-control-layers-toggle {


### PR DESCRIPTION
Previously the css would load the touch class after the retina class. This means that if viewed on a retina touch device, the retina sizing is ignored because the touch class overrides it, essentially making the retina class useless. 

This swaps the positions so that if a device is both a touch device, and a retina device, it will load the retina sizing correctly.