### PR TITLE
On non-retina screens, round Draggable values to prevent bad subpixel rendering

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -185,7 +185,7 @@ export var Draggable = Evented.extend({
 		// Fired continuously during dragging *before* each corresponding
 		// update of the element's position.
 		this.fire('predrag', e);
-		DomUtil.setPosition(this._element, this._newPos);
+		DomUtil.setPosition(this._element, !Browser.retina ? this._newPos.round() : this._newPos);
 
 		// @event drag: Event
 		// Fired continuously during dragging.


### PR DESCRIPTION
This PR fixes the issue brought up by #6069 (and potentially #6232 #3297 as well) where dragging the map pane on a non-retina screen causes the map to become blurry. This is because the resulting CSS transform is using fractional values.

You can try a demo here: https://plnkr.co/edit/wmVxVPD6S7trPlaRDBF3?p=preview