### PR TITLE
Remove horizontal scrollbar from control.layers

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -366,6 +366,7 @@
 	}
 .leaflet-control-layers-scrollbar {
 	overflow-y: scroll;
+	overflow-x: hidden;
 	padding-right: 5px;
 	}
 .leaflet-control-layers-selector {


### PR DESCRIPTION
When the vertical scrollbar is activated on Control.Layers (because the control is "taller" than the window), appears an horizontal scrollbar, just because the vertical used some space. But it is useless.

This change removes the horizontal scrollbar. Let see in these screen shots before and after the change, with a wide control (I have tested in Chrome and Firefox)

**Before:**
Normal case, no scroll bar
![pre_0](https://user-images.githubusercontent.com/15678366/29002897-2ff2d60a-7aad-11e7-9267-47808f7cf301.png)

**Vertical (and horizontal) scrollbars appear**
![pre_1](https://user-images.githubusercontent.com/15678366/29002898-34cdc8b0-7aad-11e7-826c-9039de1af603.png)

No scrollbar when window is not wide enough. The text is wrapped.
![pre_2](https://user-images.githubusercontent.com/15678366/29002899-382e1e9c-7aad-11e7-8349-d42539c6b1ab.png)

-----------

**After:**
Normal case, no scroll bar
![post_0](https://user-images.githubusercontent.com/15678366/29002903-4329079e-7aad-11e7-8df9-9c6d17c92996.png)

**Only Vertical scrollbar appears**
![post_1](https://user-images.githubusercontent.com/15678366/29002905-47bf5b32-7aad-11e7-9ec2-aa6d680216e1.png)

No scrollbar when window is not wide enough. The text is wrapped.
![post_2](https://user-images.githubusercontent.com/15678366/29002906-4b022efa-7aad-11e7-8ace-8e1d767022d5.png)


