### PR TITLE
Docs(GeoJSON): use link to official RFC 7946 GeoJSON spec

### DIFF
--- a/docs/examples/geojson/index.md
+++ b/docs/examples/geojson/index.md
@@ -5,17 +5,17 @@ title: Using GeoJSON with Leaflet
 
 <h3>Using GeoJSON with Leaflet</h3>
 
-<p>GeoJSON is becoming a very popular data format among many GIS technologies and services — it's simple, lightweight, straightforward, and Leaflet is quite good at handling it. In this example, you'll learn how to create and interact with map vectors created from <a href="http://geojson.org/">GeoJSON</a> objects.</p>
+<p>GeoJSON is becoming a very popular data format among many GIS technologies and services — it's simple, lightweight, straightforward, and Leaflet is quite good at handling it. In this example, you'll learn how to create and interact with map vectors created from <a href="https://tools.ietf.org/html/rfc7946">GeoJSON</a> objects.</p>
 
 {% include frame.html url="example.html" %}
 
 <h3>About GeoJSON</h3>
 
-<p>According to <a href="http://geojson.org">http://geojson.org</a>:</p>
+<p>According to <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Specification (RFC 7946)</a>:</p>
 
 <blockquote>GeoJSON is a format for encoding a variety of geographic data structures. A GeoJSON object may represent a geometry, a feature, or a collection of features. GeoJSON supports the following geometry types: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection. Features in GeoJSON contain a geometry object and additional properties, and a feature collection represents a list of features.</blockquote>
 
-<p>Leaflet supports all of the GeoJSON types above, but <a href="http://geojson.org/geojson-spec.html#feature-objects">Features</a> and <a href="http://geojson.org/geojson-spec.html#feature-collection-objects">FeatureCollections</a> work best as they allow you to describe features with a set of properties. We can even use these properties to style our Leaflet vectors. Here's an example of a simple GeoJSON feature:</p>
+<p>Leaflet supports all of the GeoJSON types above, but <a href="https://tools.ietf.org/html/rfc7946#section-3.2">Features</a> and <a href="https://tools.ietf.org/html/rfc7946#section-3.3">FeatureCollections</a> work best as they allow you to describe features with a set of properties. We can even use these properties to style our Leaflet vectors. Here's an example of a simple GeoJSON feature:</p>
 
 <pre><code>var geojsonFeature = {
 	"type": "Feature",

--- a/docs/examples/geojson/index.md
+++ b/docs/examples/geojson/index.md
@@ -13,7 +13,7 @@ title: Using GeoJSON with Leaflet
 
 <p>According to <a href="https://tools.ietf.org/html/rfc7946">GeoJSON Specification (RFC 7946)</a>:</p>
 
-<blockquote>GeoJSON is a format for encoding a variety of geographic data structures. A GeoJSON object may represent a geometry, a feature, or a collection of features. GeoJSON supports the following geometry types: Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection. Features in GeoJSON contain a geometry object and additional properties, and a feature collection represents a list of features.</blockquote>
+<blockquote>GeoJSON is a format for encoding a variety of geographic data structures […]. A GeoJSON object may represent a region of space (a Geometry), a spatially bounded entity (a Feature), or a list of Features (a FeatureCollection). GeoJSON supports the following geometry types: Point LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and GeometryCollection. Features in GeoJSON contain a Geometry object and additional properties, and a FeatureCollection contains a list of Features.</blockquote>
 
 <p>Leaflet supports all of the GeoJSON types above, but <a href="https://tools.ietf.org/html/rfc7946#section-3.2">Features</a> and <a href="https://tools.ietf.org/html/rfc7946#section-3.3">FeatureCollections</a> work best as they allow you to describe features with a set of properties. We can even use these properties to style our Leaflet vectors. Here's an example of a simple GeoJSON feature:</p>
 

--- a/docs/reference-1.0.0.html
+++ b/docs/reference-1.0.0.html
@@ -13598,7 +13598,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/docs/reference-1.0.2.html
+++ b/docs/reference-1.0.2.html
@@ -13893,7 +13893,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -13925,7 +13925,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/docs/reference-1.1.0.html
+++ b/docs/reference-1.1.0.html
@@ -14867,7 +14867,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/docs/reference-1.2.0.html
+++ b/docs/reference-1.2.0.html
@@ -14874,7 +14874,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/docs/reference-1.3.0.html
+++ b/docs/reference-1.3.0.html
@@ -14974,7 +14974,7 @@ GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>Fe
 	<tr id='geojson-l-geojson'>
 		<td><code><b>L.geoJSON</b>(<nobr>&lt;Object&gt;</nobr> <i>geojson?</i>, <nobr>&lt;<a href='#geojson-option'>GeoJSON options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td>Creates a GeoJSON layer. Optionally accepts an object in
-<a href="http://geojson.org/geojson-spec.html">GeoJSON format</a> to display on the map
+<a href="https://tools.ietf.org/html/rfc7946">GeoJSON format</a> to display on the map
 (you can alternatively add it later with <code>addData</code> method) and an <code>options</code> object.</td>
 	</tr>
 </tbody></table>

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -409,7 +409,7 @@ LayerGroup.include({
 // @namespace GeoJSON
 // @factory L.geoJSON(geojson?: Object, options?: GeoJSON options)
 // Creates a GeoJSON layer. Optionally accepts an object in
-// [GeoJSON format](http://geojson.org/geojson-spec.html) to display on the map
+// [GeoJSON format](https://tools.ietf.org/html/rfc7946) to display on the map
 // (you can alternatively add it later with `addData` method) and an `options` object.
 export function geoJSON(geojson, options) {
 	return new GeoJSON(geojson, options);


### PR DESCRIPTION
Hi,

This PR refactors documentation links to replace [geojson.org](http://geojson.org/) by [RFC 7946](https://tools.ietf.org/html/rfc7946) that was published in Aug 2016, as explained in https://sgillies.net/2016/08/11/rfc-7946-the-geojson-format.html

Since it was published even before Leaflet version 1.0.0 (Sep 2016), I propose to refactor all HTML doc pages from 1.0.0 onwards as well.

I also updated links in the GeoJSON [tutorial page](https://leafletjs.com/examples/geojson/) and the quote of the spec introduction.