### PR TITLE
Docs(MapPanes): add class names links to panes description

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1100,7 +1100,7 @@ export var Map = Evented.extend({
 		// Pane for `GridLayer`s and `TileLayer`s
 		this.createPane('tilePane');
 		// @pane overlayPane: HTMLElement = 400
-		// Pane for vector overlays (`Path`s), like `Polyline`s and `Polygon`s
+		// Pane for vectors (`Path`s, like `Polyline`s and `Polygon`s), `ImageOverlay`s and `VideoOverlay`s
 		this.createPane('shadowPane');
 		// @pane shadowPane: HTMLElement = 500
 		// Pane for overlay shadows (e.g. `Marker` shadows)

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1109,7 +1109,7 @@ export var Map = Evented.extend({
 		// Pane for `Icon`s of `Marker`s
 		this.createPane('markerPane');
 		// @pane tooltipPane: HTMLElement = 650
-		// Pane for tooltip.
+		// Pane for `Tooltip`s.
 		this.createPane('tooltipPane');
 		// @pane popupPane: HTMLElement = 700
 		// Pane for `Popup`s.


### PR DESCRIPTION
Add `ImageOverlay`, `VideoOverlay` and `Tooltip` classes as hyperlinks directly in the map panes description, so that it is more exhaustive and consistent.