### PR TITLE
Fix issues with spelling in documentation

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -53,7 +53,7 @@ export function bind(fn, obj) {
 export var lastId = 0;
 
 // @function stamp(obj: Object): Number
-// Returns the unique ID of an object, assiging it one if it doesn't have it.
+// Returns the unique ID of an object, assigning it one if it doesn't have it.
 export function stamp(obj) {
 	/*eslint-disable */
 	obj._leaflet_id = obj._leaflet_id || ++lastId;

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -45,7 +45,7 @@ export function LatLng(lat, lng, alt) {
 
 LatLng.prototype = {
 	// @method equals(otherLatLng: LatLng, maxMargin?: Number): Boolean
-	// Returns `true` if the given `LatLng` point is at the same position (within a small margin of error). The margin of error can be overriden by setting `maxMargin` to a small number.
+	// Returns `true` if the given `LatLng` point is at the same position (within a small margin of error). The margin of error can be overridden by setting `maxMargin` to a small number.
 	equals: function (obj, maxMargin) {
 		if (!obj) { return false; }
 

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -212,7 +212,7 @@ LatLngBounds.prototype = {
 	},
 
 	// @method equals(otherBounds: LatLngBounds, maxMargin?: Number): Boolean
-	// Returns `true` if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overriden by setting `maxMargin` to a small number.
+	// Returns `true` if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overridden by setting `maxMargin` to a small number.
 	equals: function (bounds, maxMargin) {
 		if (!bounds) { return false; }
 

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -5,7 +5,7 @@ import * as Util from '../core/Util';
 /*
  * @namespace LineUtil
  *
- * Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.
+ * Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.
  */
 
 // Simplify polyline with vertex reduction and Douglas-Peucker simplification.

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -6,10 +6,10 @@ import * as LineUtil from './LineUtil';
  */
 
 /* @function clipPolygon(points: Point[], bounds: Bounds, round?: Boolean): Point[]
- * Clips the polygon geometry defined by the given `points` by the given bounds (using the [Sutherland-Hodgeman algorithm](https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm)).
+ * Clips the polygon geometry defined by the given `points` by the given bounds (using the [Sutherland-Hodgman algorithm](https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm)).
  * Used by Leaflet to only show polygon points that are on the screen or near, increasing
  * performance. Note that polygon points needs different algorithm for clipping
- * than polyline, so there's a seperate method for it.
+ * than polyline, so there's a separate method for it.
  */
 export function clipPolygon(points, bounds, round) {
 	var clippedPoints,

--- a/src/geometry/Transformation.js
+++ b/src/geometry/Transformation.js
@@ -71,7 +71,7 @@ Transformation.prototype = {
 
 // @alternative
 // @factory L.transformation(coefficients: Array): Transformation
-// Expects an coeficients array of the form
+// Expects an coefficients array of the form
 // `[a: Number, b: Number, c: Number, d: Number]`.
 
 export function toTransformation(a, b, c, d) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -410,7 +410,7 @@ Layer.include({
 	},
 
 	// @method openPopup(latlng?: LatLng): this
-	// Opens the bound popup at the specificed `latlng` or at the default popup anchor if no `latlng` is passed.
+	// Opens the bound popup at the specified `latlng` or at the default popup anchor if no `latlng` is passed.
 	openPopup: function (layer, latlng) {
 		if (!(layer instanceof Layer)) {
 			latlng = layer;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -20,7 +20,7 @@ import * as DomUtil from '../dom/DomUtil';
  * marker.bindTooltip("my tooltip text").openTooltip();
  * ```
  * Note about tooltip offset. Leaflet takes two options in consideration
- * for computing tooltip offseting:
+ * for computing tooltip offsetting:
  * - the `offset` Tooltip option: it defaults to [0, 0], and it's specific to one tooltip.
  *   Add a positive x offset to move the tooltip to the right, and a positive y offset to
  *   move it to the bottom. Negatives will move to the left and top.
@@ -46,7 +46,7 @@ export var Tooltip = DivOverlay.extend({
 		// @option direction: String = 'auto'
 		// Direction where to open the tooltip. Possible values are: `right`, `left`,
 		// `top`, `bottom`, `center`, `auto`.
-		// `auto` will dynamicaly switch between `right` and `left` according to the tooltip
+		// `auto` will dynamically switch between `right` and `left` according to the tooltip
 		// position on the map.
 		direction: 'auto',
 
@@ -310,7 +310,7 @@ Layer.include({
 	},
 
 	// @method openTooltip(latlng?: LatLng): this
-	// Opens the bound tooltip at the specificed `latlng` or at the default tooltip anchor if no `latlng` is passed.
+	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
 	openTooltip: function (layer, latlng) {
 		if (!(layer instanceof Layer)) {
 			latlng = layer;

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -40,12 +40,12 @@ export var Marker = Layer.extend({
 		// Set it to `true` if you want the map to do panning animation when marker hits the edges.
 		autoPan: false,
 
-		// @option autoPanPadding: Point = Point(5, 5)
+		// @option autoPanPadding: Point = Point(50, 50)
 		// Equivalent of setting both top left and bottom right autopan padding to the same value.
 		autoPanPadding: [50, 50],
 
-		// @option autoPanSpeed: Number = 100
-		// Numer of pixels the map should move by.
+		// @option autoPanSpeed: Number = 10
+		// Number of pixels the map should move by.
 		autoPanSpeed: 10,
 
 		// @option keyboard: Boolean = true

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -261,7 +261,7 @@ export var GridLayer = Layer.extend({
 	// @section Extension methods
 	// Layers extending `GridLayer` shall reimplement the following method.
 	// @method createTile(coords: Object, done?: Function): HTMLElement
-	// Called only internally, must be overriden by classes extending `GridLayer`.
+	// Called only internally, must be overridden by classes extending `GridLayer`.
 	// Returns the `HTMLElement` corresponding to the given `coords`. If the `done` callback
 	// is specified, it must be called when the tile has finished loading and drawing.
 	createTile: function () {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -123,7 +123,7 @@ export var TileLayer = GridLayer.extend({
 
 	// @method createTile(coords: Object, done?: Function): HTMLElement
 	// Called only internally, overrides GridLayer's [`createTile()`](#gridlayer-createtile)
-	// to return an `<img>` HTML element with the appropiate image URL given `coords`. The `done`
+	// to return an `<img>` HTML element with the appropriate image URL given `coords`. The `done`
 	// callback is called when the tile has been loaded.
 	createTile: function (coords, done) {
 		var tile = document.createElement('img');

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -416,7 +416,7 @@ export var Canvas = Renderer.extend({
 			prev.next = next;
 		} else if (next) {
 			// Update first entry unless this is the
-			// signle entry
+			// single entry
 			this._drawFirst = next;
 		}
 
@@ -444,7 +444,7 @@ export var Canvas = Renderer.extend({
 			next.prev = prev;
 		} else if (prev) {
 			// Update last entry unless this is the
-			// signle entry
+			// single entry
 			this._drawLast = prev;
 		}
 

--- a/src/layer/vector/Rectangle.js
+++ b/src/layer/vector/Rectangle.js
@@ -7,7 +7,7 @@ import {toLatLngBounds} from '../../geo/LatLngBounds';
 
 /*
  * @class Rectangle
- * @aka L.Retangle
+ * @aka L.Rectangle
  * @inherits Polygon
  *
  * A class for drawing rectangle overlays on a map. Extends `Polygon`.

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -673,7 +673,7 @@ export var Map = Evented.extend({
 	},
 
 	// TODO handler.addTo
-	// TODO Appropiate docs section?
+	// TODO Appropriate docs section?
 	// @section Other Methods
 	// @method addHandler(name: String, HandlerClass: Function): this
 	// Adds a new `Handler` to the map, given its name and constructor function.


### PR DESCRIPTION
I wanted to fix the small issues from this pull request https://github.com/Leaflet/Leaflet/pull/5651, but I ended up with also fixing a couple of other issues with spelling in the documentation.

Ping @perliedman 