### PR TITLE
Popup/Tooltip content function: allow return undefined

### DIFF
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -175,6 +175,10 @@ export var DivOverlay = Layer.extend({
 		this.fire('contentupdate');
 	},
 
+	_hasContentFor: function (layer) {
+		return typeof this._content !== 'function' || this._content(layer || this);
+	},
+
 	_updatePosition: function () {
 		if (!this._map) { return; }
 

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -434,7 +434,7 @@ Layer.include({
 			latlng = layer.getCenter ? layer.getCenter() : layer.getLatLng();
 		}
 
-		if (this._popup && this._map) {
+		if (this._popup && this._map && this._popup._hasContentFor(layer)) {
 			// set popup source to this layer
 			this._popup._source = layer;
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -328,7 +328,7 @@ Layer.include({
 			latlng = layer.getCenter ? layer.getCenter() : layer.getLatLng();
 		}
 
-		if (this._tooltip && this._map) {
+		if (this._tooltip && this._map && this._tooltip._hasContentFor(layer)) {
 
 			// set tooltip source to this layer
 			this._tooltip._source = layer;


### PR DESCRIPTION
In this case Popup/Tooltip is not shown.

Useful when only some sublayers need popups:
- previously: it was necessary to attach independent popups to each sublayer
- now: it's enough to have common content function attached to parent layer
<details><summary>

https://github.com/Leaflet/Leaflet/commit/d8a4ba03d9180c7668e72dbbd83ec8c06d6dad6c
</summary>

```diff
diff --git a/src/layer/DivOverlay.js b/src/layer/DivOverlay.js
index efd76f1bba..0005ac6fdc 100644
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -164,7 +164,9 @@ export var DivOverlay = Layer.extend({
 		var node = this._contentNode;
 		var content = (typeof this._content === 'function') ? this._content(this._source || this) : this._content;
 
-		if (typeof content === 'string') {
+		if (!content) {
+			return;
+		} else if (typeof content === 'string') {
 			node.innerHTML = content;
 		} else {
 			while (node.hasChildNodes()) {
```
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/6599)
<!-- Reviewable:end -->
