### PR TITLE
Fix Error when calling L.Circle.getBounds (#4978)

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -30,6 +30,14 @@ describe('Circle', function () {
 			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720));
 			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
 		});
+
+		it('should return approximate bounds when not added to the map', function () {
+			circle = L.circle([50, 30], {radius: 200});
+
+			var bounds = circle.getBounds();
+			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720), 0.00145);
+			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279), 0.00145);
+		});
 	});
 
 	describe('Legacy factory', function () {

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -31,12 +31,12 @@ describe('Circle', function () {
 			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
 		});
 
-		it('should return approximate bounds when not added to the map', function () {
+		it('should return bounds event when not added to the map', function () {
 			circle = L.circle([50, 30], {radius: 200});
 
 			var bounds = circle.getBounds();
-			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720), 0.00145);
-			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279), 0.00145);
+			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720));
+			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
 		});
 	});
 

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -56,8 +56,13 @@ export var Circle = CircleMarker.extend({
 	// @method getBounds(): LatLngBounds
 	// Returns the `LatLngBounds` of the path.
 	getBounds: function () {
-		var half = [this._radius, this._radiusY || this._radius];
+		// when the map instance has not been set we fall back
+		// to approximated bounds from the center point
+		if (!this._map) {
+			return this.getLatLng().toBounds(this.getRadius());
+		}
 
+		var half = [this._radius, this._radiusY || this._radius];
 		return new LatLngBounds(
 			this._map.layerPointToLatLng(this._point.subtract(half)),
 			this._map.layerPointToLatLng(this._point.add(half)));

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -56,10 +56,10 @@ export var Circle = CircleMarker.extend({
 	// @method getBounds(): LatLngBounds
 	// Returns the `LatLngBounds` of the path.
 	getBounds: function () {
-		// when the map instance has not been set we fall back
-		// to approximated bounds from the center point
+		// when the map instance has not been set we calculate
+		// the bounds with LatLng.toBounds
 		if (!this._map) {
-			return this.getLatLng().toBounds(this.getRadius());
+			return this.getLatLng().toBounds(this.getRadius() * 2);
 		}
 
 		var half = [this._radius, this._radiusY || this._radius];


### PR DESCRIPTION
I think I've found a solution for #4978. Instead of using the map's projection to determine the bounds, I'm expanding the center LatLng by the Radius of the circle.
The results are pretty close to each other.

I've build a plunkr to demontrate: https://plnkr.co/edit/ZSxogETQ1sVj8l84abrJ?p=preview