### PR TITLE
Enable mouse events on multiple canvas renderers #2

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -342,14 +342,14 @@ export var Canvas = Renderer.extend({
 	// Canvas obviously doesn't have mouse events for individual drawn objects,
 	// so we emulate that by calculating what's under the mouse on mousemove/click manually
 
-	_dispatchEvent: function(e) {
-		switch(e.type) {
-			case 'mousemove':
-				this._onMouseMove(e);
-				break;
-			case 'click':
-				this._onClick(e);
-				break;
+	_dispatchEvent: function (e) {
+		switch (e.type) {
+		case 'mousemove':
+			this._onMouseMove(e);
+			break;
+		case 'click':
+			this._onClick(e);
+			break;
 		}
 	},
 
@@ -365,8 +365,7 @@ export var Canvas = Renderer.extend({
 		if (clickedLayer)  {
 			DomEvent.fakeStop(e);
 			this._fireEvent([clickedLayer], e);
-		}
-		else {
+		}	else {
 			// layer wasn't found, send to map to find if other canvas layers can handle event
 			this._map._forwardCanvasEvent(this, e);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -149,6 +149,7 @@ export var Map = Evented.extend({
 		this._handlers = [];
 		this._layers = {};
 		this._zoomBoundLayers = {};
+		this._canvasRenderers = [];
 		this._sizeChanged = true;
 
 		this.callInitHooks();
@@ -1649,6 +1650,17 @@ export var Map = Evented.extend({
 		Util.requestAnimFrame(function () {
 			this._moveEnd(true);
 		}, this);
+	},
+
+	_registerCanvasRenderer: function(layer) {
+		this._canvasRenderers.push(layer);
+	},
+
+	_forwardCanvasEvent: function(layer, e) {
+		if (this._canvasRenderers.indexOf(layer) > 0) {
+			// forward to the renderer *below* the renderer the originally received the event
+			this._canvasRenderers[pos - 1];._dispatchEvent(e);
+		}
 	}
 });
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1657,7 +1657,8 @@ export var Map = Evented.extend({
 	},
 
 	_forwardCanvasEvent: function (layer, e) {
-		if (this._canvasRenderers.indexOf(layer) > 0) {
+		var pos = this._canvasRenderers.indexOf(layer);
+		if (pos > 0) {
 			// forward to the renderer *below* the renderer the originally received the event
 			this._canvasRenderers[pos - 1]._dispatchEvent(e);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1652,14 +1652,14 @@ export var Map = Evented.extend({
 		}, this);
 	},
 
-	_registerCanvasRenderer: function(layer) {
+	_registerCanvasRenderer: function (layer) {
 		this._canvasRenderers.push(layer);
 	},
 
-	_forwardCanvasEvent: function(layer, e) {
+	_forwardCanvasEvent: function (layer, e) {
 		if (this._canvasRenderers.indexOf(layer) > 0) {
 			// forward to the renderer *below* the renderer the originally received the event
-			this._canvasRenderers[pos - 1];._dispatchEvent(e);
+			this._canvasRenderers[pos - 1]._dispatchEvent(e);
 		}
 	}
 });


### PR DESCRIPTION
See #5752. I know this needs work, but creating for additional discussion.

Sorry for the delay here. I just got some time to look at this again. So if I'm understanding @perliedman correctly, there are cases where the order in which canvas renderers are added to the map is not necessarily the order in which they appear in the DOM.

If so, could someone point me in the direction of how/when that happens? Is it add canvas A, add canvas B, remove canvas A? Setting z-index on the individual canvas elements? Or something else entirely?