### PR TITLE
Docs : Fix typo about zoomControl.

### DIFF
--- a/docs/reference-1.3.0.html
+++ b/docs/reference-1.3.0.html
@@ -17743,9 +17743,8 @@ styled according to the options.</p>
 	<tr id='control-zoom-zoomouttext'>
 		<td><code><b>zoomOutText</b></code></td>
 		<td><code>String</code>
-		<td><code>&#x27;&amp;#x2212</code></td>
-		<td>&#39;
-The text set on the &#39;zoom out&#39; button.</td>
+		<td><code>&#x27;&amp;#x2212&#x27;</code></td>
+		<td>The text set on the &#39;zoom out&#39; button.</td>
 	</tr>
 	<tr id='control-zoom-zoomouttitle'>
 		<td><code><b>zoomOutTitle</b></code></td>


### PR DESCRIPTION
Hello,

A little typo in the documentation of version 1.3.0/1.3.1.
The closing quote is in the wrong column.

It's my first pull request, is it ok ?

Bye !