### PR TITLE
lock rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mocha": "^6.1.4",
     "phantomjs-prebuilt": "^2.1.16",
     "prosthetic-hand": "^1.3.1",
-    "rollup": "^1.11.0",
+    "rollup": "0.51.8",
     "rollup-plugin-git-version": "0.2.1",
     "rollup-plugin-json": "^4.0.0",
     "sinon": "^7.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "karma-firefox-launcher": "~1.1.0",
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "karma-rollup-preprocessor": "^7.0.0",
+    "karma-rollup-preprocessor": "^5.0.1",
     "karma-safari-launcher": "~1.0.0",
     "karma-sinon": "^1.0.5",
     "leafdoc": "^1.4.1",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -59,11 +59,9 @@ module.exports = function (config) {
 			plugins: [
 				json()
 			],
-			output: {
-				format: 'umd',
-				name: 'L',
-				outro: outro
-			}
+			format: 'umd',
+			name: 'L',
+			outro: outro
 		},
 
 		// test results reporter to use


### PR DESCRIPTION
Fixes #6645
Closes #6646

`legacy` option was removed in rollup@0.60.0 - see https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0600

This is breaking change for leaflet.
In order to support IE8, we should use rollup < 0.60.0