### PR TITLE
Wrap references to window to prevent them from erroring in node.js environment

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -214,9 +214,10 @@ function timeoutDefer(fn) {
 	return window.setTimeout(fn, timeToCall);
 }
 
-export var requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer;
-export var cancelFn = window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
-		getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); };
+function noop() {}
+export var requestFn = window ? (window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer) : noop;
+export var cancelFn = window ? (window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
+		getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); }) : noop;
 
 // @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): Number
 // Schedules `fn` to be executed when the browser repaints. `fn` is bound to


### PR DESCRIPTION
## Motivation
Importing `leaflet` in a backend environment (e.g. in a server-side rendering context) throws errors, because `window` isn't defined on the backend, but the utils file expects `window` to have accessible attributes. It's possible to polyfill or hack around this, but it shouldn't be necessary.

## Changes
* Add a `noop` function to serve as a placeholder for `requestFn` and `cancelFn` in a backend environment where they aren't going to be called anyway
* Wrap references to `window` in a ternary check that sets those functions to `noop` if `window` isn't available