### PR TITLE
Fix doubleTap events on touch devices

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -9,6 +9,13 @@ var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'point
 var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
 var _pre = '_leaflet_';
 
+function browserFiresNativeDblClick(e) {
+	// See https://github.com/w3c/pointerevents/issues/171
+	// Note however, that Chrome stopped firing native dblclick for
+	// touch since that issue was written.
+	return (Browser.ie || e.pointerType === 'mouse');
+}
+
 // inspired by Zepto touch code by Thomas Fuchs
 export function addDoubleTapListener(obj, handler, id) {
 	var last, touch,
@@ -17,9 +24,10 @@ export function addDoubleTapListener(obj, handler, id) {
 
 	function onTouchStart(e) {
 		var count;
+		var oe = e.originalEvent;
 
 		if (Browser.pointer) {
-			if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+			if (browserFiresNativeDblClick(e) || (oe && !oe.sourceCapabilities.firesTouchEvents)) { return; }
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -38,7 +46,7 @@ export function addDoubleTapListener(obj, handler, id) {
 	function onTouchEnd(e) {
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+				if (browserFiresNativeDblClick(e)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -27,7 +27,7 @@ export function addDoubleTapListener(obj, handler, id) {
 		var oe = e.originalEvent;
 
 		if (Browser.pointer) {
-			if (browserFiresNativeDblClick(e) || (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
+			if (browserFiresNativeDblClick(e) && (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -48,7 +48,7 @@ export function addDoubleTapListener(obj, handler, id) {
 
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if (browserFiresNativeDblClick(e) || (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
+				if (browserFiresNativeDblClick(e) && (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -16,6 +16,12 @@ function browserFiresNativeDblClick(e) {
 	return (Browser.ie || e.pointerType === 'mouse');
 }
 
+function browserNeedsAManualDblClick(e) {
+	var oe = e.originalEvent;
+
+	return (L.Browser.Touch && (oe && oe.sourceCapabilities.firesTouchEvents));
+}
+
 // inspired by Zepto touch code by Thomas Fuchs
 export function addDoubleTapListener(obj, handler, id) {
 	var last, touch,
@@ -24,12 +30,12 @@ export function addDoubleTapListener(obj, handler, id) {
 
 	function onTouchStart(e) {
 		var count;
-		var oe = e.originalEvent;
 
 		if (Browser.pointer) {
-			if (browserFiresNativeDblClick(e) && (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
+			if (browserFiresNativeDblClick(e)) { return; }
 			count = _pointersCount;
 		} else {
+			if (!browserNeedsAManualDblClick(e)) { return; }
 			count = e.touches.length;
 		}
 

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -44,9 +44,11 @@ export function addDoubleTapListener(obj, handler, id) {
 	}
 
 	function onTouchEnd(e) {
+		var oe = e.originalEvent;
+
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if (browserFiresNativeDblClick(e)) { return; }
+				if (browserFiresNativeDblClick(e) || (oe && !oe.sourceCapabilities.firesTouchEvents)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -27,7 +27,7 @@ export function addDoubleTapListener(obj, handler, id) {
 		var oe = e.originalEvent;
 
 		if (Browser.pointer) {
-			if (browserFiresNativeDblClick(e) || (oe && !oe.sourceCapabilities.firesTouchEvents)) { return; }
+			if (browserFiresNativeDblClick(e) || (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -48,7 +48,7 @@ export function addDoubleTapListener(obj, handler, id) {
 
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if (browserFiresNativeDblClick(e) || (oe && !oe.sourceCapabilities.firesTouchEvents)) { return; }
+				if (browserFiresNativeDblClick(e) || (oe && oe.sourceCapabilities.firesTouchEvents)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -85,8 +85,7 @@ function addOne(obj, type, fn, context) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener &&
-	           !(Browser.pointer && Browser.chrome)) {
+	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener) {
 		// Chrome >55 does not need the synthetic dblclicks from addDoubleTapListener
 		// See #5180
 		addDoubleTapListener(obj, handler, id);


### PR DESCRIPTION
This builds on the work done in https://github.com/Leaflet/Leaflet/pull/5881, but adds an extra check that resolves all of the issues mentioned by users in the comments section. 

It also introduces a level of stability. For ex, if a newer version of Chrome does start to fire native dblclick events, the functionality will not break

Tested on Mobile: Chrome, Firefox, Safari, Opera, Samsung Internet, Edge
Desktop Chrome, IE 9 - IE 11, Firefox, Safari, Opera, Edge