### PR TITLE
Avoid modifying source props object in Class.extend

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -117,6 +117,22 @@ describe("Class", function () {
 			expect(K2.prototype.options.foo).to.eql('bar');
 		});
 
+		it("does not reuse original props.options", function () {
+			var props = {options: {}};
+			var K = L.Class.extend(props);
+
+			expect(K.prototype.options).not.to.be(props.options);
+		});
+
+		it("does not replace source props.options object", function () {
+			var K1 = L.Class.extend({options: {}});
+			var opts = {};
+			var props = {options: opts};
+			K1.extend(props);
+
+			expect(props.options).to.be(opts);
+		});
+
 		it("adds constructor hooks correctly", function () {
 			var spy1 = sinon.spy();
 

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -2,6 +2,7 @@
 describe("Class", function () {
 	describe("#extend", function () {
 		var Klass,
+		    props,
 		    constructor,
 		    method;
 
@@ -9,14 +10,15 @@ describe("Class", function () {
 			constructor = sinon.spy();
 			method = sinon.spy();
 
-			Klass = L.Class.extend({
+			props = {
 				statics: {bla: 1},
 				includes: {mixin: true},
 
 				initialize: constructor,
 				foo: 5,
 				bar: method
-			});
+			};
+			Klass = L.Class.extend(props);
 		});
 
 		it("creates a class with the given constructor & properties", function () {
@@ -46,8 +48,23 @@ describe("Class", function () {
 			expect(method.called).to.be.ok();
 		});
 
+		it("does not modify source props object", function () {
+			expect(props).to.eql({
+				statics: {bla: 1},
+				includes: {mixin: true},
+
+				initialize: constructor,
+				foo: 5,
+				bar: method
+			});
+		});
+
 		it("supports static properties", function () {
 			expect(Klass.bla).to.eql(1);
+		});
+
+		it("does not merge 'statics' property itself", function () {
+			expect('statics' in Klass.prototype).to.not.be.ok();
 		});
 
 		it("inherits parent static properties", function () {
@@ -65,6 +82,10 @@ describe("Class", function () {
 		it("includes the given mixin", function () {
 			var a = new Klass();
 			expect(a.mixin).to.be.ok();
+		});
+
+		it("does not merge 'includes' property itself", function () {
+			expect('includes' in Klass.prototype).to.not.be.ok();
 		});
 
 		it("includes multiple mixins", function () {

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -43,18 +43,18 @@ Class.extend = function (props) {
 	// mix static properties into the class
 	if (props.statics) {
 		Util.extend(NewClass, props.statics);
-		delete props.statics;
 	}
 
 	// mix includes into the prototype
 	if (props.includes) {
 		checkDeprecatedMixinEvents(props.includes);
 		Util.extend.apply(null, [proto].concat(props.includes));
-		delete props.includes;
 	}
 
 	// mix given properties into the prototype
 	Util.extend(proto, props);
+	delete proto.statics;
+	delete proto.includes;
 
 	// merge options
 	if (proto.options) {

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -53,13 +53,14 @@ Class.extend = function (props) {
 		delete props.includes;
 	}
 
-	// merge options
-	if (proto.options) {
-		props.options = Util.extend(Util.create(proto.options), props.options);
-	}
-
 	// mix given properties into the prototype
 	Util.extend(proto, props);
+
+	// merge options
+	if (proto.options) {
+		proto.options = parentProto.options ? Util.create(parentProto.options) : {};
+		Util.extend(proto.options, props.options);
+	}
 
 	proto._initHooks = [];
 


### PR DESCRIPTION
`extend` method had side effect: it replaced `props.options`
that behavior was undesirable, as it prevented to reuse props.
