### PR TITLE
Fix for zoom control and double click on map if L_DISABLE_3D = true

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control';
 import {Map} from '../map/Map';
+import {any3d} from '../core/Browser';
 import * as DomUtil from '../dom/DomUtil';
 import * as DomEvent from '../dom/DomEvent';
 
@@ -68,14 +69,16 @@ export var Zoom = Control.extend({
 	},
 
 	_zoomIn: function (e) {
+		var delta = any3d ? this._map.options.zoomDelta : 1;
 		if (!this._disabled && this._map._zoom < this._map.getMaxZoom()) {
-			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomIn(delta * (e.shiftKey ? 3 : 1));
 		}
 	},
 
 	_zoomOut: function (e) {
+		var delta = any3d ? this._map.options.zoomDelta : 1;
 		if (!this._disabled && this._map._zoom > this._map.getMinZoom()) {
-			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomOut(delta * (e.shiftKey ? 3 : 1));
 		}
 	},
 

--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
+import {any3d} from '../../core/Browser';
 
 /*
  * L.Handler.DoubleClickZoom is used to handle double-click zoom on the map, enabled by default.
@@ -29,7 +30,7 @@ export var DoubleClickZoom = Handler.extend({
 	_onDoubleClick: function (e) {
 		var map = this._map,
 		    oldZoom = map.getZoom(),
-		    delta = map.options.zoomDelta,
+		    delta = any3d ? map.options.zoomDelta : 1,
 		    zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
 
 		if (map.options.doubleClickZoom === 'center') {


### PR DESCRIPTION
Fixes #6820

When `L_DISABLE_3D` flag is set to `true` Map class ignores `zoomDelta` property from map options and set it to 1. Zoom level rounding happens in `_limitZoom` method of Map class. If zoomDelta is smaller then 0.5 and L_DISABLE_3D set to true than `_limitZoom` method will return the same zoom level and map won't be zoomed.

I found two places where this issue happens:
1. Control.Zoom, if user clicks on zoom in/out buttons
2. Double click on map.