### PR TITLE
Fix map pan when touchZoom is disabled

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -56,6 +56,8 @@
 	}
 .leaflet-container.leaflet-touch-drag {
 	-ms-touch-action: pinch-zoom;
+	/* Fallback for FF which doesn't support pinch-zoom */
+	touch-action: none;
 	touch-action: pinch-zoom;
 }
 .leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -56,8 +56,9 @@
 	}
 .leaflet-container.leaflet-touch-drag {
 	-ms-touch-action: pinch-zoom;
-	}
-.leaflet-container.leaflet-touch-drag {
+	touch-action: pinch-zoom;
+}
+.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
 	-ms-touch-action: none;
 	touch-action: none;
 }

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -57,7 +57,7 @@
 .leaflet-container.leaflet-touch-drag {
 	-ms-touch-action: pinch-zoom;
 	}
-.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
+.leaflet-container.leaflet-touch-drag {
 	-ms-touch-action: none;
 	touch-action: none;
 }


### PR DESCRIPTION
Fixes #5779, closes #5951.

In #4552 @perliedman introduced change, which allows page native scroll when the touch zoom and map drag handlers are disabled.
How it works on current master:

| `dragging`  | `touchZoom` | Result |
| ------------- | ------------- | ------  |
| enabled  | enabled  | :white_check_mark: `dragging` and `touchZoom` work |
| disabled  | disabled  | :white_check_mark: neither `dragging` nor `touchZoom` work, page is not prevented from scrolling |
| disabled  | enabled  | :white_check_mark: `dragging` doesn't work, `touchZoom` works, page is not prevented from scrolling |
| enabled  | disabled  | :warning: `touchZoom` doesn't work, but `dragging` doesn't work either, page is not prevented from scrolling. **Expected**: `touchZoom` doesn't work, `dragging` works and page is not prevented from scrolling - #5779  |

~~So `touch-action: none` should be added if `dragging` is enabled and should not be added if `dragging` is disabled, whether `touchZoom` is enabled or not.~~