### PR TITLE
Wrong release date leafletjs.com

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 layout: v2
 ---
 
-<div class="announcement">Jun 27, 2017 — <a href="/2017/08/08/leaflet-1.2.0.html">Leaflet 1.2.0</a> has been released.</div>
+<div class="announcement">Aug 8, 2017 — <a href="/2017/08/08/leaflet-1.2.0.html">Leaflet 1.2.0</a> has been released.</div>
 
 <p>Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps.
 Weighing just about <abbr title="38 KB gzipped &mdash; that's 133 KB minified and 378 KB in the source form, with 10 KB of CSS (2 KB gzipped) and 11 KB of images.">38 KB of JS</abbr>,


### PR DESCRIPTION
leafletjs.com says
Jun 27, 2017 — Leaflet 1.2.0 has been released.

and should
Aug 8, 2017 — Leaflet 1.2.0 has been released.