### PR TITLE
Round pan offset towards zero

### DIFF
--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -44,6 +44,14 @@ describe("Point", function () {
 	describe('#floor', function () {
 		it('returns a new point with floored coordinates', function () {
 			expect(new L.Point(50.56, 30.123).floor()).to.eql(new L.Point(50, 30));
+			expect(new L.Point(-50.56, -30.123).floor()).to.eql(new L.Point(-51, -31));
+		});
+	});
+
+	describe('#trunc', function () {
+		it('returns a new point with truncated coordinates', function () {
+			expect(new L.Point(50.56, 30.123).trunc()).to.eql(new L.Point(50, 30));
+			expect(new L.Point(-50.56, -30.123).trunc()).to.eql(new L.Point(-50, -30));
 		});
 	});
 

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -27,6 +27,10 @@ export function Point(x, y, round) {
 	this.y = (round ? Math.round(y) : y);
 }
 
+var trunc = Math.trunc || function (v) {
+	return v > 0 ? Math.floor(v) : Math.ceil(v);
+};
+
 Point.prototype = {
 
 	// @method clone(): Point
@@ -134,6 +138,18 @@ Point.prototype = {
 	_ceil: function () {
 		this.x = Math.ceil(this.x);
 		this.y = Math.ceil(this.y);
+		return this;
+	},
+
+	// @method ceil(): Point
+	// Returns a copy of the current point with truncated coordinates (rounded towards zero).
+	trunc: function () {
+		return this.clone()._trunc();
+	},
+
+	_trunc: function () {
+		this.x = trunc(this.x);
+		this.y = trunc(this.y);
 		return this;
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1524,7 +1524,7 @@ export var Map = Evented.extend({
 
 	_tryAnimatedPan: function (center, options) {
 		// difference between the new and current centers in pixels
-		var offset = this._getCenterOffset(center)._floor();
+		var offset = this._getCenterOffset(center)._trunc();
 
 		// don't animate too far unless animate: true specified in options
 		if ((options && options.animate) !== true && !this.getSize().contains(offset)) { return false; }


### PR DESCRIPTION
As [observed in #5821](https://github.com/Leaflet/Leaflet/issues/5821#issuecomment-334979512), we currently use `floor` on the offset when panning, causing negative offsets to be rounded towards negative infinity, instead of towards zero, which is probably the intention.

This PR adds the `trunc`/`_trunc` methods to `Point` and use it to round the pan.

Since `Math.trunc` is only available in somewhat recent browsers, I included a polyfill.