### PR TITLE
No inertia if drag is stopped before ending the drag

### DIFF
--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -129,15 +129,19 @@ export var Drag = Handler.extend({
 			this._positions.push(pos);
 			this._times.push(time);
 
-			if (time - this._times[0] > 50) {
-				this._positions.shift();
-				this._times.shift();
-			}
+			this._prunePositions(time);
 		}
 
 		this._map
 		    .fire('move', e)
 		    .fire('drag', e);
+	},
+
+	_prunePositions: function (time) {
+		while (this._positions.length > 1 && time - this._times[0] > 50) {
+			this._positions.shift();
+			this._times.shift();
+		}
 	},
 
 	_onZoomEnd: function () {
@@ -192,6 +196,7 @@ export var Drag = Handler.extend({
 			map.fire('moveend');
 
 		} else {
+			this._prunePositions(+new Date());
 
 			var direction = this._lastPos.subtract(this._positions[0]),
 			    duration = (this._lastTime - this._times[0]) / 1000,


### PR DESCRIPTION
This is an alternative to #5676 that also fixes #5652.

Currently, we accumulate positions in an array while dragging, and successively push out old positions, maintaining a list of recent positions. However, if the drag is paused for a while, and then immediately ended (by releasing mouse button/touch), we don't update the list of recent positions to reflect the pause, so it can still look as though we were dragging quickly when the drag ended.

This patch makes sure we update the positions list right before we calculate the current drag velocity and inertia.
