### PR TITLE
Update Carto tiles and attribution links to HTTPS

### DIFF
--- a/docs/examples/extending/pixelorigin.md
+++ b/docs/examples/extending/pixelorigin.md
@@ -34,8 +34,8 @@ title: Grid coordinates
 		zoom: 1
 	});
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-		attribution: "CartoDB"
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
 	}).addTo(map);
 
 	var marker = L.marker(trd).addTo(map);

--- a/docs/examples/extending/tilt.md
+++ b/docs/examples/extending/tilt.md
@@ -52,8 +52,8 @@ title: Tilt handler
 		tilt: true
 	});
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-		attribution: "CartoDB"
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
 	}).addTo(map);
 	
 </script>

--- a/docs/examples/extending/watermark.md
+++ b/docs/examples/extending/watermark.md
@@ -8,8 +8,8 @@ title: Watermark control
 		zoom: 1
 	});
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-		attribution: "CartoDB"
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
 	}).addTo(map);
 
 	L.Control.Watermark = L.Control.extend({

--- a/docs/examples/map-panes/example.md
+++ b/docs/examples/map-panes/example.md
@@ -16,10 +16,9 @@ title: Custom Icons Tutorial
 	// Layers in this pane are non-interactive and do not obscure mouse/touch events
 	map.getPane('labels').style.pointerEvents = 'none';
 
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
-
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/map-panes/index.md
+++ b/docs/examples/map-panes/index.md
@@ -21,7 +21,7 @@ A new feature of **Leaflet 1.0.0** (not present in 0.7.x) is custom map panes, w
 
 ## The default is not always right
 
-In some particular cases, the default order is not the right one for the map. We can demonstrate this with the [Carto basemaps](https://cartodb.com/basemaps/) and labels:
+In some particular cases, the default order is not the right one for the map. We can demonstrate this with the [Carto basemaps](https://carto.com/location-data-services/basemaps/) and labels:
 
 
 <style>
@@ -79,11 +79,11 @@ One of the problems of having image tiles on top of other map layers is that the
 With the pane now ready, we can add the layers, paying attention to use the `pane` option on the labels tiles:
 
 
-    var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+    var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
             attribution: '©OpenStreetMap, ©CartoDB'
     }).addTo(map);
 
-    var positronLabels = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png', {
+    var positronLabels = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png', {
             attribution: '©OpenStreetMap, ©CartoDB',
             pane: 'labels'
     }).addTo(map);

--- a/docs/examples/zoom-levels/example-delta.md
+++ b/docs/examples/zoom-levels/example-delta.md
@@ -11,9 +11,9 @@ title: Zoom Levels Tutorial
 		zoomDelta: 0.25
 	});
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-fractional.md
+++ b/docs/examples/zoom-levels/example-fractional.md
@@ -11,12 +11,11 @@ title: Zoom Levels Tutorial
 		dragging: false
 	});
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
-
 
 	function zoomCycle(){
 		map.setZoom(0);

--- a/docs/examples/zoom-levels/example-scale.md
+++ b/docs/examples/zoom-levels/example-scale.md
@@ -10,9 +10,9 @@ title: Zoom Levels Tutorial
 		dragging: false
 	});
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-setzoom.md
+++ b/docs/examples/zoom-levels/example-setzoom.md
@@ -9,9 +9,9 @@ title: Zoom Levels Tutorial
 		maxZoom: 1
 	});
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-zero.md
+++ b/docs/examples/zoom-levels/example-zero.md
@@ -9,9 +9,9 @@ title: Zoom Levels Tutorial
 		maxZoom: 0
 	});
 
-	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/index.md
+++ b/docs/examples/zoom-levels/index.md
@@ -37,7 +37,6 @@ To understand how zoom levels work, first we need a basic introduction to <i>geo
 
 Let's have a look at a simple map locked at zoom zero:
 
-```
 	var map = L.map('map', {
 		minZoom: 0,
 		maxZoom: 0
@@ -50,7 +49,6 @@ Let's have a look at a simple map locked at zoom zero:
 	}).addTo(map);
 
 	map.setView([0, 0], 0);
-```
 
 {% include frame.html url="example-zero.html" %}
 
@@ -153,7 +151,6 @@ we can see how the scale factor <b>doubles</b>. The following example uses
 [javascript timeouts](https://developer.mozilla.org/docs/Web/API/WindowTimers/setTimeout)
 to  do this automatically:
 
-```
 	L.control.scale().addTo(map);
 
 	setInterval(function(){
@@ -162,7 +159,6 @@ to  do this automatically:
 			map.setView([60, 0]);
 		}, 2000);
 	}, 4000);
-```
 
 {% include frame.html url="example-scale.html" %}
 
@@ -178,14 +174,12 @@ will set the zoom level of `map` to `0`.
 
 This example again uses timeouts to alternate between zoom levels `0` and `1` automatically:
 
-```
 	setInterval(function(){
 		map.setZoom(0);
 		setTimeout(function(){
 			map.setZoom(1);
 		}, 2000);
 	}, 4000);
-```
 
 {% include frame.html url="example-setzoom.html" %}
 
@@ -221,11 +215,9 @@ If you set a value of `0.1`, the valid zoom levels of the map will be `0`, `0.1`
 
 The following example uses a `zoomSnap` value of `0.25`:
 
-```
 	var map = L.map('map', {
 		zoomSnap: 0.25
 	});
-```
 
 {% include frame.html url="example-fractional.html" %}
 
@@ -250,12 +242,10 @@ option controls how fast the mousewheel zooms in our out.
 
 Here is an example with `zoomSnap` set to zero:
 
-```
 	var map = L.map('map', {
 		zoomDelta: 0.25,
 		zoomSnap: 0
 	});
-```
 
 Try the following, and see how the zoom level changes:
 

--- a/docs/examples/zoom-levels/index.md
+++ b/docs/examples/zoom-levels/index.md
@@ -43,7 +43,9 @@ Let's have a look at a simple map locked at zoom zero:
 		maxZoom: 0
 	});
 
-	var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	var cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
+
+	var positron = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 


### PR DESCRIPTION
I noticed some mixed content warnings while browsing the docs today.

This PR fixes all the Carto tile links.

I also updated the attribution to their new HTTPS website.

I also included a fix for the indentation that way showing tabs at the start of every line in the code blocks. I updated it to reflect the style used in other examples (indentation-based markdown code block instead of backticks)

I tested the website locally to verify all examples still run.