### PR TITLE
Add zoomOffset option to fitBounds

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -257,6 +257,9 @@ export var Map = Evented.extend({
 
 		    zoom = this.getBoundsZoom(bounds, false, paddingTL.add(paddingBR));
 
+		if (typeof options.zoomOffset === 'number') {
+			zoom += options.zoomOffset;
+		}
 		zoom = (typeof options.maxZoom === 'number') ? Math.min(options.maxZoom, zoom) : zoom;
 
 		if (zoom === Infinity) {

--- a/src/map/Map.methodOptions.leafdoc
+++ b/src/map/Map.methodOptions.leafdoc
@@ -105,4 +105,7 @@ Equivalent of setting both top left and bottom right padding to the same value.
 @option maxZoom: Number = null
 The maximum possible zoom to use.
 
+@option zoomOffset: Number = null
+The zoom level will be offset by this value, eg. use -1 to zoom out after
+setting the view to fit bounds.
 


### PR DESCRIPTION
Add an option to offset the zoom level after `fitBounds` - I feel like it's common use case to want to fit the bounds and then zoom out.

I've had some trouble calling `map.zoomOut()` right after `fitBounds`, even when disabling the animation (eg, tiles not loaded, marker positions are wrong...) and thought it would just be better to add this as an option to `fitBounds`.

Let me know what you think