### PR TITLE
moves _clampZoom to else conditional in _setView to run after max and minZoom checks

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -544,10 +544,12 @@ export var GridLayer = Layer.extend({
 	},
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
-		var tileZoom = this._clampZoom(Math.round(zoom));
-		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
-		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
+		var tileZoom;
+		if ((this.options.maxZoom !== undefined && zoom > this.options.maxZoom) ||
+		    (this.options.minZoom !== undefined && zoom < this.options.minZoom)) {
 			tileZoom = undefined;
+		} else {
+			tileZoom = this._clampZoom(Math.round(zoom));
 		}
 
 		var tileZoomChanged = this.options.updateWhenZooming && (tileZoom !== this._tileZoom);


### PR DESCRIPTION
Hi all, took a shot at fixing issue #6259  - apologies if I'm stepping on any toes.

I took my cue from @IvanSanchez on how to fix the bug and moved the zoom clamp into the max/minZoom conditional check. Basically _setView will now set the value of tileZoom conditionally based off the max/minZoom.

I received a "success" from the tests and tested against #3814 and @happicow 's example in the origin issue. I don't detect any flickering when panning maps nor do I experience any pan-pinch-zoom tile-rendering issues. I tested on Chrome and Safari on my macbook, Chrome and Safari on my iPhone, and Chrome and Safari on my iPad. Here's a gif of the iPhone test on Chrome:
![leaflet](https://user-images.githubusercontent.com/19639860/44544027-2dbbcb80-a6df-11e8-8224-45c8528a5299.gif)

This is my first PR on an open source project. Please let me know if there are anything I missed or if anything needs adjustment.