### PR TITLE
Wrap Object.freeze overwrite in try-catch

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -5,7 +5,11 @@
  */
 
 export var freeze = Object.freeze;
-Object.freeze = function (obj) { return obj; };
+try {
+	Object.freeze = function (obj) { return obj; };
+} catch (e) {
+	// eslint-disable-next-line no-empty
+}
 
 // @function extend(dest: Object, src?: Object): Object
 // Merges the properties of the `src` object (or multiple objects) into `dest` object and returns the latter. Has an `L.extend` shortcut.


### PR DESCRIPTION
This PR resolves https://github.com/Leaflet/Leaflet/pull/5658#issuecomment-532001145 by wrapping the `Object.freeze` overwrite in a try-catch.