### PR TITLE
Fix for memory leak in canvas renderer

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -161,6 +161,8 @@ export var Canvas = Renderer.extend({
 			this._drawFirst = next;
 		}
 
+		delete this._drawnLayers[layer._leaflet_id];
+
 		delete layer._order;
 
 		delete this._layers[Util.stamp(layer)];


### PR DESCRIPTION
1. Use `canvas` renderer
2. Add polylines (40K for example)
3. Remove them and add a bunch of other polylines (once more 40K)

AR: Page memory usage almost doubled

The root of the bug is in `_drawnLayers` object in canvas renderer. References to layers removed everywhere except this place.