### PR TITLE
Fix TileLayer flyTo test

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -204,7 +204,7 @@ describe('TileLayer', function () {
 		beforeEach(function () {
 			clock = sinon.useFakeTimers();
 
-			kittenLayer = kittenLayerFactory({ keepBuffer: 0 });
+			kittenLayer = kittenLayerFactory({keepBuffer: 0});
 
 			counts = {
 				tileload: 0,

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -204,7 +204,7 @@ describe('TileLayer', function () {
 		beforeEach(function () {
 			clock = sinon.useFakeTimers();
 
-			kittenLayer = kittenLayerFactory();
+			kittenLayer = kittenLayerFactory({ keepBuffer: 0 });
 
 			counts = {
 				tileload: 0,


### PR DESCRIPTION
[This test](https://github.com/Leaflet/Leaflet/blob/db10599657fa3ae2bb269b203551ed1223a6bd51/spec/suites/layer/tile/TileLayerSpec.js#L252) is failing in Chrome, since `keepBuffer` option was introduced (#4650).
I simply set `keepBuffer` to 0, like it was before it was introduced.

This PR brings #5831 one step closer for merging to master, so such regressions will be avoided in the future.