### PR TITLE
Fix insecure content error in documentation

### DIFF
--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -147,7 +147,7 @@
 
 	</div>
 
-	<script src="http://leafletjs.com/docs/js/docs.js"></script>
+	<script src="https://leafletjs.com/docs/js/docs.js"></script>
 	<script>
 	hljs.configure({tabReplace: '    '});
 	hljs.initHighlightingOnLoad();


### PR DESCRIPTION
`docs.js` is prevented from loading due to it.