### PR TITLE
Refactor Popup/Tooltip to use common code from DivOverlay

### DIFF
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -60,6 +60,27 @@ export var DivOverlay = Layer.extend({
 		return this;
 	},
 
+	// @method toggle(layer?: Layer): this
+	// Opens or closes the overlay bound to layer depending on its current state.
+	// Argument may be omitted only for overlay bound to layer.
+	// Alternative to `layer.togglePopup()`/`.toggleTooltip()`.
+	toggle: function (layer) {
+		if (this._map) {
+			this.close();
+		} else {
+			if (arguments.length) {
+				this._source = layer;
+			} else {
+				layer = this._source;
+			}
+			this._prepareOpen();
+
+			// open the overlay on the map
+			this.openOn(layer._map);
+		}
+		return this;
+	},
+
 	onAdd: function (map) {
 		this._zoomAnimated = map._zoomAnimated;
 

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -38,6 +38,28 @@ export var DivOverlay = Layer.extend({
 		this._source = source;
 	},
 
+	// @method openOn(map: Map): this
+	// Adds the overlay to the map.
+	// Alternative to `map.openPopup(popup)`/`.openTooltip(tooltip)`.
+	openOn: function (map) {
+		map = arguments.length ? map : this._source._map; // experimental, not the part of public api
+		if (!map.hasLayer(this)) {
+			map.addLayer(this);
+		}
+		return this;
+	},
+
+	// @method close(): this
+	// Closes the overlay.
+	// Alternative to `map.closePopup(popup)`/`.closeTooltip(tooltip)`
+	// and `layer.closePopup()`/`.closeTooltip()`.
+	close: function () {
+		if (this._map) {
+			this._map.removeLayer(this);
+		}
+		return this;
+	},
+
 	onAdd: function (map) {
 		this._zoomAnimated = map._zoomAnimated;
 

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -1,3 +1,4 @@
+import {Map} from '../map/Map';
 import {Layer} from './Layer';
 import {FeatureGroup} from './FeatureGroup';
 import * as Util from '../core/Util';
@@ -247,4 +248,32 @@ export var DivOverlay = Layer.extend({
 		return [0, 0];
 	}
 
+});
+
+Map.include({
+	_initOverlay: function (OverlayClass, content, latlng, options) {
+		var overlay = content;
+		if (!(overlay instanceof OverlayClass)) {
+			overlay = new OverlayClass(options).setContent(content);
+		}
+		if (latlng) {
+			overlay.setLatLng(latlng);
+		}
+		return overlay;
+	}
+});
+
+
+Layer.include({
+	_initOverlay: function (OverlayClass, old, content, options) {
+		var overlay = content;
+		if (overlay instanceof OverlayClass) {
+			Util.setOptions(overlay, options);
+			overlay._source = this;
+		} else {
+			overlay = (old && !options) ? old : new OverlayClass(options, this);
+			overlay.setContent(content);
+		}
+		return overlay;
+	}
 });

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -148,10 +148,6 @@ export var Popup = DivOverlay.extend({
 	onRemove: function (map) {
 		DivOverlay.prototype.onRemove.call(this, map);
 
-		if (this === map._popup) {
-			map._popup = null;
-		}
-
 		// @namespace Map
 		// @section Popup events
 		// @event popupclose: PopupEvent
@@ -418,11 +414,7 @@ Layer.include({
 	// Opens or closes the popup bound to this layer depending on its current state.
 	togglePopup: function () {
 		if (this._popup) {
-			if (this._popup._map) {
-				this._popup.close();
-			} else {
-				this.openPopup();
-			}
+			this._popup.toggle(this);
 		}
 		return this;
 	},

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -2,7 +2,6 @@ import {DivOverlay} from './DivOverlay';
 import {toPoint} from '../geometry/Point';
 import {Map} from '../map/Map';
 import {Layer} from './Layer';
-import * as Util from '../core/Util';
 import * as DomUtil from '../dom/DomUtil';
 
 /*
@@ -231,19 +230,13 @@ Map.include({
 	// @method openTooltip(content: String|HTMLElement, latlng: LatLng, options?: Tooltip options): this
 	// Creates a tooltip with the specified content and options and open it.
 	openTooltip: function (tooltip, latlng, options) {
-		if (!(tooltip instanceof Tooltip)) {
-			tooltip = new Tooltip(options).setContent(tooltip);
+		tooltip = this._initOverlay(Tooltip, tooltip, latlng, options);
+
+		if (!this.hasLayer(tooltip)) {
+			this.addLayer(tooltip);
 		}
 
-		if (latlng) {
-			tooltip.setLatLng(latlng);
-		}
-
-		if (this.hasLayer(tooltip)) {
-			return this;
-		}
-
-		return this.addLayer(tooltip);
+		return this;
 	},
 
 	// @method closeTooltip(tooltip: Tooltip): this
@@ -280,18 +273,7 @@ Layer.include({
 			this.unbindTooltip();
 		}
 
-		if (content instanceof Tooltip) {
-			Util.setOptions(content, options);
-			this._tooltip = content;
-			content._source = this;
-		} else {
-			if (!this._tooltip || options) {
-				this._tooltip = new Tooltip(options, this);
-			}
-			this._tooltip.setContent(content);
-
-		}
-
+		this._tooltip = this._initOverlay(Tooltip, this._tooltip, content, options);
 		this._initTooltipInteractions();
 
 		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this)) {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -118,16 +118,10 @@ export var Tooltip = DivOverlay.extend({
 		var events = DivOverlay.prototype.getEvents.call(this);
 
 		if (!this.options.permanent) {
-			events.preclick = this._close;
+			events.preclick = this.close;
 		}
 
 		return events;
-	},
-
-	_close: function () {
-		if (this._map) {
-			this._map.closeTooltip(this);
-		}
 	},
 
 	_initLayout: function () {
@@ -230,11 +224,8 @@ Map.include({
 	// @method openTooltip(content: String|HTMLElement, latlng: LatLng, options?: Tooltip options): this
 	// Creates a tooltip with the specified content and options and open it.
 	openTooltip: function (tooltip, latlng, options) {
-		tooltip = this._initOverlay(Tooltip, tooltip, latlng, options);
-
-		if (!this.hasLayer(tooltip)) {
-			this.addLayer(tooltip);
-		}
+		this._initOverlay(Tooltip, tooltip, latlng, options)
+		  .openOn(this);
 
 		return this;
 	},
@@ -242,7 +233,8 @@ Map.include({
 	// @method closeTooltip(tooltip: Tooltip): this
 	// Closes the tooltip given as parameter.
 	closeTooltip: function (tooltip) {
-		return this.removeLayer(tooltip);
+		tooltip.close();
+		return this;
 	}
 
 });
@@ -320,9 +312,8 @@ Layer.include({
 	openTooltip: function (latlng) {
 		if (this._tooltip && this._tooltip._prepareOpen(latlng)) {
 			// open the tooltip on the map
-			this._map.openTooltip(this._tooltip, latlng);
+			this._tooltip.openOn(this._map);
 		}
-
 		return this;
 	},
 
@@ -330,9 +321,8 @@ Layer.include({
 	// Closes the tooltip bound to this layer if it is open.
 	closeTooltip: function () {
 		if (this._tooltip) {
-			this._tooltip._close();
+			return this._tooltip.close();
 		}
-		return this;
 	},
 
 	// @method toggleTooltip(): this
@@ -340,7 +330,7 @@ Layer.include({
 	toggleTooltip: function () {
 		if (this._tooltip) {
 			if (this._tooltip._map) {
-				this.closeTooltip();
+				this._tooltip.close();
 			} else {
 				this.openTooltip();
 			}

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -329,11 +329,7 @@ Layer.include({
 	// Opens or closes the tooltip bound to this layer depending on its current state.
 	toggleTooltip: function () {
 		if (this._tooltip) {
-			if (this._tooltip._map) {
-				this._tooltip.close();
-			} else {
-				this.openTooltip();
-			}
+			this._tooltip.toggle(this);
 		}
 		return this;
 	},


### PR DESCRIPTION
This is continuation of #6613.

(Each commit is self-sufficient and can be reviewed independently)

**Edit**: rebased on #7531.
- internal changes
- DivOverlay: new public api:
   ```
	// @method openOn(map: Map): this
	// Adds the overlay to the map.
	// Alternative to `map.openPopup(popup)`/`.openTooltip(tooltip)`.

	// @method close(): this
	// Closes the overlay.
	// Alternative to `map.closePopup(popup)`/`.closeTooltip(tooltip)`
	// and `layer.closePopup()`/`.closeTooltip()`.

	// @method toggle(layer?: Layer): this
	// Opens or closes the overlay bound to layer depending on its current state.
	// Argument may be omitted only for overlay bound to layer.
	// Alternative to `layer.togglePopup()`/`.toggleTooltip()`.
   ```
   Notes: `openOn` used to be Popup-only method, `close` was private method.

Todo: consider https://github.com/johnd0e/Leaflet/compare/refactor-open-popup-tooltip...johnd0e:refactor-open-popup-tooltip-bind

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/6639)
<!-- Reviewable:end -->
