### PR TITLE
Fix typo in LatLng docstring.

### DIFF
--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -22,7 +22,7 @@ import {toLatLngBounds} from './LatLngBounds';
  * map.panTo(L.latLng(50, 30));
  * ```
  *
- * Note that `LatLng` does not inherit from Leafet's `Class` object,
+ * Note that `LatLng` does not inherit from Leaflet's `Class` object,
  * which means new classes can't inherit from it, and new methods
  * can't be added to it with the `include` function.
  */


### PR DESCRIPTION
Just noted this typo while reading the documentation.