### PR TITLE
[GridLayer] Do not fire 'tileload' event if tile src is empty

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -455,4 +455,27 @@ describe('TileLayer', function () {
 			});
 		}
 	});
+
+	describe('#setUrl', function () {
+		it('fires only one load event', function (done) {
+			var layer = L.tileLayer(placeKitten).addTo(map);
+			var counts = {
+				load: 0,
+				tileload: 0
+			};
+			map.setView([0, 0], 1);
+
+			layer.on('tileload load', function (e) {
+				counts[e.type]++;
+			});
+
+			layer.setUrl(placeKitten);
+
+			setTimeout(function () {
+				expect(counts.load).to.equal(1);
+				expect(counts.tileload).to.equal(8);
+				done();
+			}, 250);
+		});
+	});
 });

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -842,7 +842,7 @@ export var GridLayer = Layer.extend({
 	},
 
 	_tileReady: function (coords, err, tile) {
-		if (!this._map) { return; }
+		if (!this._map || tile.getAttribute('src') === Util.emptyImageUrl) { return; }
 
 		if (err) {
 			// @event tileerror: TileErrorEvent


### PR DESCRIPTION
Fixes #6014

In #5615 were added lines:
https://github.com/Leaflet/Leaflet/blob/2dc70945f834b7c4f50d353c166c5190a751beca/src/layer/tile/GridLayer.js#L774-L776

Setting `src` to `emptyImageUrl` causes firing `tileload` event, which is the root of problem in #6014.

This PR adds additional check for tile's src to determine if it's empty or not.