### PR TITLE
When a layer is repeated in Control.Layers, behavior is not consistent.

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -130,6 +130,33 @@ describe("Control.Layers", function () {
 
 			expect(layers._layers.length).to.be.equal(1);
 		});
+
+		it("having repeated layers works as expected", function () {
+			document.body.appendChild(map._container);
+			var layerA = L.tileLayer(''), layerB = L.tileLayer(''),
+			    baseLayers = {"Layer 1": layerA, "Layer 2": layerB, "Layer 3": layerA},
+			    layers = L.control.layers(baseLayers).addTo(map);
+
+			function checkInputs(idx) {
+				var inputs = map._container.querySelectorAll('.leaflet-control-layers-base input');
+				for (var i = 0; i < inputs.length; i++) {
+					expect(inputs[i].checked === (idx === i)).to.be.ok();
+				}
+			}
+
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[1]);
+			checkInputs(1);
+			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(layerB);
+			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(undefined);
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[0]);
+			checkInputs(0);
+			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(layerA);
+			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(undefined);
+			happen.click(layers._baseLayersList.getElementsByTagName("input")[2]);
+			checkInputs(2);
+			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(layerA);
+			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(undefined);
+		});
 	});
 
 	describe("is removed cleanly", function () {

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -373,7 +373,7 @@ export var Layers = Control.extend({
 			layer = this._getLayer(input.layerId).layer;
 			hasLayer = this._map.hasLayer(layer);
 
-			if (input.checked && !hasLayer) {
+			if (input.checked) {
 				addedLayers.push(layer);
 
 			} else if (!input.checked && hasLayer) {
@@ -386,7 +386,9 @@ export var Layers = Control.extend({
 			this._map.removeLayer(removedLayers[i]);
 		}
 		for (i = 0; i < addedLayers.length; i++) {
-			this._map.addLayer(addedLayers[i]);
+			if (!this._map.hasLayer(layer)) {
+				this._map.addLayer(addedLayers[i]);
+			}
 		}
 
 		this._handlingClick = false;

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -386,7 +386,7 @@ export var Layers = Control.extend({
 			this._map.removeLayer(removedLayers[i]);
 		}
 		for (i = 0; i < addedLayers.length; i++) {
-			if (!this._map.hasLayer(layer)) {
+			if (!this._map.hasLayer(addedLayers[i])) {
 				this._map.addLayer(addedLayers[i]);
 			}
 		}

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -362,7 +362,7 @@ export var Layers = Control.extend({
 
 	_onInputClick: function () {
 		var inputs = this._layerControlInputs,
-		    input, layer, hasLayer;
+		    input, layer;
 		var addedLayers = [],
 		    removedLayers = [];
 
@@ -371,19 +371,19 @@ export var Layers = Control.extend({
 		for (var i = inputs.length - 1; i >= 0; i--) {
 			input = inputs[i];
 			layer = this._getLayer(input.layerId).layer;
-			hasLayer = this._map.hasLayer(layer);
 
 			if (input.checked) {
 				addedLayers.push(layer);
-
-			} else if (!input.checked && hasLayer) {
+			} else if (!input.checked) {
 				removedLayers.push(layer);
 			}
 		}
 
 		// Bugfix issue 2318: Should remove all old layers before readding new ones
 		for (i = 0; i < removedLayers.length; i++) {
-			this._map.removeLayer(removedLayers[i]);
+			if (this._map.hasLayer(removedLayers[i])) {
+				this._map.removeLayer(removedLayers[i]);
+			}
 		}
 		for (i = 0; i < addedLayers.length; i++) {
 			if (!this._map.hasLayer(addedLayers[i])) {


### PR DESCRIPTION
If you include the same (base) layer in a Control.Layer more than once (obviously with a different name), the behavior is not consistent when selecting it. Usually no base layer at all is included on the map when it is selected (it works with the other layers perfectly), so you see it grey.

Why do I include a layer more than once? Well, if I want some logic in the names, maybe makes sense to have two names for the same layer. Could be:
`{ 'OpenStreetMap': osm, 'Satellite': sat, ... , 'OSM Color': osm, 'OSM B&W': osm_bw, ...}`

The problem is that two (or more) `input` has the same layerId, so the logic looking what to remove and add does not work in this case.

The fix just check if the map has the layer after the removal phase, so it is added again if was one of the repeated layers.


By the way #2033 (fixed here #2171) creates since then a strange effect, and calls twice the layers update. It was a bug in FF for Android that now it's very old. I would suggest to remove the hack, or call the hack only in FF for Android, as @JoaoFTCoutinho suggested in 2014. Should I do it?