### PR TITLE
Improving the projection of video by setting videoElement style

### DIFF
--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -34,9 +34,10 @@ export var VideoOverlay = ImageOverlay.extend({
 		// Whether the video will loop back to the beginning when played.
 		loop: true,
 
-		// @option saveAspectRatio: Boolean = true
+		// @option keepAspectRatio: Boolean = true
 		// Whether the video will save aspect ratio after the projection.
-		saveAspectRatio: true
+		// Relevant for supported browsers. Browser compatibility- https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+		keepAspectRatio: true
 	},
 
 	_initImage: function () {
@@ -66,7 +67,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
-		if (!this.options.saveAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
+		if (!this.options.keepAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -62,6 +62,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
+		vid.style['objectFit'] = 'fill';
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -32,7 +32,11 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		// @option loop: Boolean = true
 		// Whether the video will loop back to the beginning when played.
-		loop: true
+		loop: true,
+
+		// @option saveAspectRatio: Boolean = true
+		// Whether the video will save aspect ratio after the projection.
+		saveAspectRatio: true
 	},
 
 	_initImage: function () {
@@ -62,7 +66,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
-		vid.style['objectFit'] = 'fill';
+		if (!this.options.saveAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {


### PR DESCRIPTION
Video element by default saves on its ratio. So, when it is projected on the map, it still save on its ratio, and the projection not always precise. I changed the style of the video element in order to enable the element not to save on the ratio on the video. 

I attached example on projection before my commit and after.

![before commit](https://user-images.githubusercontent.com/11555001/35727543-2009f9ca-0811-11e8-8433-e719c8e64e76.JPG)
![after commit](https://user-images.githubusercontent.com/11555001/35727562-2d81388e-0811-11e8-8909-7c2fe14844ba.JPG)




