### PR TITLE
Docs(contrib): fix command to run test with karma options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,8 +130,10 @@ npm test
 To run all the tests in actual browsers at the same time, you can do:
 
 ```
-npm test -- --browsers Firefox,Chrome,Safari,IE
+npm test -- -- --browsers Firefox,Chrome,Safari,IE
 ```
+
+(Note: the doubling of "`--`" [special option](https://docs.npmjs.com/cli/run-script#description) is [important](https://github.com/Leaflet/Leaflet/pull/6166#issuecomment-390959903))
 
 To run the tests in a browser manually, open `spec/index.html`.
 


### PR DESCRIPTION
Since PR https://github.com/Leaflet/Leaflet/pull/5828 (i.e. now  "test" script calls a subscript "test-nolint"), options intended to Karma must be passed to `npm test` comment with **twice** the "`--`" special option.

This PR updates the CONTRIBUTING page accordingly.