### PR TITLE
remove comment in Control.Layers.js: TODO keyboard accessibility

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -206,8 +206,6 @@ export var Layers = Control.extend({
 			DomEvent.on(link, 'focus', this.expand, this);
 		}
 
-		// TODO keyboard accessibility
-
 		if (!collapsed) {
 			this.expand();
 		}


### PR DESCRIPTION
As mentioned in #5681, just remove the comment.