### PR TITLE
Fix(MarkerDrag): get rid of L.DomUtil calls

### DIFF
--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -67,7 +67,7 @@ export var MarkerDrag = Handler.extend({
 		    map = marker._map,
 		    speed = this._marker.options.autoPanSpeed,
 		    padding = this._marker.options.autoPanPadding,
-		    iconPos = L.DomUtil.getPosition(marker._icon),
+		    iconPos = DomUtil.getPosition(marker._icon),
 		    bounds = map.getPixelBounds(),
 		    origin = map.getPixelOrigin();
 
@@ -91,7 +91,7 @@ export var MarkerDrag = Handler.extend({
 			this._draggable._newPos._add(movement);
 			this._draggable._startPos._add(movement);
 
-			L.DomUtil.setPosition(marker._icon, this._draggable._newPos);
+			DomUtil.setPosition(marker._icon, this._draggable._newPos);
 			this._onDrag(e);
 
 			this._panRequest = requestAnimFrame(this._adjustPan.bind(this, e));

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -123,7 +123,7 @@ export var MarkerDrag = Handler.extend({
 	_onDrag: function (e) {
 		var marker = this._marker,
 		    shadow = marker._shadow,
-		iconPos = DomUtil.getPosition(marker._icon),
+		    iconPos = DomUtil.getPosition(marker._icon),
 		    latlng = marker._map.layerPointToLatLng(iconPos);
 
 		// update shadow position


### PR DESCRIPTION
Hi,

This simple PR removes calls to global `L.DomUtil` so that `MarkerDrag` is consistent with ES imports and relies on imported `DomUtil` module.

The `L.DomUtil` references have been introduced by PR https://github.com/Leaflet/Leaflet/pull/5651.