### PR TITLE
plugins.md typo fix

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3750,7 +3750,7 @@ Buttons, sliders, toolbars, sidebars, and panels.
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/publiclab/leaflet-blurred-location/">leaflet-blurred-image</a>
+			<a href="https://github.com/publiclab/leaflet-blurred-location/">leaflet-blurred-location</a>
 		</td>
 		<td>
 			A Leaflet-based interface for selecting a "blurred" or low-resolution location, to preserve privacy. <a href="https://publiclab.github.io/leaflet-blurred-location/examples/">Demo</a>.


### PR DESCRIPTION
I may have made this mistake a long time ago! Fixing now... sorry!

`leaflet-blurred-image` => `leaflet-blurred-location`