### PR TITLE
Fixed #5848 - Map drags correctly when in disabled FieldSet

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -116,8 +116,8 @@ export var Draggable = Evented.extend({
 
 		this._startPoint = new Point(first.clientX, first.clientY);
 
-		DomEvent.on(document, MOVE[e.type], this._onMove, this);
-		DomEvent.on(document, END[e.type], this._onUp, this);
+		DomEvent.on(this._dragStartTarget, MOVE[e.type], this._onMove, this);
+		DomEvent.on(this._dragStartTarget, END[e.type], this._onUp, this);
 	},
 
 	_onMove: function (e) {
@@ -202,8 +202,8 @@ export var Draggable = Evented.extend({
 		}
 
 		for (var i in MOVE) {
-			DomEvent.off(document, MOVE[i], this._onMove, this);
-			DomEvent.off(document, END[i], this._onUp, this);
+			DomEvent.off(this._dragStartTarget, MOVE[i], this._onMove, this);
+			DomEvent.off(this._dragStartTarget, END[i], this._onUp, this);
 		}
 
 		DomUtil.enableImageDrag();


### PR DESCRIPTION
Dragging functionality was setting the `eventHandler` on the `document` object (which must've not been responding to events due to the `disabled` tag.

I changed it to assign the `eventHandler` directly to the relevant object (and interestingly enough the object specified when actually setting the mousedown (`_dragStartTarget`) clickhandler!)