### PR TITLE
Better Icon.Default imagePath detection using regex

### DIFF
--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -1,4 +1,23 @@
 describe("Icon.Default", function () {
+	it("_detectIconPath using regex to match url", function () {
+		var defaultIconStub = sinon.stub(L.Icon.Default);
+		var orig = L.Icon.Default;
+		L.Icon.Default = defaultIconStub;
+		L.Icon.Default.imagePath = null;
+
+		var div = document.createElement('div');
+		div.style.height = '100px';
+		document.body.appendChild(div);
+
+		var map = L.map(div).setView([0, 0], 0);
+		var marker = new L.Marker([0, 0]);
+
+		expect(L.Icon.Default.imagePath).to.equal(null);
+		marker.addTo(map);
+		expect(L.Icon.Default.imagePath).to.equal(document.location.origin + '/base/dist/images/');
+
+		L.Icon.Default = orig;
+	});
 
 	it("icon measures 25x41px", function () {
 		var div = document.createElement('div');

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -43,6 +43,8 @@ export var IconDefault = Icon.extend({
 	},
 
 	_detectIconPath: function () {
+		var regex = /^url\(["']?((?:[^\\"]+\/)+)marker-icon(?:-2x)?.*\.png["']?\)/;
+		var matches = null;
 		var el = DomUtil.create('div',  'leaflet-default-icon-path', document.body);
 		var path = DomUtil.getStyle(el, 'background-image') ||
 		           DomUtil.getStyle(el, 'backgroundImage');	// IE8
@@ -52,7 +54,8 @@ export var IconDefault = Icon.extend({
 		if (path === null || path.indexOf('url') !== 0) {
 			path = '';
 		} else {
-			path = path.replace(/^url\(["']?/, '').replace(/marker-icon\.png["']?\)$/, '');
+			matches = path.match(regex);
+			path = matches[1];
 		}
 
 		return path;


### PR DESCRIPTION
Regex covers:
- url(http://localhost:8000/base/dist/images/marker-icon.png)
- url(http://localhost:8000/base/dist/images/marker-icon-2x.png)
- url(http://localhost:8000/base/dist/images/marker-icon.hash.png)
- url(http://localhost:8000/base/dist/images/marker-icon-2x.hash.png)
- url("http://localhost:8000/base/dist/images/marker-icon.png")
- url('http://localhost:8000/base/dist/images/marker-icon.png')