### PR TITLE
Added 'use-credentials' Cors Option to ImageOverlay and TileLayer

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -41,6 +41,10 @@ export var ImageOverlay = Layer.extend({
 		// If true, the image will have its crossOrigin attribute set to ''. This is needed if you want to access image pixel data.
 		crossOrigin: false,
 
+		// @option crossOriginCredentials: Boolean = false
+		// If true, the image will have its crossOrigin attribute set to 'use-credentials'. This is needed if you want to access image pixel data.
+		crossOriginCredentials: false,
+
 		// @option errorOverlayUrl: String = ''
 		// URL to the overlay image to show in place of the overlay that failed to load.
 		errorOverlayUrl: '',
@@ -196,6 +200,10 @@ export var ImageOverlay = Layer.extend({
 
 		if (this.options.crossOrigin) {
 			img.crossOrigin = '';
+		}
+
+		if (this.options.crossOriginCredentials) {
+			img.crossOrigin = 'use-credentials';
 		}
 
 		if (this.options.zIndex) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -37,13 +37,11 @@ export var ImageOverlay = Layer.extend({
 		// If `true`, the image overlay will emit [mouse events](#interactive-layer) when clicked or hovered.
 		interactive: false,
 
-		// @option crossOrigin: Boolean = false
-		// If true, the image will have its crossOrigin attribute set to ''. This is needed if you want to access image pixel data.
+		// @option crossOrigin: String = false
+		// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		// Any false value other than '' will omit the crossOrigin attribute from the image.
 		crossOrigin: false,
-
-		// @option crossOriginCredentials: Boolean = false
-		// If true, the image will have its crossOrigin attribute set to 'use-credentials'. This is needed if you want to access image pixel data.
-		crossOriginCredentials: false,
 
 		// @option errorOverlayUrl: String = ''
 		// URL to the overlay image to show in place of the overlay that failed to load.
@@ -198,12 +196,8 @@ export var ImageOverlay = Layer.extend({
 		img.onload = Util.bind(this.fire, this, 'load');
 		img.onerror = Util.bind(this._overlayOnError, this, 'error');
 
-		if (this.options.crossOrigin) {
-			img.crossOrigin = '';
-		}
-
-		if (this.options.crossOriginCredentials) {
-			img.crossOrigin = 'use-credentials';
+		if (this.options.crossOrigin || this.options.crossOrigin === '') {
+			img.crossOrigin = this.options.crossOrigin;
 		}
 
 		if (this.options.zIndex) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -37,10 +37,10 @@ export var ImageOverlay = Layer.extend({
 		// If `true`, the image overlay will emit [mouse events](#interactive-layer) when clicked or hovered.
 		interactive: false,
 
-		// @option crossOrigin: String = false
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the image.
 		// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
 		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-		// Any false value other than '' will omit the crossOrigin attribute from the image.
 		crossOrigin: false,
 
 		// @option errorOverlayUrl: String = ''
@@ -197,7 +197,7 @@ export var ImageOverlay = Layer.extend({
 		img.onerror = Util.bind(this._overlayOnError, this, 'error');
 
 		if (this.options.crossOrigin || this.options.crossOrigin === '') {
-			img.crossOrigin = this.options.crossOrigin;
+			img.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
 		}
 
 		if (this.options.zIndex) {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -73,13 +73,11 @@ export var TileLayer = GridLayer.extend({
 		// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
 		detectRetina: false,
 
-		// @option crossOrigin: Boolean = false
-		// If true, all tiles will have their crossOrigin attribute set to ''. This is needed if you want to access tile pixel data.
-		crossOrigin: false,
-
-		// @option crossOriginCredentials: Boolean = false
-		// If true, all tiles will have their crossOrigin attribute set to 'use-credentials'. This is needed if you want to access tile pixel data.
-		crossOriginCredentials: false
+		// @option crossOrigin: String = false
+		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		// Any false value other than '' will omit the crossOrigin attribute from the images.
+		crossOrigin: false
 	},
 
 	initialize: function (url, options) {
@@ -135,12 +133,8 @@ export var TileLayer = GridLayer.extend({
 		DomEvent.on(tile, 'load', Util.bind(this._tileOnLoad, this, done, tile));
 		DomEvent.on(tile, 'error', Util.bind(this._tileOnError, this, done, tile));
 
-		if (this.options.crossOrigin) {
-			tile.crossOrigin = '';
-		}
-
-		if (this.options.crossOriginCredentials) {
-			tile.crossOrigin = 'use-credentials';
+		if (this.options.crossOrigin || this.options.crossOrigin === '') {
+			tile.crossOrigin = this.options.crossOrigin;
 		}
 
 		/*

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -75,7 +75,11 @@ export var TileLayer = GridLayer.extend({
 
 		// @option crossOrigin: Boolean = false
 		// If true, all tiles will have their crossOrigin attribute set to ''. This is needed if you want to access tile pixel data.
-		crossOrigin: false
+		crossOrigin: false,
+
+		// @option crossOriginCredentials: Boolean = false
+		// If true, all tiles will have their crossOrigin attribute set to 'use-credentials'. This is needed if you want to access tile pixel data.
+		crossOriginCredentials: false
 	},
 
 	initialize: function (url, options) {
@@ -133,6 +137,10 @@ export var TileLayer = GridLayer.extend({
 
 		if (this.options.crossOrigin) {
 			tile.crossOrigin = '';
+		}
+
+		if (this.options.crossOriginCredentials) {
+			tile.crossOrigin = 'use-credentials';
 		}
 
 		/*

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -73,10 +73,10 @@ export var TileLayer = GridLayer.extend({
 		// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
 		detectRetina: false,
 
-		// @option crossOrigin: String = false
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the tiles.
 		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
 		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-		// Any false value other than '' will omit the crossOrigin attribute from the images.
 		crossOrigin: false
 	},
 
@@ -134,7 +134,7 @@ export var TileLayer = GridLayer.extend({
 		DomEvent.on(tile, 'error', Util.bind(this._tileOnError, this, done, tile));
 
 		if (this.options.crossOrigin || this.options.crossOrigin === '') {
-			tile.crossOrigin = this.options.crossOrigin;
+			tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
 		}
 
 		/*


### PR DESCRIPTION
Fixes  #5891 

I added a new option to set the crossOrigin property to 'use-credentials'. Another solution would be to make crossOrigin a String and set the default value to null. Let the user set crossOrigin as a String.