### PR TITLE
Set alt attribute for img-based Icons only

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -190,6 +190,21 @@ describe("Marker", function () {
 			expect(marker._icon.parentNode).to.be(map._panes.markerPane);
 			expect(marker._shadow.parentNode).to.be(map._panes.shadowPane);
 		});
+
+		it("sets the alt attribute to an empty string when no alt text is passed", function () {
+			var marker = L.marker([0, 0], {icon: icon1});
+			map.addLayer(marker);
+			var icon = marker._icon;
+			expect(icon.hasAttribute('alt')).to.be(true);
+			expect(icon.alt).to.be('');
+		});
+
+		it("doesn't set the alt attribute for DivIcons", function () {
+			var marker = L.marker([0, 0], {icon: L.divIcon(), alt: 'test'});
+			map.addLayer(marker);
+			var icon = marker._icon;
+			expect(icon.hasAttribute('alt')).to.be(false);
+		});
 	});
 
 	describe("#setLatLng", function () {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -203,8 +203,9 @@ export var Marker = Layer.extend({
 			if (options.title) {
 				icon.title = options.title;
 			}
-			if (options.alt) {
-				icon.alt = options.alt;
+
+			if (icon.tagName === 'IMG') {
+				icon.alt = options.alt || '';
 			}
 		}
 


### PR DESCRIPTION
Closes #5953 

I considered and ultimately decided against following @IvanSanchez's suggestion to create a private _setAlt function in the Icon and DivIcon classes.  Because the alt attribute is only valid for img elements in the context of a marker, we can just do a quick test for the icon's tagName and only set alt if it's an img.  This seemed like a cleaner solution to me than implementing _setAlt for img based Icon subclasses and implementing a no-op _setAlt for non-img based subclasses.