### PR TITLE
fixed capitalization of 'webkitTransform'

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -18,7 +18,7 @@ import * as Browser from '../core/Browser';
 // @property TRANSFORM: String
 // Vendor-prefixed transform style name (e.g. `'webkitTransform'` for WebKit).
 export var TRANSFORM = testProp(
-	['transform', 'WebkitTransform', 'OTransform', 'MozTransform', 'msTransform']);
+	['transform', 'webkitTransform', 'OTransform', 'MozTransform', 'msTransform']);
 
 // webkitTransition comes first because some browser versions that drop vendor prefix don't do
 // the same for the transitionend event, in particular the Android 4.1 stock browser


### PR DESCRIPTION
Fixing capitalization issue that broke transformations on certain webkit browsers (e.g. IOS 8.1). 

This was the root of this issue on StackOverflow: https://stackoverflow.com/questions/51861944/leaflet-tiles-not-loading-correctly-in-angular-on-mobile?noredirect=1#comment90689799_51861944