### PR TITLE
Use translate instead of translate3d

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -216,7 +216,7 @@ export function setTransform(el, offset, scale) {
 	el.style[TRANSFORM] =
 		(Browser.ie3d ?
 			'translate(' + pos.x + 'px,' + pos.y + 'px)' :
-			'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
+			'translate(' + pos.x + 'px,' + pos.y + 'px)') +
 		(scale ? ' scale(' + scale + ')' : '');
 }
 


### PR DESCRIPTION
related to #3575
do not merge together with #6543

This change should not affect performance. As you can see [here](https://jsperf.com/translate3d-vs-xy), modern browsers use GPU acceleration for both properties.