### PR TITLE
enable to pass simple array form to the method setBounds

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -136,7 +136,7 @@ export var ImageOverlay = Layer.extend({
 	// @method setBounds(bounds: LatLngBounds): this
 	// Update the bounds that this ImageOverlay covers
 	setBounds: function (bounds) {
-		this._bounds = bounds;
+		this._bounds = toLatLngBounds(bounds);
 
 		if (this._map) {
 			this._reset();


### PR DESCRIPTION
I am not really sure if it's bug or not. In your docs to create imageOverlay I can to pass bounds as simple array. However the function setBounds work only when it gets L.LatLngBounds, It's not work with simple array. so, I change the logic of this function in order to enable to pass simple array to this function.