### PR TITLE
CSS z-index bug

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -94,8 +94,6 @@
 	-moz-user-select: none;
 	}
 
-.leaflet-pane         { z-index: 400; }
-
 .leaflet-tile-pane    { z-index: 200; }
 .leaflet-overlay-pane { z-index: 400; }
 .leaflet-shadow-pane  { z-index: 500; }


### PR DESCRIPTION
Unfortunately a bug in Chrome browser does not respect CSS stacking context regarding z-index. Therefore tile-pane with 400 z-index overlays the stuff, that is even outside map container.

The patch is applied on Windy.com and works flawlessly more than 1 month