### PR TITLE
Fix for bad zoom center when zoomAnimation === false

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1131,8 +1131,6 @@ export var Map = Evented.extend({
 
 	// @section Map state change events
 	_resetView: function (center, zoom) {
-		DomUtil.setPosition(this._mapPane, new Point(0, 0));
-
 		var loading = !this._loaded;
 		this._loaded = true;
 		zoom = this._limitZoom(zoom);


### PR DESCRIPTION
I'm not 100% sure this is really safe but this fixes a part of issue #6099.
(Step to reproduce from a map with `{zoomAnimation:false}` with a scrollwheel mouse:
-press left button and perform some panning
-use the scrollwheel to change zoom while keeping left mouse button pressed

Then the new map center is not the expected map center.

This can also be seen with a touch device with a panning followed by a pinch zoom but it is easier to reproduce with a mouse.)