### PR TITLE
Move set/getAttribute('src') calls from GridLayer into TileLayer

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -768,12 +768,6 @@ export var GridLayer = Layer.extend({
 		var tile = this._tiles[key];
 		if (!tile) { return; }
 
-		// Cancels any pending http requests associated with the tile
-		// unless we're on Android's stock browser,
-		// see https://github.com/Leaflet/Leaflet/issues/137
-		if (!Browser.androidStock) {
-			tile.el.setAttribute('src', Util.emptyImageUrl);
-		}
 		DomUtil.remove(tile.el);
 
 		delete this._tiles[key];
@@ -842,8 +836,6 @@ export var GridLayer = Layer.extend({
 	},
 
 	_tileReady: function (coords, err, tile) {
-		if (!this._map || tile.getAttribute('src') === Util.emptyImageUrl) { return; }
-
 		if (err) {
 			// @event tileerror: TileErrorEvent
 			// Fired when there is an error loading a tile.

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -235,6 +235,28 @@ export var TileLayer = GridLayer.extend({
 				}
 			}
 		}
+	},
+
+	_removeTile: function (key) {
+		var tile = this._tiles[key];
+		if (!tile) { return; }
+
+		// Cancels any pending http requests associated with the tile
+		// unless we're on Android's stock browser,
+		// see https://github.com/Leaflet/Leaflet/issues/137
+		if (!Browser.androidStock) {
+			tile.el.setAttribute('src', Util.emptyImageUrl);
+		}
+
+		return GridLayer.prototype._removeTile.call(this, key);
+	},
+
+	_tileReady: function (coords, err, tile) {
+		if (!this._map || (tile && tile.getAttribute('src') === Util.emptyImageUrl)) {
+			return;
+		}
+
+		return GridLayer.prototype._tileReady.call(this, coords, err, tile);
 	}
 });
 


### PR DESCRIPTION
This is a blind (meaning "I haven't tested this myself") attempt to fix #6245.

The idea is that any functionality that assumes that `tile` is an instance of `HTMLImageElement` (such as the `getAttribute('src')` calls) go into `TileLayer`. `GridLayer` only assumes that `tile`s are instances of `HTMLElement`. There is no reason to set the `src` attribute on something that is not an `HTMLImageElement`.

This also includes the proposed sanity check by @devinfluencer from https://github.com/Leaflet/Leaflet/issues/6245#issue-343077349 .