### PR TITLE
Hack for Android Firefox not needed.

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -206,11 +206,6 @@ export var Layers = Control.extend({
 			DomEvent.on(link, 'focus', this.expand, this);
 		}
 
-		// work around for Firefox Android issue https://github.com/Leaflet/Leaflet/issues/2033
-		DomEvent.on(form, 'click', function () {
-			setTimeout(Util.bind(this._onInputClick, this), 0);
-		}, this);
-
 		// TODO keyboard accessibility
 
 		if (!collapsed) {


### PR DESCRIPTION
The PR #2171 (based on issue #2033) introduces in 2013 a hack to workaround a bug in Android Firefox (v24 & 25).
It is a call that updates the layers in `Control.Layers` just for clicking the form. Again it is updated when clicking the input control.

This produces two consecutive calls that may have strange behaviors in some cases.
I have tested Firefox 54.0.1 in Android 4.3, 6.0 and 7.1.1 removing the hack, and the control is responsive.