### PR TITLE
Added Leaflet.Antimeridian to the plugin list.

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3537,6 +3537,15 @@ The following plugins perform several sorts of geoprocessing (mathematical and t
 			<a href="https://github.com/jjimenezshaw/">Javier Jimenez Shaw</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/briannaAndCo/Leaflet.Antimeridian">Leaflet.Antimeridian</a>
+		</td><td>
+			A plugin to allow polygons and polylines to naturally draw across the Antimeridian (or the Internation Date Line) instead of always wrapping across the Greenwich meridian. (<a href="https://briannaandco.github.io/Leaflet.Antimeridian/">Demo</a>)
+		</td><td>
+			<a href="https://github.com/briannaAndCo">Brianna Landon</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Per an earlier pull request, the automatic drawing of polylines and polygons across the International Date Line has been turned into a plugin (Leaflet.Antimeridian) and added to the list of plugins.



![image](https://user-images.githubusercontent.com/28913842/32623151-04a1d0aa-c53a-11e7-9d45-73b7c8f262f7.png)