### PR TITLE
Fix Tooltip tests for non-touch

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -253,21 +253,16 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
 	});
 
-	it("is opened when tapping on touch", function () {
-		var oldTouch = L.Browser.touch;
-		L.Browser.touch = true;
+	it.skipIfNotTouch("is opened when tapping on touch", function () {
 		var layer = new L.Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 		expect(map.hasLayer(layer._tooltip)).to.be(false);
 		happen.click(layer._icon);
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
-		L.Browser.touch = oldTouch;
 	});
 
-	it("is closed if not permanent when clicking on the map elsewhere on touch", function () {
-		var oldTouch = L.Browser.touch;
-		L.Browser.touch = true;
+	it.skipIfNotTouch("is closed if not permanent when clicking on the map elsewhere on touch", function () {
 		var layer = new L.Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
@@ -275,7 +270,6 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
 		happen.click(map._container);
 		expect(map.hasLayer(layer._tooltip)).to.be(false);
-		L.Browser.touch = oldTouch;
 	});
 
 


### PR DESCRIPTION
These 2 tests fail in Firefox.
They used to override `L.Browser.touch`, which makes no sense after ES6 modules were introduced - `Browser` is imported each time unchanged, so there is no way to override `Browser.touch` globally.
Instead, I added `skipIfNotTouch` to those tests.