### PR TITLE
Apply #5498 for Polygons too

### DIFF
--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -155,7 +155,7 @@ export var Polygon = Polyline.extend({
 		var inside = false,
 		    part, p1, p2, i, j, k, len, len2;
 
-		if (!this._pxBounds.contains(p)) { return false; }
+		if (!this._pxBounds || !this._pxBounds.contains(p)) { return false; }
 
 		// ray casting algorithm for detecting if point is in polygon
 		for (i = 0, len = this._parts.length; i < len; i++) {


### PR DESCRIPTION
Extend the fix on #5498 to handle Polygons with empty arrays.