### PR TITLE
Increased retina detection threshold (readability on non-retina screens)

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -111,8 +111,8 @@ export var mobileOpera = mobile && opera;
 export var mobileGecko = mobile && gecko;
 
 // @property retina: Boolean
-// `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom is more than 100%.
-export var retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1;
+// `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom 200% or more.
+export var retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) >= 2;
 
 // @property passiveEvents: Boolean
 // `true` for browsers that support passive events.


### PR DESCRIPTION
## What
This very simple PR raises the threshold for retina detection. 

Before: `devicePixelRatio > 1.00`
After: `devicePixelRatio >= 2.00`

Tested on three different screens: 1.00, 1.25, 2.00 and default "mapnik" OpenStreetMap tiles. The 1.25 screen gets readable with this change.

## Why
The detection of hi-res displays is awesome and yields a brilliant picture on MacBooks or 4K displays where `devicePixelRatio == 2.00`.
On the other hand, it gives unreadable output on middle-resolution displays where `devicePixelRatio == 1.25`. The text labels on downsampled tiles aren't readable (screenshot on the right). Such a display doesn't seem to be a candidate.

Motivation: visual experiance on DPR=1.25 screen with `detectRetina:false` (left) or `detectRetina:true`:
![egaplnaaepcodopg](https://user-images.githubusercontent.com/20604326/60674621-c92ed880-9e7a-11e9-87e7-5b9709e1f7b7.png)
Note the unreadable street names on the right (download the image and display it 1:1 - still unreadable)



