### PR TITLE
Docs(Download): add CDN alternatives

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -55,6 +55,8 @@ Leaflet is available on the following free CDN's:
 - cdnjs: https://cdnjs.com/libraries/leaflet
 - jsDelivr: https://www.jsdelivr.com/package/npm/leaflet?path=dist
 
+_Disclaimer: these services are external to Leaflet; for questions or support, please contact them directly._
+
 ### Using a Downloaded Version of Leaflet
 
 Inside the archives downloaded from the above links, you will see four things:

--- a/docs/download.md
+++ b/docs/download.md
@@ -32,7 +32,7 @@ so please read the changelog carefully when upgrading to it.
 
 ### Using a Hosted Version of Leaflet
 
-The latest stable Leaflet release is hosted on a CDN &mdash; to start using
+The latest stable Leaflet release is available on several CDN's &mdash; to start using
 it straight away, place this in the `head` of your HTML code:
 
     <link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" />
@@ -48,6 +48,12 @@ when using Leaflet from a CDN:
     <script src="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
       integrity="{{site.integrity_hash_uglified}}"
       crossorigin=""></script>
+
+Leaflet is available on the following free CDN's:
+
+- unpkg: https://unpkg.com/leaflet/dist/
+- cdnjs: https://cdnjs.com/libraries/leaflet
+- jsDelivr: https://www.jsdelivr.com/package/npm/leaflet?path=dist
 
 ### Using a Downloaded Version of Leaflet
 


### PR DESCRIPTION
Hi,

This PR follows https://github.com/Leaflet/Leaflet/pull/5814.

Instead of duplicating the example code with several CDN's path (as done in the above mentioned PR), I propose to list the CDN alternatives at the end of the "Using a Hosted Version of Leaflet" section.

All 3 listed CDN's automatically update based on npm registry, so there is nothing to do on Leaflet side when releasing new versions.
(but `cdnjs` might need a PR on the [autoupdate configuration file](https://github.com/cdnjs/cdnjs/blob/master/ajax/libs/leaflet/package.json) in case the `dist/` folder changes)

An advantageous side effect is that we can link to the package "page" provided by these services, which usually lists the available files and gives access to different versions through a drop-down menu.

I also added a disclaimer to try preventing questions and/or complaints about these services, especially in case of availability issues.

Closes https://github.com/Leaflet/Leaflet/pull/5814