### PR TITLE
Fix(TileLayer.WMS & Canvas): get rid of calls to global L

### DIFF
--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -109,7 +109,7 @@ export var TileLayerWMS = TileLayer.extend({
 		    bbox = (this._wmsVersion >= 1.3 && this._crs === EPSG4326 ?
 		    [min.y, min.x, max.y, max.x] :
 		    [min.x, min.y, max.x, max.y]).join(','),
-		url = L.TileLayer.prototype.getTileUrl.call(this, coords);
+		    url = TileLayer.prototype.getTileUrl.call(this, coords);
 		return url +
 			getParamString(this.wmsParams, url, this.options.uppercase) +
 			(this.options.uppercase ? '&BBOX=' : '&bbox=') + bbox;

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -163,7 +163,7 @@ export var Canvas = Renderer.extend({
 
 		delete layer._order;
 
-		delete this._layers[L.stamp(layer)];
+		delete this._layers[Util.stamp(layer)];
 
 		this._requestRedraw(layer);
 	},


### PR DESCRIPTION
This simple PR is similar to https://github.com/Leaflet/Leaflet/pull/6047.

It gets rid of leftover calls to global `L`:
- in TileLayer.WMS: the global call had been introduced by PR https://github.com/Leaflet/Leaflet/pull/5618.
- in Canvas: introduced by PR https://github.com/Leaflet/Leaflet/pull/5115, while the PR https://github.com/Leaflet/Leaflet/pull/4989 that switched to ES6 was in process.

These should be the last references to global `L`, apart from `L.Mixin` in [`checkDeprecatedMixinEvents`](https://github.com/Leaflet/Leaflet/blob/v1.3.1/src/core/Class.js#L114-L126) of `Class`, which refers to it on purpose.