### PR TITLE
Allow overriding of GeoJSON output

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -471,3 +471,44 @@ describe("L.LayerGroup#toGeoJSON", function () {
 		});
 	});
 });
+
+describe("Overriding #toGeoJSON formatting", function () {
+	it("is possible to overwrite output of #toGeoJSON coordinates", function () {
+		var marker = new L.Marker([-1.4837191022531273, 43.49222084042808]),
+		    layerGroup = new L.LayerGroup([marker]);
+
+		expect(layerGroup.toGeoJSON()).to.eql({
+			type: 'FeatureCollection',
+			features: [{
+				type: 'Feature',
+				properties: {},
+				geometry: {
+					type: 'Point',
+					coordinates: [43.492221, -1.483719]
+				}
+			}]
+		});
+
+		L.GeoJSON.latLngToCoords = function (latlng, precision) {
+			if (typeof precision === 'number') {
+				return latlng.alt !== undefined ?
+					[L.Util.formatNum(latlng.lng, precision), L.Util.formatNum(latlng.lat, precision), L.Util.formatNum(latlng.alt, precision)] :
+					[L.Util.formatNum(latlng.lng, precision), L.Util.formatNum(latlng.lat, precision)];
+			} else {
+				return latlng.alt !== undefined ? [latlng.lng, latlng.lat, latlng.alt] : [latlng.lng, latlng.lat];
+			}
+		};
+
+		expect(layerGroup.toGeoJSON()).to.eql({
+			type: 'FeatureCollection',
+			features: [{
+				type: 'Feature',
+				properties: {},
+				geometry: {
+					type: 'Point',
+					coordinates: [43.49222084042808, -1.4837191022531273]
+				}
+			}]
+		});
+	});
+});

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -258,7 +258,7 @@ export function latLngsToCoords(latlngs, levelsDeep, closed, precision) {
 	for (var i = 0, len = latlngs.length; i < len; i++) {
 		coords.push(levelsDeep ?
 			latLngsToCoords(latlngs[i], levelsDeep - 1, closed, precision) :
-			latLngToCoords(latlngs[i], precision));
+			GeoJSON.latLngToCoords(latlngs[i], precision));
 	}
 
 	if (!levelsDeep && closed) {
@@ -292,7 +292,7 @@ var PointToGeoJSON = {
 	toGeoJSON: function (precision) {
 		return getFeature(this, {
 			type: 'Point',
-			coordinates: latLngToCoords(this.getLatLng(), precision)
+			coordinates: GeoJSON.latLngToCoords(this.getLatLng(), precision)
 		});
 	}
 };


### PR DESCRIPTION
**Background:**

I reported in #6586 a problem about accuracy in `L.Util.formatNum` rounding method.
Following my pull request, a performance issue has been reported in #6668, and my changes have been reverted.

**Problem:**

I agree with the arguments advanced in this last thread.
In the end, I especially have a problem with the inaccuracy of the `toGeoJson` function.

The solution for me was to overwrite the `GeoJSON.latLngToCoords` but it's not so easy because Leaflet uses internal API.
If I overwrite this function, it won't be used by `GeoJSON.latLngsToCoords`.
If I also overwrite this function,  it won't be used by every `toGeoJSON` declared for each feature.
Et cetera. At the end, I have to copy so many functions.

**Solution:**

I just replaced `latLngToCoords` with `GeoJSON.latLngToCoords`

EDIT : the first PR text was submitted by error.
