### PR TITLE
Check for elements in e.touches

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -112,7 +112,7 @@ export var Draggable = Evented.extend({
 		// Fired when a drag is about to start.
 		this.fire('down');
 
-		var first = e.touches ? e.touches[0] : e,
+		var first = e.touches && e.touches.length > 0 ? e.touches[0] : e,
 		    sizedParent = DomUtil.getSizedParentNode(this._element);
 
 		this._startPoint = new Point(first.clientX, first.clientY);


### PR DESCRIPTION
My map wouldn't drag.  After inspecting, I found that the touches element existed on the object, but had no elements.  Doing a check for the number of elements avoided an array out of bounds issue.