### PR TITLE
Round circle radius in renderer instead of layer

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -27,8 +27,8 @@ describe('Circle', function () {
 		it('returns bounds', function () {
 			var bounds = circle.getBounds();
 
-			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.94347, 29.91211));
-			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.05646, 30.08789));
+			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720));
+			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
 		});
 	});
 
@@ -44,8 +44,8 @@ describe('Circle', function () {
 		it('returns same bounds as 1.0 factory', function () {
 			var bounds = circle.getBounds();
 
-			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.94347, 29.91211));
-			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.05646, 30.08789));
+			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720));
+			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
 		});
 	});
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -294,8 +294,8 @@ export var Canvas = Renderer.extend({
 
 		var p = layer._point,
 		    ctx = this._ctx,
-		    r = layer._radius,
-		    s = (layer._radiusY || r) / r;
+		    r = Math.max(Math.round(layer._radius), 1),
+		    s = (Math.max(Math.round(layer._radiusY), 1) || r) / r;
 
 		this._drawnLayers[layer._leaflet_id] = layer;
 

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -87,8 +87,8 @@ export var Circle = CircleMarker.extend({
 			}
 
 			this._point = p.subtract(map.getPixelOrigin());
-			this._radius = isNaN(lngR) ? 0 : Math.max(Math.round(p.x - map.project([lat2, lng - lngR]).x), 1);
-			this._radiusY = Math.max(Math.round(p.y - top.y), 1);
+			this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
+			this._radiusY = p.y - top.y;
 
 		} else {
 			var latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -180,8 +180,8 @@ export var SVG = Renderer.extend({
 
 	_updateCircle: function (layer) {
 		var p = layer._point,
-		    r = layer._radius,
-		    r2 = layer._radiusY || r,
+		    r = Math.max(Math.round(layer._radius), 1),
+		    r2 = Math.max(Math.round(layer._radiusY), 1) || r,
 		    arc = 'a' + r + ',' + r2 + ' 0 1,0 ';
 
 		// drawing a circle with two half-arcs


### PR DESCRIPTION
Makes bounds calculation more precise and zoom level independant.
Fixes #4582.