### PR TITLE
removed throttle for Canvas 'mousemove'

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -60,7 +60,7 @@ export var Canvas = Renderer.extend({
 	_initContainer: function () {
 		var container = this._container = document.createElement('canvas');
 
-		DomEvent.on(container, 'mousemove', Util.throttle(this._onMouseMove, 32, this), this);
+		DomEvent.on(container, 'mousemove', this._onMouseMove, this);
 		DomEvent.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this);
 		DomEvent.on(container, 'mouseout', this._handleMouseOut, this);
 


### PR DESCRIPTION
Due to throttle some events of 'mousemove' not fired which leads to incorrect behavior.

Reproduce for the issue: https://codepen.io/anon/pen/ZgJPzx
Check console, there are a lot of outputs: mouseover and mouseout. With the fix mouseover and mouseout have to be consistently.

The bug only in the Canvas. If change Canvas to SVG everything will good. Just remove rendererFactory: L.canvas.tile from the example.