### PR TITLE
Fix setTransform function for desktop webkit

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -208,8 +208,14 @@ export function testProp(props) {
 export function setTransform(el, offset, scale) {
 	var pos = offset || new Point(0, 0);
 
-	el.style[TRANSFORM] =
-		(Browser.ie3d ?
+	el.style.willChange = scale !== 1 ? 'auto' : 'transform';
+	el.style[L.DomUtil.TRANSFORM] =
+		// Based on https://github.com/Leaflet/Leaflet/pull/5354:
+		// We don't want to use `translate3d` for webkit since it causes the
+		// white lines issue (tile's gaps) while panning or zooming:
+		// https://bugs.chromium.org/p/chromium/issues/detail?id=600120#c15
+		// This issue does not appear on mobile devices.
+		(!Browser.mobile && (Browser.ie3d || Browser.webkit3d) ?
 			'translate(' + pos.x + 'px,' + pos.y + 'px)' :
 			'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
 		(scale ? ' scale(' + scale + ')' : '');


### PR DESCRIPTION
### Abstract

This PR solves an old (2016) and a common issue regarding gaps between the tiles :white_square_button: The following GIF proves that his fix already works: no gaps are appreciated.

![dark](https://user-images.githubusercontent.com/5215798/42044600-b62defdc-7af9-11e8-82c9-46b5fb7b1cdc.gif)

### History

I attach below the related tickets and pull requests regarding this issue, only inside Leaflet's repository (there are more tickets talking about the same issue in other projects that use Leaflet):

Tickets related:
- https://github.com/Leaflet/Leaflet/issues/3575
- https://github.com/Leaflet/Leaflet/issues/3339
- https://github.com/Leaflet/Leaflet/issues/1379
- https://github.com/Leaflet/Leaflet/issues/1066
- https://github.com/Leaflet/Leaflet/issues/5078

PRs related:
- https://github.com/Leaflet/Leaflet/pull/4941 (superseded)
- https://github.com/Leaflet/Leaflet/pull/5290 (superseded)
- https://github.com/Leaflet/Leaflet/pull/5354 (ignored)
- https://github.com/Leaflet/Leaflet/pull/5476

We see that these PRs https://github.com/Leaflet/Leaflet/pull/4941, https://github.com/Leaflet/Leaflet/pull/5290 tried to fix the issue but finally, they were superseded by this one https://github.com/Leaflet/Leaflet/pull/5476 that enabled the [Leaflet.TileLayer.NoGap](https://github.com/Leaflet/Leaflet.TileLayer.NoGap) plugin.

The problem is that this Leaflet.TileLayer.NoGap doesn't work at all. Only navigating in the git-tree you can find pseudo-working states. And there is another issue of that implementation: using a canvas for the transitions has a very bad performance.

### Solution

There was an ignored PR (https://github.com/Leaflet/Leaflet/pull/5354) closed in favour of the non-working TileLayer.NoGap plugin. The point is that this approach goes in the right direction to fix the issue and that's why this PR is based on that one.

This solution is based on using `translate` instead of `translate3d` in the transformation function.

A key difference implemented in this PR is that the bug is not happening in mobile devices so it shouldn't be fixed there. That's why the condition is `!mobile && (ie3d || webkit3d)`.

Final notes. We have this solution successfully working at CARTO, using a forked Leaflet, so it would be nice for us to move this forward and have the solution in the upstream, that will allow also other users with the same problem to benefit from it.

Thanks in advance!