### PR TITLE
Fix error removing map and resizing window at the same time

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -732,6 +732,10 @@ export var Map = Evented.extend({
 		if (this._clearControlPos) {
 			this._clearControlPos();
 		}
+		if (this._resizeRequest) {
+			Util.cancelAnimFrame(this._resizeRequest);
+			this._resizeRequest = null;
+		}
 
 		this._clearHandlers();
 


### PR DESCRIPTION
Reproduction:
https://plnkr.co/edit/P7wG3BRrJE8hbDZ7DBOB?p=preview

Open this and resize the window.
The map gets removed in the resize event, and the map queues up an `invalidateSize()`
This results in this lovely stack trace:
![image](https://user-images.githubusercontent.com/393086/39953096-18bddc74-55f8-11e8-9e03-d88bf63fdd79.png)

(Found this while trying to get the leaflet.markercluster tests working again)

ref https://github.com/Leaflet/Leaflet/blob/master/src/map/Map.js#L1272-L1274