### PR TITLE
test(Map): set div width for getBoundsZoom parameter inside, Firefox

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -224,6 +224,7 @@ describe("Map", function () {
 		it("respects the 'inside' parameter", function () {
 			var container = map.getContainer();
 			container.style.height = height;
+			container.style.width = '1024px'; // Make sure the width is defined for browsers other than PhantomJS (in particular Firefox).
 			document.body.appendChild(container);
 			expect(map.getBoundsZoom(wideBounds, false, padding)).to.be.equal(17);
 			expect(map.getBoundsZoom(wideBounds, true, padding)).to.be.equal(20);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -820,7 +820,7 @@ export var Map = Evented.extend({
 			this.options.maxZoom;
 	},
 
-	// @method getBoundsZoom(bounds: LatLngBounds, inside?: Boolean): Number
+	// @method getBoundsZoom(bounds: LatLngBounds, inside?: Boolean, padding?: Point): Number
 	// Returns the maximum zoom level on which the given bounds fit to the map
 	// view in its entirety. If `inside` (optional) is set to `true`, the method
 	// instead returns the minimum zoom level on which the map view fits into


### PR DESCRIPTION
Hi,

This PR fixes a small test issue when launched in a browser which default width is different than in PhantomJS.
In my case it was happening in Firefox (`npm run test-nolint -- --browsers Firefox`)