### PR TITLE
RIP Mapzen: update Pelias geocoder plugin info

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4209,10 +4209,10 @@ External services that transform an address or the name of a place into latitude
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/mapzen/leaflet-geocoder">Mapzen Search Leaflet Geocoder</a>
+			<a href="https://github.com/pelias/leaflet-plugin">Pelias Leaflet Plugin</a>
 		</td>
 		<td>
-			A geocoding control using <a href="https://mapzen.com/projects/search">Mapzen Search</a> or any hosted service powered by the <a href="https://github.com/pelias/api">Pelias Geocoder API</a>.  <a href="https://mapzen.github.io/leaflet-geocoder/">Demo</a>
+			A geocoding control using <a href="https://geocode.earth">Geocode Earth</a> or any hosted service powered by the <a href="https://github.com/pelias/api">Pelias Geocoder API</a>.  <a href="https://pelias.github.io/leaflet-plugin/">Demo</a>
 		</td>
 		<td>
 			<a href="https://github.com/louh">Lou Huang</a>


### PR DESCRIPTION
This PR updates information about what was previously called the `mapzen/leaflet-geocoder` and is now named `pelias/leaflet-plugin`.

I've updated the service URL to point to 'geocode.earth' which is run by the same people that ran the 'Mapzen Search' (full disclosure, I am one of them).

I just merged https://github.com/pelias/leaflet-plugin/pull/179 to fix the demo to remove all the old `mapzen.com` links.
The geocode.earth API key hasn't been enabled on our rate-limiter yet but should be available for use shortly.
