### PR TITLE
Fixes setStyle to handle undefined style variable

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -102,6 +102,9 @@ export var Path = Layer.extend({
 	// @method setStyle(style: Path options): this
 	// Changes the appearance of a Path based on the options in the `Path options` object.
 	setStyle: function (style) {
+		if (typeof style === 'undefined') {
+			style = {};
+		}
 		Util.setOptions(this, style);
 		if (this._renderer) {
 			this._renderer._updateStyle(this);


### PR DESCRIPTION
Fixes the following error:

```
TypeError: Cannot read property 'hasOwnProperty' of undefined
    at NewClass.setStyle (leaflet-src.js?9eb7:7853)
    at NewClass.removeHooks (leaflet.draw.js?18c5:8)
    at eval (leaflet.draw.js?18c5:8)
    at NewClass._eachVertexHandler (leaflet.draw.js?18c5:8)
    at NewClass.removeHooks (leaflet.draw.js?18c5:8)
    at NewClass.eval (leaflet.draw.js?18c5:8)
    at NewClass.fire (leaflet-src.js?9eb7:593)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6681)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6823)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6969)
```