### PR TITLE
Test(TileLayer): make sure zoomOffset option is used

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -377,5 +377,46 @@ describe('TileLayer', function () {
 				expect(['q', 'r', 's'].indexOf(img.src[7]) >= 0).to.eql(true);
 			});
 		});
+
+		it('uses zoomOffset option', function () {
+			// Map view is set at zoom 2 in beforeEach.
+			var layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+				zoomOffset: 1 // => zoom 2 + zoomOffset 1 => z 3 in URL.
+			}).addTo(map);
+
+			var urls = [
+				'http://example.com/3/1/1.png',
+				'http://example.com/3/1/2.png',
+				'http://example.com/3/2/1.png',
+				'http://example.com/3/2/2.png'
+			];
+
+			var i = 0;
+			eachImg(layer, function (img) {
+				expect(img.src).to.eql(urls[i]);
+				i++;
+			});
+		});
+
+		it('uses negative zoomOffset option', function () {
+			// Map view is set at zoom 2 in beforeEach.
+			var layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+				zoomOffset: -3 // => zoom 2 + zoomOffset -3 => z -1 in URL.
+			}).addTo(map);
+
+			var urls = [
+				'http://example.com/-1/1/1.png',
+				'http://example.com/-1/1/2.png',
+				'http://example.com/-1/2/1.png',
+				'http://example.com/-1/2/2.png'
+			];
+
+			var i = 0;
+			eachImg(layer, function (img) {
+				expect(img.src).to.eql(urls[i]);
+				i++;
+			});
+		});
+
 	});
 });


### PR DESCRIPTION
This PR adds 2 dedicated tests to make sure that the Tile Layer's `zoomOffset` option is correctly taken into account when building the tiles URL.
As mentioned in https://github.com/Leaflet/Leaflet/pull/6010#issuecomment-358637070

Follows issue #6004 (fixed by PR #6006).

The tests fail when PR #5822 is active, and pass correctly after PR #6006 is applied.

Unfortunately I could not add a similar test for `detectRetina` option that easily, because since the move to Rollup build, `Browser` values became internal variables, and overriding them later on does not have any effect on Leaflet internal references…
Not sure how to workaround this for the sake of testing.