### PR TITLE
[ docs] add leaflet-sidebar-v2 to docs/plugins.md

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3621,6 +3621,16 @@ Buttons, sliders, toolbars, sidebars, and panels.
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/nickpeihl/leaflet-sidebar-v2/">leaflet-sidebar-v2</a>
+		</td><td>
+			A responsive, tabbed sidebar with HTML & JS API.
+			Compatible with old (0.7) and current leaflet.
+		</td><td>
+			<a href="https://github.com/noerw/">Norwin Roosen</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/turbo87/leaflet-sidebar/">leaflet-sidebar</a>
 		</td><td>
 			A responsive sidebar plugin.


### PR DESCRIPTION
[leaflet-sidebar-v2] is a fork of [sidebar-v2](https://github.com/turbo87/sidebar-v2), but is more actively developed & has new features.

[leaflet-sidebar-v2]: https://github.com/nickpeihl/leaflet-sidebar-v2