### PR TITLE
Updated path to check for style being passed

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -105,7 +105,7 @@ export var Path = Layer.extend({
 		Util.setOptions(this, style);
 		if (this._renderer) {
 			this._renderer._updateStyle(this);
-			if (this.options.stroke && style.hasOwnProperty('weight')) {
+			if (this.options.stroke && style && style.hasOwnProperty('weight')) {
 				this._updateBounds();
 			}
 		}


### PR DESCRIPTION
Errors were thrown if the style object was not being passed so I added an extra check for the style object before checking if it "hasOwnProperty('weight').