### PR TITLE
get rid of focus for map container as it forces iframe scrolling in iOS

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -82,8 +82,6 @@ export var Keyboard = Handler.extend({
 		    top = body.scrollTop || docEl.scrollTop,
 		    left = body.scrollLeft || docEl.scrollLeft;
 
-		this._map._container.focus();
-
 		window.scrollTo(left, top);
 	},
 


### PR DESCRIPTION
Dealing with this bug: https://github.com/Leaflet/Leaflet/issues/5392
The issue here is that due to a bug in Webkit on iOS devices (both on Chrome and Safari) a focus() event for an element in an item that is already in viewport scrolls the parent to the bottom, which certainly is not a desired behaviour.