### PR TITLE
Fix setStyle method for Circle class

### DIFF
--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,5 +1,4 @@
 import {CircleMarker} from './CircleMarker';
-import {Path} from './Path';
 import * as Util from '../../core/Util';
 import {toLatLng} from '../../geo/LatLng';
 import {LatLngBounds} from '../../geo/LatLngBounds';
@@ -63,7 +62,12 @@ export var Circle = CircleMarker.extend({
 			this._map.layerPointToLatLng(this._point.add(half)));
 	},
 
-	setStyle: Path.prototype.setStyle,
+	setStyle : function (options) {
+		var radius = options && options.radius || this._mRadius;
+		CircleMarker.prototype.setStyle.call(this, options);
+		this.setRadius(radius);
+		return this;
+	},
 
 	_project: function () {
 


### PR DESCRIPTION
The Circle class inherits from CircleMarker class, which has a `setStyle` method which sets the radius. There was no equivalent in Circle class (the `setStyle` method was the one from the Path class), so we couldn't set the Circle radius with the `setStyle` method