### PR TITLE
Avoid unnecessary redrawing in TileLayer.setUrl() when URL does not change.

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -114,7 +114,13 @@ export var TileLayer = GridLayer.extend({
 
 	// @method setUrl(url: String, noRedraw?: Boolean): this
 	// Updates the layer's URL template and redraws it (unless `noRedraw` is set to `true`).
+	// If the URL does not change, the layer's URL template will not be redrawn unless
+	// the noRedraw parameter is set to false.
 	setUrl: function (url, noRedraw) {
+		if (this._url === url && noRedraw === undefined) {
+			noRedraw = true;
+		}
+
 		this._url = url;
 
 		if (!noRedraw) {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -114,7 +114,7 @@ export var TileLayer = GridLayer.extend({
 
 	// @method setUrl(url: String, noRedraw?: Boolean): this
 	// Updates the layer's URL template and redraws it (unless `noRedraw` is set to `true`).
-	// If the URL does not change, the layer's URL template will not be redrawn unless
+	// If the URL does not change, the layer will not be redrawn unless
 	// the noRedraw parameter is set to false.
 	setUrl: function (url, noRedraw) {
 		if (this._url === url && noRedraw === undefined) {


### PR DESCRIPTION
I've written a potential fix for issue #6158.

I essentially added a check in TileLayer.setURL() to see if the current url is the same as the new one. If this is the case AND noRedraw is undefined, I set noRedraw to true, which avoids redrawing a tile that hasn't actually changed. If, for some reason, a developer wants to redraw, they can still do that by passing a value of true to the noRedraw parameter.

I received "SUCCESS" when testing as detailed in CONTRIBUTING.md. I also tested against @kwankong's example (https://plnkr.co/edit/nxnga7MqeC3bgUEM07Dz?p=preview).  The flickering stops with my fix.

This is my first open source contribution, so please let me know if there's anything I can do better. I'd appreciate all the feedback I can get!