### PR TITLE
Remove double background definition

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -397,7 +397,6 @@
 
 .leaflet-container .leaflet-control-attribution {
 	background: #fff;
-	background: rgba(255, 255, 255, 0.7);
 	margin: 0;
 	}
 .leaflet-control-attribution,


### PR DESCRIPTION
For the control attribution container are two background CSS commands defined. Better to use the white one so we meet the requirements of WCAG 2.0 AA for the contrast between the link and it's background which is inherited from the container.