### PR TITLE
Fix removing canvas bug (#6030)

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -190,3 +190,49 @@ describe('Canvas', function () {
 	});
 
 });
+
+describe('Canvas remove', function () {
+
+	var c;
+
+	before(function () {
+		c = document.createElement('div');
+		c.style.width = '400px';
+		c.style.height = '400px';
+		c.style.position = 'absolute';
+		c.style.top = '0';
+		c.style.left = '0';
+		document.body.appendChild(c);
+	});
+
+	after(function () {
+		document.body.removeChild(c);
+	});
+
+	function createCanvasMap(c, options) {
+		var map = new L.Map(c, options);
+		map.setView([0, 0], 6);
+		var p2ll = function (x, y) {
+			return map.layerPointToLatLng([x, y]);
+		};
+		var latLngs = [p2ll(0, 0), p2ll(0, 100), p2ll(100, 100), p2ll(100, 0)];
+		var layer = L.polygon(latLngs).addTo(map);
+		return map;
+	}
+
+	it("can remove the map without errors", function (done) {
+		var map1 = createCanvasMap(c, {preferCanvas: true, zoomControl: false});
+		map1.remove();
+		L.Util.requestAnimFrame(function () { done(); });
+	});
+
+	it("can remove renderer without errors", function (done) {
+		var canvas = L.canvas();
+		var map = createCanvasMap(c, {renderer: canvas, zoomControl: false});
+		canvas.remove();
+		map.remove();
+		L.Util.requestAnimFrame(function () { done(); });
+	});
+
+});
+

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -68,6 +68,7 @@ export var Canvas = Renderer.extend({
 	},
 
 	_destroyContainer: function () {
+		Util.cancelAnimFrame(this._redrawRequest);
 		delete this._ctx;
 		DomUtil.remove(this._container);
 		DomEvent.off(this._container);


### PR DESCRIPTION
Cancel animation frame before removing the map.
This fixes the bug where the the delayed call to _redraw is trying to get the drawing context which has already been destroyed.