### PR TITLE
Make L.Class.Include() extends the options of the prototype instead of replacing them

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -84,7 +84,7 @@ describe("Class", function () {
 			expect(a.mixin2).to.be.ok();
 		});
 
-		it("merges options instead of replacing them", function () {
+		it("extend()ing merges options instead of replacing them", function () {
 			var KlassWithOptions1 = L.Class.extend({
 				options: {
 					foo1: 1,
@@ -99,6 +99,26 @@ describe("Class", function () {
 			});
 
 			var a = new KlassWithOptions2();
+			expect(a.options.foo1).to.eql(1);
+			expect(a.options.foo2).to.eql(3);
+			expect(a.options.foo3).to.eql(4);
+		});
+
+		it("include()ing merges options instead of replacing them", function () {
+			var KlassWithOptions = L.Class.extend({
+				options: {
+					foo1: 1,
+					foo2: 2
+				}
+			});
+			KlassWithOptions.include({
+				options: {
+					foo2: 3,
+					foo3: 4
+				}
+			});
+
+			var a = new KlassWithOptions();
 			expect(a.options.foo1).to.eql(1);
 			expect(a.options.foo2).to.eql(3);
 			expect(a.options.foo3).to.eql(4);

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -86,7 +86,14 @@ Class.extend = function (props) {
 // @function include(properties: Object): this
 // [Includes a mixin](#class-includes) into the current class.
 Class.include = function (props) {
+	var options;
+	if (props.options) {
+		options = Util.extend({}, this.prototype.options, props.options);
+	}
 	Util.extend(this.prototype, props);
+	if (options) {
+		this.prototype.options = options;
+	}
 	return this;
 };
 


### PR DESCRIPTION
Fixes #6070. Includes unit test.