### PR TITLE
Solves error: "Argument 1 of Node.appendChild does not implement interface Node"

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -317,7 +317,7 @@ Map.include({
 	// Creates a popup with the specified content and options and opens it in the given point on a map.
 	openPopup: function (popup, latlng, options) {
 		if (!(popup instanceof Popup)) {
-			popup = new Popup(options).setContent(popup._content);
+			popup = new Popup(options).setContent(popup._content ? popup._content : popup);
 		}
 
 		if (latlng) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -317,7 +317,7 @@ Map.include({
 	// Creates a popup with the specified content and options and opens it in the given point on a map.
 	openPopup: function (popup, latlng, options) {
 		if (!(popup instanceof Popup)) {
-			popup = new Popup(options).setContent(popup);
+			popup = new Popup(options).setContent(popup._content);
 		}
 
 		if (latlng) {


### PR DESCRIPTION
Hey,
So the popup was not opening when i have multiple leaflet maps on my screen each with markers.

<img width="426" alt="Screenshot 2019-10-06 at 2 17 14 PM" src="https://user-images.githubusercontent.com/14952645/66266563-556ae600-e844-11e9-92e1-c6e0e478871a.png">



I tried adding/appending String in `bindPopup` function but still same error. This PR resolves that bug and popups are now opening, see screenshot. 

Thanks!