### PR TITLE
Add ceilZoom to GridLayer to select zoom level used between integers

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -128,6 +128,12 @@ export var GridLayer = Layer.extend({
 		// from `minNativeZoom` level and auto-scaled.
 		minNativeZoom: undefined,
 
+		// @option ceilZoom: boolean = false
+		// If set, tiles with fractional zoom level will be selected using ceil
+		// instead of rounding. It can be used to prevent larger than 1 scaling
+		// of a tile.
+		ceilZoom: false,
+
 		// @option noWrap: Boolean = false
 		// Whether the layer is wrapped around the antimeridian. If `true`, the
 		// GridLayer will only be displayed once at low zoom levels. Has no
@@ -544,7 +550,7 @@ export var GridLayer = Layer.extend({
 	},
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
-		var tileZoom = this._clampZoom(Math.round(zoom));
+		var tileZoom = this._clampZoom(this.options.ceilZoom ? Math.ceil(zoom) : Math.round(zoom));
 		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
 		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
 			tileZoom = undefined;


### PR DESCRIPTION
By default, a fractional zoom level is rounded, that is, the tiles switch zoom level at halfway point which creates undesirable >1 scale when a canvas is used within a GridLayer tile. This change allows avoiding >1 scales by setting ceilZoom to true that makes the tile zoom level to be always larger than a non-integer zoom level.
