### PR TITLE
Pad method fixed (#5741)

### DIFF
--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -77,12 +77,12 @@ LatLngBounds.prototype = {
 	},
 
 	// @method pad(bufferRatio: Number): LatLngBounds
-	// Returns bigger bounds created by extending the current bounds by a given percentage in each direction.
+	// Returns bounds created by extending or retracting by a percentage.
 	pad: function (bufferRatio) {
 		var sw = this._southWest,
 		    ne = this._northEast,
-		    heightBuffer = Math.abs(sw.lat - ne.lat) * bufferRatio,
-		    widthBuffer = Math.abs(sw.lng - ne.lng) * bufferRatio;
+		    heightBuffer = Math.abs(sw.lat - ne.lat) * (bufferRatio/100),
+		    widthBuffer = Math.abs(sw.lng - ne.lng) * (bufferRatio/100);
 
 		return new LatLngBounds(
 		        new LatLng(sw.lat - heightBuffer, sw.lng - widthBuffer),

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -81,8 +81,8 @@ LatLngBounds.prototype = {
 	pad: function (bufferRatio) {
 		var sw = this._southWest,
 		    ne = this._northEast,
-		    heightBuffer = Math.abs(sw.lat - ne.lat) * (bufferRatio/100),
-		    widthBuffer = Math.abs(sw.lng - ne.lng) * (bufferRatio/100);
+		    heightBuffer = Math.abs(sw.lat - ne.lat) * (bufferRatio / 100),
+		    widthBuffer = Math.abs(sw.lng - ne.lng) * (bufferRatio / 100);
 
 		return new LatLngBounds(
 		        new LatLng(sw.lat - heightBuffer, sw.lng - widthBuffer),


### PR DESCRIPTION
New contributor here I think I've done everything right but let me know if I haven't.

The Pad method in src/geo/LatLngBounds.js was not doing what it said it was doing(see Issue #5741 ). 

The previous pad method was not using percentages(as the comment said it was) and would therefore give you the wrong bounds so I fixed it!

Here is the answers to the contributing questions:

1. Are you sure that this new feature is important enough to justify its presence in the Leaflet core? Or will it look better as a plugin in a separate repository?

It is a bug fix with an updated comment, so in my opinion very important in the core.

2. Is it written in a simple, concise way that doesn't add bulk to the codebase?

Very simple.

I ran the tests using
```
jake test
```
and did not get any errors other than in some file I didn't touch had 4 spaces instead of tabs but I let that be.
