### PR TITLE
Fix duplicated sentence in SVG section of docs

### DIFF
--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -24,7 +24,6 @@ export var vmlCreate = (function () {
 /*
  * @class SVG
  *
- * Although SVG is not available on IE7 and IE8, these browsers support [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language), and the SVG renderer will fall back to VML in this case.
  *
  * VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
  * with old versions of Internet Explorer.


### PR DESCRIPTION
This should fix the duplicated sentence that appears in the documents. This is my first time so please teach me if I'm doing anything incorrectly. Thanks!

Fixes issue [#6418](https://github.com/Leaflet/Leaflet/issues/6418).