### PR TITLE
Fixes chrome dragging issue #5779

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -244,6 +244,8 @@
 .leaflet-container {
 	background: #ddd;
 	outline: 0;
+	-ms-touch-action: none;
+    	touch-action: none;
 	}
 .leaflet-container a {
 	color: #0078A8;


### PR DESCRIPTION
Fixes chrome dragging issue on mobile chrome.

Issue #5779 reported that if map.touchZoom.disable(); was called, you would not be able to drag properly on Chrome mobile browsers. Which is true as I faced the same issue. You can see that this works again using chrome dev tools once you change to a mobile device. 

This is similar CSS to version 0.7.7.