### PR TITLE
Add locks and logs to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ bower.json
 component.json
 debug/local/
 Gemfile.lock
+*lock*
+*.log


### PR DESCRIPTION
When new contributors run `npm install` or `yarn` in this project, they get corresponding lockfiles. If they get an error, they get `*.log` files.  Since Leaflet is a _library_, there's no reason to commit lockfiles to the repo. However, these files are not ignored, so newbie is gonna get something like this:

<img width="584" alt="screen shot 2018-04-06 at 20 59 25" src="https://user-images.githubusercontent.com/3459374/38436788-3dc9e886-39de-11e8-92da-bc13571c79e1.png">

This PR ignores `*.log`s and `*.lock`s, so newcomers cannot commit them.

P.S: Let me know if you prefer to use `.npmrc`.