### PR TITLE
Fix map styles in "Extending Leaflet" example

### DIFF
--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -14,6 +14,9 @@
 
 {% unless page.customMapContainer == "true" %}
 	<style>
+		html, body {
+			height: 100%;
+		}
 		#map {
 			width: 600px;
 			height: 400px;

--- a/docs/examples/extending/class-diagram.md
+++ b/docs/examples/extending/class-diagram.md
@@ -14,7 +14,7 @@ title: Leaflet class diagram
 	});
 
 	map.getContainer().style.width = '100vw';
-	map.getContainer().style.height= '100%';
+	map.getContainer().style.height= '100vh';
 	document.body.style.margin = 0;
 
 	var image = L.imageOverlay('class-diagram.png', bounds).addTo(map);

--- a/docs/examples/extending/class-diagram.md
+++ b/docs/examples/extending/class-diagram.md
@@ -1,6 +1,14 @@
 ---
 layout: tutorial_frame
 title: Leaflet class diagram
+css: "body {
+            margin: 0;
+        }
+
+        #map {
+            width: 100vw;
+            height: 100%;
+        }"
 ---
 <script type='text/javascript'>
 
@@ -12,10 +20,6 @@ title: Leaflet class diagram
 		minZoom: -4,
 		maxBounds: bounds
 	});
-
-	map.getContainer().style.width = '100vw';
-	map.getContainer().style.height= '100vh';
-	document.body.style.margin = 0;
 
 	var image = L.imageOverlay('class-diagram.png', bounds).addTo(map);
 

--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -5,7 +5,7 @@ css: "body {
 		padding: 0;
 		margin: 0;
 	}
-	html, body, #map {
+	#map {
 		height: 100%;
 		width: 100vw;
 	}"


### PR DESCRIPTION
Map height changed from `100vh` to `100%` in #5772, but now map [doesn't appear at all](http://leafletjs.com/examples/extending/extending-1-classes.html).
So I set `body` and `html` height to `100%` in `tutorial_frame.html` layout.
So map with height `100%` should look good now.