### PR TITLE
Improve heuristic for what event targets are considered markers

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1363,7 +1363,7 @@ export var Map = Evented.extend({
 		};
 
 		if (e.type !== 'keypress') {
-			var isMarker = (target.options && 'icon' in target.options);
+			var isMarker = target.getLatLng && (!target._radius || target._radius <= 10);
 			data.containerPoint = isMarker ?
 				this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
 			data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);


### PR DESCRIPTION
As mentioned in #5635, the current logic for determining what is a marker has flaws (if you add an option called `icon`, it will be considered a marker).

As realized by @ghybs, it's not possible to just replace this with an `instanceof` check for technical reasons. Also, my opinion is that this is not the desired effect: what this code tries to accomplish is that layers that denote _a specific location_, like markers and circle markers, should always get their location as event location; other layers, that show areas (circles, polygons, lines) should get the exact clicked location.

This PR addresses this by considering if the layer has a `getLatLng` method (layer has an exact point location) and is missing radius or has a small radius (measured in pixels).

As any heuristic, this will have edge cases, but I think it will cover the codes intention better with less risk of doing the wrong thing.