### PR TITLE
Fix(Map): set internal flags at beginning of map initialization

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -735,6 +735,7 @@ describe("Map", function () {
 			// Now notifying the map that the container size has changed,
 			// it should return new values and correctly position coordinates
 			map.invalidateSize();
+			
 			expect(map.getSize().x).to.equal(600);
 			expect(map.latLngToContainerPoint(center).x).to.equal(300);
 		});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -710,6 +710,34 @@ describe("Map", function () {
 
 			expect(spy.called).to.be.ok();
 		});
+
+		it("correctly adjusts for new container size when view is set during map initialization (#6165)", function () {
+			// Use a newly initialized map
+			map.remove();
+
+			var center = [0, 0];
+
+			// The edge case is only if view is set directly during map initialization
+			map = L.map(container, {
+				center: center,
+				zoom: 0
+			});
+
+			// Change the container size
+			container.style.width = '600px';
+
+			// The map should not be aware yet of container size change,
+			// otherwise the next invalidateSize will not be able to
+			// compute the size difference
+			expect(map.getSize().x).to.equal(100);
+			expect(map.latLngToContainerPoint(center).x).to.equal(50);
+
+			// Now notifying the map that the container size has changed,
+			// it should return new values and correctly position coordinates
+			map.invalidateSize();
+			expect(map.getSize().x).to.equal(600);
+			expect(map.latLngToContainerPoint(center).x).to.equal(300);
+		});
 	});
 
 	describe('#flyTo', function () {

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -735,7 +735,7 @@ describe("Map", function () {
 			// Now notifying the map that the container size has changed,
 			// it should return new values and correctly position coordinates
 			map.invalidateSize();
-			
+
 			expect(map.getSize().x).to.equal(600);
 			expect(map.latLngToContainerPoint(center).x).to.equal(300);
 		});

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -126,6 +126,13 @@ export var Map = Evented.extend({
 	initialize: function (id, options) { // (HTMLElement or String, Object)
 		options = Util.setOptions(this, options);
 
+		// Make sure to assign internal flags at the beginning,
+		// to avoid inconsistent state in some edge cases.
+		this._handlers = [];
+		this._layers = {};
+		this._zoomBoundLayers = {};
+		this._sizeChanged = true;
+
 		this._initContainer(id);
 		this._initLayout();
 
@@ -145,11 +152,6 @@ export var Map = Evented.extend({
 		if (options.center && options.zoom !== undefined) {
 			this.setView(toLatLng(options.center), options.zoom, {reset: true});
 		}
-
-		this._handlers = [];
-		this._layers = {};
-		this._zoomBoundLayers = {};
-		this._sizeChanged = true;
 
 		this.callInitHooks();
 


### PR DESCRIPTION
Hi again,

Fix https://github.com/Leaflet/Leaflet/issues/6165

As explained in the above issue, due to assignment of some internal flags in the middle of the map initialization, there is an edge case where `invalidateSize` will have trouble computing the size difference when called.

By setting these flags at the beginning of the map init (in particular, before any call to `setView`, which is internally executed when the map is initialized with `center` and `zoom` options), we avoid an inconsistent internal state and restore the correct behaviour of `invalidateSize`.

Sending this PR in 2 steps:
1. with added test only, to show that it fails in current state.
2. with actual fix, to show that it now passes.