### PR TITLE
Make DivIcon html option accept Element

### DIFF
--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -44,7 +44,12 @@ export var DivIcon = Icon.extend({
 		var div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),
 		    options = this.options;
 
-		div.innerHTML = options.html !== false ? options.html : '';
+		if (options.html instanceof Element) {
+			div.innerHTML = '';
+			div.appendChild(options.html);
+		} else {
+			div.innerHTML = options.html !== false ? options.html : '';
+		}
 
 		if (options.bgPos) {
 			var bgPos = point(options.bgPos);

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -1,5 +1,6 @@
 import {Icon} from './Icon';
 import {toPoint as point} from '../../geometry/Point';
+import {empty} from '../../dom/DomUtil';
 
 /*
  * @class DivIcon
@@ -45,7 +46,7 @@ export var DivIcon = Icon.extend({
 		    options = this.options;
 
 		if (options.html instanceof Element) {
-			div.innerHTML = '';
+			empty(div);
 			div.appendChild(options.html);
 		} else {
 			div.innerHTML = options.html !== false ? options.html : '';

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -30,8 +30,9 @@ export var DivIcon = Icon.extend({
 		// iconAnchor: (Point),
 		// popupAnchor: (Point),
 
-		// @option html: String = ''
-		// Custom HTML code to put inside the div element, empty by default.
+		// @option html: String|HTMLElement = ''
+		// Custom HTML code to put inside the div element, empty by default. Alternatively,
+		// an instance of `HTMLElement`.
 		html: false,
 
 		// @option bgPos: Point = [0, 0]


### PR DESCRIPTION
Adds the possibility to use a DOM `Element` instance as the `html` option for a `DivIcon`.