### PR TITLE
Docs(plugins): add Rotated Marker plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1536,6 +1536,17 @@ These plugins provide new markers or news ways of converting abstract data into 
 			<a href="https://github.com/JackZouShao">Jack Zou</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/bbecquet/Leaflet.RotatedMarker">Leaflet Rotated Marker</a>
+		</td>
+		<td>
+			Enables rotation of marker icons in Leaflet. (<a href='http://bbecquet.github.io/Leaflet.RotatedMarker/example.html'>Demo</a>)
+		</td>
+		<td>
+			<a href="https://github.com/bbecquet">Benjamin Becquet</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Hi,

This simple PR adds [Leaflet Rotated Marker](https://github.com/bbecquet/Leaflet.RotatedMarker) plugin ([demo](http://bbecquet.github.io/Leaflet.RotatedMarker/example.html)) to the Plugins list page on Leaflet website.

Plugin by Benjamin Becquet, who already submitted a few plugins on this list and mentioned this one in https://github.com/Leaflet/Leaflet/issues/143

Added into "Overlay Display > Markers & renderers" section.

Closes #143