### PR TITLE
Fix(Draggable): compensate for container CSS scale

### DIFF
--- a/debug/map/map-scaled.html
+++ b/debug/map/map-scaled.html
@@ -10,11 +10,21 @@
 	<link rel="stylesheet" href="../css/screen.css" />
 
 	<style>
+		html, body {
+			margin: 0;
+			padding: 0;
+		}
+		#wrapper {
+			transform: scale(.5, .25); /* scaleX0 = .5 ; scaleY0 = .25 */
+			transform-origin: 0 0;
+			padding: 40px 100px; /* displayed padding-top = scaleY0 * 40px = 10px ; displayed padding-left = scaleX0 * 100px = 50px */
+		}
 		#map {
 			width: 400px;
 			height: 300px;
-			transform: scale(1.5, 1.5);
+			transform: scale(3, 8); /* scaleX = .5 * 3 = 1.5 ; scaleY = .25 * 8 = 2 */
 			transform-origin: 0 0;
+			border-width: 30px 70px; /* displayed border-top-width = scaleY * 30px = 60px ; displayed border-left-width = scaleX * 70px = 105px */
 		}
 	</style>
 
@@ -22,7 +32,9 @@
 </head>
 <body>
 
-	<div id="map"></div>
+	<div id="wrapper">
+		<div id="map"></div>
+	</div>
 
 	<script>
 
@@ -33,6 +45,21 @@
 		var map = L.map('map')
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
+
+		var mapContainer = map.getContainer();
+
+		var marker = L.marker([50.5, 30.51], {
+			draggable: true
+		}).addTo(map);
+
+		map.on('drag', function (event) {
+			console.log('map:');
+			console.log(L.DomEvent.getMousePosition(event.originalEvent, mapContainer));
+		});
+		marker.on('drag', function (event) {
+			console.log('marker:');
+			console.log(L.DomEvent.getMousePosition(event.originalEvent, mapContainer));
+		});
 	</script>
 </body>
 </html>

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -86,7 +86,7 @@ describe("Marker.Drag", function () {
 				var toucher = hand.growFinger('mouse');
 
 				toucher.wait(100).moveTo(scaleX * 300, scaleY * 280, 0)
-					.down().moveBy(scaleX * 5, scaleY * 0, 20).moveBy(scaleX * 256, scaleY * 32, 1000).wait(100).up().wait(100);
+					.down().moveBy(5, 0, 20).moveBy(scaleX * 256, scaleY * 32, 1000).wait(100).up().wait(100);
 			});
 		});
 

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -46,6 +46,50 @@ describe("Marker.Drag", function () {
 				.down().moveBy(5, 0, 20).moveBy(256, 32, 1000).wait(100).up().wait(100);
 		});
 
+		describe("in CSS scaled container", function () {
+			var scaleX = 2;
+			var scaleY = 1.5;
+
+			beforeEach(function () {
+				div.style.webkitTransformOrigin = 'top left';
+				div.style.webkitTransform = 'scale(' + scaleX + ', ' + scaleY + ')';
+			});
+
+			afterEach(function () {
+				div.style.webkitTransformOrigin = '';
+				div.style.webkitTransform = '';
+			});
+
+			it("drags a marker with mouse, compensating for CSS scale", function (done) {
+				var marker = new L.Marker([0, 0], {
+					draggable: true
+				});
+				map.addLayer(marker);
+
+				var hand = new Hand({
+					timing: 'fastframe',
+					onStop: function () {
+						var center = map.getCenter();
+						expect(center.lat).to.be(0);
+						expect(center.lng).to.be(0);
+
+						var markerPos = marker.getLatLng();
+						// Marker drag is very timing sensitive, so we can't check
+						// exact values here, just verify that the drag is in the
+						// right ballpark
+						expect(markerPos.lat).to.be.within(-50, -30);
+						expect(markerPos.lng).to.be.within(340, 380);
+
+						done();
+					}
+				});
+				var toucher = hand.growFinger('mouse');
+
+				toucher.wait(100).moveTo(scaleX * 300, scaleY * 280, 0)
+					.down().moveBy(scaleX * 5, scaleY * 0, 20).moveBy(scaleX * 256, scaleY * 32, 1000).wait(100).up().wait(100);
+			});
+		});
+
 		it("pans map when autoPan is enabled", function (done) {
 			var marker = new L.Marker([0, 0], {
 				draggable: true,

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -114,10 +114,10 @@ describe("Map.Drag", function () {
 				});
 				var mouse = hand.growFinger('mouse');
 
-				// We move scaleX * 5 pixels first to overcome the 3-pixel threshold of
+				// We move 5 pixels first to overcome the 3-pixel threshold of
 				// L.Draggable.
 				mouse.wait(100).moveTo(200, 200, 0)
-					.down().moveBy(scaleX * 5, scaleY * 0, 20).moveBy(scaleX * 256, scaleY * 32, 200).up();
+					.down().moveBy(5, 0, 20).moveBy(scaleX * 256, scaleY * 32, 200).up();
 			});
 		});
 

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -79,6 +79,48 @@ describe("Map.Drag", function () {
 				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
 		});
 
