### PR TITLE
Enable to define how GeoJSON polygons and lineStrings spawn Leaflet layers

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -46,6 +46,26 @@ export var GeoJSON = FeatureGroup.extend({
 	 * }
 	 * ```
 	 *
+	 * @option lineStringToLayer: Function = *
+	 * A `Function` defining how GeoJSON lineStrings spawn Leaflet layers. It is internally
+	 * called when data is added, passing the GeoJSON lineString feature and its `LatLngs`.
+	 * The default is to spawn a default `Polyline`:
+	 * ```js
+	 * function(geoJsonLineString, latlngs) {
+	 * 	return L.Polyline(latlng);
+	 * }
+	 * ```
+	 *
+	 * @option polygonToLayer: Function = *
+	 * A `Function` defining how GeoJSON polygons spawn Leaflet layers. It is internally
+	 * called when data is added, passing the GeoJSON polygon feature and its `LatLngs`.
+	 * The default is to spawn a default `Polygon`:
+	 * ```js
+	 * function(geoJsonPolygon, latlngs) {
+	 * 	return L.Polygon(latlng);
+	 * }
+	 * ```
+	 *
 	 * @option style: Function = *
 	 * A `Function` defining the `Path options` for styling GeoJSON lines and polygons,
 	 * called internally when data is added.
@@ -167,6 +187,8 @@ export function geometryToLayer(geojson, options) {
 	    coords = geometry ? geometry.coordinates : null,
 	    layers = [],
 	    pointToLayer = options && options.pointToLayer,
+	    lineStringToLayer = options && options.lineStringToLayer,
+	    polygonToLayer = options && options.polygonToLayer,
 	    _coordsToLatLng = options && options.coordsToLatLng || coordsToLatLng,
 	    latlng, latlngs, i, len;
 
@@ -189,12 +211,12 @@ export function geometryToLayer(geojson, options) {
 	case 'LineString':
 	case 'MultiLineString':
 		latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, _coordsToLatLng);
-		return new Polyline(latlngs, options);
+		return lineStringToLayer ? lineStringToLayer(geojson, latlngs) : new Polyline(latlngs, options);
 
 	case 'Polygon':
 	case 'MultiPolygon':
 		latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, _coordsToLatLng);
-		return new Polygon(latlngs, options);
+		return polygonToLayer ? polygonToLayer(geojson, latlngs) : new Polygon(latlngs, options);
 
 	case 'GeometryCollection':
 		for (i = 0, len = geometry.geometries.length; i < len; i++) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -34,9 +34,10 @@ export var VideoOverlay = ImageOverlay.extend({
 		// Whether the video will loop back to the beginning when played.
 		loop: true,
 
-		// @option saveAspectRatio: Boolean = true
+		// @option keepAspectRatio: Boolean = true
 		// Whether the video will save aspect ratio after the projection.
-		saveAspectRatio: true
+		// Relevant for supported browsers. Browser compatibility- https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit
+		keepAspectRatio: true
 	},
 
 	_initImage: function () {
@@ -66,7 +67,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
-		if (!this.options.saveAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
+		if (!this.options.keepAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -62,6 +62,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
+		vid.style['objectFit'] = 'fill';
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -32,7 +32,11 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		// @option loop: Boolean = true
 		// Whether the video will loop back to the beginning when played.
-		loop: true
+		loop: true,
+
+		// @option saveAspectRatio: Boolean = true
+		// Whether the video will save aspect ratio after the projection.
+		saveAspectRatio: true
 	},
 
 	_initImage: function () {
@@ -62,7 +66,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
-		vid.style['objectFit'] = 'fill';
+		if (!this.options.saveAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		for (var i = 0; i < this._url.length; i++) {


### PR DESCRIPTION
Today, `L.GeoJson` enables to define how GeoJSON points spawn Leaflet layers, but no for polygons and lineStrings.
I added to `GeoJSON options` two fields in order to enable users to define how polygons and lineStrings spawn.