### PR TITLE
Fix function _animateZoom if redirects in the middle of a transition (flyTo)

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1608,8 +1608,8 @@ export var Map = Evented.extend({
 	},
 
 	_animateZoom: function (center, zoom, startAnim, noUpdate) {
-        if(!this._mapPane) { return; }
-        
+        if(!this._mapPane) return;
+
 		if (startAnim) {
 			this._animatingZoom = true;
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1608,6 +1608,8 @@ export var Map = Evented.extend({
 	},
 
 	_animateZoom: function (center, zoom, startAnim, noUpdate) {
+        if(!this._mapPane) { return; }
+        
 		if (startAnim) {
 			this._animatingZoom = true;
 


### PR DESCRIPTION
Hello,

I have seen the issue #5876 inserted by @dnepromell and works fine but, in my personal project, I have seen that if you redirect to another page in the middle of a transition (working, for instance, with the _flyTo_ function) it returns this error:
```javascript
leaflet-src.js:2588 Uncaught TypeError: Cannot read property 'classList' of undefined
    at addClass (leaflet-src.js:2588)
    at NewClass._animateZoom (leaflet-src.js:4517)
    at NewClass.<anonymous> (leaflet-src.js:4499)
```

That's because we are trying to add a class to an element of the DOM that doesn't exist (```DomUtil.addClass```) and, after that, we are trying, too, to call a function that will return an error (```this.fire('zoomanim', { ... })```).

With this previous check it will work and will solve both issues.

Best regards!

PD: Thanks @perliedman for answering all my questions.