### PR TITLE
formatting fix to surface ImageOverlay.setZIndex() in documentation site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,10 +165,11 @@ If you need to make edits in a local repository to see how it looks in the proce
  1. [Install Ruby](http://www.ruby-lang.org/en/) if don't have it yet.
  2. Run `gem install jekyll`.
  3. Enter the directory where you cloned the Leaflet repository
- 4. Make sure you are in the `master` branch by running `git checkout master`
- 5. Enter the documentation subdirectory by running `cd docs`
- 6. Run `jekyll serve --watch`.
- 7. Open `localhost:4000` in your web browser.
+ 4. Run `bundle install`
+ 5. Make sure you are in the `master` branch by running `git checkout master`
+ 6. Enter the documentation subdirectory by running `cd docs`
+ 7. Run `jekyll serve --watch`.
+ 8. Open `localhost:4000` in your web browser.
 
 Now any file changes will be updated when you reload pages automatically.
 After committing the changes, just send a pull request.

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -48,7 +48,7 @@ export var ImageOverlay = Layer.extend({
 		errorOverlayUrl: '',
 
 		// @option zIndex: Number = 1
-		// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the tile layer.
+		// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the overlay layer.
 		zIndex: 1,
 
 		// @option className: String = ''
@@ -159,7 +159,7 @@ export var ImageOverlay = Layer.extend({
 		return events;
 	},
 
-	// @method: setZIndex(value: Number) : this
+	// @method setZIndex(value: Number): this
 	// Changes the [zIndex](#imageoverlay-zindex) of the image overlay.
 	setZIndex: function (value) {
 		this.options.zIndex = value;
@@ -245,7 +245,7 @@ export var ImageOverlay = Layer.extend({
 
 	_overlayOnError: function () {
 		// @event error: Event
-		// Fired when the ImageOverlay layer has loaded its image
+		// Fired when the ImageOverlay layer fails to load its image
 		this.fire('error');
 
 		var errorUrl = this.options.errorOverlayUrl;


### PR DESCRIPTION
also fixed a couple <sub><sup>small</sup></sub> typos.