### PR TITLE
[css] Add unprefixed 'cursor: grab'

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -210,6 +210,7 @@
 .leaflet-grab {
 	cursor: -webkit-grab;
 	cursor:    -moz-grab;
+	cursor:         grab;
 	}
 .leaflet-crosshair,
 .leaflet-crosshair .leaflet-interactive {


### PR DESCRIPTION
I'm not sure why the unprefixed `cursor: grab` hasn't been used before, this PR adds it.

Chrome [unprefixed `grab|grabbing` in v68.](https://www.chromestatus.com/feature/5575087101050880)

<hr>

### Question

Should `.leaflet-dragging .leaflet-marker-draggable` include `cursor: grabbing`?

https://github.com/Leaflet/Leaflet/blob/c88fb97184962ab32e0ebebe0758c273aaedc5ec/dist/leaflet.css#L224-L228