### PR TITLE
Update ssri to 5.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rollup-watch": "^4.3.1",
     "sinon": "^1.6.0",
     "source-map": "^0.5.6",
-    "ssri": "^4.1.2",
+    "ssri": "^5.2.2",
     "uglify-js": "~3.0.26"
   },
   "main": "dist/leaflet-src.js",


### PR DESCRIPTION
Update `ssri` due to potential security vulnerability.
See https://nvd.nist.gov/vuln/detail/CVE-2018-7651 for details.