### PR TITLE
Reset width & padding to prevent cascading CSS from breaking image rendering

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -53,6 +53,8 @@
 .leaflet-container .leaflet-tile {
 	max-width: none !important;
 	max-height: none !important;
+	width: auto;
+	padding: 0;
 	}
 
 .leaflet-container.leaflet-touch-zoom {


### PR DESCRIPTION
Description of problem
-----------------------

I encountered a problem when adding a Leaflet map to an existing page, in which the map tiles and marker pin appeared squashed and with vertical grey bands on the map.

Problem can be seen here: https://stackoverflow.com/questions/58235408/leafletjs-rendering-with-squashed-tiles/58235762#58235762

Solution
--------

The issue was caused by CSS linked to the parent element that was setting styles for `img` elements within it. Specifically, it was setting `width` and `padding` styles. These were intended to layout a set of images in an information card; the map is replacing one of the images.

To prevent styles like this from inadvertently breaking the rendering of an embedded Leaflet map, I have added styles to leaflet.css to force the images within a leaflet map to use `width:auto` and `padding:0`.