### PR TITLE
fix(DomEvent): change stopPropagation to fakeStop on disableClickPropagation

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -184,7 +184,7 @@ export function disableScrollPropagation(el) {
 // Adds `stopPropagation` to the element's `'click'`, `'doubleclick'`,
 // `'mousedown'` and `'touchstart'` events (plus browser variants).
 export function disableClickPropagation(el) {
-	on(el, 'mousedown touchstart dblclick', stopPropagation);
+	on(el, 'mousedown touchstart dblclick', fakeStop);
 	addOne(el, 'click', fakeStop);
 	return this;
 }


### PR DESCRIPTION
Hello!

The ev.stopPropagation() on the mousedown event was preventing the click event to be handled inside popup children elements. With this change we're able to handle click events inside the popup content.

Hopefully close #6044.