### PR TITLE
Test(ImageOverlay+TileLayer): crossOrigin option add 5th test case

### DIFF
--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -168,6 +168,7 @@ describe('ImageOverlay', function () {
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
 		testCrossOriginValue(undefined, null); // Falsy value (other than empty string '') => no attribute set.
 		testCrossOriginValue(true, '');
+		testCrossOriginValue('', '');
 		testCrossOriginValue('anonymous', 'anonymous');
 		testCrossOriginValue('use-credentials', 'use-credentials');
 

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -440,6 +440,7 @@ describe('TileLayer', function () {
 		// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-settings-attributes
 		testCrossOriginValue(undefined, null); // Falsy value (other than empty string '') => no attribute set.
 		testCrossOriginValue(true, '');
+		testCrossOriginValue('', '');
 		testCrossOriginValue('anonymous', 'anonymous');
 		testCrossOriginValue('use-credentials', 'use-credentials');
 


### PR DESCRIPTION
Hi,

Following PR #6022, this PR adds a 5th test case for both ImageOverlay and TileLayer classes.

When passing `crossOrigin: ''` (empty string) option, the `crossorigin` attribute should also be set an empty string value (valid keyword, with same effect as `"anonymous"` value).

Need to add this test, because in JavaScript the empty string is a falsy value that could have been caught as `false` and led to no `crossorigin` attribute set.