### PR TITLE
Tweak 'legacy' option in rollup config

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -30,9 +30,9 @@ export default {
 		format: 'umd',
 		name: 'L',
 		banner: banner,
-		sourcemap: true,
-		legacy: true // Needed to create files loadable by IE8
+		sourcemap: true
 	},
+	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
 		release ? json() : rollupGitVersion()
 	]

--- a/build/rollup-watch-config.js
+++ b/build/rollup-watch-config.js
@@ -20,9 +20,9 @@ export default {
 		format: 'umd',
 		name: 'L',
 		banner: banner,
-		sourcemap: true,
-		legacy: true // Needed to create files loadable by IE8
+		sourcemap: true
 	},
+	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
 		rollupGitVersion()
 	]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^3.1.0",
     "phantomjs-prebuilt": "^2.1.12",
     "prosthetic-hand": "^1.3.1",
-    "rollup": "^0.49.2",
+    "rollup": "^0.51.8",
     "rollup-plugin-git-version": "0.2.1",
     "rollup-plugin-json": "^2.1.0",
     "rollup-watch": "^4.3.1",


### PR DESCRIPTION
Should fix #5928 .

According to the latest [rollup docs](https://rollupjs.org/#configuration-files), the `legacy` option is a top-level option, and not an option for each of the outputs.