### PR TITLE
Made Zoom/pan options clickable in invalidateSize

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -509,7 +509,7 @@ export var Map = Evented.extend({
 		return this;
 	},
 
-	// @method invalidateSize(options: Zoom/Pan options): this
+	// @method invalidateSize(options: Zoom/pan options): this
 	// Checks if the map container size changed and updates the map if so —
 	// call it after you've changed the map size dynamically, also animating
 	// pan by default. If `options.pan` is `false`, panning will not occur.


### PR DESCRIPTION
Renamed Zoom/Pan to Zoom/pan to match the correct docstrings and have a clickable link for invalidateSize.

Fix for #5896 