### PR TITLE
ScrollWheelZoom._performZoom: use zoomDelta instead of zoomSnap

### DIFF
--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -62,14 +62,14 @@ export var ScrollWheelZoom = Handler.extend({
 	_performZoom: function () {
 		var map = this._map,
 		    zoom = map.getZoom(),
-		    snap = this._map.options.zoomSnap || 0;
+		    zoomDelta = this._map.options.zoomDelta || 1;
 
 		map._stop(); // stop panning and fly animations if any
 
 		// map the delta with a sigmoid function to -4..4 range leaning on -1..1
 		var d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4),
 		    d3 = 4 * Math.log(2 / (1 + Math.exp(-Math.abs(d2)))) / Math.LN2,
-		    d4 = snap ? Math.ceil(d3 / snap) * snap : d3,
+		    d4 = Math.ceil(d3 / zoomDelta) * zoomDelta,
 		    delta = map._limitZoom(zoom + (this._delta > 0 ? d4 : -d4)) - zoom;
 
 		this._delta = 0;


### PR DESCRIPTION
Comparing the Zoom Control +/- buttons and the scroll wheel zoom behavior
it became obvious that these two use different "delta" values. I.e, the
scroll wheel code zooms by zoomSnap steps, not zoomDelta.

Looking a bit at the history, commit a1ff60bf9be did change zoomDelta
to zoomSnap for reasons that are not clear.

This commit makes _performZoom use use zoomDelta instead of zoomSnap
which makes scrollwheel zoom behave the same as the zoom controls +/-.