### PR TITLE
Docs(tutorials): map panes use more explicit tiles

### DIFF
--- a/docs/examples/map-panes/index.md
+++ b/docs/examples/map-panes/index.md
@@ -33,18 +33,18 @@ In some particular cases, the default order is not the right one for the map. We
 
 <div class='tiles'>
 <div style='display: inline-block'>
-<img src="http://a.basemaps.cartocdn.com/light_nolabels/0/0/0.png" class="bordered-img" /><br/>
+<img src="http://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png" class="bordered-img" /><br/>
 Basemap tile with no labels
 </div>
 
 <div style='display: inline-block'>
-<img src="http://a.basemaps.cartocdn.com/light_only_labels/0/0/0.png" class="bordered-img" /><br/>
+<img src="http://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png" class="bordered-img" /><br/>
 Transparent labels-only tile
 </div>
 
 <div style='display: inline-block; position:relative;'>
-<img src="http://a.basemaps.cartocdn.com/light_nolabels/0/0/0.png" class="bordered-img" />
-<img src="http://a.basemaps.cartocdn.com/light_only_labels/0/0/0.png"  style='position:absolute; left:0; top:0;'/><br/>
+<img src="http://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png" class="bordered-img" />
+<img src="http://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png"  style='position:absolute; left:0; top:0;'/><br/>
 Labels on top of basemap
 </div>
 </div>


### PR DESCRIPTION
This PR modifies the tiles that are shown as examples of stacking a base map with labels (transparent tiles), so that it is more obvious what the difference is between the base map, the labels, and when both are stacked.

The chosen tile is similar to the initial view of the result example just below in the tutorial page (example.html), and contains many labels.

![basemap tile over Central Europe](http://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png)

![labels tile over Central Europe](http://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png)
