### PR TITLE
Fix popupAnchor option test in Popup test suite

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -194,39 +194,74 @@ describe('Popup', function () {
 		expect(spy.callCount).to.be(2);
 	});
 
-	it("should take into account icon popupAnchor option", function () {
-		var autoPanBefore = L.Popup.prototype.options.autoPan;
-		L.Popup.prototype.options.autoPan = false;
-		var popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
-		L.Icon.Default.prototype.options.popupAnchor = [0, 0];
+	describe('should take into account icon popupAnchor option on', function () {
+		var latlng = new L.LatLng(55.8, 37.6);
+		var offset = new L.Point(20, 30);
+		var autoPanBefore;
+		var popupAnchorBefore;
+		var icon;
+		var marker1;
+		var marker2;
 
-		var latlng = new L.LatLng(55.8, 37.6),
-		    offset = new L.Point(20, 30),
-		    icon = new L.DivIcon({popupAnchor: offset}),
-		    marker1 = new L.Marker(latlng),
-		    marker2 = new L.Marker(latlng, {icon: icon});
+		before(function () {
+			autoPanBefore = L.Popup.prototype.options.autoPan;
+			L.Popup.prototype.options.autoPan = false;
+			popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
+			L.Icon.Default.prototype.options.popupAnchor = [0, 0];
+		});
 
-		marker1.bindPopup('Popup').addTo(map);
-		marker1.openPopup();
-		var defaultLeft = parseInt(marker1._popup._container.style.left, 10);
-		var defaultBottom = parseInt(marker1._popup._container.style.bottom, 10);
-		marker2.bindPopup('Popup').addTo(map);
-		marker2.openPopup();
-		var offsetLeft = parseInt(marker2._popup._container.style.left, 10);
-		var offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
-		expect(offsetLeft - offset.x).to.eql(defaultLeft);
-		expect(offsetBottom + offset.y).to.eql(defaultBottom);
+		beforeEach(function () {
+			icon = new L.DivIcon({popupAnchor: offset});
+			marker1 = new L.Marker(latlng);
+			marker2 = new L.Marker(latlng, {icon: icon});
+		});
 
-		// Now retry passing a popup instance to bindPopup
-		marker2.bindPopup(new L.Popup());
-		marker2.openPopup();
-		offsetLeft = parseInt(marker2._popup._container.style.left, 10);
-		offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
-		expect(offsetLeft - offset.x).to.eql(defaultLeft);
-		expect(offsetBottom + offset.y).to.eql(defaultBottom);
+		after(function () {
+			L.Popup.prototype.options.autoPan = autoPanBefore;
+			L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
+		});
 
-		L.Popup.prototype.options.autoPan = autoPanBefore;
-		L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
+		it.skipInNonPhantom("non-any3d browsers", function () {
+			marker1.bindPopup('Popup').addTo(map);
+			marker1.openPopup();
+			var defaultLeft = parseInt(marker1._popup._container.style.left, 10);
+			var defaultBottom = parseInt(marker1._popup._container.style.bottom, 10);
+			marker2.bindPopup('Popup').addTo(map);
+			marker2.openPopup();
+			var offsetLeft = parseInt(marker2._popup._container.style.left, 10);
+			var offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
+			expect(offsetLeft - offset.x).to.eql(defaultLeft);
+			expect(offsetBottom + offset.y).to.eql(defaultBottom);
+
+			// Now retry passing a popup instance to bindPopup
+			marker2.bindPopup(new L.Popup());
+			marker2.openPopup();
+			offsetLeft = parseInt(marker2._popup._container.style.left, 10);
+			offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
+			expect(offsetLeft - offset.x).to.eql(defaultLeft);
+			expect(offsetBottom + offset.y).to.eql(defaultBottom);
+		});
+
+		it.skipInPhantom("any3d browsers", function () {
+			marker1.bindPopup('Popup').addTo(map);
+			marker1.openPopup();
+			var defaultLeft = marker1._popup._container._leaflet_pos.x;
+			var defaultTop = marker1._popup._container._leaflet_pos.y;
+			marker2.bindPopup('Popup').addTo(map);
+			marker2.openPopup();
+			var offsetLeft = marker2._popup._container._leaflet_pos.x;
+			var offsetTop = marker2._popup._container._leaflet_pos.y;
+			expect(offsetLeft - offset.x).to.eql(defaultLeft);
+			expect(offsetTop - offset.y).to.eql(defaultTop);
+
+			// Now retry passing a popup instance to bindPopup
+			marker2.bindPopup(new L.Popup());
+			marker2.openPopup();
+			offsetLeft = marker2._popup._container._leaflet_pos.x;
+			offsetTop = marker2._popup._container._leaflet_pos.y;
+			expect(offsetLeft - offset.x).to.eql(defaultLeft);
+			expect(offsetTop - offset.y).to.eql(defaultTop);
+		});
 	});
 
 	it("prevents an underlying map click for Layer", function () {


### PR DESCRIPTION
[This test](https://github.com/Leaflet/Leaflet/blob/master/spec/suites/layer/PopupSpec.js#L197) fails on FF and Chrome, since in those browsers CSS Transitions are used to [set popup position](https://github.com/Leaflet/Leaflet/blob/master/src/layer/DivOverlay.js#L186).

So I added `skipInNonPhantom` flag for this test and added similar test with `skipInPhantom` flag for browsers, which support CSS Transitions. This test uses `_leaflet_pos` (which is set [right here](https://github.com/Leaflet/Leaflet/blob/master/src/dom/DomUtil.js#L225)) for checking popup position.

Also, I united those 2 tests in a single suite and pulled out common code to `before`, `beforeEach` and `after` hooks.

P.S. This PR brings #5831 and #5845 one step closer for merging to master :)