### PR TITLE
Document tooltipAnchor option

### DIFF
--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -54,6 +54,9 @@ export var Icon = Class.extend({
 	 * @option popupAnchor: Point = null
 	 * The coordinates of the point from which popups will "open", relative to the icon anchor.
 	 *
+	 * @option tooltipAnchor: Point = null
+	 * The coordinates of the point from which tooltips will "open", relative to the icon anchor.
+	 *
 	 * @option shadowUrl: String = null
 	 * The URL to the icon shadow image. If not specified, no shadow image will be created.
 	 *

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -51,10 +51,10 @@ export var Icon = Class.extend({
 	 * will be aligned so that this point is at the marker's geographical location. Centered
 	 * by default if size is specified, also can be set in CSS with negative margins.
 	 *
-	 * @option popupAnchor: Point = null
+	 * @option popupAnchor: Point = [0, 0]
 	 * The coordinates of the point from which popups will "open", relative to the icon anchor.
 	 *
-	 * @option tooltipAnchor: Point = null
+	 * @option tooltipAnchor: Point = [0, 0]
 	 * The coordinates of the point from which tooltips will "open", relative to the icon anchor.
 	 *
 	 * @option shadowUrl: String = null

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -73,6 +73,11 @@ export var Icon = Class.extend({
 	 * A custom class name to assign to both icon and shadow images. Empty by default.
 	 */
 
+	options: {
+		popupAnchor: [0, 0],
+		tooltipAnchor: [0, 0],
+	},
+
 	initialize: function (options) {
 		setOptions(this, options);
 	},

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -349,11 +349,11 @@ export var Marker = Layer.extend({
 	},
 
 	_getPopupAnchor: function () {
-		return this.options.icon.options.popupAnchor || [0, 0];
+		return this.options.icon.options.popupAnchor;
 	},
 
 	_getTooltipAnchor: function () {
-		return this.options.icon.options.tooltipAnchor || [0, 0];
+		return this.options.icon.options.tooltipAnchor;
 	}
 });
 


### PR DESCRIPTION
This PR adds `tooltipAnchor` to docs and moves `tooltipAnchor` and `popupAnchor` default values from `Marker` to `Icon`.
Also `tooltipAnchor` and `popupAnchor` default values docs updated from `null` to `[0, 0]`.