### PR TITLE
Expose a server api

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -2,6 +2,7 @@
 
 import rollupGitVersion from 'rollup-plugin-git-version'
 import json from 'rollup-plugin-json'
+import resolve from 'rollup-plugin-node-resolve'
 import gitRev from 'git-rev-sync'
 import pkg from '../package.json'
 
@@ -53,6 +54,9 @@ export default {
 	],
 	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
-		release ? json() : rollupGitVersion()
+		release ? json() : rollupGitVersion(),
+		resolve({
+			browser: true
+		})
 	]
 };

--- a/build/rollup-watch-config.js
+++ b/build/rollup-watch-config.js
@@ -2,6 +2,7 @@
 // This adds a sanity check to help ourselves to run 'rollup -w' as needed.
 
 import rollupGitVersion from 'rollup-plugin-git-version'
+import resolve from 'rollup-plugin-node-resolve'
 import gitRev from 'git-rev-sync'
 
 const branch = gitRev.branch();
@@ -24,6 +25,9 @@ export default {
 	},
 	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
-		rollupGitVersion()
+		rollupGitVersion(),
+		resolve({
+			browser: true
+		})
 	]
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "rollup": "0.51.8",
     "rollup-plugin-git-version": "0.2.1",
     "rollup-plugin-json": "^4.0.0",
+    "rollup-plugin-node-resolve": "^3.4.0",
     "sinon": "^7.3.2",
     "ssri": "^6.0.1",
     "uglify-js": "~3.5.10"
@@ -34,10 +35,14 @@
     "src",
     "!dist/leaflet.zip"
   ],
+  "browser": {
+    "./src/core/Browser.js": "./src/core/BrowserActual.js"
+  },
   "scripts": {
     "docs": "node ./build/docs.js",
     "pretest": "npm run lint && npm run lint-spec",
-    "test": "npm run test-nolint",
+    "test": "npm run test-node && npm run test-nolint",
+    "test-node": "mocha",
     "test-nolint": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
     "release": "./build/publish.sh",
@@ -48,6 +53,15 @@
     "watch": "rollup -w -c build/rollup-watch-config.js",
     "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --in-source-map dist/leaflet-src.js.map --source-map-url leaflet.js.map --comments",
     "integrity": "node ./build/integrity.js"
+  },
+  "mocha": {
+    "file": [
+      "./spec/ServerHelper.js",
+      "./spec/suites/SpecHelper.js"
+    ],
+    "spec": [
+      "./spec/suites/@(core|geometry|geo)/*.js"
+    ]
   },
   "eslintConfig": {
     "root": true,
@@ -97,5 +111,8 @@
     "gis",
     "map"
   ],
