### PR TITLE
docs(plugins): add defaulticon-compatibility plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3961,6 +3961,15 @@ Ease your development integrating Leaflet into a development framework or automa
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 	<tr>
 		<td>
+			<a href="https://github.com/ghybs/leaflet-defaulticon-compatibility">leaflet-defaulticon-compatibility</a>
+		</td><td>
+			Retrieve all Leaflet Default Icon options from CSS, in particular all icon images URL's, to improve compatibility with bundlers and frameworks that modify URL's in CSS. In particular for webpack (with style-, css-, file- and url-loader's), Rails Asset Pipeline and Django pipeline. Should solve all use cases linked to <a href="https://github.com/Leaflet/Leaflet/issues/4968">issue Leaflet/Leaflet #4968</a>. <a href="https://ghybs.github.io/leaflet-defaulticon-compatibility/webpack-demo.html">Demo with webpack</a> (and <a href="https://ghybs.github.io/leaflet-defaulticon-compatibility/webpack-demo.html?demo=no-plugin">without this plugin</a>).
+		</td><td>
+			<a href="https://github.com/ghybs">ghybs</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/moklick/generator-leaflet">Leaflet Yeoman Generator</a>
 		</td><td>
 			Yeoman generator that scaffolds out a basic Leaflet map application.


### PR DESCRIPTION
Hi,

This PR adds a new "[leaflet-defaulticon-compatibility](https://github.com/ghybs/leaflet-defaulticon-compatibility)" plugin to the PLUGINS page, in "[Frameworks & built systems](https://leafletjs.com/plugins.html#frameworks--build-systems)" section.

Added as first plugin in list, so that developers have less chance missing it, and since it is useful to many integrations.

This plugin is actually the code from PR https://github.com/Leaflet/Leaflet/pull/5771.
I thought exporting it as an external plugin instead of having it in core would be beneficial for "the majority" of users, while still providing an easy solution for developers with build systems that modify Leaflet CSS.

The idea is that the developers loads this plugin (CSS + JS) _after_ Leaflet, and the default icon works again automatically, no matter what happens to `url()`'s in CSS.
E.g. in webpack:
```javascript
import 'leaflet/dist/leaflet.css'
import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'
import * as L from 'leaflet'
import 'leaflet-defaulticon-compatibility'
```
([demo](https://ghybs.github.io/leaflet-defaulticon-compatibility/webpack-demo.html))

Close #5771, close #6154 (PR's).
Close #4968 (issue).

Let me know if you see other ways to address this issue.