### PR TITLE
Feat(IconDefault): retrieve all options from CSS

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -386,12 +386,14 @@
 
 /* Default icon options */
 .leaflet-default-icon-icon {
+	background-image: url(images/marker-icon.png), url(images/marker-icon-2x.png); /* normal[, Retina] */
 	cursor: url(images/marker-icon.png), url(images/marker-icon-2x.png), auto; /* normal[, Retina], auto for compliance with cursor syntax */
 	width: 25px;
 	height: 41px;
 	margin: -41px -12px; /* margin top and left to reversely position iconAnchor */
 	}
 .leaflet-default-icon-shadow {
+	background-image: url(images/marker-shadow.png); /* normal[, Retina] */
 	cursor: url(images/marker-shadow.png), auto; /* normal[, Retina], auto */
 	width: 41px;
 	height: 41px;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -383,9 +383,24 @@
 	margin: 5px -10px 5px -6px;
 	}
 
-/* Default icon URLs */
-.leaflet-default-icon-path {
-	background-image: url(images/marker-icon.png);
+/* Default icon options */
+.leaflet-default-icon-icon {
+	background-image: url(images/marker-icon.png), url(images/marker-icon-2x.png); /* normal[, Retina] */
+	width: 25px;
+	height: 41px;
+	margin: -41px -12px; /* margin top and left to reversely position iconAnchor */
+	}
+.leaflet-default-icon-shadow {
+	background-image: url(images/marker-shadow.png); /* normal[, Retina] */
+	width: 41px;
+	height: 41px;
+	margin: -41px -12px; /* margin top and left to reversely position shadowAnchor */
+	}
+.leaflet-default-icon-popup {
+	margin: -34px 1px; /* margin top and left to position popupAnchor */
+	}
+.leaflet-default-icon-tooltip {
+	margin: -28px 16px; /* margin top and left to position tooltipAnchor, even if direction 'bottom' or 'right' */
 	}
 
 

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -385,13 +385,13 @@
 
 /* Default icon options */
 .leaflet-default-icon-icon {
-	background-image: url(images/marker-icon.png), url(images/marker-icon-2x.png); /* normal[, Retina] */
+	cursor: url(images/marker-icon.png), url(images/marker-icon-2x.png), auto; /* normal[, Retina], auto for compliance with cursor syntax */
 	width: 25px;
 	height: 41px;
 	margin: -41px -12px; /* margin top and left to reversely position iconAnchor */
 	}
 .leaflet-default-icon-shadow {
-	background-image: url(images/marker-shadow.png); /* normal[, Retina] */
+	cursor: url(images/marker-shadow.png), auto; /* normal[, Retina], auto */
 	width: 41px;
 	height: 41px;
 	margin: -41px -12px; /* margin top and left to reversely position shadowAnchor */

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -197,8 +197,12 @@ describe('Popup', function () {
 	it("should take into account icon popupAnchor option", function () {
 		var autoPanBefore = L.Popup.prototype.options.autoPan;
 		L.Popup.prototype.options.autoPan = false;
-		var popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
-		L.Icon.Default.prototype.options.popupAnchor = [0, 0];
+
+		// Default icon options are now applied per instance, not on the L.Icon.Default.prototype.
+		var markerDefaultIconOptions = L.Marker.prototype.options.icon.options,
+		    popupAnchorBefore = markerDefaultIconOptions.popupAnchor;
+
+		markerDefaultIconOptions.popupAnchor = [0, 0];
 
 		var latlng = new L.LatLng(55.8, 37.6),
 		    offset = new L.Point(20, 30),
@@ -226,7 +230,7 @@ describe('Popup', function () {
 		expect(offsetBottom + offset.y).to.eql(defaultBottom);
 
 		L.Popup.prototype.options.autoPan = autoPanBefore;
-		L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
+		markerDefaultIconOptions.popupAnchor = popupAnchorBefore;
 	});
 
 	it("prevents an underlying map click for Layer", function () {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -145,6 +145,39 @@ describe("Icon.Default", function () {
 		}
 	});
 
+	it("is compatible with data URL / base64 image (no imagePath)", function () {
+		// As specified in: https://github.com/Leaflet/Leaflet/blob/v1.2.0/spec/after.js#L1
+		var previousImagePath = L.Icon.Default.imagePath;
+
+		var className = 'leaflet-default-icon-icon';
+		var el = L.DomUtil.create('div',  className, document.body);
+		var previousBkgImage = L.DomUtil.getStyle(el, 'background-image');
+		var dataUri = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
+		try {
+			L.Icon.Default.imagePath = null;
+
+			// Modify the CSS rules.
+			addCSSRule(document.styleSheets[0], '.' + className, 'background: url(' + dataUri + ')');
+
+			var iconDefault = new L.Icon.Default();
+			var iconDefaultOptions = iconDefault.options;
+
+			var path = iconDefault._getIconUrl('icon');
+
+			expect(path).to.be(dataUri);
+			expect(iconDefaultOptions.iconUrl).to.be(dataUri);
+		} finally {
+			// Restore imagePath.
+			// Make so in a `finally` block so that it is executed even if the above test expectations fail,
+			// and they do not affect next tests. Similar to specifying an `after` block.
+			L.Icon.Default.imagePath = previousImagePath;
+
+			// Reset the CSS rules.
+			addCSSRule(document.styleSheets[0], '.' + className, 'background: ' + previousBkgImage);
+		}
+	});
+
 	it("fallsback to cursor CSS rule in case background-image is empty (for FF high contrast option)", function () {
 
 		var className = 'leaflet-default-icon-icon';
@@ -186,21 +219,21 @@ describe("Icon.Default", function () {
 			addCSSRule(document.styleSheets[0], '.' + className, 'background: ' + previousBkgImage);
 			addCSSRule(document.styleSheets[0], '.' + className, 'cursor: ' + previousCursor);
 		}
-
-
-		function addCSSRule(sheet, selector, rules, index) {
-			if (sheet.insertRule) {
-				// https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule
-				if (typeof index !== 'number') {
-					index = sheet.cssRules.length;
-				}
-				sheet.insertRule(selector + '{' + rules + '}', index);
-			} else if (sheet.addRule) {
-				sheet.addRule(selector, rules, index);
-			} else {
-				console.log('cannot add CSS rule');
-			}
-		}
 	});
 
 });
+
+
+function addCSSRule(sheet, selector, rules, index) {
+	if (sheet.insertRule) {
+		// https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule
+		if (typeof index !== 'number') {
+			index = sheet.cssRules.length;
+		}
+		sheet.insertRule(selector + '{' + rules + '}', index);
+	} else if (sheet.addRule) {
+		sheet.addRule(selector, rules, index);
+	} else {
+		console.log('cannot add CSS rule');
+	}
+}

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -94,22 +94,17 @@ describe("Icon.Default", function () {
 		expect(iconDefaultOptions.shadowAnchor).to.be(newOptions.shadowAnchor);
 
 		// Reset default options and re-force re-evaluation.
-		_deleteIconOptions(L.Icon.Default.prototype.options);
+		_deleteIconOptions(L.Icon.Default.prototype.options, newOptions);
 
 		// Re-instantiate a new Default Icon, for next tests to use default values (i.e. the ones from CSS).
 		L.Marker.mergeOptions({
 			icon: new L.Icon.Default()
 		});
 
-		function _deleteIconOptions(iconOptions) {
-			delete iconOptions.iconUrl;
-			delete iconOptions.iconRetinaUrl;
-			delete iconOptions.iconSize;
-			delete iconOptions.iconAnchor;
-			delete iconOptions.shadowUrl;
-			delete iconOptions.shadowRetinaUrl;
-			delete iconOptions.shadowSize;
-			delete iconOptions.shadowAnchor;
+		function _deleteIconOptions(iconOptions, keysObj) {
+			for (var key in keysObj) {
+				delete iconOptions[key];
+			}
 		}
 	});
 

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -34,16 +34,17 @@ describe("Icon.Default", function () {
 		// No need for a map in this test.
 		// This also avoids printing a warning in console due to HTML 404 resource not found.
 		// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
-		var iconDefault = new L.Icon.Default();
-		var iconDefaultOptions = iconDefault.options;
-
-		iconDefaultOptions.imagePath = 'IconDefault/dummy/imagePath/';
+		var iconFilenameInCSS = 'marker-icon.png';
+		var imagePath = 'IconDefault/dummy/imagePath/';
+		var iconDefault = new L.Icon.Default({
+			imagePath: imagePath
+		});
 
 		var path = iconDefault._getIconUrl('icon');
 
 		// 'marker-icon.png' is now defined in CSS.
-		expect(iconDefaultOptions.iconUrl).to.be('marker-icon.png');
-		expect(path).to.be('IconDefault/dummy/imagePath/marker-icon.png');
+		expect(iconDefault.options.iconUrl).to.be(iconFilenameInCSS);
+		expect(path).to.be(imagePath + iconFilenameInCSS);
 	});
 
 	it("uses imagePath and iconUrl options", function () {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -30,6 +30,42 @@ describe("Icon.Default", function () {
 		document.body.removeChild(div);
 	});
 
+	it("retrieves full icon URL if no imagePath is specified", function () {
+		// As specified in: https://github.com/Leaflet/Leaflet/blob/v1.2.0/spec/after.js#L1
+		var previousImagePath = L.Icon.Default.imagePath;
+
+		// Caution: in case of error, the printed path will be proxied as specified in:
+		// https://github.com/Leaflet/Leaflet/blob/v1.2.0/spec/karma.conf.js#L42
+		var cssFilePath = '/base/dist/';
+
+		// Unfortunately previousImagePath is exactly like the actual path that should be retrieved.
+		// In order to make sure we read the full URL, without depending on imagePath, we will also
+		// make sure there is a localhost.
+		var localhost = '^http://localhost(.)*?';
+		var cssFilePathFull = localhost + cssFilePath;
+
+		try {
+			L.Icon.Default.imagePath = null;
+
+			var iconDefault = new L.Icon.Default();
+			var iconDefaultOptions = iconDefault.options;
+
+			var path = iconDefault._getIconUrl('icon');
+
+			// Images URL are now defined in CSS.
+			expect(new RegExp(cssFilePathFull + 'images/marker-icon.png$').test(path)).to.be.ok();
+			expect(new RegExp(cssFilePathFull + 'images/marker-icon.png$').test(iconDefaultOptions.iconUrl)).to.be.ok();
+			expect(new RegExp(cssFilePathFull + 'images/marker-icon-2x.png$').test(iconDefaultOptions.iconRetinaUrl)).to.be.ok();
+			expect(new RegExp(cssFilePathFull + 'images/marker-shadow.png$').test(iconDefaultOptions.shadowUrl)).to.be.ok();
+			expect(iconDefaultOptions.shadowRetinaUrl).to.be.an('undefined');
+		} finally {
+			// Restore imagePath.
+			// Make so in a `finally` block so that it is executed even if the above test expectations fail,
+			// and they do not affect next tests. Similar to specifying an `after` block.
+			L.Icon.Default.imagePath = previousImagePath;
+		}
+	});
+
 	it("uses imagePath option if specified", function () {
 		// No need for a map in this test.
 		// This also avoids printing a warning in console due to HTML 404 resource not found.

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -54,4 +54,69 @@ describe("Icon.Default", function () {
 		delete iconDefaultOptions.iconUrl;
 	});
 
+	it("uses options set on L.Icon.Default.prototype (for backward compatibility)", function () {
+		// No need for a map in this test.
+		// This also avoids printing a warning in console due to HTML 404 resource not found.
+		var iconUrl = 'dummy/icon.png';
+		var iconRetinaUrl = 'dummy/iconRetina.png';
+		var iconSize = [100, 200];
+		var iconAnchor = [50, 75];
+		var shadowUrl = 'dummy/shadow.png';
+		var shadowRetinaUrl = 'dummy/shadowRetina.png';
+		var shadowSize = [110, 210];
+		var shadowAnchor = [55, 80];
+
+		// Add options to L.Icon.Default.prototype like what previous apps may have done.
+		L.Icon.Default.mergeOptions({
+			iconUrl: iconUrl,
+			iconRetinaUrl: iconRetinaUrl,
+			iconSize: iconSize,
+			iconAnchor: iconAnchor,
+			shadowUrl: shadowUrl,
+			shadowRetinaUrl: shadowRetinaUrl,
+			shadowSize: shadowSize,
+			shadowAnchor: shadowAnchor
+		});
+
+		// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
+		var iconDefault = new L.Icon.Default();
+
+		L.Marker.mergeOptions({
+			icon: iconDefault
+		});
+
+		var marker = new L.Marker([0, 0]);
+		// Force retrieval of Default Icon options from CSS.
+		marker.options.icon._getIconUrl('icon');
+
+		// Make sure it used the specified default options instead of the ones from CSS.
+		expect(iconDefault.options.iconUrl).to.be(iconUrl);
+		expect(iconDefault.options.iconRetinaUrl).to.be(iconRetinaUrl);
+		expect(iconDefault.options.iconSize).to.be(iconSize);
+		expect(iconDefault.options.iconAnchor).to.be(iconAnchor);
+		expect(iconDefault.options.shadowUrl).to.be(shadowUrl);
+		expect(iconDefault.options.shadowRetinaUrl).to.be(shadowRetinaUrl);
+		expect(iconDefault.options.shadowSize).to.be(shadowSize);
+		expect(iconDefault.options.shadowAnchor).to.be(shadowAnchor);
+
+		// Reset default options and re-force re-evaluation.
+		_deleteIconOptions(L.Icon.Default.prototype.options);
+
+		// Re-instantiate a new Default Icon, for next tests to use default values (i.e. the ones from CSS).
+		L.Marker.mergeOptions({
+			icon: new L.Icon.Default()
+		});
+
+		function _deleteIconOptions(iconOptions) {
+			delete iconOptions.iconUrl;
+			delete iconOptions.iconRetinaUrl;
+			delete iconOptions.iconSize;
+			delete iconOptions.iconAnchor;
+			delete iconOptions.shadowUrl;
+			delete iconOptions.shadowRetinaUrl;
+			delete iconOptions.shadowSize;
+			delete iconOptions.shadowAnchor;
+		}
+	});
+
 });

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -138,8 +138,9 @@ describe("Icon.Default", function () {
 			// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
 			var iconDefault = new L.Icon.Default();
 
-			iconDefault._getIconUrl('icon');
-			expect(iconDefault.options.iconUrl).to.be(expectedImagePath + newCursorFilename);
+			var path = iconDefault._getIconUrl('icon');
+			expect(iconDefault.options.iconUrl).to.be(newCursorFilename);
+			expect(path).to.be(expectedImagePath + newCursorFilename);
 
 		} finally {
 			// Reset the CSS rules.

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -75,31 +75,24 @@ describe("Icon.Default", function () {
 		var iconDefault = new L.Icon.Default();
 		var iconDefaultOptions = iconDefault.options;
 
-		L.Marker.mergeOptions({
-			icon: iconDefault
-		});
+		iconDefault._getIconUrl('icon');
 
-		var marker = new L.Marker([0, 0]);
-		// Force retrieval of Default Icon options from CSS.
-		marker.options.icon._getIconUrl('icon');
-
-		// Make sure it used the specified default options instead of the ones from CSS.
-		expect(iconDefaultOptions.iconUrl).to.be(newOptions.iconUrl);
-		expect(iconDefaultOptions.iconRetinaUrl).to.be(newOptions.iconRetinaUrl);
-		expect(iconDefaultOptions.iconSize).to.be(newOptions.iconSize);
-		expect(iconDefaultOptions.iconAnchor).to.be(newOptions.iconAnchor);
-		expect(iconDefaultOptions.shadowUrl).to.be(newOptions.shadowUrl);
-		expect(iconDefaultOptions.shadowRetinaUrl).to.be(newOptions.shadowRetinaUrl);
-		expect(iconDefaultOptions.shadowSize).to.be(newOptions.shadowSize);
-		expect(iconDefaultOptions.shadowAnchor).to.be(newOptions.shadowAnchor);
-
-		// Reset default options and re-force re-evaluation.
-		_deleteIconOptions(L.Icon.Default.prototype.options, newOptions);
-
-		// Re-instantiate a new Default Icon, for next tests to use default values (i.e. the ones from CSS).
-		L.Marker.mergeOptions({
-			icon: new L.Icon.Default()
-		});
+		try {
+			// Make sure it used the specified default options instead of the ones from CSS.
+			expect(iconDefaultOptions.iconUrl).to.be(newOptions.iconUrl);
+			expect(iconDefaultOptions.iconRetinaUrl).to.be(newOptions.iconRetinaUrl);
+			expect(iconDefaultOptions.iconSize).to.be(newOptions.iconSize);
+			expect(iconDefaultOptions.iconAnchor).to.be(newOptions.iconAnchor);
+			expect(iconDefaultOptions.shadowUrl).to.be(newOptions.shadowUrl);
+			expect(iconDefaultOptions.shadowRetinaUrl).to.be(newOptions.shadowRetinaUrl);
+			expect(iconDefaultOptions.shadowSize).to.be(newOptions.shadowSize);
+			expect(iconDefaultOptions.shadowAnchor).to.be(newOptions.shadowAnchor);
+		} finally {
+			// Reset default options and re-force re-evaluation.
+			// Make so in a `finally` block so that it is executed even if the above test expectations fail,
+			// and they do not affect next tests. Similar to specifying an `after` block.
+			_deleteIconOptions(L.Icon.Default.prototype.options, newOptions);
+		}
 
 		function _deleteIconOptions(iconOptions, keysObj) {
 			for (var key in keysObj) {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -33,25 +33,16 @@ describe("Icon.Default", function () {
 	it("uses imagePath option if specified", function () {
 		// No need for a map in this test.
 		// This also avoids printing a warning in console due to HTML 404 resource not found.
-		var iconDefault = L.Marker.prototype.options.icon;
+		// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
+		var iconDefault = new L.Icon.Default();
 		var iconDefaultOptions = iconDefault.options;
 
-		// Force re-evaluation of IconDefault options from CSS, using imagePath.
-		iconDefault._needsInit = true;
 		iconDefaultOptions.imagePath = 'IconDefault/dummy/imagePath/';
-		iconDefaultOptions.iconUrl = null;
 
-		var marker = new L.Marker([0, 0]);
-
-		var path = marker.options.icon._getIconUrl('icon');
+		var path = iconDefault._getIconUrl('icon');
 
 		// 'marker-icon.png' is now defined in CSS.
 		expect(path).to.be('IconDefault/dummy/imagePath/marker-icon.png');
-
-		// Force re-evaluation of IconDefault options from CSS, without imagePath.
-		iconDefault._needsInit = true;
-		delete iconDefaultOptions.imagePath;
-		delete iconDefaultOptions.iconUrl;
 	});
 
 	it("uses options set on L.Icon.Default.prototype (for backward compatibility)", function () {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -57,29 +57,23 @@ describe("Icon.Default", function () {
 	it("uses options set on L.Icon.Default.prototype (for backward compatibility)", function () {
 		// No need for a map in this test.
 		// This also avoids printing a warning in console due to HTML 404 resource not found.
-		var iconUrl = 'dummy/icon.png';
-		var iconRetinaUrl = 'dummy/iconRetina.png';
-		var iconSize = [100, 200];
-		var iconAnchor = [50, 75];
-		var shadowUrl = 'dummy/shadow.png';
-		var shadowRetinaUrl = 'dummy/shadowRetina.png';
-		var shadowSize = [110, 210];
-		var shadowAnchor = [55, 80];
+		var newOptions = {
+			iconUrl: 'dummy/icon.png',
+			iconRetinaUrl: 'dummy/iconRetina.png',
+			iconSize: [100, 200],
+			iconAnchor: [50, 75],
+			shadowUrl: 'dummy/shadow.png',
+			shadowRetinaUrl: 'dummy/shadowRetina.png',
+			shadowSize: [110, 210],
+			shadowAnchor: [55, 80]
+		};
 
 		// Add options to L.Icon.Default.prototype like what previous apps may have done.
-		L.Icon.Default.mergeOptions({
-			iconUrl: iconUrl,
-			iconRetinaUrl: iconRetinaUrl,
-			iconSize: iconSize,
-			iconAnchor: iconAnchor,
-			shadowUrl: shadowUrl,
-			shadowRetinaUrl: shadowRetinaUrl,
-			shadowSize: shadowSize,
-			shadowAnchor: shadowAnchor
-		});
+		L.Icon.Default.mergeOptions(newOptions);
 
 		// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
 		var iconDefault = new L.Icon.Default();
+		var iconDefaultOptions = iconDefault.options;
 
 		L.Marker.mergeOptions({
 			icon: iconDefault
@@ -90,14 +84,14 @@ describe("Icon.Default", function () {
 		marker.options.icon._getIconUrl('icon');
 
 		// Make sure it used the specified default options instead of the ones from CSS.
-		expect(iconDefault.options.iconUrl).to.be(iconUrl);
-		expect(iconDefault.options.iconRetinaUrl).to.be(iconRetinaUrl);
-		expect(iconDefault.options.iconSize).to.be(iconSize);
-		expect(iconDefault.options.iconAnchor).to.be(iconAnchor);
-		expect(iconDefault.options.shadowUrl).to.be(shadowUrl);
-		expect(iconDefault.options.shadowRetinaUrl).to.be(shadowRetinaUrl);
-		expect(iconDefault.options.shadowSize).to.be(shadowSize);
-		expect(iconDefault.options.shadowAnchor).to.be(shadowAnchor);
+		expect(iconDefaultOptions.iconUrl).to.be(newOptions.iconUrl);
+		expect(iconDefaultOptions.iconRetinaUrl).to.be(newOptions.iconRetinaUrl);
+		expect(iconDefaultOptions.iconSize).to.be(newOptions.iconSize);
+		expect(iconDefaultOptions.iconAnchor).to.be(newOptions.iconAnchor);
+		expect(iconDefaultOptions.shadowUrl).to.be(newOptions.shadowUrl);
+		expect(iconDefaultOptions.shadowRetinaUrl).to.be(newOptions.shadowRetinaUrl);
+		expect(iconDefaultOptions.shadowSize).to.be(newOptions.shadowSize);
+		expect(iconDefaultOptions.shadowAnchor).to.be(newOptions.shadowAnchor);
 
 		// Reset default options and re-force re-evaluation.
 		_deleteIconOptions(L.Icon.Default.prototype.options);

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -42,7 +42,23 @@ describe("Icon.Default", function () {
 		var path = iconDefault._getIconUrl('icon');
 
 		// 'marker-icon.png' is now defined in CSS.
+		expect(iconDefaultOptions.iconUrl).to.be('marker-icon.png');
 		expect(path).to.be('IconDefault/dummy/imagePath/marker-icon.png');
+	});
+
+	it("uses imagePath and iconUrl options", function () {
+		// No need for a map in this test.
+		// This also avoids printing a warning in console due to HTML 404 resource not found.
+		// Re-instantiate a new Default Icon, so that its options will be evaluated just now.
+		var options = {
+			iconUrl: 'extra/path/to/marker.png',
+			imagePath: 'IconDefault/dummy/imagePath/'
+		};
+		var iconDefault = new L.Icon.Default(options);
+
+		var path = iconDefault._getIconUrl('icon');
+
+		expect(path).to.be(options.imagePath + options.iconUrl);
 	});
 
 	it("uses options set on L.Icon.Default.prototype (for backward compatibility)", function () {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -30,4 +30,28 @@ describe("Icon.Default", function () {
 		document.body.removeChild(div);
 	});
 
+	it("uses imagePath option if specified", function () {
+		// No need for a map in this test.
+		// This also avoids printing a warning in console due to HTML 404 resource not found.
+		var iconDefault = L.Marker.prototype.options.icon;
+		var iconDefaultOptions = iconDefault.options;
+
+		// Force re-evaluation of IconDefault options from CSS, using imagePath.
+		iconDefault._needsInit = true;
+		iconDefaultOptions.imagePath = 'IconDefault/dummy/imagePath/';
+		iconDefaultOptions.iconUrl = null;
+
+		var marker = new L.Marker([0, 0]);
+
+		var path = marker.options.icon._getIconUrl('icon');
+
+		// 'marker-icon.png' is now defined in CSS.
+		expect(path).to.be('IconDefault/dummy/imagePath/marker-icon.png');
+
+		// Force re-evaluation of IconDefault options from CSS, without imagePath.
+		iconDefault._needsInit = true;
+		delete iconDefaultOptions.imagePath;
+		delete iconDefaultOptions.iconUrl;
+	});
+
 });

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -12,6 +12,11 @@ describe("Marker", function () {
 
 		map = L.map(div).setView([0, 0], 0);
 		icon1 = new L.Icon.Default();
+
+		// Force initialization of Default Icon options, so that we can use icon1.options right away.
+		// Default iconUrl and shadowUrl are no longer hard coded in JS, but retrieved from CSS.
+		icon1._getIconUrl('icon');
+
 		icon2 = new L.Icon.Default({
 			iconUrl: icon1.options.iconUrl + '?2',
 			shadowUrl: icon1.options.shadowUrl + '?2'

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -58,9 +58,9 @@ export var IconDefault = Icon.extend({
 
 	// Retrieve values from CSS and assign to this instance options.
 	_setOptions: function (name, detectorFn, imagePath) {
-		var prefix = this.options.classNamePrefix,
-		    optionValues = detectorFn(prefix + name, imagePath),
-		    options = this.options;
+		var options = this.options,
+		    prefix = options.classNamePrefix,
+		    optionValues = detectorFn(prefix + name, imagePath);
 
 		for (var optionName in optionValues) {
 			options[name + optionName] = options[name + optionName] || optionValues[optionName];

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -71,7 +71,7 @@ export var IconDefault = Icon.extend({
 // Retrieve icon option values from CSS (icon or shadow).
 function _detectIconOptions(className, imagePath) {
 	var el = DomUtil.create('div',  className, document.body),
-	    urlsContainer = _getStyle(el, 'cursor'),
+	    urlsContainer = _getBkgImageOrCursor(el),
 	    urls = _extractUrls(urlsContainer, imagePath),
 	    iconX = parseInt(_getStyle(el, 'width'), 10),
 	    iconY = parseInt(_getStyle(el, 'height'), 10),
@@ -124,6 +124,17 @@ function _replaceUrl(url, imagePath) {
 // Factorize style reading fallback for IE8.
 function _getStyle(el, style) {
 	return DomUtil.getStyle(el, style) || DomUtil.getStyle(el, _kebabToCamelCase(style));
+}
+
+// When Firefox high contrast (colours override) option is enabled,
+// "background-image" is overridden by the browser as "none".
+// In that case, fallback to "cursor". But keep "background-image"
+// as primary source because IE expects cursor URL as relative to HTML page
+// instead of relative to CSS file.
+function _getBkgImageOrCursor(el) {
+	var bkgImage = _getStyle(el, 'background-image');
+
+	return bkgImage && bkgImage !== 'none' ? bkgImage : _getStyle(el, 'cursor');
 }
 
 // Convert kebab-case CSS property name to camelCase for IE currentStyle.

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -37,6 +37,7 @@ export var IconDefault = Icon.extend({
 			// path, before any marker is added to a map.
 			// Caution: do not use this option with inline base64 image(s).
 			var imagePath = this.options.imagePath || IconDefault.imagePath;
+			// Deprecated (IconDefault.imagePath), backwards-compatibility only
 
 			// Modifying imagePath option after _getIconUrl has been called
 			// once in this instance of IconDefault will no longer have any

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -29,23 +29,23 @@ export var IconDefault = Icon.extend({
 
 	// Override to make sure options are retrieved from CSS.
 	_getIconUrl: function (name) {
-		if (this._needsInit) {
-			// @option imagePath: String
-			// `Icon.Default` will try to auto-detect the location of
-			// the blue icon images. If you are placing these images in a
-			// non-standard way, set this option to point to the right
-			// path, before any marker is added to a map.
-			// Caution: do not use this option with inline base64 image(s).
-			var imagePath = this.options.imagePath || IconDefault.imagePath;
-			// Deprecated (IconDefault.imagePath), backwards-compatibility only
+		// @option imagePath: String
+		// `Icon.Default` will try to auto-detect the location of
+		// the blue icon images. If you are placing these images in a
+		// non-standard way, set this option to point to the right
+		// path, before any marker is added to a map.
+		// Caution: do not use this option with inline base64 image(s).
+		var imagePath = this.options.imagePath || IconDefault.imagePath || '';
+		// Deprecated (IconDefault.imagePath), backwards-compatibility only
 
+		if (this._needsInit) {
 			// Modifying imagePath option after _getIconUrl has been called
 			// once in this instance of IconDefault will no longer have any
 			// effect.
 			this._initializeOptions(imagePath);
 		}
 
-		return Icon.prototype._getIconUrl.call(this, name);
+		return imagePath + Icon.prototype._getIconUrl.call(this, name);
 	},
 
 	// Initialize all necessary options for this instance.
@@ -107,19 +107,20 @@ function _extractUrls(urlsContainer, imagePath) {
 	    m = re.exec(urlsContainer);
 
 	while (m) {
-		urls.push(_replaceUrl(m[1], imagePath));
+		// Keep the entire URL from CSS rule, so that each image can have its own full URL.
+		// Except in the case imagePath is provided: remove the path part (i.e. keep only the file name).
+		urls.push(imagePath ? _stripPath(m[1]) : m[1]);
 		m = re.exec(urlsContainer);
 	}
 
 	return urls;
 }
 
-// If imagePath is set, use it to replace anything before the last slash (/)
-// occurrence (inclusive).
+// Remove anything before the last slash (/) occurrence (inclusive).
 // Caution: will give unexpected result if url is inline base64 data
 // => do not specify imagePath in that case!
-function _replaceUrl(url, imagePath) {
-	return imagePath ? imagePath + url.substr(url.lastIndexOf('/') + 1) : url;
+function _stripPath(url) {
+	return url.substr(url.lastIndexOf('/') + 1);
 }
 
 // Factorize style reading fallback for IE8.

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -74,10 +74,10 @@ function _detectIconOptions(className, imagePath) {
 	var el = DomUtil.create('div',  className, document.body),
 	    urlsContainer = _getBkgImageOrCursor(el),
 	    urls = _extractUrls(urlsContainer, imagePath),
-	    iconX = parseInt(_getStyle(el, 'width'), 10),
-	    iconY = parseInt(_getStyle(el, 'height'), 10),
-	    anchorNX = parseInt(_getStyle(el, 'margin-left'), 10),
-	    anchorNY = parseInt(_getStyle(el, 'margin-top'), 10);
+	    iconX = _getStyleInt(el, 'width'),
+	    iconY = _getStyleInt(el, 'height'),
+	    anchorNX = _getStyleInt(el, 'margin-left'),
+	    anchorNY = _getStyleInt(el, 'margin-top');
 
 	return {
 		Url: urls[0],
@@ -90,8 +90,8 @@ function _detectIconOptions(className, imagePath) {
 // Retrieve anchor option values from CSS (popup or tooltip).
 function _detectDivOverlayOptions(className) {
 	var el = DomUtil.create('div', className, document.body),
-	    anchorX = parseInt(_getStyle(el, 'margin-left'), 10),
-	    anchorY = parseInt(_getStyle(el, 'margin-top'), 10);
+	    anchorX = _getStyleInt(el, 'margin-left'),
+	    anchorY = _getStyleInt(el, 'margin-top');
 
 	return {
 		Anchor: [anchorX, anchorY]
@@ -121,6 +121,10 @@ function _extractUrls(urlsContainer, imagePath) {
 // => do not specify imagePath in that case!
 function _stripPath(url) {
 	return url.substr(url.lastIndexOf('/') + 1);
+}
+
+function _getStyleInt(el, style) {
+	return parseInt(_getStyle(el, style), 10);
 }
 
 // Factorize style reading fallback for IE8.

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -71,8 +71,8 @@ export var IconDefault = Icon.extend({
 // Retrieve icon option values from CSS (icon or shadow).
 function _detectIconOptions(className, imagePath) {
 	var el = DomUtil.create('div',  className, document.body),
-	    bgImage = _getStyle(el, 'background-image'),
-	    urls = _extractUrls(bgImage, imagePath),
+	    urlsContainer = _getStyle(el, 'cursor'),
+	    urls = _extractUrls(urlsContainer, imagePath),
 	    iconX = parseInt(_getStyle(el, 'width'), 10),
 	    iconY = parseInt(_getStyle(el, 'height'), 10),
 	    anchorNX = parseInt(_getStyle(el, 'margin-left'), 10),
@@ -100,14 +100,14 @@ function _detectDivOverlayOptions(className) {
 // Read the CSS url (could be path or inline base64), may be multiple
 // First: normal icon
 // Second: Retina icon
-function _extractUrls(bgImage, imagePath) {
+function _extractUrls(urlsContainer, imagePath) {
 	var re = /url\(['"]?([^"']*?)['"]?\)/gi, // Match anything between url( and ), possibly with single or double quotes.
 	    urls = [],
-	    m = re.exec(bgImage);
+	    m = re.exec(urlsContainer);
 
 	while (m) {
 		urls.push(_replaceUrl(m[1], imagePath));
-		m = re.exec(bgImage);
+		m = re.exec(urlsContainer);
 	}
 
 	return urls;


### PR DESCRIPTION
Should fix #4968 

This PR attempts to improve the Default Icon automatic images path resolution, especially for build engines (typically webpack) which can be configured to manage images linked through image CSS data types (e.g. `url(path/to/image.png)`) and re-write them, hence breaking the Leaflet path detection and re-building (the previously hard coded `marker-icon.png` file name no longer exists after the build engine renamed it or inlined it as base64 data).

To achieve this, this PR takes the radical approach to outsource **all** Default Icon option values to the CSS (image url's including file name, sizes and anchor positions, for icon, shadow and their Retina version) and retrieve all these values the first time `_getIconUrl` is called.

That way, everything related to the default icon images is located in one place (the CSS) and can be easily modified by the app developer (and the build engine…)

Due to this shift, `IconDefault` no longer has default options (except for a new option `classNamePrefix`, more on that below), and when retrieved from CSS, the option values are applied to the _instance_ options rather than on `IconDefault.prototype.options`.
That way, it makes it possible to use other instances of `IconDefault` with a different `classNamePrefix` option to target another set of CSS rules and define a new icon through that CSS. May not be very useful outside the default icon, but still an extra functionality.

There is however a change in how `imagePath` is applied: it must be set _before_ the first call to `_getIconUrl` occurs (typically before any Marker is added to a map), because it is no longer used after that. Whereas previously it can be changed dynamically and affect re-drawn Markers.

Another tweak is the `margin` (top and left) used to specify the icon (and shadow) anchor: to be closer to how currently we can position an icon through its `className` with negative margins, I took the approach to use negative margins here as well, although the `iconAnchor` (and `shadowAnchor`) typically have positive values. Then the margin values are reverted to get the positive options. (but then Leaflet re-reverts them to negative margins to make the actual positioning…)

Finally, I replaced the use of `background-image` by `cursor` CSS rule in order to workaround the high contrast / colours overriding mode in Firefox (see https://github.com/Leaflet/Leaflet/issues/4968#issuecomment-328277840).

Note that both the normal url and its Retina version are specified as multiple images in this `cursor` rule, as allowed by the spec.

Tests:
- Added 1 test for `imagePath`.
- Adjusted Popup and Marker tests to account for the new IconDefault behaviour.

Quite some code for this simple feature, so I am expecting some critics in review(s)… :-)