### PR TITLE
Stop animation before destroy map

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -178,7 +178,7 @@ export var Marker = Layer.extend({
 
 	update: function () {
 
-		if (this._icon) {
+		if (this._icon && this._map) {
 			var pos = this._map.latLngToLayerPoint(this._latlng).round();
 			this._setPos(pos);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -722,6 +722,8 @@ export var Map = Evented.extend({
 			this._containerId = undefined;
 		}
 
+		this._stop();
+
 		DomUtil.remove(this._mapPane);
 
 		if (this._clearControlPos) {
@@ -1627,7 +1629,9 @@ export var Map = Evented.extend({
 	_onZoomTransitionEnd: function () {
 		if (!this._animatingZoom) { return; }
 
-		DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
+		if (this._mapPane) {
+			DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
+		}
 
 		this._animatingZoom = false;
 


### PR DESCRIPTION
If create and remove map very quickly, animation stuck in a loop with exception:

"TypeError: Cannot read property _leaflet_pos of undefined\n    at getPosition (http://local/js/app/vendor/leaflet-1.2.0.js?t=:2713:12)\n    at NewClass._getMapPanePos (http://local/js/app/vendor/leaflet-1.2.0.js?t=:4308:10)\n    at NewClass.containerPointToLayerPoint (http://local/js/app/vendor/leaflet-1.2.0.js?t=:3891:39)\n    at NewClass.containerPointToLatLng (http://local/js/app/vendor/leaflet-1.2.0.js?t=:3905:25)\n    at NewClass._update (http://local/js/app/vendor/leaflet-1.2.0.js?t=:5346:9)\n    at NewClass.fire (http://local/js/app/vendor/leaflet-1.2.0.js?t=:588:11)\n    at NewClass._onPanTransitionStep (http://local/js/app/vendor/leaflet-1.2.0.js?t=:4415:8)\n    at NewClass.fire (http://local/js/app/vendor/leaflet-1.2.0.js?t=:588:11)\n    at NewClass._runFrame (http://local/js/app/vendor/leaflet-1.2.0.js?t=:2904:8)\n    at NewClass._step (http://local/js/app/vendor/leaflet-1.2.0.js?t=:2890:9)"