### PR TITLE
Add general purpose metric grid overlay

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1005,6 +1005,15 @@ These plugins create useful overlays from scratch, no loading required.
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/bill-chadwick/Leaflet.MetricGrid">L.MetricGrid</a>
+		</td><td>
+			A general purpose Metric Grid overlay for Leaflet with ready defined British and Irish Grids.
+		</td><td>
+			<a href="https://github.com/bill-chadwick">Bill Chadwick</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/joergdietrich/Leaflet.Terminator">Leaflet.Terminator</a>
 		</td><td>Overlay day and night regions on a map.
 		</td><td>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1005,7 +1005,7 @@ These plugins create useful overlays from scratch, no loading required.
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/bill-chadwick/Leaflet.MetricGrid">L.MetricGrid</a>
+			<a href="https://github.com/bill-chadwick/Leaflet.MetricGrid">Leaflet.MetricGrid</a>
 		</td><td>
 			A general purpose Metric Grid overlay for Leaflet with ready defined British and Irish Grids.
 		</td><td>


### PR DESCRIPTION
A better metric grid overlay suitable for British, Irish, UTM grids etc. With example and definitions for British and Irish grids.