### PR TITLE
Control.Layers: add stamp id to the radio button name.

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -327,7 +327,7 @@ export var Layers = Control.extend({
 			input.className = 'leaflet-control-layers-selector';
 			input.defaultChecked = checked;
 		} else {
-			input = this._createRadioElement('leaflet-base-layers', checked);
+			input = this._createRadioElement('leaflet-base-layers_' + Util.stamp(this), checked);
 		}
 
 		this._layerControlInputs.push(input);


### PR DESCRIPTION
After opening #6482, I realized that this may be a simple solution: make radio button name unique per control just adding the control id.