### PR TITLE
Throw if argument to addLayer is not actually a layer

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -419,6 +419,13 @@ describe("Map", function () {
 			map.addLayer(layer);
 		});
 
+		it("throws if adding something which is not a layer", function () {
+			var control = L.control.layers();
+			expect(function () {
+				map.addLayer(control);
+			}).to.throwError();
+		});
+
 		describe("When the first layer is added to a map", function () {
 			it("fires a zoomlevelschange event", function () {
 				var spy = sinon.spy();

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -155,6 +155,10 @@ Map.include({
 	// @method addLayer(layer: Layer): this
 	// Adds the given layer to the map
 	addLayer: function (layer) {
+		if (!layer._layerAdd) {
+			throw new Error('The provided object is not a Layer.');
+		}
+
 		var id = Util.stamp(layer);
 		if (this._layers[id]) { return this; }
 		this._layers[id] = layer;


### PR DESCRIPTION
It's a somewhat common error trying to add something which isn't a layer with `addLayer` - it can for example happen when using a plugin written before Leaflet 1.0, where layers didn't have to inherit from `Layer`, but it can also happen in other cases like #5225.

This adds a clearer error message if a non-layer is accidentally passed to `addLayer`.