+		describe("in CSS scaled container", function () {
+			var scaleX = 2;
+			var scaleY = 1.5;
+
+			beforeEach(function () {
+				container.style.webkitTransformOrigin = 'top left';
+				container.style.webkitTransform = 'scale(' + scaleX + ', ' + scaleY + ')';
+			});
+
+			afterEach(function () {
+				container.style.webkitTransformOrigin = '';
+				container.style.webkitTransform = '';
+			});
+
+			it("change the center of the map, compensating for CSS scale", function (done) {
+				var map = new L.Map(container, {
+				    dragging: true,
+				    inertia: false
+				});
+				map.setView([0, 0], 1);
+
+				var hand = new Hand({
+					timing: 'fastframe',
+					onStop: function () {
+						var center = map.getCenter();
+						var zoom = map.getZoom();
+						expect(center.lat).to.be.within(21.9430, 21.9431);
+						expect(center.lng).to.be(-180);
+						expect(zoom).to.be(1);
+
+						done();
+					}
+				});
+				var mouse = hand.growFinger('mouse');
+
+				// We move scaleX * 5 pixels first to overcome the 3-pixel threshold of
+				// L.Draggable.
+				mouse.wait(100).moveTo(200, 200, 0)
+					.down().moveBy(scaleX * 5, scaleY * 0, 20).moveBy(scaleX * 256, scaleY * 32, 200).up();
+			});
+		});
+
 		it("does not change the center of the map when mouse is moved less than the drag threshold", function (done) {
 			var map = new L.Map(container, {
 				dragging: true,

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -225,8 +225,11 @@ export function getMousePosition(e, container) {
 	var scaleX = rect.width / container.offsetWidth || 1;
 	var scaleY = rect.height / container.offsetHeight || 1;
 	return new Point(
-		e.clientX / scaleX - rect.left - container.clientLeft,
-		e.clientY / scaleY - rect.top - container.clientTop);
+		// rect.left/top values are in page scale (like clientX/Y),
+		// whereas clientLeft/Top (border width) values are the original values (before CSS scale applies).
+		(e.clientX - rect.left) / scaleX - container.clientLeft,
+		(e.clientY - rect.top) / scaleY - container.clientTop
+	);
 }
 
 // Chrome on Win scrolls double the pixels as in other platforms (see #4538),

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -214,7 +214,7 @@ export function stop(e) {
 
 // @function getMousePosition(ev: DOMEvent, container?: HTMLElement): Point
 // Gets normalized mouse position from a DOM event relative to the
-// `container` or to the whole page if not specified.
+// `container` (border excluded) or to the whole page if not specified.
 export function getMousePosition(e, container) {
 	if (!container) {
 		return new Point(e.clientX, e.clientY);

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -3,6 +3,7 @@ import * as Util from '../core/Util';
 import * as Browser from '../core/Browser';
 import {addPointerListener, removePointerListener} from './DomEvent.Pointer';
 import {addDoubleTapListener, removeDoubleTapListener} from './DomEvent.DoubleTap';
+import {getScale} from './DomUtil';
 
 /*
  * @namespace DomEvent
@@ -220,15 +221,14 @@ export function getMousePosition(e, container) {
 		return new Point(e.clientX, e.clientY);
 	}
 
-	var rect = container.getBoundingClientRect();
+	var scale = getScale(container),
+	    offset = scale.boundingClientRect; // left and top  values are in page scale (like the event clientX/Y)
 
-	var scaleX = rect.width / container.offsetWidth || 1;
-	var scaleY = rect.height / container.offsetHeight || 1;
 	return new Point(
-		// rect.left/top values are in page scale (like clientX/Y),
+		// offset.left/top values are in page scale (like clientX/Y),
 		// whereas clientLeft/Top (border width) values are the original values (before CSS scale applies).
-		(e.clientX - rect.left) / scaleX - container.clientLeft,
-		(e.clientY - rect.top) / scaleY - container.clientTop
+		(e.clientX - offset.left) / scale.x - container.clientLeft,
+		(e.clientY - offset.top) / scale.y - container.clientTop
 	);
 }
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -319,3 +319,12 @@ export function restoreOutline() {
 	_outlineStyle = undefined;
 	DomEvent.off(window, 'keydown', restoreOutline);
 }
+
+// @function getSizedParentNode(el: HTMLElement)
+// Finds the closest parent node which size (width and height) is not null.
+export function getSizedParentNode(element) {
+	do {
+		element = element.parentNode;
+	} while ((!element.offsetWidth || !element.offsetHeight) && element !== document.body);
+	return element;
+}

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -328,3 +328,17 @@ export function getSizedParentNode(element) {
 	} while ((!element.offsetWidth || !element.offsetHeight) && element !== document.body);
 	return element;
 }
+
+// @function getScale(el: HTMLElement): Object
+// Computes the CSS scale currently applied on the element.
+// Returns an object with `x` and `y` members as horizontal and vertical scales respectively,
+// and `boundingClientRect` as the result of [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
+export function getScale(element) {
+	var rect = element.getBoundingClientRect(); // Read-only in old browsers.
+
+	return {
+		x: rect.width / element.offsetWidth || 1,
+		y: rect.height / element.offsetHeight || 1,
+		boundingClientRect: rect
+	};
+}

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -320,7 +320,7 @@ export function restoreOutline() {
 	DomEvent.off(window, 'keydown', restoreOutline);
 }
 
-// @function getSizedParentNode(el: HTMLElement)
+// @function getSizedParentNode(el: HTMLElement): HTMLElement
 // Finds the closest parent node which size (width and height) is not null.
 export function getSizedParentNode(element) {
 	do {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -3,7 +3,6 @@ import * as Browser from '../core/Browser';
 import * as DomEvent from './DomEvent';
 import * as DomUtil from './DomUtil';
 import * as Util from '../core/Util';
-import {Point} from '../geometry/Point';
 
 /*
  * @class Draggable
@@ -112,9 +111,12 @@ export var Draggable = Evented.extend({
 		// Fired when a drag is about to start.
 		this.fire('down');
 
-		var first = e.touches ? e.touches[0] : e;
+		var first = e.touches ? e.touches[0] : e,
+		    sizedParent = DomUtil.getSizedParentNode(this._element);
 
-		this._startPoint = new Point(first.clientX, first.clientY);
+		// The re-positioning will be affected by CSS scale.
+		// In order to re-position as per the user drag, make sure all point measurements compensate for this scale.
+		this._startPoint = DomEvent.getMousePosition(first, sizedParent);
 
 		DomEvent.on(document, MOVE[e.type], this._onMove, this);
 		DomEvent.on(document, END[e.type], this._onUp, this);
@@ -134,7 +136,8 @@ export var Draggable = Evented.extend({
 		}
 
 		var first = (e.touches && e.touches.length === 1 ? e.touches[0] : e),
-		    newPoint = new Point(first.clientX, first.clientY),
+		    sizedParent = DomUtil.getSizedParentNode(this._element),
+		    newPoint = DomEvent.getMousePosition(first, sizedParent),
 		    offset = newPoint.subtract(this._startPoint);
 
 		if (!offset.x && !offset.y) { return; }


### PR DESCRIPTION
Closes #5997 as replacement PR.
Fixes #6001, fixes #6002.

As done by #5997, this PR patches `Draggable` class so that it measures the user drag through `DomEvent.getMousePosition` instead of directly reading the `event.clientX` / `event.clientY` values, and we get a chance to compensate for the container CSS scale.

In order to avoid having to explicitly cache some map container, `Draggable` automatically looks for the `_element`'s closest parent node with a non null size, using a new `DomUtil.getSizedParentNode` function. This way, the scale computation can determine the value that applies on the `container` (an edge case is when some skipped intermediate parent nodes - with null size - also apply a CSS scale).

Added 2 dedicated test suites for the Map Drag and Marker Drag.
Also modified the `map-scaled.html` debug page to test both features more easily.