### PR TITLE
Adding leaflet-blurred-location plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3398,6 +3398,17 @@ Buttons, sliders, toolbars, sidebars, and panels.
 			<a href="https://github.com/ka7eh">Kaveh Karimi</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/publiclab/leaflet-blurred-location/">leaflet-blurred-image</a>
+		</td>
+		<td>
+			A Leaflet-based interface for selecting a "blurred" or low-resolution location, to preserve privacy. <a href="https://publiclab.github.io/leaflet-blurred-location/examples/">Demo</a>.
+		</td>
+		<td>
+			<a href="https://github.com/publiclab">Public Lab</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
https://github.com/publiclab/leaflet-blurred-location/

A Leaflet-based interface for selecting a "blurred" or low-resolution location, to preserve privacy

Demo: https://publiclab.github.io/leaflet-blurred-location/examples/

I hope this is the right place to add it to the list!

Some amazing plugins have been added over the past year or so, btw -- very impressive. 😄 