### PR TITLE
Make _detectIconPath play nice with fingerprinting

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -52,7 +52,7 @@ export var IconDefault = Icon.extend({
 		if (path === null || path.indexOf('url') !== 0) {
 			path = '';
 		} else {
-			path = path.replace(/^url\(["']?/, '').replace(/marker-icon\.png["']?\)$/, '');
+			path = path.replace(/^url\(["']?/, '').replace(/marker-icon[^/]*\.png["']?\)$/, '');
 		}
 
 		return path;


### PR DESCRIPTION
This way `_detectIconPath` works correctly when the CSS was changed to e.g. `url(/foo/marker-icon-908e25f-hash.png)`, as is the case when using [Rails asset pipeline fingerprinting](http://guides.rubyonrails.org/asset_pipeline.html#what-is-fingerprinting-and-why-should-i-care-questionmark).

Test:

    > var path = "url(foo/bar/marker-icon-123asdf.png)"
    > path.replace(/^url\(["']?/, '').replace(/marker-icon[^/]*\.png["']?\)$/, '');
    "foo/bar/"
