### PR TITLE
Add namespace to SVG factory

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -211,6 +211,7 @@ if (Browser.vml) {
 	SVG.include(vmlMixin);
 }
 
+// @namespace SVG
 // @factory L.svg(options?: Renderer options)
 // Creates a SVG renderer with the given options.
 export function svg(options) {


### PR DESCRIPTION
SVG factory docs appear in Path section, since Path doesn't have own factory declaration.
Adding namespace to SVG factory docs fixes this.

![screenshot_2](https://user-images.githubusercontent.com/13808724/31861045-84ff9f84-b725-11e7-82f5-17d61d2b60e4.png)
