### PR TITLE
If Marker is added to custom pane, its shadow should be added there too

### DIFF
--- a/debug/map/panes.html
+++ b/debug/map/panes.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leaflet debug page</title>
+
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <link rel="stylesheet" href="../css/screen.css" />
+
+    <script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+    <div id="map"></div>
+
+    <script>
+        map = L.map('map', { center: [0, 0], zoom: 5 });
+
+        var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+            }).addTo(map);
+
+        map.createPane('custom-pane-1').setAttribute('style', 'z-index: 300');
+        map.createPane('custom-pane-2').setAttribute('style', 'z-index: 301');
+
+        L.marker([0, 2], { pane: 'custom-pane-1' })
+        .bindTooltip('This marker and its shadow should be hidden by an orange box')
+        .addTo(map);
+
+        L.rectangle([[5, -5], [-5, 5]], {pane: 'custom-pane-2', color: '#ff7800', fillOpacity: 1, weight: 1})
+        .addTo(map);
+    </script>
+</body>
+</html>

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -251,7 +251,9 @@ export var Marker = Layer.extend({
 		}
 		this._initInteraction();
 		if (newShadow && addShadow) {
-			this.getPane('shadowPane').appendChild(this._shadow);
+			// If the Marker is being added to a pane other than the default 'markerPane', the shadow should go there, too.
+			var shadowPane = options.pane === 'markerPane' ? 'shadowPane' : options.pane;
+			this.getPane(shadowPane).appendChild(this._shadow);
 		}
 	},
 


### PR DESCRIPTION
## How to reproduce

_Environment_

- Leaflet 1.3.4
- Firefox 61, Chrome 68

_Steps_

1. Create a custom pane (`Pane A`) with z-index 300.
1. Create a `Marker` and specify that it should be added to `Pane A`.
1. Create a custom pane (`Pane B`) with z-index 301.
1. Create an opaque `Rectangle` with coordinates/dimensions that overlap the Marker, and specify that the rectangle should be added to `Pane B`.

## What behavior I'm expecting and which behavior I'm seeing

**Expected**: the marker+shadow in `Pane A` to be hidden by the rectangle in `Pane B`, which has a higher z-index.

**Actual**: the marker's shadow in `Pane A` is still visible. This is happening because [Marker.js:254](https://github.com/Leaflet/Leaflet/blob/master/src/layer/marker/Marker.js#L254) is hard-coded to alway add a marker's shadow icon to the `shadowPane`.

## Minimal example reproducing the issue

- [x] this example is as simple as possible
- [x] this example does not rely on any third party code

**Example**: https://plnkr.co/edit/PwS1sNmAfqAXIydn1lFW?p=preview

## Proposed Solution

Modify `Marker.js` so that when the shadow icon is created, the shadow `<img>` is added to the same pane (`<div>`) as the marker _if_ a `pane` option other than the default `markerPane` was specified.

## Additional Context

At a higher level, I think this is more about expectations for how panes work. If I add a marker to a custom pane, I expect the marker's shadow to also be added to the pane. In other words, I am deliberately choosing to no longer use Leaflet's default/automatic layer logic--it should be possible for me to hide the marker/shadow with the contents of other panes.