### PR TITLE
Test(ImageOverlay+TileLayer): crossOrigin option to IMG crossorigin attribute

### DIFF
--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -141,4 +141,45 @@ describe('ImageOverlay', function () {
 			expect(overlay.setZIndex()).to.equal(overlay);
 		});
 	});
+
+	// For tests that do not actually need to append the map container to the document.
+	// This saves PhantomJS memory.
+	describe('_image2', function () {
+		var c, map, overlay;
+		var blankUrl = "data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==";
+		var bounds = [[40.712216, -74.22655], [40.773941, -74.12544]];
+
+		// Create map and overlay for each test
+		beforeEach(function () {
+			c = document.createElement('div');
+			c.style.width = '400px';
+			c.style.height = '400px';
+			map = new L.Map(c);
+			map.setView(new L.LatLng(55.8, 37.6), 6);	// view needs to be set so when layer is added it is initialized
+		});
+
+		// Clean up after each test run
+		afterEach(function () {
+			map.removeLayer(overlay);
+			overlay = null;
+			map = null;
+		});
+
+		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+		testCrossOriginValue(undefined, null); // Falsy value (other than empty string '') => no attribute set.
+		testCrossOriginValue(true, '');
+		testCrossOriginValue('anonymous', 'anonymous');
+		testCrossOriginValue('use-credentials', 'use-credentials');
+
+		function testCrossOriginValue(crossOrigin, expectedValue) {
+			it('uses crossOrigin option value ' + crossOrigin, function () {
+				overlay = L.imageOverlay(blankUrl, bounds, {
+					crossOrigin: crossOrigin
+				});
+				map.addLayer(overlay);
+
+				expect(overlay._image.getAttribute('crossorigin')).to.be(expectedValue);
+			});
+		}
+	});
 });

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -428,9 +428,6 @@ describe('TileLayer', function () {
 			div = document.createElement('div');
 			div.style.width = '400px';
 			div.style.height = '400px';
-			// div.style.visibility = 'hidden';
-
-			// document.body.appendChild(div);
 
 			map = L.map(div).setView([0, 0], 2);
 		});

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -176,7 +176,6 @@ describe('TileLayer', function () {
 		if (div) {
 			document.body.removeChild(div);
 		}
-		// document.body.removeChild(div);
 	});
 
 	function kittenLayerFactory(options) {

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -173,11 +173,23 @@ describe('TileLayer', function () {
 	});
 
 	afterEach(function () {
-		document.body.removeChild(div);
+		if (div) {
+			document.body.removeChild(div);
+		}
+		// document.body.removeChild(div);
 	});
 
 	function kittenLayerFactory(options) {
 		return L.tileLayer(placeKitten, options || {});
+	}
+
+	function eachImg(layer, callback) {
+		var imgtags = layer._container.children[0].children;
+		for (var i in imgtags) {
+			if (imgtags[i].tagName === 'IMG') {
+				callback(imgtags[i]);
+			}
+		}
 	}
 
 	describe("number of kittens loaded", function () {
@@ -299,15 +311,6 @@ describe('TileLayer', function () {
 			map = L.map(div).setView([0, 0], 2);
 		});
 
-		function eachImg(layer, callback) {
-			var imgtags = layer._container.children[0].children;
-			for (var i in imgtags) {
-				if (imgtags[i].tagName === 'IMG') {
-					callback(imgtags[i]);
-				}
-			}
-		}
-
 		it('replaces {y} with y coordinate', function () {
 			var layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png').addTo(map);
 
@@ -418,5 +421,42 @@ describe('TileLayer', function () {
 			});
 		});
 
+	});
+
+	describe('options', function () {
+
+		beforeEach(function () {
+			div = document.createElement('div');
+			div.style.width = '400px';
+			div.style.height = '400px';
+			// div.style.visibility = 'hidden';
+
+			// document.body.appendChild(div);
+
+			map = L.map(div).setView([0, 0], 2);
+		});
+
+		afterEach(function () {
+			map = null;
+			div = null;
+		});
+
+		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
+		testCrossOriginValue(undefined, null); // Falsy value (other than empty string '') => no attribute set.
+		testCrossOriginValue(true, '');
+		testCrossOriginValue('anonymous', 'anonymous');
+		testCrossOriginValue('use-credentials', 'use-credentials');
+
+		function testCrossOriginValue(crossOrigin, expectedValue) {
+			it('uses crossOrigin value ' + crossOrigin, function () {
+				var layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+					crossOrigin: crossOrigin
+				}).addTo(map);
+
+				eachImg(layer, function (img) {
+					expect(img.getAttribute('crossorigin')).to.be(expectedValue);
+				});
+			});
+		}
 	});
 });


### PR DESCRIPTION
Hi,

This PR follows PR https://github.com/Leaflet/Leaflet/pull/6016 which enables passing a string value to ImageOverlay and TileLayer's `crossOrigin` option.

There are 4 tests for each class, to test the typical values, i.e.:
- no value passed / `false` (default) => no `crossorigin` attribute
- `crossOrigin: true` => `crossorigin=""`
- `crossOrigin: 'anonymous'` => `crossorigin="anonymous"`
- `crossOrigin: 'use-credentials'` => `crossorigin="use-credentials"`