### PR TITLE
Docs(issueTemplate): use generic reference URL

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 Thanks for taking the time to open an issue! Help us have good bug requests:
 
 - [ ] I'm reporting a bug, not asking for help; support questions like "How can I do X with Leaflet?" will be closed (use [Stack Overflow](http://stackoverflow.com/) or [gis.stackexchange.com](http://gis.stackexchange.com/) for questions)
-- [ ] I've looked at the [documentation](http://leafletjs.com/reference-1.0.3.html) to make sure the behaviour is documented and expected
+- [ ] I've looked at the [documentation](http://leafletjs.com/reference.html) to make sure the behaviour is documented and expected
 - [ ] I'm sure this is a Leaflet code issue, not an issue with my own code nor with the framework I'm using (Cordova, Ionic, Angular, React…)
 - [ ] I've searched through the issues to make sure it's not yet reported
 -->


### PR DESCRIPTION
Hi,

This simple PR uses the generic reference documentation URL (http://leafletjs.com/reference.html), relying on redirection to point to the latest reference page, instead of the hard-coded versioned one.