### PR TITLE
Fix GridLayer occassionally leaving tiles from two layers active

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -313,11 +313,15 @@ export var GridLayer = Layer.extend({
 
 		var now = +new Date(),
 		    nextFrame = false,
-		    willPrune = false;
+		    willPrune = false,
+		    endPrune = false;
 
 		for (var key in this._tiles) {
 			var tile = this._tiles[key];
-			if (!tile.current || !tile.loaded) { continue; }
+			if (!tile.current || !tile.loaded) {
+			  if (tile.active) { endPrune = true; }
+			  continue;
+			}
 
 			var fade = Math.min(1, (now - tile.loaded) / 200);
 
@@ -334,6 +338,7 @@ export var GridLayer = Layer.extend({
 			}
 		}
 
+		if (!nextFrame && endPrune) { willPrune = true; }
 		if (willPrune && !this._noPrune) { this._pruneTiles(); }
 
 		if (nextFrame) {


### PR DESCRIPTION
If GridLayer finds a tile that is not current but is still active, set a flag to do a prune if at the end of the fade.

I suspect the original problem might be due to a race between _updateOpacity and timed prune from _tileReady. As it seems cheap to calculate when a clearing prune is needed at the end of the fade, just do it.
