### PR TITLE
Fix(SVGrenderer): reset svgSize on remove from map

### DIFF
--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -68,6 +68,7 @@ export var SVG = Renderer.extend({
 		DomEvent.off(this._container);
 		delete this._container;
 		delete this._rootGroup;
+		delete this._svgSize;
 	},
 
 	_onZoomStart: function () {


### PR DESCRIPTION
Hi,

This PR resets the `_svgSize` cache on SVG Renderer, so that when it is re-used and re-added on map, in `_update` method, the check on `_svgSize` triggers and re-assigns `width` and `height` attributes on the `_container`.

Otherwise, the latter no longer has width and height, therefore is invisible, until the viewport size is changed.

I will try to include a unit test later on.

Fix https://github.com/Leaflet/Leaflet/issues/5960