### PR TITLE
[LayerGroup] Use `eachLayer` for iterations over layers

### DIFF
--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -92,4 +92,20 @@
 			L.geoJson(layerGroup.toGeoJSON());
 		});
 	});
+
+	describe("#invoke", function () {
+		it('should invoke `setOpacity` method on every layer', function () {
+			var layers = [
+				L.marker([0, 0]),
+				L.marker([1, 1])
+			];
+			var lg = L.layerGroup(layers);
+			var opacity = 0.5;
+
+			expect(layers[0].options.opacity).to.not.eql(opacity);
+			lg.invoke('setOpacity', opacity);
+			expect(layers[0].options.opacity).to.eql(opacity);
+			expect(layers[1].options.opacity).to.eql(opacity);
+		});
+	});
 });

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -100,15 +100,11 @@ export var LayerGroup = Layer.extend({
 	},
 
 	onAdd: function (map) {
-		for (var i in this._layers) {
-			map.addLayer(this._layers[i]);
-		}
+		this.eachLayer(map.addLayer, map);
 	},
 
 	onRemove: function (map) {
-		for (var i in this._layers) {
-			map.removeLayer(this._layers[i]);
-		}
+		this.eachLayer(map.removeLayer, map);
 	},
 
 	// @method eachLayer(fn: Function, context?: Object): this

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -85,18 +85,13 @@ export var LayerGroup = Layer.extend({
 	// additional parameters. Has no effect if the layers contained do not
 	// implement `methodName`.
 	invoke: function (methodName) {
-		var args = Array.prototype.slice.call(arguments, 1),
-		    i, layer;
+		var args = Array.prototype.slice.call(arguments, 1);
 
-		for (i in this._layers) {
-			layer = this._layers[i];
-
+		return this.eachLayer(function (layer) {
 			if (layer[methodName]) {
 				layer[methodName].apply(layer, args);
 			}
-		}
-
-		return this;
+		});
 	},
 
 	onAdd: function (map) {

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -135,10 +135,7 @@ export var LayerGroup = Layer.extend({
 	// Returns an array of all the layers added to the group.
 	getLayers: function () {
 		var layers = [];
-
-		for (var i in this._layers) {
-			layers.push(this._layers[i]);
-		}
+		this.eachLayer(layers.push, layers);
 		return layers;
 	},
 

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -77,10 +77,7 @@ export var LayerGroup = Layer.extend({
 	// @method clearLayers(): this
 	// Removes all the layers from the group.
 	clearLayers: function () {
-		for (var i in this._layers) {
-			this.removeLayer(this._layers[i]);
-		}
-		return this;
+		return this.eachLayer(this.removeLayer, this);
 	},
 
 	// @method invoke(methodName: String, …): this

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -85,13 +85,18 @@ export var LayerGroup = Layer.extend({
 	// additional parameters. Has no effect if the layers contained do not
 	// implement `methodName`.
 	invoke: function (methodName) {
-		var args = Array.prototype.slice.call(arguments, 1);
+		var args = Array.prototype.slice.call(arguments, 1),
+		    i, layer;
 
-		return this.eachLayer(function (layer) {
+		for (i in this._layers) {
+			layer = this._layers[i];
+
 			if (layer[methodName]) {
 				layer[methodName].apply(layer, args);
 			}
-		});
+		}
+
+		return this;
 	},
 
 	onAdd: function (map) {


### PR DESCRIPTION
Since there is a generic `eachLayer` method, it is better to use it for iterations instead of `for...in`.
Also added unit test for `invoke` method, which wasn't covered before.