### PR TITLE
TileLayer: fire a 'tileabort' event when a tile load is cancelled

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -236,8 +236,14 @@ export var TileLayer = GridLayer.extend({
 
 				if (!tile.complete) {
 					tile.src = Util.emptyImageUrl;
+					var coords = this._tiles[i].coords;
 					DomUtil.remove(tile);
 					delete this._tiles[i];
+					// @event tileabort: TileEvent
+					// Fired when a tile was loading but is now not wanted.
+					this.fire('tileabort', {
+						tile: tile,
+						coords: coords });
 				}
 			}
 		}

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -243,7 +243,8 @@ export var TileLayer = GridLayer.extend({
 					// Fired when a tile was loading but is now not wanted.
 					this.fire('tileabort', {
 						tile: tile,
-						coords: coords });
+						coords: coords
+					});
 				}
 			}
 		}


### PR DESCRIPTION
It seems like every `'tileloadstart'` event should have a matching event for what eventually happens to the tile.  There is `'tileload'` for success, `'tileerror'` for completion with errors, but nothing if, eg, the user goes to a new zoom level before the tile is loaded; in that case, it gets aborted (in TileLayer, at least), but there is no event for that.  This patch fires an event for that case.

