### PR TITLE
Update `happen` to 0.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "eslint": "^4.5.0",
     "eslint-config-mourner": "^2.0.1",
     "git-rev-sync": "^1.8.0",
-    "happen": "~0.3.1",
+    "happen": "~0.3.2",
     "jake": "~8.0.12",
     "karma": "^1.3.0",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
Fixes [this Popup test](https://github.com/Leaflet/Leaflet/blob/master/spec/suites/layer/PopupSpec.js#L287), which fails in Chrome and Firefox due to [disabled event bubbling in `happen`](https://github.com/tmcw/happen/pull/27).