### PR TITLE
Fix minNativeZoom causing browser crash

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -631,7 +631,20 @@ export var GridLayer = Layer.extend({
 		    pixelCenter = map.project(center, this._tileZoom).floor(),
 		    halfSize = map.getSize().divideBy(scale * 2);
 
-		return new Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
+		var tiledPixelBounds = new Bounds(pixelCenter.subtract(halfSize), pixelCenter.add(halfSize));
+
+		// Crop to tile bounds
+		if (this.options.bounds && scale < 1) {
+			var pixelNorthEastBounds = map.project(this.options.bounds._northEast, this._tileZoom),
+			    pixelSouthWestBounds = map.project(this.options.bounds._southWest, this._tileZoom);
+
+			tiledPixelBounds.min.x = tiledPixelBounds.min.x < pixelSouthWestBounds.x ? pixelSouthWestBounds.x : tiledPixelBounds.min.x;
+			tiledPixelBounds.max.x = tiledPixelBounds.max.x > pixelNorthEastBounds.x ? pixelNorthEastBounds.x : tiledPixelBounds.max.x;
+			tiledPixelBounds.min.y = tiledPixelBounds.min.y < pixelSouthWestBounds.y ? pixelSouthWestBounds.y : tiledPixelBounds.min.y;
+			tiledPixelBounds.max.y = tiledPixelBounds.max.y > pixelNorthEastBounds.y ? pixelNorthEastBounds.y : tiledPixelBounds.max.y;
+		}
+
+		return tiledPixelBounds;
 	},
 
 	// Private method to load tiles in the grid's active zoom level according to map bounds


### PR DESCRIPTION
Fixed browser crash when user set minNativeZoom in a tilelayer.

When the mapZoom is 1 and minNativeZoom is 17, for example, the funcion _getTiledPixelBounds result in a huge bounds due to scale, then the function _update try to load a big tileRange, ocasioning browser crash.

What I did was check if tile has bounds and just try to load tiles inside this bounds.

It improves a lot the performance of tile loading