### PR TITLE
Fix(Canvas): Use ctx.save() and ctx.restore() in _fillStroke

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -312,6 +312,7 @@ export var Canvas = Renderer.extend({
 	},
 
 	_fillStroke: function (ctx, layer) {
+    ctx.save();
 		var options = layer.options;
 
 		if (options.fill) {
@@ -331,6 +332,7 @@ export var Canvas = Renderer.extend({
 			ctx.lineJoin = options.lineJoin;
 			ctx.stroke();
 		}
+    ctx.restore();
 	},
 
 	// Canvas obviously doesn't have mouse events for individual drawn objects,


### PR DESCRIPTION
~Fixes #6367~ It does fix the issue but it might not be the fix you want. See issue for more details.