### PR TITLE
add typeof check to checkDeprecatedMixinEvents

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -112,7 +112,7 @@ Class.addInitHook = function (fn) { // (Function) || (String, args...)
 };
 
 function checkDeprecatedMixinEvents(includes) {
-	if (!L || !L.Mixin) { return; }
+	if (typeof L === 'undefined' || !L || !L.Mixin) { return; }
 
 	includes = Util.isArray(includes) ? includes : [includes];
 


### PR DESCRIPTION
!L may result in a undefined error when running tests outside the browser that also touch including a leaflet plugin.