### PR TITLE
Add setLastLatLng to Polyline

### DIFF
--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -172,6 +172,21 @@ export var Polyline = Path.extend({
 		return this.redraw();
 	},
 
+	// @method setLastLatLng(latlng: LatLng, latlngs? LatLng[]): this
+	// Modifies the last point of the polyline to be the specified point.
+	// By default, adds to the first ring of the polyline in case of a
+	// multi-polyline, but can be overridden by passing a specific ring as a
+	// LatLng array (that you can earlier access with
+	// [`getLatLngs`](#polyline-getlatlngs)).
+	setLastLatLng: function (latlng, latlngs) {
+		latlngs = latlngs || this._defaultShape();
+		latlng = toLatLng(latlng);
+		latlngs.pop();
+		latlngs.push(latlng);
+		this._bounds.extend(latlng);
+		return this.redraw();
+	},
+
 	_setLatLngs: function (latlngs) {
 		this._bounds = new LatLngBounds();
 		this._latlngs = this._convertLatLngs(latlngs);


### PR DESCRIPTION
I added a new method to set the last point of a Polyline to a certain value (without copying, modifying and replacing the original array each time).

I think it is a useful feature so I have added the method. I have respected the coding style the best I could and `npm run lint` doesn't return any errors. I have compiled the rolled up JS file and used it in my project successfully.