### PR TITLE
Explicitly remove controls from the map on map unload

### DIFF
--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -79,6 +79,8 @@ export var Control = Class.extend({
 			corner.appendChild(container);
 		}
 
+		this._map.on('unload', this.remove, this);
+
 		return this;
 	},
 
@@ -95,6 +97,7 @@ export var Control = Class.extend({
 			this.onRemove(this._map);
 		}
 
+		this._map.off('unload', this.remove, this);
 		this._map = null;
 
 		return this;


### PR DESCRIPTION
This is a blind attempt (i.e. *untested*) to fix #6487. A map being destroyed will fire the `unload` event, and any controls from that map can use that event to remove themselves from the map.