-  "license": "BSD-2-Clause"
+  "license": "BSD-2-Clause",
+  "dependencies": {
+    "esm": "^3.2.25"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,2 @@
+module.exports = require('esm')(module)('./src/LeafletServer');
+

--- a/spec/ServerHelper.js
+++ b/spec/ServerHelper.js
@@ -1,0 +1,4 @@
+global.L = require('../server');
+global.expect = require('expect.js');
+global.happen = require('happen');
+global.sinon = require('sinon');

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -1,4 +1,5 @@
 var json = require('rollup-plugin-json');
+var resolve = require('rollup-plugin-node-resolve');
 
 const outro = `var oldL = window.L;
 exports.noConflict = function() {
@@ -57,6 +58,9 @@ module.exports = function (config) {
 		preprocessors: preprocessors,
 		rollupPreprocessor: {
 			plugins: [
+				resolve({
+					browser: true
+				}),
 				json()
 			],
 			format: 'umd',

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -59,11 +59,10 @@ it.skipInPhantom = L.Browser.any3d ? it : it.skip;
 it.skipInNonPhantom = L.Browser.any3d ? it.skip : it;
 
 // A couple of tests need the browser to be touch-capable
-it.skipIfNotTouch = window.TouchEvent ? it : it.skip;
+it.skipIfNotTouch = L.Browser.touch ? it : it.skip;
 
 // A couple of tests need the browser to be pointer-capable
-it.skipIfNotEdge = window.PointerEvent ? it : it.skip;
-
+it.skipIfNotEdge = L.Browser.pointer ? it : it.skip;
 
 function takeScreenshot(path) {
 	window.top.callPhantom({'render': path || 'screenshot.png'});

--- a/spec/suites/core/GeneralSpec.js
+++ b/spec/suites/core/GeneralSpec.js
@@ -1,5 +1,7 @@
 describe('General', function () {
-	describe('noConflict', function () {
+	it.skipInNode = L.Browser.node ? it.skip : it;
+
+	it.skipInNode('noConflict', function () {
 		var leaflet = L;
 
 		after(function () {
@@ -9,7 +11,7 @@ describe('General', function () {
 		expect(L.noConflict()).to.eql(leaflet);
 	});
 
-	describe('namespace extension', function () {
+	it('namespace extension', function () {
 		L.Util.foo = 'bar';
 		L.Foo = 'Bar';
 

--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -123,14 +123,14 @@ describe('Util', function () {
 			var spy = sinon.spy(),
 			    foo = {};
 
-			L.Util.requestAnimFrame(spy);
+			var id = L.Util.requestAnimFrame(spy);
 
 			L.Util.requestAnimFrame(function () {
 				expect(this).to.eql(foo);
 				done();
 			}, foo);
 
-			L.Util.cancelAnimFrame(spy);
+			L.Util.cancelAnimFrame(id);
 		});
 	});
 

--- a/src/LeafletServer.js
+++ b/src/LeafletServer.js
@@ -1,0 +1,24 @@
+// A subset of the API that will work in Node.
+
+import {version} from '../package.json';
+export {version};
+
+// control -- not supported
+
+// core
+export * from './core/index';
+
+// dom -- not supported
+
+// geometry
+export * from './geometry/index';
+
+// geo
+export * from './geo/index';
+
+// layer -- not supported
+
+// map -- not supported
+
+import {freeze} from './core/Util';
+Object.freeze = freeze;

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -1,165 +1,50 @@
-import * as Util from './Util';
-import {svgCreate} from '../layer/vector/SVG.Util';
+/* eslint-env node */
+// This is just a shim for node.js. See BrowserActual.js for actual implementation
 
-/*
- * @namespace Browser
- * @aka L.Browser
- *
- * A namespace with static properties for browser/feature detection used by Leaflet internally.
- *
- * @example
- *
- * ```js
- * if (L.Browser.ielt9) {
- *   alert('Upgrade your browser, dude!');
- * }
- * ```
- */
+export var node = true;
+export var ie = false;
+export var ielt9 = false;
+export var edge = false;
+export var webkit = false;
+export var android = false;
+export var android23 = false;
+export var androidStock = false;
+export var opera = false;
+export var chrome = false;
+export var gecko = false;
+export var safari = false;
+export var phantom = false;
+export var opera12 = false;
+export var win = false;
+export var ie3d = false;
+export var webkit3d = false;
+export var gecko3d = false;
+export var any3d = false;
+export var mobile = false;
+export var mobileWebkit = false;
+export var mobileWebkit3d = false;
+export var msPointer = false;
+export var pointer = false;
+export var touch = false;
+export var mobileOpera = false;
+export var mobileGecko = false;
+export var retina = false;
+export var passiveEvents = false;
 
-var style = document.documentElement.style;
+// TODO: There are libraries that support some of these in Node (i.e. github.com/Automattic/node-canvas).
+export var canvas = false;
+export var svg = false;
+export var vml = false;
 
-// @property ie: Boolean; `true` for all Internet Explorer versions (not Edge).
-export var ie = 'ActiveXObject' in window;
+export var requestFn = setImmediate;
+export var cancelFn = clearImmediate;
 
-// @property ielt9: Boolean; `true` for Internet Explorer versions less than 9.
-export var ielt9 = ie && !document.addEventListener;
+export function requestAnimFrame(fn, context) {
+	return setImmediate(fn.bind(context));
+}
 
-// @property edge: Boolean; `true` for the Edge web browser.
-export var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
-
-// @property webkit: Boolean;
-// `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
-export var webkit = userAgentContains('webkit');
-
-// @property android: Boolean
-// `true` for any browser running on an Android platform.
-export var android = userAgentContains('android');
-
-// @property android23: Boolean; `true` for browsers running on Android 2 or Android 3.
-export var android23 = userAgentContains('android 2') || userAgentContains('android 3');
-
-/* See https://stackoverflow.com/a/17961266 for details on detecting stock Android */
-var webkitVer = parseInt(/WebKit\/([0-9]+)|$/.exec(navigator.userAgent)[1], 10); // also matches AppleWebKit
-// @property androidStock: Boolean; `true` for the Android stock browser (i.e. not Chrome)
-export var androidStock = android && userAgentContains('Google') && webkitVer < 537 && !('AudioNode' in window);
-
-// @property opera: Boolean; `true` for the Opera browser
-export var opera = !!window.opera;
-
-// @property chrome: Boolean; `true` for the Chrome browser.
-export var chrome = userAgentContains('chrome');
-
-// @property gecko: Boolean; `true` for gecko-based browsers like Firefox.
-export var gecko = userAgentContains('gecko') && !webkit && !opera && !ie;
-
-// @property safari: Boolean; `true` for the Safari browser.
-export var safari = !chrome && userAgentContains('safari');
-
-export var phantom = userAgentContains('phantom');
-
-// @property opera12: Boolean
-// `true` for the Opera browser supporting CSS transforms (version 12 or later).
-export var opera12 = 'OTransition' in style;
-
-// @property win: Boolean; `true` when the browser is running in a Windows platform
-export var win = navigator.platform.indexOf('Win') === 0;
-
-// @property ie3d: Boolean; `true` for all Internet Explorer versions supporting CSS transforms.
-export var ie3d = ie && ('transition' in style);
-
-// @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
-export var webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23;
-
-// @property gecko3d: Boolean; `true` for gecko-based browsers supporting CSS transforms.
-export var gecko3d = 'MozPerspective' in style;
-
-// @property any3d: Boolean
-// `true` for all browsers supporting CSS transforms.
-export var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
-
-// @property mobile: Boolean; `true` for all browsers running in a mobile device.
-export var mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
-
-// @property mobileWebkit: Boolean; `true` for all webkit-based browsers in a mobile device.
-export var mobileWebkit = mobile && webkit;
-
-// @property mobileWebkit3d: Boolean
-// `true` for all webkit-based browsers in a mobile device supporting CSS transforms.
-export var mobileWebkit3d = mobile && webkit3d;
-
-// @property msPointer: Boolean
-// `true` for browsers implementing the Microsoft touch events model (notably IE10).
-export var msPointer = !window.PointerEvent && window.MSPointerEvent;
-
-// @property pointer: Boolean
-// `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
-export var pointer = !!(window.PointerEvent || msPointer);
-
-// @property touch: Boolean
-// `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).
-// This does not necessarily mean that the browser is running in a computer with
-// a touchscreen, it only means that the browser is capable of understanding
-// touch events.
-export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
-		(window.DocumentTouch && document instanceof window.DocumentTouch));
-
-// @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
-export var mobileOpera = mobile && opera;
-
-// @property mobileGecko: Boolean
-// `true` for gecko-based browsers running in a mobile device.
-export var mobileGecko = mobile && gecko;
-
-// @property retina: Boolean
-// `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom is more than 100%.
-export var retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1;
-
-// @property passiveEvents: Boolean
-// `true` for browsers that support passive events.
-export var passiveEvents = (function () {
-	var supportsPassiveOption = false;
-	try {
-		var opts = Object.defineProperty({}, 'passive', {
-			get: function () {
-				supportsPassiveOption = true;
-			}
-		});
-		window.addEventListener('testPassiveEventSupport', Util.falseFn, opts);
-		window.removeEventListener('testPassiveEventSupport', Util.falseFn, opts);
-	} catch (e) {
-		// Errors can safely be ignored since this is only a browser support test.
+export function cancelAnimFrame(id) {
+	if (id) {
+		clearImmediate(id);
 	}
-	return supportsPassiveOption;
-});
-
-// @property canvas: Boolean
-// `true` when the browser supports [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).
-export var canvas = (function () {
-	return !!document.createElement('canvas').getContext;
-}());
-
-// @property svg: Boolean
-// `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
-export var svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
-
-// @property vml: Boolean
-// `true` if the browser supports [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language).
-export var vml = !svg && (function () {
-	try {
-		var div = document.createElement('div');
-		div.innerHTML = '<v:shape adj="1"/>';
-
-		var shape = div.firstChild;
-		shape.style.behavior = 'url(#default#VML)';
-
-		return shape && (typeof shape.adj === 'object');
-
-	} catch (e) {
-		return false;
-	}
-}());
-
-
-function userAgentContains(str) {
-	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
 }

--- a/src/core/BrowserActual.js
+++ b/src/core/BrowserActual.js
@@ -1,0 +1,211 @@
+import {bind, falseFn} from './BrowserCommon';
+import {svgCreate} from '../layer/vector/SVG.Util';
+
+/*
+ * @namespace Browser
+ * @aka L.Browser
+ *
+ * A namespace with static properties for browser/feature detection used by Leaflet internally.
+ *
+ * @example
+ *
+ * ```js
+ * if (L.Browser.ielt9) {
+ *   alert('Upgrade your browser, dude!');
+ * }
+ * ```
+ */
+
+// @property node: Boolean; `true` if running in Node.js
+export var node = false;
+
+var style = document.documentElement.style;
+
+// @property ie: Boolean; `true` for all Internet Explorer versions (not Edge).
+export var ie = 'ActiveXObject' in window;
+
+// @property ielt9: Boolean; `true` for Internet Explorer versions less than 9.
+export var ielt9 = ie && !document.addEventListener;
+
+// @property edge: Boolean; `true` for the Edge web browser.
+export var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
+
+// @property webkit: Boolean;
+// `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
+export var webkit = userAgentContains('webkit');
+
+// @property android: Boolean
+// `true` for any browser running on an Android platform.
+export var android = userAgentContains('android');
+
+// @property android23: Boolean; `true` for browsers running on Android 2 or Android 3.
+export var android23 = userAgentContains('android 2') || userAgentContains('android 3');
+
+/* See https://stackoverflow.com/a/17961266 for details on detecting stock Android */
+var webkitVer = parseInt(/WebKit\/([0-9]+)|$/.exec(navigator.userAgent)[1], 10); // also matches AppleWebKit
+// @property androidStock: Boolean; `true` for the Android stock browser (i.e. not Chrome)
+export var androidStock = android && userAgentContains('Google') && webkitVer < 537 && !('AudioNode' in window);
+
+// @property opera: Boolean; `true` for the Opera browser
+export var opera = !!window.opera;
+
+// @property chrome: Boolean; `true` for the Chrome browser.
+export var chrome = userAgentContains('chrome');
+
+// @property gecko: Boolean; `true` for gecko-based browsers like Firefox.
+export var gecko = userAgentContains('gecko') && !webkit && !opera && !ie;
+
+// @property safari: Boolean; `true` for the Safari browser.
+export var safari = !chrome && userAgentContains('safari');
+
+export var phantom = userAgentContains('phantom');
+
+// @property opera12: Boolean
+// `true` for the Opera browser supporting CSS transforms (version 12 or later).
+export var opera12 = 'OTransition' in style;
+
+// @property win: Boolean; `true` when the browser is running in a Windows platform
+export var win = navigator.platform.indexOf('Win') === 0;
+
+// @property ie3d: Boolean; `true` for all Internet Explorer versions supporting CSS transforms.
+export var ie3d = ie && ('transition' in style);
+
+// @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
+export var webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23;
+
+// @property gecko3d: Boolean; `true` for gecko-based browsers supporting CSS transforms.
+export var gecko3d = 'MozPerspective' in style;
+
+// @property any3d: Boolean
+// `true` for all browsers supporting CSS transforms.
+export var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
+
+// @property mobile: Boolean; `true` for all browsers running in a mobile device.
+export var mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
+
+// @property mobileWebkit: Boolean; `true` for all webkit-based browsers in a mobile device.
+export var mobileWebkit = mobile && webkit;
+
+// @property mobileWebkit3d: Boolean
+// `true` for all webkit-based browsers in a mobile device supporting CSS transforms.
+export var mobileWebkit3d = mobile && webkit3d;
+
+// @property msPointer: Boolean
+// `true` for browsers implementing the Microsoft touch events model (notably IE10).
+export var msPointer = !window.PointerEvent && window.MSPointerEvent;
+
+// @property pointer: Boolean
+// `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
+export var pointer = !!(window.PointerEvent || msPointer);
+
+// @property touch: Boolean
+// `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).
+// This does not necessarily mean that the browser is running in a computer with
+// a touchscreen, it only means that the browser is capable of understanding
+// touch events.
+export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
+	(window.DocumentTouch && document instanceof window.DocumentTouch));
+
+// @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
+export var mobileOpera = mobile && opera;
+
+// @property mobileGecko: Boolean
+// `true` for gecko-based browsers running in a mobile device.
+export var mobileGecko = mobile && gecko;
+
+// @property retina: Boolean
+// `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom is more than 100%.
+export var retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1;
+
+// @property passiveEvents: Boolean
+// `true` for browsers that support passive events.
+export var passiveEvents = (function () {
+	var supportsPassiveOption = false;
+	try {
+		var opts = Object.defineProperty({}, 'passive', {
+			get: function () {
+				supportsPassiveOption = true;
+			}
+		});
+		window.addEventListener('testPassiveEventSupport', falseFn, opts);
+		window.removeEventListener('testPassiveEventSupport', falseFn, opts);
+	} catch (e) {
+		// Errors can safely be ignored since this is only a browser support test.
+	}
+	return supportsPassiveOption;
+});
+
+// @property canvas: Boolean
+// `true` when the browser supports [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).
+export var canvas = (function () {
+	return !!document.createElement('canvas').getContext;
+}());
+
+// @property svg: Boolean
+// `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
+export var svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
+
+// @property vml: Boolean
+// `true` if the browser supports [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language).
+export var vml = !svg && (function () {
+	try {
+		var div = document.createElement('div');
+		div.innerHTML = '<v:shape adj="1"/>';
+
+		var shape = div.firstChild;
+		shape.style.behavior = 'url(#default#VML)';
+
+		return shape && (typeof shape.adj === 'object');
+
+	} catch (e) {
+		return false;
+	}
+}());
+
+function userAgentContains(str) {
+	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
+}
+
+// inspired by http://paulirish.com/2011/requestanimationframe-for-smart-animating/
+
+function getPrefixed(name) {
+	return window['webkit' + name] || window['moz' + name] || window['ms' + name];
+}
+
+var lastTime = 0;
+
+// fallback for IE 7-8
+function timeoutDefer(fn) {
+	var time = +new Date(),
+	    timeToCall = Math.max(0, 16 - (time - lastTime));
+
+	lastTime = time + timeToCall;
+	return window.setTimeout(fn, timeToCall);
+}
+
+export var requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer;
+export var cancelFn = window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
+	getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); };
+
+// @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): Number
+// Schedules `fn` to be executed when the browser repaints. `fn` is bound to
+// `context` if given. When `immediate` is set, `fn` is called immediately if
+// the browser doesn't have native support for
+// [`window.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame),
+// otherwise it's delayed. Returns a request ID that can be used to cancel the request.
+export function requestAnimFrame(fn, context, immediate) {
+	if (immediate && requestFn === timeoutDefer) {
+		fn.call(context);
+	} else {
+		return requestFn.call(window, bind(fn, context));
+	}
+}
+
+// @function cancelAnimFrame(id: Number): undefined
+// Cancels a previous `requestAnimFrame`. See also [window.cancelAnimationFrame](https://developer.mozilla.org/docs/Web/API/window/cancelAnimationFrame).
+export function cancelAnimFrame(id) {
+	if (id) {
+		cancelFn.call(window, id);
+	}
+}
+

