### PR TITLE
Update VideoOverlay.js

### DIFF
--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -39,8 +39,8 @@ export var VideoOverlay = ImageOverlay.extend({
 		var wasElementSupplied = this._url.tagName === 'VIDEO';
 		var vid = this._image = wasElementSupplied ? this._url : DomUtil.create('video');
 
-		vid.className = vid.className || '';
-		vid.className += 'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : '');
+		DomUtil.addClass('leaflet-image-layer');
+		if (this._zoomAnimated) { DomUtil.addClass('leaflet-zoom-animated'); }
 
 		vid.onselectstart = Util.falseFn;
 		vid.onmousemove = Util.falseFn;

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -39,8 +39,8 @@ export var VideoOverlay = ImageOverlay.extend({
 		var wasElementSupplied = this._url.tagName === 'VIDEO';
 		var vid = this._image = wasElementSupplied ? this._url : DomUtil.create('video');
 
-		vid.class = vid.class || '';
-		vid.class += 'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : '');
+		vid.className = vid.className || '';
+		vid.className += 'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : '');
 
 		vid.onselectstart = Util.falseFn;
 		vid.onmousemove = Util.falseFn;


### PR DESCRIPTION
wrong keyword uses - className should be used instead
found this when testing new leaflet on ie8 - map doesn't load because of this