### PR TITLE
ensure copyright banner survives minification

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV === 'release') {
 }
 
 
-const banner = `/*
+const banner = `/* @preserve
  * Leaflet ` + version + `, a JS library for interactive maps. http://leafletjs.com
  * (c) 2010-2017 Vladimir Agafonkin, (c) 2010-2011 CloudMade
  */`;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lintfix": "eslint src --fix; eslint spec/suites --fix; ",
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-watch-config.js",
-    "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map dist/leaflet.js.map --in-source-map dist/leaflet-src.js.map --source-map-url leaflet.js.map",
+    "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --in-source-map dist/leaflet-src.js.map --source-map-url leaflet.js.map --comments",
     "integrity": "nodejs ./build/integrity.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
[`v1.1.0`](https://unpkg.com/leaflet@1.1.0/dist/leaflet.js) is missing the copyright banner.

adding `@preserve` (and `--comments` in the uglify CLI command) resolves the problem.

prior to making this patch i encountered an unrelated error:

```bash
$ uglifyjs --version
uglify-js 3.0.27

$ npm run uglify

> leaflet@1.1.0 uglify /Users/john/github/Leaflet
> uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map dist/leaflet.js.map --in-source-map dist/leaflet-src.js.map --source-map-url leaflet.js.map

Supported options:
  content         null
  filename        null
  includeSources  false
  root            null
  url             null
ERROR: `dist/leaflet.js.map` is not a supported option
```

substituting `filename=dist/leaflet.js.map` took care of that as well.