### PR TITLE
Fix race condition in Marker._setPos when _icon is not present

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -302,8 +302,9 @@ export var Marker = Layer.extend({
 	},
 
 	_updateZIndex: function (offset) {
-		if (this._icon)
+		if (this._icon) {
 			this._icon.style.zIndex = this._zIndex + offset;
+    }
 	},
 
 	_animateZoom: function (opt) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -304,7 +304,7 @@ export var Marker = Layer.extend({
 	_updateZIndex: function (offset) {
 		if (this._icon) {
 			this._icon.style.zIndex = this._zIndex + offset;
-    }
+		}
 	},
 
 	_animateZoom: function (opt) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -302,7 +302,7 @@ export var Marker = Layer.extend({
 	},
 
 	_updateZIndex: function (offset) {
-		if(this._icon)
+		if (this._icon)
 			this._icon.style.zIndex = this._zIndex + offset;
 	},
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -287,7 +287,10 @@ export var Marker = Layer.extend({
 	},
 
 	_setPos: function (pos) {
-		DomUtil.setPosition(this._icon, pos);
+
+		if (this._icon) {
+			DomUtil.setPosition(this._icon, pos);
+		}
 
 		if (this._shadow) {
 			DomUtil.setPosition(this._shadow, pos);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -302,7 +302,8 @@ export var Marker = Layer.extend({
 	},
 
 	_updateZIndex: function (offset) {
-		this._icon.style.zIndex = this._zIndex + offset;
+		if(this._icon)
+			this._icon.style.zIndex = this._zIndex + offset;
 	},
 
 	_animateZoom: function (opt) {


### PR DESCRIPTION
Hi, this is a PR for #6743 . Since it seems that in certain conditions, it could be legit to call _setPos on a marker without a _icon, I've simply mimicd what's done for the _shadow attribute. 
