### PR TITLE
iOS L.Map.Tap shadow DOM click event fix

### DIFF
--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -124,7 +124,10 @@ export var Tap = Handler.extend({
 		        e.clientX, e.clientY,
 		        false, false, false, false, 0, null);
 
-		e.target.dispatchEvent(simulatedEvent);
+		// Dispatch the event from the map container object rather than e.target,
+		// since e.target is incorrectly specified when the map is contained within
+		// a shadow DOM.
+		this._map._container.dispatchEvent(simulatedEvent);
 	}
 });
 


### PR DESCRIPTION
iOS (or more generally platforms without [PointerEvent](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent) support) uses Map.Tap to handle touch events. This change provides support for the case where the map exists within a shadow DOM. In such a case the PointerEvent.target references the outer web component, which means events are not dispatched from the expected element.