### PR TITLE
Fix missing <tr> tag

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2397,6 +2397,7 @@ Most data is two-dimensional (latitude and longitude), but some data has more di
 			<a href="https://github.com/svitkin">Sol Vitkin</a>
 		</td>
 	</tr>
+	<tr>
 		<td>
 			<a href="https://github.com/socib/Leaflet.TimeDimension">Leaflet.TimeDimension</a>
 		</td>


### PR DESCRIPTION
Currently </tr> shows up on website. I think this is due to my last PR not correctly closing the <tr>.