### PR TITLE
Round point before CSS translate is set

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -211,7 +211,7 @@ export function testProp(props) {
 // and optionally scaled by `scale`. Does not have an effect if the
 // browser doesn't support 3D CSS transforms.
 export function setTransform(el, offset, scale) {
-	var pos = offset || new Point(0, 0);
+	var pos = (offset && offset.round()) || new Point(0, 0);
 
 	el.style[TRANSFORM] =
 		(Browser.ie3d ?


### PR DESCRIPTION
related to #3575

Some additional testing is required. We do not use scaling, not even decimal zooming. But this commit definitely solved pixel gap issue for all our cases.