### PR TITLE
Ignore dash arrays with non-numeric entries in canvas

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -186,9 +186,13 @@ export var Canvas = Renderer.extend({
 		if (typeof layer.options.dashArray === 'string') {
 			var parts = layer.options.dashArray.split(/[, ]+/),
 			    dashArray = [],
+			    dashValue,
 			    i;
 			for (i = 0; i < parts.length; i++) {
-				dashArray.push(Number(parts[i]));
+				dashValue = Number(parts[i]);
+				// Ignore dash array containing invalid lengths
+				if (isNaN(dashValue)) { return; }
+				dashArray.push();
 			}
 			layer.options._dashArray = dashArray;
 		} else {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -192,7 +192,7 @@ export var Canvas = Renderer.extend({
 				dashValue = Number(parts[i]);
 				// Ignore dash array containing invalid lengths
 				if (isNaN(dashValue)) { return; }
-				dashArray.push();
+				dashArray.push(dashValue);
 			}
 			layer.options._dashArray = dashArray;
 		} else {


### PR DESCRIPTION
This is more or less exactly the fix suggested by @ghybs in https://github.com/Leaflet/Leaflet/issues/6367#issuecomment-430471778

I thought about adding a test, but could not come up with a failure scenario that could be tested except visually, since the problem only occurs inside the canvas rendering internals.