### PR TITLE
Microoptimize GeoJSON._setLayerStyle

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -145,10 +145,10 @@ export var GeoJSON = FeatureGroup.extend({
 	},
 
 	_setLayerStyle: function (layer, style) {
-		if (typeof style === 'function') {
-			style = style(layer.feature);
-		}
 		if (layer.setStyle) {
+			if (typeof style === 'function') {
+				style = style(layer.feature);
+			}
 			layer.setStyle(style);
 		}
 	}


### PR DESCRIPTION
`GeoJSON._setLayerStyle`: call [`style`](https://leafletjs.com/reference-1.4.0.html#geojson-style) function only if _layer_ has `setStyle` method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/6616)
<!-- Reviewable:end -->
