### PR TITLE
update Map.Keyboard.js

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -79,7 +79,7 @@ export var Keyboard = Handler.extend({
 
 		var body = document.body,
 		    docEl = document.documentElement,
-		    top = body.scrollTop || docEl.scrollTop,
+		    top = body.scrollTop || docEl.scrollTop || window.pageYOffset,
 		    left = body.scrollLeft || docEl.scrollLeft;
 
 		this._map._container.focus();


### PR DESCRIPTION
In chrome when using 100% height or for some reason left = body.scrollLeft || docEl.scrollLeft return 0 by adding window.pageYOffset  it return the exact value