### PR TITLE
Docs(download): add link to release notification

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -30,6 +30,8 @@ bodyclass: download-page
 Note that the master version can contain incompatible changes,
 so please read the changelog carefully when upgrading to it.
 
+[Get notified of new Leaflet releases](https://github.com/Leaflet/Leaflet/issues/6295)
+
 ### Using a Hosted Version of Leaflet
 
 The latest stable Leaflet release is available on several CDN's &mdash; to start using


### PR DESCRIPTION
Hi,

Last action for issue https://github.com/Leaflet/Leaflet/issues/6274

The linked issue https://github.com/Leaflet/Leaflet/issues/6295 already contains the 2 ways of subscribing:
- manually subscribe to the issue
- subscribe to the RSS feed mentioned by IvanSanchez

I do not think we need anything fancier than this.