### PR TITLE
Fix DomEvent.off() Not Removing Events When Calling with One Argument

### DIFF
--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -79,6 +79,45 @@ describe('DomEvent', function () {
 			expect(listener.called).to.not.be.ok();
 		});
 
+		it('only removes the specified listener', function () {
+			var listenerA = sinon.spy(),
+			listenerB = sinon.spy();
+
+			L.DomEvent.addListener(el, 'click', listenerA);
+			L.DomEvent.addListener(el, 'click', listenerB);
+			L.DomEvent.removeListener(el, 'click', listenerA);
+
+			simulateClick(el);
+
+			expect(listenerA.called).to.not.be.ok();
+			expect(listenerB.called).to.be.ok();
+		});
+
+		it('removes all listeners when only passed the HTMLElement', function () {
+			var listenerA = sinon.spy(),
+			listenerB = sinon.spy();
+
+			L.DomEvent.addListener(el, 'click', listenerA);
+			L.DomEvent.addListener(el, 'click', listenerB, {});
+			L.DomEvent.removeListener(el);
+
+			simulateClick(el);
+
+			expect(listenerA.called).to.not.be.ok();
+			expect(listenerB.called).to.not.be.ok();
+		});
+
+		it('removes listener when passed an event map', function () {
+			var listener = sinon.spy();
+
+			L.DomEvent.addListener(el, 'click', listener);
+			L.DomEvent.removeListener(el, {'click': listener});
+
+			simulateClick(el);
+
+			expect(listener.called).to.not.be.ok();
+		});
+
 		it('is chainable', function () {
 			var res = L.DomEvent.removeListener(el, 'click', function () {});
 			expect(res.removeListener).to.be.a('function');

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -61,7 +61,7 @@ export function off(obj, types, fn, context) {
 		}
 	} else {
 		for (var j in obj[eventsKey]) {
-			removeOne(obj, j, obj[eventsKey][j]);
+			removeOne(obj, j);
 		}
 		delete obj[eventsKey];
 	}
@@ -122,9 +122,14 @@ function addOne(obj, type, fn, context) {
 }
 
 function removeOne(obj, type, fn, context) {
-
-	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : ''),
-	    handler = obj[eventsKey] && obj[eventsKey][id];
+	var id;
+	if (!fn) {
+		id = type;
+		type = type.split(/\d/)[0];
+	} else {
+		id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : '');
+	}
+	var handler = obj[eventsKey] && obj[eventsKey][id];
 
 	if (!handler) { return this; }
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -47,6 +47,10 @@ var eventsKey = '_leaflet_events';
 // @alternative
 // @function off(el: HTMLElement, eventMap: Object, context?: Object): this
 // Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
+
+// @alternative
+// @function off(el: HTMLElement): this
+// Removes all known event listeners
 export function off(obj, types, fn, context) {
 
 	if (typeof types === 'object') {


### PR DESCRIPTION
fixes #6013 

`removeOne()` uses the original function to get the id for the wrapper handler attached to the object. When calling `off()` with only one argument, we don't have the original function, but we do have `type` which will be equal to the id (`type, stamp, context`) as a string. It may make more sense to pull this logic up out of `removeOne()`, but I wasn't sure how to do that without changing a lot of code.