### PR TITLE
[GridLayer] redraw tiles properly after changing maxNativeZoom

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -354,6 +354,18 @@ describe('GridLayer', function () {
 
 			map.addLayer(grid);
 		});
+
+		it("redraws tiles properly after changing maxNativeZoom", function () {
+			var initialZoom = 12;
+			map.setView([0, 0], initialZoom);
+
+			var grid = L.gridLayer().addTo(map);
+			expect(grid._tileZoom).to.be(initialZoom);
+
+			grid.options.maxNativeZoom = 11;
+			grid.redraw();
+			expect(grid._tileZoom).to.be(11);
+		});
 	});
 
 	describe("number of 256px tiles loaded in synchronous non-animated grid @800x600px", function () {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -671,7 +671,7 @@ export var GridLayer = Layer.extend({
 
 		// _update just loads more tiles. If the tile zoom level differs too much
 		// from the map's, let _setView reset levels and prune old tiles.
-		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, map.getZoom()); return; }
+		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, zoom); return; }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -669,7 +669,7 @@ export var GridLayer = Layer.extend({
 
 		// _update just loads more tiles. If the tile zoom level differs too much
 		// from the map's, let _setView reset levels and prune old tiles.
-		if (Math.abs(zoom - this._tileZoom) > 0) { this._setView(center, map.getZoom()); return; }
+		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, map.getZoom()); return; }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -229,8 +229,11 @@ export var GridLayer = Layer.extend({
 	redraw: function () {
 		if (this._map) {
 			this._removeAllTiles();
-			this._tileZoom = this._clampZoom(this._map.getZoom());
-			this._updateLevels();
+			var tileZoom = this._clampZoom(this._map.getZoom());
+			if (tileZoom !== this._tileZoom) {
+				this._tileZoom = tileZoom;
+				this._updateLevels();
+			}
 			this._update();
 		}
 		return this;

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -669,7 +669,7 @@ export var GridLayer = Layer.extend({
 
 		// _update just loads more tiles. If the tile zoom level differs too much
 		// from the map's, let _setView reset levels and prune old tiles.
-		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, zoom); return; }
+		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, map.getZoom()); return; }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -229,6 +229,8 @@ export var GridLayer = Layer.extend({
 	redraw: function () {
 		if (this._map) {
 			this._removeAllTiles();
+			this._tileZoom = this._clampZoom(this._map.getZoom());
+			this._updateLevels();
 			this._update();
 		}
 		return this;

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -669,7 +669,7 @@ export var GridLayer = Layer.extend({
 
 		// _update just loads more tiles. If the tile zoom level differs too much
 		// from the map's, let _setView reset levels and prune old tiles.
-		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, map.getZoom()); return; }
+		if (Math.abs(zoom - this._tileZoom) > 0) { this._setView(center, map.getZoom()); return; }
 
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {


### PR DESCRIPTION
This is blind attempt to fix #6438

## Case 1: set `maxNativeZoom` higher than current zoom and redraw:
### Before / After:
<img src="https://user-images.githubusercontent.com/13808724/50402486-5b9d4380-0797-11e9-9346-00dfb4af5e4c.gif" width="50%" /><img src="https://user-images.githubusercontent.com/13808724/50402489-5f30ca80-0797-11e9-9ee1-5c91e38847b6.gif" width="50%" />

---

## Case 2: Zoom in, set `maxNativeZoom` higher than initial zoom and redraw:
### Before / After:
<img src="https://user-images.githubusercontent.com/13808724/50402575-e3834d80-0797-11e9-840e-8907eddc6e70.gif" width="50%" /><img src="https://user-images.githubusercontent.com/13808724/50402577-e716d480-0797-11e9-818f-4cd3df62628d.gif" width="50%" />

## Playground link:
https://plnkr.co/edit/ORkCquW4i2kIYLyOmcjl?p=preview