### PR TITLE
Do not prevent default on source of simulated event if simulated event is unhandled

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1152,6 +1152,17 @@ describe("Map", function () {
 			happen.click(layer._icon);
 		});
 
+		it('does not preventDefault on touches when no other listener catches simulated events', function () {
+			var checkNotPrevented = function (e) {
+				L.DomEvent.off(map._container.parentNode, 'touchstart', checkNotPrevented);
+				expect(e.defaultPrevented).not.to.be.ok();
+			};
+
+			map.dragging.disable();
+			var spy = sinon.spy();
+			L.DomEvent.on(map._container.parentNode, 'touchstart', checkNotPrevented);
+			happen.touchstart(map._container, {touches: [{target: map._container}]});
+		});
 	});
 
 	describe('#getScaleZoom && #getZoomScale', function () {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1302,7 +1302,7 @@ export var Map = Evented.extend({
 			if (src === this._container) { break; }
 			src = src.parentNode;
 		}
-		if (!targets.length && !dragging && !isHover && DomEvent.isExternalTarget(src, e)) {
+		if (!targets.length && !dragging && !isHover && DomEvent.isExternalTarget(src, e) && this.listens(type, true)) {
 			targets = [this];
 		}
 		return targets;
@@ -1342,6 +1342,10 @@ export var Map = Evented.extend({
 		targets = (targets || []).concat(this._findEventTargets(e, type));
 
 		if (!targets.length) { return; }
+
+		if (e._simulated && e._originalEvent) {
+			DomEvent.preventDefault(e._originalEvent);
+		}
 
 		var target = targets[0];
 		if (type === 'contextmenu' && target.listens(type, true)) {

--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -38,8 +38,6 @@ export var Tap = Handler.extend({
 	_onDown: function (e) {
 		if (!e.touches) { return; }
 
-		DomEvent.preventDefault(e);
-
 		this._fireClick = true;
 
 		// don't simulate click or track longpress if more than 1 touch
@@ -68,7 +66,7 @@ export var Tap = Handler.extend({
 			}
 		}, this), 1000);
 
-		this._simulateEvent('mousedown', first);
+		this._simulateEvent('mousedown', first, e);
 
 		DomEvent.on(document, {
 			touchmove: this._onMove,
@@ -93,7 +91,7 @@ export var Tap = Handler.extend({
 				DomUtil.removeClass(el, 'leaflet-active');
 			}
 
-			this._simulateEvent('mouseup', first);
+			this._simulateEvent('mouseup', first, e);
 
 			// simulate click if the touch didn't move too much
 			if (this._isTapValid()) {
@@ -109,13 +107,14 @@ export var Tap = Handler.extend({
 	_onMove: function (e) {
 		var first = e.touches[0];
 		this._newPos = new Point(first.clientX, first.clientY);
-		this._simulateEvent('mousemove', first);
+		this._simulateEvent('mousemove', first, e);
 	},
 
-	_simulateEvent: function (type, e) {
+	_simulateEvent: function (type, e, originalEvent) {
 		var simulatedEvent = document.createEvent('MouseEvents');
 
 		simulatedEvent._simulated = true;
+		simulatedEvent._originalEvent = originalEvent;
 		e.target._simulatedClick = true;
 
 		simulatedEvent.initMouseEvent(


### PR DESCRIPTION
This allows for example `touchstart` events to propagate so that they can be used to scroll the map when `dragging` is disabled. This fixes #5425.