### PR TITLE
Fix(Map): call stopLocate on map.remove

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -722,6 +722,10 @@ export var Map = Evented.extend({
 			this._containerId = undefined;
 		}
 
+		if (this._locationWatchId !== undefined) {
+			this.stopLocate();
+		}
+
 		this._stop();
 
 		DomUtil.remove(this._mapPane);


### PR DESCRIPTION
Hi,

Following SO post [Leaflet .locate watch option breaks .locate after changing tab](https://stackoverflow.com/questions/47021405/leaflet-locate-watch-option-breaks-locate-after-changing-tab-ionic-3), this PR proposes to automatically call [`map.stopLocate()`](http://leafletjs.com/reference.html#map-stoplocate) as part of [`map.remove()`](http://leafletjs.com/reference.html#map-remove) process, so that app developer does not need to remember about having used the Geolocation with [`watch`](http://leafletjs.com/reference.html#locate-options-watch) option or not.

Otherwise, Geolocation handlers (namely `_handleGeolocationResponse` and `_handleGeolocationError`) are still called regulary and try to access DOM elements which have been previously cleared by `map.remove()`.

Check for `_locationWatchId` is not perfect (watch may have been already stopped), but calling `stopLocate` again does not harm. It prevents trying to access the Geolocation API if `locate` had never been called, even though doing so should not harm either.