### PR TITLE
Minor: Background color CSS declaration

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -12,6 +12,7 @@ html, body, input, select, button, textarea, table {
 body {
 	line-height: 1.5;
 	color: #333;
+	background-color: white;
 }
 
 p {


### PR DESCRIPTION
For the sake of compatibility, it's best to make as few assumptions about the browser as possible.

On the current docs website, it's assumed that the background will be `white`. As a result of my distro's dark theme, that's not the case... The website looks like this on my machine:
![image](https://user-images.githubusercontent.com/14067660/56448089-583b4400-62c1-11e9-8a06-3bd584d572a7.png)

With one small declaration, the site will look as intended on any browser:
![image](https://user-images.githubusercontent.com/14067660/56448124-96d0fe80-62c1-11e9-96e3-fbfe754a78e3.png)