--- a/src/core/BrowserCommon.js
+++ b/src/core/BrowserCommon.js
@@ -1,0 +1,22 @@
+// Code used to define the environment that is shared by both Node and browser implementations.
+
+// @function bind(fn: Function, …): Function
+// Returns a new function bound to the arguments passed, like [Function.prototype.bind](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
+// Has a `L.bind()` shortcut.
+export function bind(fn, obj) {
+	var slice = Array.prototype.slice;
+
+	if (fn.bind) {
+		return fn.bind.apply(fn, slice.call(arguments, 1));
+	}
+
+	var args = slice.call(arguments, 2);
+
+	return function () {
+		return fn.apply(obj, args.length ? args.concat(slice.call(arguments)) : arguments);
+	};
+}
+
+// @function falseFn(): Function
+// Returns a function which always returns `false`.
+export function falseFn() { return false; }


### PR DESCRIPTION
Exposes a limited subset of the API that functions in Node.js.

Includes the following modules:
  * core
  * geo
  * geometry

The following modules are NOT included (because they depend on browser/dom):
  * control
  * dom
  * layer
  * map

I moved around a few functions `core/Util` and `core/Browser` to make swapping the implementation for Node easier. Specifically, any references to `window` were moved out of Util, and into the browser package (Util still exports exactly the same functionality, there should be no breaking changes).

The test suites for the exported API are now also run in Node.

Uses `esm` to provide module support. No bundler / transpiler necessary!

Usage:

```js
const L = require('leaflet/server');
const crs = L.CRS.EPSG3857;

crs.latLngToPoint(L.latLng(0, 0));
```