### PR TITLE
doc: Elliptical Mercator projection - Earth is an ellipsoid

### DIFF
--- a/src/geo/projection/Projection.Mercator.js
+++ b/src/geo/projection/Projection.Mercator.js
@@ -6,7 +6,7 @@ import {Point} from '../../geometry/Point';
  * @namespace Projection
  * @projection L.Projection.Mercator
  *
- * Elliptical Mercator projection — more complex than Spherical Mercator. Takes into account that Earth is an ellipsoid, not a perfect sphere. Used by the EPSG:3395 CRS.
+ * Elliptical Mercator projection — more complex than Spherical Mercator. Assumes that Earth is an ellipsoid. Used by the EPSG:3395 CRS.
  */
 
 export var Mercator = {

--- a/src/geo/projection/Projection.Mercator.js
+++ b/src/geo/projection/Projection.Mercator.js
@@ -6,7 +6,7 @@ import {Point} from '../../geometry/Point';
  * @namespace Projection
  * @projection L.Projection.Mercator
  *
- * Elliptical Mercator projection — more complex than Spherical Mercator. Takes into account that Earth is a geoid, not a perfect sphere. Used by the EPSG:3395 CRS.
+ * Elliptical Mercator projection — more complex than Spherical Mercator. Takes into account that Earth is an ellipsoid, not a perfect sphere. Used by the EPSG:3395 CRS.
  */
 
 export var Mercator = {


### PR DESCRIPTION
Minor change in documentation:
Elliptical Mercator projection (EPSG:3395) assumes that the Earth is an ellipsoid, not a geoid (in comparison with Spherical Mercator (EPSG:3857), that assumes the Earth is a perfect sphere).

https://sciencing.com/difference-between-geoid-ellipsoid-8638149.html