### PR TITLE
Added rotate check for setTransform function.

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -208,11 +208,16 @@ export function testProp(props) {
 export function setTransform(el, offset, scale) {
 	var pos = offset || new Point(0, 0);
 
+	//Here we need to get rotate value, if it exists, not rewrite it by new tranform value
+	var rotateRegexp = /(rotate)(\(.*(?:deg\)))/g; //regex to match rotateZ(...deg)
+	var rotate = rotateRegexp.exec(el.style[L.DomUtil.TRANSFORM]);
+
 	el.style[TRANSFORM] =
 		(Browser.ie3d ?
 			'translate(' + pos.x + 'px,' + pos.y + 'px)' :
 			'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
-		(scale ? ' scale(' + scale + ')' : '');
+			(rotate ? ' ' + rotate : '') +
+			(scale ? ' scale(' + scale + ')' : '');
 }
 
 // @function setPosition(el: HTMLElement, position: Point)

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -209,7 +209,7 @@ export function setTransform(el, offset, scale) {
 	var pos = offset || new Point(0, 0);
 
 	//Here we need to get rotate value, if it exists, not rewrite it by new tranform value
-	var rotateRegexp = /(rotate)(\(.*(?:deg\)))/g; //regex to match rotateZ(...deg)
+	var rotateRegexp = /(rotate.*)(\(.*(?:deg\)))/g; //regex to match rotate*(...deg)
 	var rotate = rotateRegexp.exec(el.style[L.DomUtil.TRANSFORM]);
 
 	el.style[TRANSFORM] =


### PR DESCRIPTION
Since Leaflet doesn't support rotation of marker I doing it manualy by changing transform property of markers. But in case of zoom leaflet rewrites transform property of objects. And it doesn`t check if it has rotate in it. So it removes it by adding only translate and scale to new transform value. 

I`ve added regex to check if it has rotate in it to add it to the new value. In this case rotate wouldn`t be losed.