### PR TITLE
synthetic dblclick events relate to left button

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -50,6 +50,7 @@ export function addDoubleTapListener(obj, handler, id) {
 				touch = newTouch;
 			}
 			touch.type = 'dblclick';
+			touch.button = 0;
 			handler(touch);
 			last = null;
 		}


### PR DESCRIPTION
This is a backport of https://cgit.freedesktop.org/libreoffice/online/commit/?id=d0906c12d82e0242b0709349979a9061da9c6a83 - synthetic `dblclick` events spawned from `DomEvent.DoubleTap.js` shall refer to [button 0](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#Return_value), so double taps can be interpreted as double clicks of the *left* button (instead of double clicks of an *`undefined`* button).