### PR TITLE
Add quote marks to leaflet.css

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -539,7 +539,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	margin: 0 auto;
 
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
-	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
+	filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	}
 .leaflet-oldie .leaflet-popup-tip-container {
 	margin-top: -1px;


### PR DESCRIPTION
This fixes an error with `mini-css-extract-plugin` when importing leaflet.css