### PR TITLE
docs show 'zoomanim' event under "Other events" section

### DIFF
--- a/docs/reference-1.2.0.html
+++ b/docs/reference-1.2.0.html
@@ -865,7 +865,7 @@ handlers start running).</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-other-methods'>Other Methods</h4>
+<h4 id='map-other-events'>Other Events</h4>
 
 
 <table><thead>


### PR DESCRIPTION
Seems to be copy-paste mistake "Other Methods" instead of "Other Events"