### PR TITLE
Make L.LineUtil._flat public as L.LineUtil.isFlat

### DIFF
--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -12,7 +12,7 @@ describe('Polygon', function () {
 
 			var polygon = new L.Polygon(latLngs);
 
-			expect(L.LineUtil._flat(polygon._latlngs)).to.be(false);
+			expect(L.LineUtil.isFlat(polygon._latlngs)).to.be(false);
 			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
 		});
 

--- a/spec/suites/layer/vector/PolylineGeometrySpec.js
+++ b/spec/suites/layer/vector/PolylineGeometrySpec.js
@@ -35,27 +35,35 @@ describe('PolylineGeometry', function () {
 });
 
 describe('LineUtil', function () {
-	describe('#_flat', function () {
+	describe('#isFlat', function () {
 		var layer = L.polyline([]);
 
 		it('should return true for an array of LatLngs', function () {
-			expect(L.LineUtil._flat([L.latLng([0, 0])])).to.be(true);
+			expect(L.LineUtil.isFlat([L.latLng([0, 0])])).to.be(true);
 		});
 
 		it('should return true for an array of LatLngs arrays', function () {
-			expect(L.LineUtil._flat([[0, 0]])).to.be(true);
+			expect(L.LineUtil.isFlat([[0, 0]])).to.be(true);
 		});
 
 		it('should return true for an empty array', function () {
-			expect(L.LineUtil._flat([])).to.be(true);
+			expect(L.LineUtil.isFlat([])).to.be(true);
 		});
 
 		it('should return false for a nested array of LatLngs', function () {
-			expect(L.LineUtil._flat([[L.latLng([0, 0])]])).to.be(false);
+			expect(L.LineUtil.isFlat([[L.latLng([0, 0])]])).to.be(false);
 		});
 
 		it('should return false for a nested empty array', function () {
-			expect(L.LineUtil._flat([[]])).to.be(false);
+			expect(L.LineUtil.isFlat([[]])).to.be(false);
+		});
+
+		it('should be aliased as _flat for retrocompat', function () {
+			expect(L.LineUtil._flat([L.latLng([0, 0])])).to.be(true);
+		});
+
+		it('should be aliased as L.Polyline._flat for retrocompat', function () {
+			expect(L.Polyline._flat([L.latLng([0, 0])])).to.be(true);
 		});
 	});
 });

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -230,7 +230,13 @@ export function _sqClosestPointOnSegment(p, p1, p2, sqDist) {
 }
 
 
-export function _flat(latlngs) {
-	// true if it's a flat array of latlngs; false if nested
+// @function isFlat(latlngs: LatLng[]): Boolean
+// Returns true if `latlngs` is a flat array, false is nested.
+export function isFlat(latlngs) {
 	return !Util.isArray(latlngs[0]) || (typeof latlngs[0][0] !== 'object' && typeof latlngs[0][0] !== 'undefined');
+}
+
+export function _flat(latlngs) {
+	console.warn('Deprecated use of _flat, please use L.LineUtil.isFlat instead.');
+	return isFlat(latlngs);
 }

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -314,7 +314,7 @@ CircleMarker.include(PointToGeoJSON);
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polyline (as a GeoJSON `LineString` or `MultiLineString` Feature).
 Polyline.include({
 	toGeoJSON: function (precision) {
-		var multi = !LineUtil._flat(this._latlngs);
+		var multi = !LineUtil.isFlat(this._latlngs);
 
 		var coords = latLngsToCoords(this._latlngs, multi ? 1 : 0, false, precision);
 
@@ -330,8 +330,8 @@ Polyline.include({
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polygon (as a GeoJSON `Polygon` or `MultiPolygon` Feature).
 Polygon.include({
 	toGeoJSON: function (precision) {
-		var holes = !LineUtil._flat(this._latlngs),
-		    multi = holes && !LineUtil._flat(this._latlngs[0]);
+		var holes = !LineUtil.isFlat(this._latlngs),
+		    multi = holes && !LineUtil.isFlat(this._latlngs[0]);
 
 		var coords = latLngsToCoords(this._latlngs, multi ? 2 : holes ? 1 : 0, true, precision);
 

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -109,13 +109,13 @@ export var Polygon = Polyline.extend({
 
 	_setLatLngs: function (latlngs) {
 		Polyline.prototype._setLatLngs.call(this, latlngs);
-		if (LineUtil._flat(this._latlngs)) {
+		if (LineUtil.isFlat(this._latlngs)) {
 			this._latlngs = [this._latlngs];
 		}
 	},
 
 	_defaultShape: function () {
-		return LineUtil._flat(this._latlngs[0]) ? this._latlngs[0] : this._latlngs[0][0];
+		return LineUtil.isFlat(this._latlngs[0]) ? this._latlngs[0] : this._latlngs[0][0];
 	},
 
 	_clipPoints: function () {

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -176,13 +176,13 @@ export var Polyline = Path.extend({
 	},
 
 	_defaultShape: function () {
-		return LineUtil._flat(this._latlngs) ? this._latlngs : this._latlngs[0];
+		return LineUtil.isFlat(this._latlngs) ? this._latlngs : this._latlngs[0];
 	},
 
 	// recursively convert latlngs input into actual LatLng instances; calculate bounds along the way
 	_convertLatLngs: function (latlngs) {
 		var result = [],
-		    flat = LineUtil._flat(latlngs);
+		    flat = LineUtil.isFlat(latlngs);
 
 		for (var i = 0, len = latlngs.length; i < len; i++) {
 			if (flat) {
@@ -322,3 +322,5 @@ export function polyline(latlngs, options) {
 	return new Polyline(latlngs, options);
 }
 
+// Retrocompat. Allow plugins to support Leaflet versions before and after 1.1.
+Polyline._flat = LineUtil._flat;


### PR DESCRIPTION
Also, keep retrocompat for both L.LineUtil._flat and L.Polyline._flat (<1.1).