### PR TITLE
New rollup config signature

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -1,11 +1,8 @@
-
 // Config file for running Rollup in "normal" mode (non-watch)
 
 import rollupGitVersion from 'rollup-plugin-git-version'
 import json from 'rollup-plugin-json'
-
 import gitRev from 'git-rev-sync'
-
 
 let version = require('../package.json').version;
 let release;
@@ -20,21 +17,23 @@ if (process.env.NODE_ENV === 'release') {
 	version += '+' + branch + '.' + rev;
 }
 
-
 const banner = `/* @preserve
- * Leaflet ` + version + `, a JS library for interactive maps. http://leafletjs.com
+ * Leaflet ${version}, a JS library for interactive maps. http://leafletjs.com
  * (c) 2010-2017 Vladimir Agafonkin, (c) 2010-2011 CloudMade
- */`;
+ */
+`;
 
 export default {
-	format: 'umd',
-	name: 'L',
-	banner: banner,
-	entry: 'src/Leaflet.js',
-	dest: 'dist/leaflet-src.js',
+	input: 'src/Leaflet.js',
+	output: {
+		file: 'dist/leaflet-src.js',
+		format: 'umd',
+		name: 'L',
+		banner: banner,
+		sourcemap: true,
+		legacy: true // Needed to create files loadable by IE8
+	},
 	plugins: [
-		release ? json() : rollupGitVersion(),
-	],
-	sourceMap: true,
-	legacy: true // Needed to create files loadable by IE8
+		release ? json() : rollupGitVersion()
+	]
 };

--- a/build/rollup-watch-config.js
+++ b/build/rollup-watch-config.js
@@ -1,34 +1,29 @@
-
 // Config file for running Rollup in "watch" mode
 // This adds a sanity check to help ourselves to run 'rollup -w' as needed.
 
-// Needed to create files loadable by IE8
 import rollupGitVersion from 'rollup-plugin-git-version'
-
 import gitRev from 'git-rev-sync'
 
 const branch = gitRev.branch();
 const rev = gitRev.short();
-
 const version = require('../package.json').version + '+' + branch + '.' + rev;
-
-const banner = `
-/*
+const banner = `/* @preserve
  * Leaflet ${version}, a JS library for interactive maps. http://leafletjs.com
  * (c) 2010-2016 Vladimir Agafonkin, (c) 2010-2011 CloudMade
  */
-
 `;
 
 export default {
-	format: 'umd',
-	name: 'L',
-	banner,
-	entry: 'src/Leaflet.js',
-	dest: 'dist/leaflet-src.js',
+	input: 'src/Leaflet.js',
+	output: {
+		file: 'dist/leaflet-src.js',
+		format: 'umd',
+		name: 'L',
+		banner: banner,
+		sourcemap: true,
+		legacy: true // Needed to create files loadable by IE8
+	},
 	plugins: [
 		rollupGitVersion()
-	],
-	sourceMap: true,
-	legacy: true // Needed to create files loadable by IE8
+	]
 };


### PR DESCRIPTION
Adapted rollup configurations to new signature., ironed out some minor inconsistencies between configurations and some syntax cleanup. Fixes following warnings when running rollup:

(!) Some options have been renamed
https://gist.github.com/Rich-Harris/d472c50732dab03efeb37472b08a3f32
options.entry is now options.input
options.sourceMap is now options.sourcemap
options.dest is now options.output.file
options.format is now options.output.format