### PR TITLE
Prevent error when pass undefined to stamp

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -73,6 +73,12 @@ describe('Util', function () {
 
 			expect(id2).not.to.eql(id);
 		});
+
+		it("pass undefined as prop, returns object with id", function () {
+			var id = L.Util.stamp(undefined);
+
+			expect(typeof id).to.eql("number");
+		});
 	});
 
 	describe('#falseFn', function () {

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -56,6 +56,7 @@ export var lastId = 0;
 // Returns the unique ID of an object, assigning it one if it doesn't have it.
 export function stamp(obj) {
 	/*eslint-disable */
+	if (!obj) obj = {};
 	obj._leaflet_id = obj._leaflet_id || ++lastId;
 	return obj._leaflet_id;
 	/* eslint-enable */


### PR DESCRIPTION
React app using [react-leaflet](https://github.com/PaulLeCam/react-leaflet)
Also [Leaflet.Deflate](https://github.com/oliverroick/Leaflet.Deflate), and lib for react called [react-leaflet-deflate](https://github.com/mhasbie/react-leaflet-deflate).

In this stack, I encountered an error, described here: https://github.com/mhasbie/react-leaflet-deflate/issues/2

I don't know if this fix is correct, but solve my problem :)