### PR TITLE
Docs(imagePath): "absolute path" to "path"

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -36,9 +36,9 @@ export var IconDefault = Icon.extend({
 		}
 
 		// @option imagePath: String
-		// `Icon.Default` will try to auto-detect the absolute location of the
+		// `Icon.Default` will try to auto-detect the location of the
 		// blue icon images. If you are placing these images in a non-standard
-		// way, set this option to point to the right absolute path.
+		// way, set this option to point to the right path.
 		return (this.options.imagePath || IconDefault.imagePath) + Icon.prototype._getIconUrl.call(this, name);
 	},
 


### PR DESCRIPTION
This simply removes the word "absolute" from the documentation of Icon.Default.imagePath. This path can be relative or absolute.

e.g. L.Icon.Default.imagePath = 'style/images/'; works just fine for me.