### PR TITLE
Fix touch dblclick events (double tap) in recent Chrome versions

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -10,6 +10,9 @@ var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup
 var _pre = '_leaflet_';
 
 function browserFiresNativeDblClick(e) {
+	// See https://github.com/w3c/pointerevents/issues/171
+	// Note however, that Chrome stopped firing native dblclick for
+	// touch since that issue was written.
 	return Browser.ie || e.pointerType === 'mouse';
 }
 

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -9,6 +9,10 @@ var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'point
 var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
 var _pre = '_leaflet_';
 
+function browserFiresNativeDblClick(e) {
+	return Browser.ie || e.pointerType === 'mouse';
+}
+
 // inspired by Zepto touch code by Thomas Fuchs
 export function addDoubleTapListener(obj, handler, id) {
 	var last, touch,
@@ -19,7 +23,7 @@ export function addDoubleTapListener(obj, handler, id) {
 		var count;
 
 		if (Browser.pointer) {
-			if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+			if (browserFiresNativeDblClick(e)) { return; }
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -38,7 +42,7 @@ export function addDoubleTapListener(obj, handler, id) {
 	function onTouchEnd(e) {
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+				if (browserFiresNativeDblClick(e)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -85,10 +85,7 @@ function addOne(obj, type, fn, context) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener &&
-	           !(Browser.pointer && Browser.chrome)) {
-		// Chrome >55 does not need the synthetic dblclicks from addDoubleTapListener
-		// See #5180
+	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener) {
 		addDoubleTapListener(obj, handler, id);
 
 	} else if ('addEventListener' in obj) {


### PR DESCRIPTION
I finally took the time to dig into #5627 and its related issues (#5185, #5248 and probably a few more).

My summary is that in Chrome 55, the browser started firing `dblclick` events from touch (double taps), but this change was again reverted in some later version of Chrome, so recent Chromes _does not_ fire `dblclick` from touch.

Looking at the very handy matrix @IvanSanchez put together here https://github.com/w3c/pointerevents/issues/171, this leads me to believe IE is now _the only_ browser that fires `dblclick` from touch events.

This PR addresses this, and also tries to make it at least a little bit clearer what is going on in this code.

I've tested this in Chrome and Firefox on Linux, and it resolves the Chrome issue when device emulation is enabled; I will also try this out on IE and Edge. Testing this on more platforms would be very welcome.