### PR TITLE
add pkg.module

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -25,7 +25,7 @@ const banner = `/* @preserve
 `;
 
 const outro = `var oldL = window.L;
-function noConflict() {
+exports.noConflict = function() {
 	window.L = oldL;
 	return this;
 }

--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -3,8 +3,9 @@
 import rollupGitVersion from 'rollup-plugin-git-version'
 import json from 'rollup-plugin-json'
 import gitRev from 'git-rev-sync'
+import pkg from '../package.json'
 
-let version = require('../package.json').version;
+let {version} = pkg;
 let release;
 
 // Skip the git branch+rev in the banner when doing a release build
@@ -23,15 +24,33 @@ const banner = `/* @preserve
  */
 `;
 
+const outro = `var oldL = window.L;
+function noConflict() {
+	window.L = oldL;
+	return this;
+}
+
+// Always export us to window global (see #2364)
+window.L = exports;`;
+
 export default {
 	input: 'src/Leaflet.js',
-	output: {
-		file: 'dist/leaflet-src.js',
-		format: 'umd',
-		name: 'L',
-		banner: banner,
-		sourcemap: true
-	},
+	output: [
+		{
+			file: pkg.main,
+			format: 'umd',
+			name: 'L',
+			banner: banner,
+			outro: outro,
+			sourcemap: true
+		},
+		{
+			file: pkg.module,
+			format: 'es',
+			banner: banner,
+			sourcemap: true
+		}
+	],
 	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
 		release ? json() : rollupGitVersion()

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "uglify-js": "~3.0.26"
   },
   "main": "dist/leaflet-src.js",
+  "module": "dist/leaflet-src.esm.js",
   "style": "dist/leaflet.css",
   "files": [
     "dist",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -1,5 +1,14 @@
 var json = require('rollup-plugin-json');
 
+const outro = `var oldL = window.L;
+exports.noConflict = function() {
+	window.L = oldL;
+	return this;
+}
+
+// Always export us to window global (see #2364)
+window.L = exports;`;
+
 // Karma configuration
 module.exports = function (config) {
 
@@ -52,7 +61,8 @@ module.exports = function (config) {
 				json()
 			],
 			format: 'umd',
-			name: 'L'
+			name: 'L',
+			outro: outro
 		},
 
 		// test results reporter to use

--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -23,16 +23,5 @@ export * from './layer/index';
 // map
 export * from './map/index';
 
-// misc
-
-var oldL = window.L;
-export function noConflict() {
-	window.L = oldL;
-	return this;
-}
-
-// Always export us to window global (see #2364)
-window.L = exports;
-
 import {freeze} from './core/Util';
 Object.freeze = freeze;


### PR DESCRIPTION
This is a follow-up to a [Twitter conversation](https://twitter.com/Rich_Harris/status/955851611225706499) — essentially, it adds an ES module build of Leaflet which means more efficient bundles (and a slightly easier workflow for Rollup users, since they no longer need the commonjs plugin to use Leaflet).

It would also allow people to do this sort of thing in modern browsers:

```html
<script type='module'>
  import * as L from 'https://unpkg.com/leaflet?module';

  // look ma, no build step!
  let map = L.map('map', {
    center: [51.505, -0.09],
    zoom: 13
  });
</script>
```