### PR TITLE
Bugfix: unregister event listeners when destroying AnimProxy

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1628,6 +1628,7 @@ export var Map = Evented.extend({
 	},
 
 	_destroyAnimProxy: function () {
+		this.off('load moveend', this._setTransform, this);
 		DomUtil.remove(this._proxy);
 		delete this._proxy;
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1599,6 +1599,12 @@ export var Map = Evented.extend({
 		return true;
 	},
 
+	_setTransform: function () {
+		var c = this.getCenter(),
+		  z = this.getZoom();
+		DomUtil.setTransform(this._proxy, this.project(c, z), this.getZoomScale(z, 1));
+	},
+
 	_createAnimProxy: function () {
 
 		var proxy = this._proxy = DomUtil.create('div', 'leaflet-proxy leaflet-zoom-animated');
@@ -1616,11 +1622,7 @@ export var Map = Evented.extend({
 			}
 		}, this);
 
-		this.on('load moveend', function () {
-			var c = this.getCenter(),
-			    z = this.getZoom();
-			DomUtil.setTransform(this._proxy, this.project(c, z), this.getZoomScale(z, 1));
-		}, this);
+		this.on('load moveend', this._setTransform, this);
 
 		this._on('unload', this._destroyAnimProxy, this);
 	},


### PR DESCRIPTION
I have a React application that removes (unmounts) the map on a certain breakpoint. When resizing the window, the error `Uncaught TypeError: Cannot read property '_leaflet_pos' of undefined` showed up because the React component that contains the map gets unmounted. 

This PR solves this issue by unregistering the (previously) anonymous event handler in `_destroyAnimProxy`.
