### PR TITLE
Enhance Popup/Tooltip content function handling

### DIFF
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -259,5 +259,12 @@ Map.include({
 		}
 
 		return this;
+	},
+
+	_closeOverlay: function (overlay) {
+		if (overlay) {
+			this.removeLayer(overlay);
+		}
+		return this;
 	}
 });

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -159,7 +159,9 @@ export var DivOverlay = Layer.extend({
 		return this;
 	},
 
-	_prepareOpen: function (parent, layer, latlng) {
+	_open: function (parent, layer, latlng) {
+		if (!parent._map) { return; }
+
 		if (!(layer instanceof Layer)) {
 			latlng = layer;
 			layer = parent;
@@ -188,7 +190,10 @@ export var DivOverlay = Layer.extend({
 		// update the overlay (content, layout, ect...)
 		this.update();
 
-		return latlng;
+		// open the overlay on the map
+		this._openOnMap(parent._map, latlng);
+
+		return true;
 	},
 
 	_updateContent: function () {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -242,7 +242,7 @@ export var DivOverlay = Layer.extend({
 });
 
 Map.include({
-	_initOverlay: function (OverlayClass, overlay, latlng, options) {
+	_openOverlay: function (OverlayClass, overlay, latlng, options, fnInit) {
 		if (!(overlay instanceof OverlayClass)) {
 			overlay = new OverlayClass(options).setContent(overlay);
 		}
@@ -251,6 +251,13 @@ Map.include({
 			overlay.setLatLng(latlng);
 		}
 
-		return overlay;
+		if (!this.hasLayer(overlay)) {
+			if (fnInit) {
+				fnInit.call(this, overlay);
+			}
+			this.addLayer(overlay);
+		}
+
+		return this;
 	}
 });

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -4,6 +4,7 @@ import * as Util from '../core/Util';
 import {toLatLng} from '../geo/LatLng';
 import {toPoint} from '../geometry/Point';
 import * as DomUtil from '../dom/DomUtil';
+import {Map} from '../map/Map';
 
 /*
  * @class DivOverlay
@@ -238,4 +239,18 @@ export var DivOverlay = Layer.extend({
 		return [0, 0];
 	}
 
+});
+
+Map.include({
+	_initOverlay: function (OverlayClass, overlay, latlng, options) {
+		if (!(overlay instanceof OverlayClass)) {
+			overlay = new OverlayClass(options).setContent(overlay);
+		}
+
+		if (latlng) {
+			overlay.setLatLng(latlng);
+		}
+
+		return overlay;
+	}
 });

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -175,6 +175,10 @@ export var DivOverlay = Layer.extend({
 			}
 		}
 
+		if (typeof this._content === 'function' && !this._content(layer || this)) {
+			return; // no content for tooltip
+		}
+
 		if (!latlng) {
 			if (layer.getCenter) {
 				latlng = layer.getCenter();

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -320,19 +320,13 @@ Map.include({
 	// @method openPopup(content: String|HTMLElement, latlng: LatLng, options?: Popup options): this
 	// Creates a popup with the specified content and options and opens it in the given point on a map.
 	openPopup: function (popup, latlng, options) {
-		popup = this._initOverlay(Popup, popup, latlng, options);
-
-		if (!this.hasLayer(popup)) {
+		return this._openOverlay(Popup, popup, latlng, options, function (popup) {
 			if (this._popup && this._popup.options.autoClose) {
 				this.closePopup();
 			}
 
 			this._popup = popup;
-			this.addLayer(popup);
-		}
-
-		return this;
-
+		});
 	},
 
 	// @method closePopup(popup?: Popup): this

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -285,6 +285,10 @@ export var Popup = DivOverlay.extend({
 	_getAnchor: function () {
 		// Where should we anchor the popup on the source layer?
 		return toPoint(this._source && this._source._getPopupAnchor ? this._source._getPopupAnchor() : [0, 0]);
+	},
+
+	_openOnMap: function (map, latlng) {
+		map.openPopup(this, latlng);
 	}
 
 });
@@ -417,11 +421,8 @@ Layer.include({
 	// @method openPopup(latlng?: LatLng): this
 	// Opens the bound popup at the specified `latlng` or at the default popup anchor if no `latlng` is passed.
 	openPopup: function (layer, latlng) {
-		if (this._popup && this._map) {
-			latlng = this._popup._prepareOpen(this, layer, latlng);
-
-			// open the popup on the map
-			this._map.openPopup(this._popup, latlng);
+		if (this._popup) {
+			this._popup._open(this, layer, latlng);
 		}
 
 		return this;

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -320,24 +320,19 @@ Map.include({
 	// @method openPopup(content: String|HTMLElement, latlng: LatLng, options?: Popup options): this
 	// Creates a popup with the specified content and options and opens it in the given point on a map.
 	openPopup: function (popup, latlng, options) {
-		if (!(popup instanceof Popup)) {
-			popup = new Popup(options).setContent(popup);
+		popup = this._initOverlay(Popup, popup, latlng, options);
+
+		if (!this.hasLayer(popup)) {
+			if (this._popup && this._popup.options.autoClose) {
+				this.closePopup();
+			}
+
+			this._popup = popup;
+			this.addLayer(popup);
 		}
 
-		if (latlng) {
-			popup.setLatLng(latlng);
-		}
+		return this;
 
-		if (this.hasLayer(popup)) {
-			return this;
-		}
-
-		if (this._popup && this._popup.options.autoClose) {
-			this.closePopup();
-		}
-
-		this._popup = popup;
-		return this.addLayer(popup);
 	},
 
 	// @method closePopup(popup?: Popup): this

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -336,10 +336,7 @@ Map.include({
 			popup = this._popup;
 			this._popup = null;
 		}
-		if (popup) {
-			this.removeLayer(popup);
-		}
-		return this;
+		return this._closeOverlay(popup);
 	}
 });
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -184,6 +184,10 @@ export var Tooltip = DivOverlay.extend({
 	_getAnchor: function () {
 		// Where should we anchor the tooltip on the source layer?
 		return toPoint(this._source && this._source._getTooltipAnchor && !this.options.sticky ? this._source._getTooltipAnchor() : [0, 0]);
+	},
+
+	_openOnMap: function (map, latlng) {
+		map.openTooltip(this, latlng);
 	}
 
 });
@@ -311,11 +315,7 @@ Layer.include({
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
 	openTooltip: function (layer, latlng) {
-		if (this._tooltip && this._map) {
-			latlng = this._tooltip._prepareOpen(this, layer, latlng);
-
-			// open the tooltip on the map
-			this._map.openTooltip(this._tooltip, latlng);
+		if (this._tooltip && this._tooltip._open(this, layer, latlng)) {
 
 			// Tooltip container may not be defined if not permanent and never
 			// opened.

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -215,10 +215,7 @@ Map.include({
 	// @method closeTooltip(tooltip?: Tooltip): this
 	// Closes the tooltip given as parameter.
 	closeTooltip: function (tooltip) {
-		if (tooltip) {
-			this.removeLayer(tooltip);
-		}
-		return this;
+		return this._closeOverlay(tooltip);
 	}
 
 });

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -209,19 +209,13 @@ Map.include({
 	// @method openTooltip(content: String|HTMLElement, latlng: LatLng, options?: Tooltip options): this
 	// Creates a tooltip with the specified content and options and open it.
 	openTooltip: function (tooltip, latlng, options) {
-		if (!(tooltip instanceof Tooltip)) {
-			tooltip = new Tooltip(options).setContent(tooltip);
+		tooltip = this._initOverlay(Tooltip, tooltip, latlng, options);
+
+		if (!this.hasLayer(tooltip)) {
+			this.addLayer(tooltip);
 		}
 
-		if (latlng) {
-			tooltip.setLatLng(latlng);
-		}
-
-		if (this.hasLayer(tooltip)) {
-			return this;
-		}
-
-		return this.addLayer(tooltip);
+		return this;
 	},
 
 	// @method closeTooltip(tooltip?: Tooltip): this

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -209,13 +209,7 @@ Map.include({
 	// @method openTooltip(content: String|HTMLElement, latlng: LatLng, options?: Tooltip options): this
 	// Creates a tooltip with the specified content and options and open it.
 	openTooltip: function (tooltip, latlng, options) {
-		tooltip = this._initOverlay(Tooltip, tooltip, latlng, options);
-
-		if (!this.hasLayer(tooltip)) {
-			this.addLayer(tooltip);
-		}
-
-		return this;
+		return this._openOverlay(Tooltip, tooltip, latlng, options);
 	},
 
 	// @method closeTooltip(tooltip?: Tooltip): this


### PR DESCRIPTION
Allow return undefined (in this case Popup/Tooltip is not shown)

Note: _This adds single commit to already reviewed #6639_

---
As said in docs to [`FeatureGroup`](https://leafletjs.com/reference-1.5.0.html#featuregroup) (and thus `GeoJSON`, as it extends `FeatureGroup`), _`bindPopup` binds a popup **to all of the layers at once** (likewise with `bindTooltip`)_.

And what is implied (but not said explicitly) - function **must** return value for every layer (otherwise we get exception).

But in my practice it's more common when only **some** of layers need Popup/Tooltip.
This PR adds such possibility.