### PR TITLE
Fix imageOverlay className 

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -180,7 +180,7 @@ export var ImageOverlay = Layer.extend({
 
 	_initImage: function () {
 		var img = this._image = DomUtil.create('img',
-			'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated' : '') +
+			'leaflet-image-layer ' + (this._zoomAnimated ? 'leaflet-zoom-animated ' : '') +
 			 (this.options.className || ''));
 
 		img.onselectstart = Util.falseFn;


### PR DESCRIPTION
If `className` option is set, it should not be concatenated with `leaflet-zoom-animated` class.
There is [test](https://github.com/Leaflet/Leaflet/blob/master/spec/suites/layer/ImageOverlaySpec.js#L82) for custom className, it passes in PhantomJS but fails in Chome and FF (and probably other browsers), because in real browsers `zoomAnimated` is set to true, so there is no space before custom `className`.

There are other tests failing in real browsers, so I'll try to fix them too.
Btw, I think we should run tests in real browsers as part of CI. I'll check if there are free tools for that.