### PR TITLE
Clean up and document event propagation properties

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -565,6 +565,37 @@ describe('Events', function () {
 			expect(spy1.callCount).to.eql(0);
 			expect(spy2.callCount).to.eql(1);
 		});
+
+		it('sets target, sourceTarget and layer correctly', function () {
+			var obj = new L.Evented(),
+			    parent = new L.Evented(),
+			    spy1 = sinon.spy(),
+			    spy2 = sinon.spy();
+
+			/* register without context */
+			obj.on('test2', spy1);
+			parent.on('test2', spy2);
+
+			obj.addEventParent(parent);
+
+			/* Should be called once */
+			obj.fire('test2', null, true);
+
+			expect(spy1.calledWith({
+				type: 'test2',
+				target: obj,
+				sourceTarget: obj
+			})).to.be.ok();
+			expect(spy2.calledWith({
+				type: 'test2',
+				target: parent,
+				// layer should be deprecated in the future
+				// in favor of sourceTarget
+				layer: obj,
+				sourceTarget: obj,
+				propagatedFrom: obj
+			})).to.be.ok();
+		});
 	});
 
 	describe('#listens', function () {

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -10,7 +10,7 @@
 			marker = L.marker([0, 0]);
 		});
 		describe("when a Marker is added to multiple FeatureGroups ", function () {
-			it("e.layer should be the Marker", function () {
+			it("e.sourceTarget should be the Marker", function () {
 				var fg1 = L.featureGroup(),
 				    fg2 = L.featureGroup();
 
@@ -21,13 +21,13 @@
 				    wasClicked2;
 
 				fg2.on('click', function (e) {
-					expect(e.layer).to.be(marker);
+					expect(e.sourceTarget).to.be(marker);
 					expect(e.target).to.be(fg2);
 					wasClicked2 = true;
 				});
 
 				fg1.on('click', function (e) {
-					expect(e.layer).to.be(marker);
+					expect(e.sourceTarget).to.be(marker);
 					expect(e.target).to.be(fg1);
 					wasClicked1 = true;
 				});

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -10,7 +10,7 @@
 			marker = L.marker([0, 0]);
 		});
 		describe("when a Marker is added to multiple FeatureGroups ", function () {
-			it("e.sourceTarget should be the Marker", function () {
+			it("e.propagatedFrom should be the Marker", function () {
 				var fg1 = L.featureGroup(),
 				    fg2 = L.featureGroup();
 
@@ -21,13 +21,13 @@
 				    wasClicked2;
 
 				fg2.on('click', function (e) {
-					expect(e.sourceTarget).to.be(marker);
+					expect(e.propagatedFrom).to.be(marker);
 					expect(e.target).to.be(fg2);
 					wasClicked2 = true;
 				});
 
 				fg1.on('click', function (e) {
-					expect(e.sourceTarget).to.be(marker);
+					expect(e.propagatedFrom).to.be(marker);
 					expect(e.target).to.be(fg1);
 					wasClicked1 = true;
 				});

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -174,7 +174,11 @@ export var Events = {
 	fire: function (type, data, propagate) {
 		if (!this.listens(type, propagate)) { return this; }
 
-		var event = Util.extend({}, data, {type: type, target: this});
+		var event = Util.extend({}, data, {
+			type: type,
+			target: this,
+			sourceTarget: data && data.sourceTarget || this
+		});
 
 		if (this._events) {
 			var listeners = this._events[type];
@@ -255,7 +259,10 @@ export var Events = {
 
 	_propagateEvent: function (e) {
 		for (var id in this._eventParents) {
-			this._eventParents[id].fire(e.type, Util.extend({layer: e.target}, e), true);
+			this._eventParents[id].fire(e.type, Util.extend({
+				layer: e.target,
+				propagatedFrom: e.target
+			}, e), true);
 		}
 	}
 };

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -21,7 +21,16 @@ The base event object. All other event objects contain these properties too.
 @property type: String
 The event type (e.g. `'click'`).
 @property target: Object
-The object that fired the event.
+The object that fired the event. For propagated events, the last object in
+the propagation chain that fired the event.
+@property sourceTarget: Object
+The object that originally fired the event. For non-propagated events, this will
+be the same as the `target`.
+@property propagatedFrom: Object
+For propagated events, the last object that propagated the event to its
+event parent.
+@property layer: Object
+**Deprecated.** The same as `propagetedFrom`.
 
 
 @miniclass KeyboardEvent (Event objects)

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -30,7 +30,7 @@ be the same as the `target`.
 For propagated events, the last object that propagated the event to its
 event parent.
 @property layer: Object
-**Deprecated.** The same as `propagetedFrom`.
+**Deprecated.** The same as `propagatedFrom`.
 
 
 @miniclass KeyboardEvent (Event objects)


### PR DESCRIPTION
I had somehow missed #4510 and was a bit surprised to find out about this undocumented hack to get `FeatureGroup` to work.

Thinking about it, I think the approach in itself is sane, but the real problem lies in the naming of the event property - `layer` is very specific to `FeatureGroup`'s utilization of the property.

On the other hand, there's probably a lot of code out there that use this property, so I'm going for deprecating this property, although actually removing it is not something we need to do soon.

Instead, I added two properties:

* `sourceTarget` - this is the original target of the event, the object it was first fire on before any propagation occured
* `propagatedFrom` - this is exactly the same as the current `layer`; that is, the previous object in the chain of object propagating the event (to be honest, I don't feel 100% about the name of this property, so feel free to suggest a better one)

Ideally, we should have made this analog to the DOM's `target` and `currentTarget`, but we already use the property `target` with the same semantic as the DOM's `currentTarget`, so that will unfortunately not work.