### PR TITLE
tooltips will display directly from tooltipAnchor in a marker

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -149,7 +149,7 @@ describe('Tooltip', function () {
 
 		layer.bindTooltip('A tooltip that should be displayed on the center', {permanent: true, direction: 'center', interactive: true});
 		expect(map.hasLayer(layer._tooltip)).to.be(true);
-		happen.at('click', 150, 180);  // Marker is on the map center, which is 400px large.
+		happen.at('click', 200, 180);  // Marker is on the map center, which is 400px large.
 		expect(spy.calledOnce).to.be(true);
 	});
 
@@ -288,4 +288,3 @@ describe('Tooltip', function () {
 	});
 
 });
-

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -132,7 +132,8 @@ export var Tooltip = DivOverlay.extend({
 	_adjustPan: function () {},
 
 	_setPosition: function (pos) {
-		var map = this._map,
+		var addX, addY,
+		    map = this._map,
 		    container = this._container,
 		    centerPoint = map.latLngToContainerPoint(map.getCenter()),
 		    tooltipPoint = map.layerPointToContainerPoint(pos),
@@ -143,18 +144,24 @@ export var Tooltip = DivOverlay.extend({
 		    anchor = this._getAnchor();
 
 		if (direction === 'top') {
-			pos = pos.add(toPoint(-tooltipWidth / 2 + offset.x, -tooltipHeight + offset.y + anchor.y, true));
+			addX = -tooltipWidth / 2;
+			addY = -tooltipHeight + anchor.y - anchor.x;
 		} else if (direction === 'bottom') {
-			pos = pos.subtract(toPoint(tooltipWidth / 2 - offset.x, -offset.y, true));
+			addX = -tooltipWidth / 2;
+			addY = 0 + anchor.y + anchor.x;
 		} else if (direction === 'center') {
-			pos = pos.subtract(toPoint(tooltipWidth / 2 + offset.x, tooltipHeight / 2 - anchor.y + offset.y, true));
+			addX = -tooltipWidth / 2;
+			addY = -tooltipHeight / 2;
 		} else if (direction === 'right' || direction === 'auto' && tooltipPoint.x < centerPoint.x) {
 			direction = 'right';
-			pos = pos.add(toPoint(offset.x + anchor.x, anchor.y - tooltipHeight / 2 + offset.y, true));
+			addX = 0 + anchor.x;
+			addY = -tooltipHeight / 2 + anchor.y;
 		} else {
 			direction = 'left';
-			pos = pos.subtract(toPoint(tooltipWidth + anchor.x - offset.x, tooltipHeight / 2 - anchor.y - offset.y, true));
+			addX = -tooltipWidth - anchor.x;
+			addY = -tooltipHeight / 2 + anchor.y;
 		}
+		pos = pos.add(toPoint(addX + offset.x, addY + offset.y, true));
 
 		DomUtil.removeClass(container, 'leaflet-tooltip-right');
 		DomUtil.removeClass(container, 'leaflet-tooltip-left');

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -26,7 +26,7 @@ export var IconDefault = Icon.extend({
 		iconSize:    [25, 41],
 		iconAnchor:  [12, 41],
 		popupAnchor: [1, -34],
-		tooltipAnchor: [16, -28],
+		tooltipAnchor: [0, -28],
 		shadowSize:  [41, 41]
 	},
 


### PR DESCRIPTION
Tooltips are not being displayed properly according to their direction and tooltipAnchor.

I am expecting all tooltips to be directly touching the tooltip anchor.

## Minimal example reproducing the issue

https://plnkr.co/edit/MkmbNqtfYrPiq8430CUs?p=preview
* First row shows the current setup, which I believe is wrong
* Second row shows the proposed setup.
* Third row shows a "tooltipPadding" around the anchor, which I believe is the desired behavior.

![screen shot 2018-04-03 at 2 14 08 pm](https://user-images.githubusercontent.com/93231/38267397-5f337696-3749-11e8-825e-b89ad112bce9.png)


I believe a core issue is stemming from overloading how tooltipAnchor is used and what it stands for.
* The x value is currently being used as "padding" from the anchor point
* while the y value is a true anchor point

I would even propose adding a `tooltipPadding` variable that is the dynamic offset away from the anchor given the tooltip direction.  This variable could be added or subtracted to the `addX` and `addY` depending on the direction.

I have removed the 16px from the default icon as it's a false value. It could be moved to default icon's `tooltipPadding` value.

