### PR TITLE
devDependancy: "karma-firefox-launcher": "^1.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "karma-chrome-launcher": "^2.0.0",
     "karma-coverage": "~1.1.1",
     "karma-expect": "^1.1.3",
-    "karma-firefox-launcher": "~1.0.0",
+    "karma-firefox-launcher": "^1.1.0",
     "karma-mocha": "^1.2.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-rollup-preprocessor": "^5.0.1",


### PR DESCRIPTION
Fix tests failing on Windows with:
```
ERROR [plugin]: Error during loading "karma-firefox-launcher" plugin:
  Cannot read property 'substr' of undefined
```
See: https://github.com/karma-runner/karma-firefox-launcher/issues/67

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/6611)
<!-- Reviewable:end -->
