### PR TITLE
Fix GridLayer flyTo test

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -778,6 +778,8 @@ describe('GridLayer', function () {
 				runFrames(500);
 			});
 
+			grid.options.keepBuffer = 0;
+
 			map.addLayer(grid).setView(mad, 12);
 			clock.tick(250);
 		});


### PR DESCRIPTION
Same fix as #5843, but for [GridLayer's flyTo test](https://github.com/Leaflet/Leaflet/blob/db10599657fa3ae2bb269b203551ed1223a6bd51/spec/suites/layer/tile/GridLayerSpec.js#L752).