### PR TITLE
Canvas: allow reset of dashArray and allow array-type as option

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -187,7 +187,7 @@ export var Canvas = Renderer.extend({
 	},
 
 	_updateDashArray: function (layer) {
-		if (layer.options.dashArray) {
+		if (typeof layer.options.dashArray === 'string') {
 			var parts = layer.options.dashArray.split(','),
 			    dashArray = [],
 			    i;
@@ -195,6 +195,8 @@ export var Canvas = Renderer.extend({
 				dashArray.push(Number(parts[i]));
 			}
 			layer.options._dashArray = dashArray;
+		} else {
+			layer.options._dashArray = layer.options.dashArray;
 		}
 	},
 


### PR DESCRIPTION
A style update was not able to clear a dashed line.
Additional it allows to use an array for 'dashArray' in canvas mode too. 

The name 'dashArray' is misleading. I seen many developers assigning an array to it.
Since the SVG-Render doesn't care if it's an array or string (undocumented feature of 'SetAttribute'?) nobody even realize that this is wrong.


