### PR TITLE
Fix some spelling errors in the docs (non-functional change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -805,7 +805,7 @@ Animation code in Leaflet had undergone a major rewrite (main PR: [#2382](https:
 * Fixed `Map` `panInsideBounds` to accept array-form bounds (by [@RLRR](https://github.com/RLRR)). [#3489](https://github.com/Leaflet/Leaflet/pull/3489)
 * Fixed marker draggable state to persist when removing and adding back to the map (by [@IvanSanchez](https://github.com/IvanSanchez)). [#3488](https://github.com/Leaflet/Leaflet/pull/3488)
 * Fixed inertia not working when parallel to axis (by [@rikvanmechelen](https://github.com/rikvanmechelen)).  [#3432](https://github.com/Leaflet/Leaflet/issues/3432)
-* Fixed images and SVG inside popups having max-width property overriden (by [@yohanboniface](https://github.com/yohanboniface)). [#3452](https://github.com/Leaflet/Leaflet/pull/3452)
+* Fixed images and SVG inside popups having max-width property overridden (by [@yohanboniface](https://github.com/yohanboniface)). [#3452](https://github.com/Leaflet/Leaflet/pull/3452)
 * Fixed cursors when dragging is disabled (by [@juliensoret](https://github.com/juliensoret)). [#3219](https://github.com/Leaflet/Leaflet/issues/3219) [#3233](https://github.com/Leaflet/Leaflet/pull/3233)
 * Fixed `LatLng` `wrap` to not drop altitude (by [@IvanSanchez](https://github.com/IvanSanchez)).  [#3420](https://github.com/Leaflet/Leaflet/issues/3420)
 * Fixed Firefox for Android not being detected as mobile (by [@IvanSanchez](https://github.com/IvanSanchez)). [#3419](https://github.com/Leaflet/Leaflet/pull/3419)
@@ -1103,7 +1103,7 @@ Note tha we skipped 0.7.6 version for which we accidentally published a broken b
 
 ### Dev Workflow improvements
 
-* Leaflet builds (*.js files in the `dist` folder) were removed from the repo and are now done automatically on each commit for `master` and `stable` branches by [Travis CI](travis-ci.org/Leaflet/Leaflet). The download links are on the [Leafet download page](http://leafletjs.com/download.html).
+* Leaflet builds (*.js files in the `dist` folder) were removed from the repo and are now done automatically on each commit for `master` and `stable` branches by [Travis CI](travis-ci.org/Leaflet/Leaflet). The download links are on the [Leaflet download page](http://leafletjs.com/download.html).
 
 ## 0.6.2 (2013-06-28)
 

--- a/docs/_posts/2012-07-30-leaflet-0-4-released.md
+++ b/docs/_posts/2012-07-30-leaflet-0-4-released.md
@@ -91,7 +91,7 @@ Rectangle is a convenient shortcut for creating rectangular area layers. You cou
 
 #### Icon API
 
-[Icon][] API was improved to be simpler and more flexible, and the changes are not backwards-compatible too (the old code can be updated very quickly though). Check out the updated [Custom Icons tutorial](../../../examples/custom-icons.html), or head straigt to the [API docs](../../../reference.html#icon).
+[Icon][] API was improved to be simpler and more flexible, and the changes are not backwards-compatible too (the old code can be updated very quickly though). Check out the updated [Custom Icons tutorial](../../../examples/custom-icons.html), or head straight to the [API docs](../../../reference.html#icon).
 
 #### Control API
 
@@ -99,7 +99,7 @@ Custom Controls are much easier to create now --- checkout the [API docs](../../
 
 #### Better Events API
 
-[Aaron King][] brough some improvements to [event methods](../../../reference.html#events). `on` and `off` methods can now accept multiple event types at once as a string space-separated types:
+[Aaron King][] brought some improvements to [event methods](../../../reference.html#events). `on` and `off` methods can now accept multiple event types at once as a string space-separated types:
 
 	map.on('click dblclick moveend', doStuff);
 
@@ -127,7 +127,7 @@ You may think that Leaflet is unbelievably fast already, but this version brings
  * Box shadows on controls were replaced with simple borders on mobile devices to improve performance.
  * Vector layers won't flicker after each panning on iOS now.
 
-In addition, there are several usability improvents not already mentioned:
+In addition, there are several usability improvements not already mentioned:
 
  * Panning now works even if there are markers under the cursor (helps on crowded maps).
  * Popup appearance is slightly improved.
@@ -143,11 +143,11 @@ Here's [a full list of bugfixes](https://github.com/Leaflet/Leaflet/blob/master/
 
 Besides the GeoJSON and Icon changes mentioned above, here's a [list of potentially breaking changes](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#other-breaking-api-changes) --- read it carefully when updating your code (shouldn't take much time though).
 
-Download options for Leaflet 0.4 (including the actual download, the CDN-hosted version, and intructions for building manually) are listed on the [download page](../../../download.html).
+Download options for Leaflet 0.4 (including the actual download, the CDN-hosted version, and instructions for building manually) are listed on the [download page](../../../download.html).
 
 ### Code Stats
 
-I'm still commited to keeping Leaflet as small and lightweight as possible. Here's a breakdown of the current size of the library:
+I'm still committed to keeping Leaflet as small and lightweight as possible. Here's a breakdown of the current size of the library:
 
  * JavaScript: **27 KB** minified and gzipped (102 KB minified, 176 KB in source, 7578 lines of code)
  * CSS: **1.8 KB** gzipped (8 KB, 377 lines of code)
@@ -155,7 +155,7 @@ I'm still commited to keeping Leaflet as small and lightweight as possible. Here
 
 ### Documentation Update
 
-Until now, Leaflet API reference was incomplete. But for this release, enourmous effort was put into making it 100% complete, up-to-date and generally the best API reference page you've ever seen. All remaining classes, methods, options, events and properties were carefully documented and more code examples added, and the docs will always be kept up-to-date from now on.
+Until now, Leaflet API reference was incomplete. But for this release, enormous effort was put into making it 100% complete, up-to-date and generally the best API reference page you've ever seen. All remaining classes, methods, options, events and properties were carefully documented and more code examples added, and the docs will always be kept up-to-date from now on.
 
 Besides, the design of the page was significantly improved --- with better colors, font, spacing, hyphenation, manually adjusted column widths, etc. --- lots of detail to make it beautiful and easy to read.
 
@@ -181,7 +181,7 @@ Since the previous release, Leaflet got adopted by many great companies, includi
 
 ### Thank You
 
-I'd like to thank all the awesome people that helped Leaflet becoming what it is now --- contributed code, reported bugs, used Leaflet on their websites, told collegues about it, talked about it on conferences, etc. Keep up the great work!
+I'd like to thank all the awesome people that helped Leaflet becoming what it is now --- contributed code, reported bugs, used Leaflet on their websites, told colleagues about it, talked about it on conferences, etc. Keep up the great work!
 
 Special thanks go to [Dave Leaver][] for his inspiring contributions including improved zoom animation and the state-of-the-art clustering plugin, and [Jason Sanford][] for his friendly support (and setting up the Leaflet CDN among other things).
 

--- a/docs/_posts/2012-10-25-leaflet-0-4-5-bugfix-release-and-plans-for-0.5.md
+++ b/docs/_posts/2012-10-25-leaflet-0-4-5-bugfix-release-and-plans-for-0.5.md
@@ -8,7 +8,7 @@ authorsite: http://agafonkin.com/en
 
 ### 0.4.5 release
 
-While we contrinue working on the next major release (0.5), today we decided to release **Leaflet 0.4.5**. It contains only one small but important bugfix for **wonky zoom animation** on upcoming **Chrome 23** (currently in beta and to be released in a couple of weeks) and **Internet Explorer 10** (that will eventually hit Windows 7 in addition to Windows 8).
+While we continue working on the next major release (0.5), today we decided to release **Leaflet 0.4.5**. It contains only one small but important bugfix for **wonky zoom animation** on upcoming **Chrome 23** (currently in beta and to be released in a couple of weeks) and **Internet Explorer 10** (that will eventually hit Windows 7 in addition to Windows 8).
 
 Everyone is encouraged to upgrade (before Chrome 23 turns stable). As always, you can find CDN links and downloads for the new release on the [download page](../../../download.html).
 
@@ -20,7 +20,7 @@ Highlights of things already implemented in the `master` branch include touch in
 
 We're also in the process of a major refactoring of vector rendering code to allow much simpler extension of base functionality with custom shapes, additional rendering systems (like WebGL in addition to existing SVG/VML and Canvas renderers), easy switching between renderers, also making the code simpler and easier to understand.
 
-The same goes for projection-related code to make using Leaflet with non-standard projections easier, inluding plain projections for game and indoor maps. Thanks to these changes, in addition to making advanced GIS folks happier, we'll see much more awesome Leaflet projects like [interactive Skyrim map on IGN](http://www.ign.com/wikis/the-elder-scrolls-5-skyrim/interactive-maps/Skyrim) or [World of Warcraft map on Wowhead](http://www.wowhead.com/map).
+The same goes for projection-related code to make using Leaflet with non-standard projections easier, including plain projections for game and indoor maps. Thanks to these changes, in addition to making advanced GIS folks happier, we'll see much more awesome Leaflet projects like [interactive Skyrim map on IGN](http://www.ign.com/wikis/the-elder-scrolls-5-skyrim/interactive-maps/Skyrim) or [World of Warcraft map on Wowhead](http://www.wowhead.com/map).
 
 Another important task for upcoming weeks is working more closely with plugin developers. In particular, one of the areas of focus will be the [Leaflet.draw](https://github.com/jacobtoye/Leaflet.draw) plugin that will soon become a state-of-the-art map vector drawing/editing solution, just as Dave's [Leaflet.markercluster](https://github.com/danzel/Leaflet.markercluster) became the best marker clustering solution among all mapping platforms out there.
 

--- a/docs/_posts/2013-01-17-leaflet-0-5-released.md
+++ b/docs/_posts/2013-01-17-leaflet-0-5-released.md
@@ -12,7 +12,7 @@ Rejoice, everyone &mdash; after 4.5 months of development with [26 contributors 
 
 As always, you can find CDN links and downloads for the new release on the [download page](../../../download.html).
 
-The huge detailed list of changes is documented in the [changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md). Be sure to read the "Breaking Changes" part of it before upgrading to avoid any issues! The [API reference](../../../reference.html) was updated to accomodate all the changes too.
+The huge detailed list of changes is documented in the [changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md). Be sure to read the "Breaking Changes" part of it before upgrading to avoid any issues! The [API reference](../../../reference.html) was updated to accommodate all the changes too.
 
 In other news, [Leaflet repository](https://github.com/Leaflet/Leaflet) has moved to [its own GitHub organization](https://github.com/Leaflet), along with the two of the most important plugins &mdash; [Leaflet.markercluster](https://github.com/Leaflet/Leaflet.markercluster) and [Leaflet.draw](https://github.com/Leaflet/Leaflet.draw). As some of you have noticed, this is one of the clues to a really nice upcoming announcement about Leaflet future &mdash; stay tuned. :)
 

--- a/docs/_posts/2013-02-20-guest-post-draw.md
+++ b/docs/_posts/2013-02-20-guest-post-draw.md
@@ -12,7 +12,7 @@ _This is a guest post from Jacob Toye, an active Leaflet contributor and also th
 
 Upon release the immediate response from the Leaflet community was very positive. It became clear that the next step would be progressing this tool to a state where users could edit and delete shapes in addition to creating them. This is ultimately what Leaflet.draw 0.2 set out to do.
 
-After a few months of off and on development, with most of this spare time kindy sponsored by my employer <a href="http://www.smartrak.co.nz" title="GPS Fleet Management solutions" target="_blank">Smartrak</a>, we proudly present Leaflet.draw 0.2 -- your one stop plugin for drawing, editing and deleting vectors and markers on Leaflet maps. :)
+After a few months of off and on development, with most of this spare time kindly sponsored by my employer <a href="http://www.smartrak.co.nz" title="GPS Fleet Management solutions" target="_blank">Smartrak</a>, we proudly present Leaflet.draw 0.2 -- your one stop plugin for drawing, editing and deleting vectors and markers on Leaflet maps. :)
 
 _Note from Vladimir: the polyline/polygon editing functionality from Leaflet core has been moved into this plugin where it fits much better. The plugin in turn has moved into [Leaflet organization on GitHub](https://github.com/Leaflet) and is now officially supported by the Leaflet development team. Note that version 0.2 currently depends on Leaflet master (in-progress development version) to work._
 

--- a/docs/_posts/2013-11-18-leaflet-0-7-released-plans-for-future.md
+++ b/docs/_posts/2013-11-18-leaflet-0-7-released-plans-for-future.md
@@ -23,7 +23,7 @@ For Leaflet, this can only mean very good things &mdash; much more time on Leafl
 You can check out the [detailed changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md#07-dev-master) of what's already done over the recent months for 0.7 (about 90 improvements and bugfixes), but I'd like to mention some highlights:
 
 * Added the ability to **upscale tiles** to higher zoom levels (e.g. have zoom 19-20 when the source has 18 max).
-* Added support for **IE11 touch devices**. MS unexpectedly broke their pointer API compatibility between Developer Preview and final IE11 release, and we eventually rewrote quite a bit of code to make everything work smoothly across all IE versions (both dekstop & mobile), fixing a bunch of IE10 bugs along the way as well.
+* Added support for **IE11 touch devices**. MS unexpectedly broke their pointer API compatibility between Developer Preview and final IE11 release, and we eventually rewrote quite a bit of code to make everything work smoothly across all IE versions (both desktop & mobile), fixing a bunch of IE10 bugs along the way as well.
 * Officially **dropped IE6 support** (nobody cares anyway) and cleaned up/fixed IE7-8 styles.
 * Dropped the need for **IE conditional comment** when including Leaflet, making the snippet much simpler &mdash; all IE7/8-specific styles got simplified and moved to the main `leaflet.css` file.
 * Fixed an **obscure iOS7 memory leak** that crashed Safari when you tried to create several thousands of layers (e.g. markers for clustering). I still don't understand why it happens, but we managed to fix it with a bit of trickery.
@@ -46,7 +46,7 @@ While it's an ambitious plan and it may take more than one stable release, finis
 
 Another direction I'd like to focus on after releasing 0.7 is **website and documentation improvements**. First, Leaflet is begging for **more step-by-step tutorials** (with more advanced features like custom layers, custom controls, etc.), and I'd love to do a docs/tutorials sprint some time in future. Second, the presentation could be significantly improved &mdash; adding a prominent visual **showcase** or app gallery, making Leaflet users more prominent with some logos and quotes/testimonials, and updating the layout/design for a more stylish, clean look, etc.
 
-Hope that gives a good glimpse of the stuff to expect from Leafet in near future, and don't hesitate to ask any questions in comments &mdash; I'll be happy to answer!
+Hope that gives a good glimpse of the stuff to expect from Leaflet in near future, and don't hesitate to ask any questions in comments &mdash; I'll be happy to answer!
 
 Grab the CDN links or downloads for the new release on the [download page](../../../download.html) as always. Be sure to try it out on your apps and report any regressions so that we can patch them up immediately. And lets make some nice Twitter buzz about the release as usual!
 

--- a/docs/_posts/2015-09-01-leaflet-0.7.4-released.md
+++ b/docs/_posts/2015-09-01-leaflet-0.7.4-released.md
@@ -21,7 +21,7 @@ The 0.7.x releases will not implement new features. Stay tuned for more news on 
 
 ### Get the update
 
-Developers using Leaflet 0.7.3 are advised to upgrade to 0.7.5 to prevent problems arising from modern browers.
+Developers using Leaflet 0.7.3 are advised to upgrade to 0.7.5 to prevent problems arising from modern browsers.
 
 The release is also available through NPM, Bower, [direct download](http://cdn.leafletjs.com/downloads/leaflet-0.7.5.zip), or through our CDN:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2187,7 +2187,7 @@ Powerful multi-purpose libraries for data visualization.
 		<td>
 			<a href="https://github.com/react-map/leaflet.migrationLayer">leaflet.migrationLayer</a>
 		</td><td>
-			leafet.migrationLayer is used to show migration data such as population, flight, vehicle, traffic and so on. Data visualization on map.<a href="https://react-map.github.io/leaflet.migrationLayer">demo</a>
+			leaflet.migrationLayer is used to show migration data such as population, flight, vehicle, traffic and so on. Data visualization on map.<a href="https://react-map.github.io/leaflet.migrationLayer">demo</a>
 		</td><td>
 			<a href="https://github.com/react-map">Sylvenas</a>
 		</td>
@@ -2874,7 +2874,7 @@ The following plugins enhance or extend `L.Control.Layers`.
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/bambrikii/leaflet-layer-tree-plugin">Leafet.LayerTreePlugin</a>
+			<a href="https://github.com/bambrikii/leaflet-layer-tree-plugin">Leaflet.LayerTreePlugin</a>
 		</td><td>
 			Leaflet control allows to switch layers on and off, display them in a tree-like way (<a href="http://rawgit.com/bambrikii/leaflet-layer-tree-plugin/master/examples/basic-example.htm">demo</a>).
 		</td><td>

--- a/docs/reference-0.7.7.html
+++ b/docs/reference-0.7.7.html
@@ -6131,7 +6131,7 @@ map.addLayer(new MyCustomLayer(latlng));
 		</code></td>
 
 		<td><code>HTMLElement</code></td>
-		<td>Should contain code that creates all the neccessary DOM elements for the control, adds listeners on relevant map events, and returns the element containing the control. Called on <code>map.addControl(control)</code> or <code>control.addTo(map)</code>.</td>
+		<td>Should contain code that creates all the necessary DOM elements for the control, adds listeners on relevant map events, and returns the element containing the control. Called on <code>map.addControl(control)</code> or <code>control.addTo(map)</code>.</td>
 	</tr>
 	<tr>
 		<td><code><b>onRemove</b>(

--- a/docs/reference-1.0.0.html
+++ b/docs/reference-1.0.0.html
@@ -1703,7 +1703,7 @@ is a plain javascript object with the following optional components:</div>
 		<td><code><b>watch</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continous watching of location changes (instead of detecting it
+		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
 once) using W3C <code>watchPosition</code> method. You can later stop watching using
 <code>map.stopLocate()</code> method.</td>
 	</tr>
@@ -2474,7 +2474,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2487,7 +2487,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closepopup'>
@@ -2545,7 +2545,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2558,7 +2558,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closetooltip'>
@@ -3174,7 +3174,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3187,7 +3187,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closepopup'>
@@ -3245,7 +3245,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3258,7 +3258,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closetooltip'>
@@ -3546,7 +3546,7 @@ should adapt this value if you use a custom icon.</li>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Direction where to open the tooltip. Possible values are: <code>right</code>, <code>left</code>,
 <code>top</code>, <code>bottom</code>, <code>center</code>, <code>auto</code>.
-<code>auto</code> will dynamicaly switch between <code>right</code> and <code>left</code> according to the tooltip
+<code>auto</code> will dynamically switch between <code>right</code> and <code>left</code> according to the tooltip
 position on the map.</td>
 	</tr>
 	<tr id='tooltip-permanent'>
@@ -3730,7 +3730,7 @@ position on the map.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3743,7 +3743,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closepopup'>
@@ -3801,7 +3801,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3814,7 +3814,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closetooltip'>
@@ -4426,7 +4426,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -4551,7 +4551,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4564,7 +4564,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closepopup'>
@@ -4622,7 +4622,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4635,7 +4635,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closetooltip'>
@@ -5333,7 +5333,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -5437,7 +5437,7 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5450,7 +5450,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closepopup'>
@@ -5508,7 +5508,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5521,7 +5521,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closetooltip'>
@@ -6064,7 +6064,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6077,7 +6077,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closepopup'>
@@ -6135,7 +6135,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6148,7 +6148,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closetooltip'>
@@ -6732,7 +6732,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6745,7 +6745,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closepopup'>
@@ -6803,7 +6803,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6816,7 +6816,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closetooltip'>
@@ -7561,7 +7561,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7574,7 +7574,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closepopup'>
@@ -7632,7 +7632,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7645,7 +7645,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closetooltip'>
@@ -8418,7 +8418,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8431,7 +8431,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closepopup'>
@@ -8489,7 +8489,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8502,7 +8502,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closetooltip'>
@@ -9285,7 +9285,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9298,7 +9298,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closepopup'>
@@ -9356,7 +9356,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9369,7 +9369,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closetooltip'>
@@ -10105,7 +10105,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10118,7 +10118,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closepopup'>
@@ -10176,7 +10176,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10189,7 +10189,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closetooltip'>
@@ -10875,7 +10875,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10888,7 +10888,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closepopup'>
@@ -10946,7 +10946,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10959,7 +10959,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closetooltip'>
@@ -11437,7 +11437,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11450,7 +11450,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closepopup'>
@@ -11508,7 +11508,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11521,7 +11521,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closetooltip'>
@@ -12027,7 +12027,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12040,7 +12040,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closepopup'>
@@ -12098,7 +12098,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12111,7 +12111,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closetooltip'>
@@ -12610,7 +12610,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12623,7 +12623,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closepopup'>
@@ -12681,7 +12681,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12694,7 +12694,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closetooltip'>
@@ -13268,7 +13268,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13281,7 +13281,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closepopup'>
@@ -13339,7 +13339,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13352,7 +13352,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closetooltip'>
@@ -14006,7 +14006,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14019,7 +14019,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closepopup'>
@@ -14077,7 +14077,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14090,7 +14090,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closetooltip'>
@@ -14786,7 +14786,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 	<tr id='gridlayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td><p>Called only internally, must be overriden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
+		<td><p>Called only internally, must be overridden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
 Returns the <code>HTMLElement</code> corresponding to the given <code>coords</code>. If the <code>done</code> callback
 is specified, it must be called when the tile has finished loading and drawing.</p>
 </td>
@@ -14815,7 +14815,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14828,7 +14828,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closepopup'>
@@ -14886,7 +14886,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14899,7 +14899,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closetooltip'>
@@ -15174,7 +15174,7 @@ map.panTo(L.latLng(50, 30));
 	<tr id='latlng-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>otherLatLng</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlng-tostring'>
@@ -16064,7 +16064,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16077,7 +16077,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closepopup'>
@@ -16135,7 +16135,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16148,7 +16148,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closetooltip'>
@@ -16738,7 +16738,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16751,7 +16751,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closepopup'>
@@ -16809,7 +16809,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16822,7 +16822,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closetooltip'>
@@ -17964,7 +17964,7 @@ Has a <code>L.bind()</code> shortcut.</td>
 	<tr id='util-stamp'>
 		<td><code><b>stamp</b>(<nobr>&lt;Object&gt;</nobr> <i>obj</i>)</nobr></code></td>
 		<td><code>Number</code></td>
-		<td>Returns the unique ID of an object, assiging it one if it doesn&#39;t have it.</td>
+		<td>Returns the unique ID of an object, assigning it one if it doesn&#39;t have it.</td>
 	</tr>
 	<tr id='util-throttle'>
 		<td><code><b>throttle</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Number&gt;</nobr> <i>time</i>, <nobr>&lt;Object&gt;</nobr> <i>context</i>)</nobr></code></td>
@@ -18143,7 +18143,7 @@ by the given scale. Only accepts real <a href="#point"><code>L.Point</code></a> 
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -18217,7 +18217,7 @@ points that are on the screen or near, increasing performance.</td>
 		<td>Clips the polygon geometry defined by the given <code>points</code> by the given bounds (using the <a href="https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm">Sutherland-Hodgeman algorithm</a>).
 Used by Leaflet to only show polygon points that are on the screen or near, increasing
 performance. Note that polygon points needs different algorithm for clipping
-than polyline, so there&#39;s a seperate method for it.</td>
+than polyline, so there&#39;s a separate method for it.</td>
 	</tr>
 </tbody></table>
 
@@ -19574,7 +19574,7 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -19587,7 +19587,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closepopup'>
@@ -19643,7 +19643,7 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -19656,7 +19656,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closetooltip'>
@@ -20133,7 +20133,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20146,7 +20146,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closepopup'>
@@ -20204,7 +20204,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20217,7 +20217,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closetooltip'>
@@ -21079,7 +21079,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21092,7 +21092,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closepopup'>
@@ -21150,7 +21150,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21163,7 +21163,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closetooltip'>
@@ -21441,17 +21441,17 @@ information about the event. For example:</p>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>
@@ -22423,7 +22423,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -22436,7 +22436,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closepopup'>
@@ -22494,7 +22494,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -22507,7 +22507,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closetooltip'>

--- a/docs/reference-1.0.2.html
+++ b/docs/reference-1.0.2.html
@@ -1705,7 +1705,7 @@ is a plain javascript object with the following optional components:</div>
 		<td><code><b>watch</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continous watching of location changes (instead of detecting it
+		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
 once) using W3C <code>watchPosition</code> method. You can later stop watching using
 <code>map.stopLocate()</code> method.</td>
 	</tr>
@@ -2561,7 +2561,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2574,7 +2574,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closepopup'>
@@ -2632,7 +2632,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2645,7 +2645,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closetooltip'>
@@ -3295,7 +3295,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3308,7 +3308,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closepopup'>
@@ -3366,7 +3366,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3379,7 +3379,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closetooltip'>
@@ -3622,7 +3622,7 @@ should adapt this value if you use a custom icon.</li>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Direction where to open the tooltip. Possible values are: <code>right</code>, <code>left</code>,
 <code>top</code>, <code>bottom</code>, <code>center</code>, <code>auto</code>.
-<code>auto</code> will dynamicaly switch between <code>right</code> and <code>left</code> according to the tooltip
+<code>auto</code> will dynamically switch between <code>right</code> and <code>left</code> according to the tooltip
 position on the map.</td>
 	</tr>
 	<tr id='tooltip-permanent'>
@@ -3885,7 +3885,7 @@ position on the map.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3898,7 +3898,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closepopup'>
@@ -3956,7 +3956,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3969,7 +3969,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closetooltip'>
@@ -4566,7 +4566,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -4736,7 +4736,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4749,7 +4749,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closepopup'>
@@ -4807,7 +4807,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4820,7 +4820,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closetooltip'>
@@ -5503,7 +5503,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -5652,7 +5652,7 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5665,7 +5665,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closepopup'>
@@ -5723,7 +5723,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5736,7 +5736,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closetooltip'>
@@ -6285,7 +6285,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6298,7 +6298,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closepopup'>
@@ -6356,7 +6356,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6369,7 +6369,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closetooltip'>
@@ -6965,7 +6965,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6978,7 +6978,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closepopup'>
@@ -7036,7 +7036,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7049,7 +7049,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closetooltip'>
@@ -7806,7 +7806,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7819,7 +7819,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closepopup'>
@@ -7877,7 +7877,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7890,7 +7890,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closetooltip'>
@@ -8675,7 +8675,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8688,7 +8688,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closepopup'>
@@ -8746,7 +8746,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8759,7 +8759,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closetooltip'>
@@ -9554,7 +9554,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9567,7 +9567,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closepopup'>
@@ -9625,7 +9625,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9638,7 +9638,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closetooltip'>
@@ -10386,7 +10386,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10399,7 +10399,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closepopup'>
@@ -10457,7 +10457,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10470,7 +10470,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closetooltip'>
@@ -11167,7 +11167,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11180,7 +11180,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closepopup'>
@@ -11238,7 +11238,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11251,7 +11251,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closetooltip'>
@@ -11741,7 +11741,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11754,7 +11754,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closepopup'>
@@ -11812,7 +11812,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11825,7 +11825,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closetooltip'>
@@ -12343,7 +12343,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12356,7 +12356,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closepopup'>
@@ -12414,7 +12414,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12427,7 +12427,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closetooltip'>
@@ -12938,7 +12938,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12951,7 +12951,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closepopup'>
@@ -13009,7 +13009,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13022,7 +13022,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closetooltip'>
@@ -13608,7 +13608,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13621,7 +13621,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closepopup'>
@@ -13679,7 +13679,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13692,7 +13692,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closetooltip'>
@@ -14386,7 +14386,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14399,7 +14399,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closepopup'>
@@ -14457,7 +14457,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14470,7 +14470,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closetooltip'>
@@ -15123,7 +15123,7 @@ effect when the <a href="#map-crs">map CRS</a> doesn&#39;t wrap around.</td>
 	<tr id='gridlayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td><p>Called only internally, must be overriden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
+		<td><p>Called only internally, must be overridden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
 Returns the <code>HTMLElement</code> corresponding to the given <code>coords</code>. If the <code>done</code> callback
 is specified, it must be called when the tile has finished loading and drawing.</p>
 </td>
@@ -15203,7 +15203,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15216,7 +15216,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closepopup'>
@@ -15274,7 +15274,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15287,7 +15287,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closetooltip'>
@@ -15517,7 +15517,7 @@ map.panTo(L.latLng(50, 30));
 	<tr id='latlng-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>otherLatLng</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlng-tostring'>
@@ -16495,7 +16495,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16508,7 +16508,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closepopup'>
@@ -16566,7 +16566,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16579,7 +16579,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closetooltip'>
@@ -17183,7 +17183,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -17196,7 +17196,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closepopup'>
@@ -17254,7 +17254,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -17267,7 +17267,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closetooltip'>
@@ -18381,7 +18381,7 @@ Has a <code>L.bind()</code> shortcut.</td>
 	<tr id='util-stamp'>
 		<td><code><b>stamp</b>(<nobr>&lt;Object&gt;</nobr> <i>obj</i>)</nobr></code></td>
 		<td><code>Number</code></td>
-		<td>Returns the unique ID of an object, assiging it one if it doesn&#39;t have it.</td>
+		<td>Returns the unique ID of an object, assigning it one if it doesn&#39;t have it.</td>
 	</tr>
 	<tr id='util-throttle'>
 		<td><code><b>throttle</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Number&gt;</nobr> <i>time</i>, <nobr>&lt;Object&gt;</nobr> <i>context</i>)</nobr></code></td>
@@ -18560,7 +18560,7 @@ by the given scale. Only accepts actual <a href="#point"><code>L.Point</code></a
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -18634,7 +18634,7 @@ points that are on the screen or near, increasing performance.</td>
 		<td>Clips the polygon geometry defined by the given <code>points</code> by the given bounds (using the <a href="https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm">Sutherland-Hodgeman algorithm</a>).
 Used by Leaflet to only show polygon points that are on the screen or near, increasing
 performance. Note that polygon points needs different algorithm for clipping
-than polyline, so there&#39;s a seperate method for it.</td>
+than polyline, so there&#39;s a separate method for it.</td>
 	</tr>
 </tbody></table>
 
@@ -20048,7 +20048,7 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20061,7 +20061,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closepopup'>
@@ -20117,7 +20117,7 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20130,7 +20130,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closetooltip'>
@@ -20574,7 +20574,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20587,7 +20587,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closepopup'>
@@ -20645,7 +20645,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20658,7 +20658,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closetooltip'>
@@ -21537,7 +21537,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21550,7 +21550,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closepopup'>
@@ -21608,7 +21608,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21621,7 +21621,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closetooltip'>
@@ -21899,17 +21899,17 @@ information about the event. For example:</p>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>
@@ -22915,7 +22915,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -22928,7 +22928,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closepopup'>
@@ -22986,7 +22986,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -22999,7 +22999,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closetooltip'>

--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -1715,7 +1715,7 @@ is a plain javascript object with the following optional components:</div>
 		<td><code><b>watch</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continous watching of location changes (instead of detecting it
+		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
 once) using W3C <code>watchPosition</code> method. You can later stop watching using
 <code>map.stopLocate()</code> method.</td>
 	</tr>
@@ -2571,7 +2571,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2584,7 +2584,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closepopup'>
@@ -2642,7 +2642,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2655,7 +2655,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closetooltip'>
@@ -3305,7 +3305,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3318,7 +3318,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closepopup'>
@@ -3376,7 +3376,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3389,7 +3389,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closetooltip'>
@@ -3632,7 +3632,7 @@ should adapt this value if you use a custom icon.</li>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Direction where to open the tooltip. Possible values are: <code>right</code>, <code>left</code>,
 <code>top</code>, <code>bottom</code>, <code>center</code>, <code>auto</code>.
-<code>auto</code> will dynamicaly switch between <code>right</code> and <code>left</code> according to the tooltip
+<code>auto</code> will dynamically switch between <code>right</code> and <code>left</code> according to the tooltip
 position on the map.</td>
 	</tr>
 	<tr id='tooltip-permanent'>
@@ -3895,7 +3895,7 @@ position on the map.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3908,7 +3908,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closepopup'>
@@ -3966,7 +3966,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3979,7 +3979,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closetooltip'>
@@ -4578,7 +4578,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -4748,7 +4748,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4761,7 +4761,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closepopup'>
@@ -4819,7 +4819,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4832,7 +4832,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closetooltip'>
@@ -5517,7 +5517,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -5666,7 +5666,7 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5679,7 +5679,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closepopup'>
@@ -5737,7 +5737,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5750,7 +5750,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closetooltip'>
@@ -6317,7 +6317,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6330,7 +6330,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closepopup'>
@@ -6388,7 +6388,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6401,7 +6401,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closetooltip'>
@@ -6997,7 +6997,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7010,7 +7010,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closepopup'>
@@ -7068,7 +7068,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7081,7 +7081,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closetooltip'>
@@ -7838,7 +7838,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7851,7 +7851,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closepopup'>
@@ -7909,7 +7909,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7922,7 +7922,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closetooltip'>
@@ -8707,7 +8707,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8720,7 +8720,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closepopup'>
@@ -8778,7 +8778,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8791,7 +8791,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closetooltip'>
@@ -9586,7 +9586,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9599,7 +9599,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closepopup'>
@@ -9657,7 +9657,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9670,7 +9670,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closetooltip'>
@@ -10418,7 +10418,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10431,7 +10431,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closepopup'>
@@ -10489,7 +10489,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10502,7 +10502,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closetooltip'>
@@ -11199,7 +11199,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11212,7 +11212,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closepopup'>
@@ -11270,7 +11270,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11283,7 +11283,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closetooltip'>
@@ -11773,7 +11773,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11786,7 +11786,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closepopup'>
@@ -11844,7 +11844,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11857,7 +11857,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closetooltip'>
@@ -12375,7 +12375,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12388,7 +12388,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closepopup'>
@@ -12446,7 +12446,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12459,7 +12459,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closetooltip'>
@@ -12970,7 +12970,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12983,7 +12983,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closepopup'>
@@ -13041,7 +13041,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13054,7 +13054,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closetooltip'>
@@ -13640,7 +13640,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13653,7 +13653,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closepopup'>
@@ -13711,7 +13711,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13724,7 +13724,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closetooltip'>
@@ -14418,7 +14418,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14431,7 +14431,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closepopup'>
@@ -14489,7 +14489,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14502,7 +14502,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closetooltip'>
@@ -15157,7 +15157,7 @@ tiles outside the CRS limits.</td>
 	<tr id='gridlayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td><p>Called only internally, must be overriden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
+		<td><p>Called only internally, must be overridden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
 Returns the <code>HTMLElement</code> corresponding to the given <code>coords</code>. If the <code>done</code> callback
 is specified, it must be called when the tile has finished loading and drawing.</p>
 </td>
@@ -15237,7 +15237,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15250,7 +15250,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closepopup'>
@@ -15308,7 +15308,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15321,7 +15321,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closetooltip'>
@@ -15551,7 +15551,7 @@ map.panTo(L.latLng(50, 30));
 	<tr id='latlng-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>otherLatLng</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlng-tostring'>
@@ -16529,7 +16529,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16542,7 +16542,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closepopup'>
@@ -16600,7 +16600,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16613,7 +16613,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='icon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='icon-closetooltip'>
@@ -17217,7 +17217,7 @@ styled according to the options.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -17230,7 +17230,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closepopup'>
@@ -17288,7 +17288,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -17301,7 +17301,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divicon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divicon-closetooltip'>
@@ -18418,7 +18418,7 @@ Has a <code>L.bind()</code> shortcut.</td>
 	<tr id='util-stamp'>
 		<td><code><b>stamp</b>(<nobr>&lt;Object&gt;</nobr> <i>obj</i>)</nobr></code></td>
 		<td><code>Number</code></td>
-		<td>Returns the unique ID of an object, assiging it one if it doesn&#39;t have it.</td>
+		<td>Returns the unique ID of an object, assigning it one if it doesn&#39;t have it.</td>
 	</tr>
 	<tr id='util-throttle'>
 		<td><code><b>throttle</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Number&gt;</nobr> <i>time</i>, <nobr>&lt;Object&gt;</nobr> <i>context</i>)</nobr></code></td>
@@ -18597,7 +18597,7 @@ by the given scale. Only accepts actual <a href="#point"><code>L.Point</code></a
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -18671,7 +18671,7 @@ points that are on the screen or near, increasing performance.</td>
 		<td>Clips the polygon geometry defined by the given <code>points</code> by the given bounds (using the <a href="https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm">Sutherland-Hodgeman algorithm</a>).
 Used by Leaflet to only show polygon points that are on the screen or near, increasing
 performance. Note that polygon points needs different algorithm for clipping
-than polyline, so there&#39;s a seperate method for it.</td>
+than polyline, so there&#39;s a separate method for it.</td>
 	</tr>
 </tbody></table>
 
@@ -20085,7 +20085,7 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20098,7 +20098,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closepopup'>
@@ -20154,7 +20154,7 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20167,7 +20167,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closetooltip'>
@@ -20611,7 +20611,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20624,7 +20624,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closepopup'>
@@ -20682,7 +20682,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20695,7 +20695,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closetooltip'>
@@ -21583,7 +21583,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21596,7 +21596,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closepopup'>
@@ -21654,7 +21654,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21667,7 +21667,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closetooltip'>
@@ -21945,17 +21945,17 @@ information about the event. For example:</p>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>
@@ -23029,7 +23029,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -23042,7 +23042,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closepopup'>
@@ -23100,7 +23100,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -23113,7 +23113,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closetooltip'>

--- a/docs/reference-1.1.0.html
+++ b/docs/reference-1.1.0.html
@@ -1719,7 +1719,7 @@ is a plain javascript object with the following optional components:</div>
 		<td><code><b>watch</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continous watching of location changes (instead of detecting it
+		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
 once) using W3C <code>watchPosition</code> method. You can later stop watching using
 <code>map.stopLocate()</code> method.</td>
 	</tr>
@@ -2584,7 +2584,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2597,7 +2597,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closepopup'>
@@ -2655,7 +2655,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -2668,7 +2668,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closetooltip'>
@@ -3318,7 +3318,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3331,7 +3331,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closepopup'>
@@ -3389,7 +3389,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3402,7 +3402,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closetooltip'>
@@ -3645,7 +3645,7 @@ should adapt this value if you use a custom icon.</li>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Direction where to open the tooltip. Possible values are: <code>right</code>, <code>left</code>,
 <code>top</code>, <code>bottom</code>, <code>center</code>, <code>auto</code>.
-<code>auto</code> will dynamicaly switch between <code>right</code> and <code>left</code> according to the tooltip
+<code>auto</code> will dynamically switch between <code>right</code> and <code>left</code> according to the tooltip
 position on the map.</td>
 	</tr>
 	<tr id='tooltip-permanent'>
@@ -3908,7 +3908,7 @@ position on the map.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3921,7 +3921,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closepopup'>
@@ -3979,7 +3979,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -3992,7 +3992,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closetooltip'>
@@ -4591,7 +4591,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -4761,7 +4761,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4774,7 +4774,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closepopup'>
@@ -4832,7 +4832,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -4845,7 +4845,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closetooltip'>
@@ -5530,7 +5530,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -5679,7 +5679,7 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5692,7 +5692,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closepopup'>
@@ -5750,7 +5750,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -5763,7 +5763,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closetooltip'>
@@ -6403,7 +6403,7 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6416,7 +6416,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closepopup'>
@@ -6474,7 +6474,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -6487,7 +6487,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closetooltip'>
@@ -7205,7 +7205,7 @@ Changes the <a href="#imageoverlay-zindex">zIndex</a> of the image overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7218,7 +7218,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-closepopup'>
@@ -7276,7 +7276,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7289,7 +7289,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-closetooltip'>
@@ -7915,7 +7915,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7928,7 +7928,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closepopup'>
@@ -7986,7 +7986,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -7999,7 +7999,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closetooltip'>
@@ -8763,7 +8763,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8776,7 +8776,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closepopup'>
@@ -8834,7 +8834,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -8847,7 +8847,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closetooltip'>
@@ -9639,7 +9639,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9652,7 +9652,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closepopup'>
@@ -9710,7 +9710,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -9723,7 +9723,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closetooltip'>
@@ -10525,7 +10525,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10538,7 +10538,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closepopup'>
@@ -10596,7 +10596,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -10609,7 +10609,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closetooltip'>
@@ -11364,7 +11364,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11377,7 +11377,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closepopup'>
@@ -11435,7 +11435,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -11448,7 +11448,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closetooltip'>
@@ -12152,7 +12152,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12165,7 +12165,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closepopup'>
@@ -12223,7 +12223,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12236,7 +12236,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closetooltip'>
@@ -12703,7 +12703,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12716,7 +12716,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closepopup'>
@@ -12774,7 +12774,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -12787,7 +12787,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closetooltip'>
@@ -13305,7 +13305,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13318,7 +13318,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closepopup'>
@@ -13376,7 +13376,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13389,7 +13389,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closetooltip'>
@@ -13906,7 +13906,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13919,7 +13919,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closepopup'>
@@ -13977,7 +13977,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -13990,7 +13990,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closetooltip'>
@@ -14582,7 +14582,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14595,7 +14595,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closepopup'>
@@ -14653,7 +14653,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -14666,7 +14666,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closetooltip'>
@@ -15366,7 +15366,7 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15379,7 +15379,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closepopup'>
@@ -15437,7 +15437,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -15450,7 +15450,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closetooltip'>
@@ -16121,7 +16121,7 @@ tiles outside the CRS limits.</td>
 	<tr id='gridlayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td><p>Called only internally, must be overriden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
+		<td><p>Called only internally, must be overridden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
 Returns the <code>HTMLElement</code> corresponding to the given <code>coords</code>. If the <code>done</code> callback
 is specified, it must be called when the tile has finished loading and drawing.</p>
 </td>
@@ -16201,7 +16201,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16214,7 +16214,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closepopup'>
@@ -16272,7 +16272,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -16285,7 +16285,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closetooltip'>
@@ -16515,7 +16515,7 @@ map.panTo(L.latLng(50, 30));
 	<tr id='latlng-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>otherLatLng</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlng-tostring'>
@@ -16757,7 +16757,7 @@ bounds = L.latLngBounds(corner1, corner2);
 	<tr id='latlngbounds-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>otherBounds</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlngbounds-isvalid'>
@@ -18510,7 +18510,7 @@ Has a <code>L.bind()</code> shortcut.</td>
 	<tr id='util-stamp'>
 		<td><code><b>stamp</b>(<nobr>&lt;Object&gt;</nobr> <i>obj</i>)</nobr></code></td>
 		<td><code>Number</code></td>
-		<td>Returns the unique ID of an object, assiging it one if it doesn&#39;t have it.</td>
+		<td>Returns the unique ID of an object, assigning it one if it doesn&#39;t have it.</td>
 	</tr>
 	<tr id='util-throttle'>
 		<td><code><b>throttle</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Number&gt;</nobr> <i>time</i>, <nobr>&lt;Object&gt;</nobr> <i>context</i>)</nobr></code></td>
@@ -18675,7 +18675,7 @@ the reverse. Used by Leaflet in its projections code.</p>
 	</tr>
 	<tr id='transformation-l-transformation'>
 		<td><code><b>L.transformation</b>(<nobr>&lt;Array&gt;</nobr> <i>coefficients</i>)</nobr></code></td>
-		<td>Expects an coeficients array of the form
+		<td>Expects an coefficients array of the form
 <code>[a: Number, b: Number, c: Number, d: Number]</code>.</td>
 	</tr>
 </tbody></table>
@@ -18717,7 +18717,7 @@ by the given scale. Only accepts actual <a href="#point"><code>L.Point</code></a
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -18791,7 +18791,7 @@ points that are on the screen or near, increasing performance.</td>
 		<td>Clips the polygon geometry defined by the given <code>points</code> by the given bounds (using the <a href="https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm">Sutherland-Hodgeman algorithm</a>).
 Used by Leaflet to only show polygon points that are on the screen or near, increasing
 performance. Note that polygon points needs different algorithm for clipping
-than polyline, so there&#39;s a seperate method for it.</td>
+than polyline, so there&#39;s a separate method for it.</td>
 	</tr>
 </tbody></table>
 
@@ -20215,7 +20215,7 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20228,7 +20228,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closepopup'>
@@ -20284,7 +20284,7 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20297,7 +20297,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closetooltip'>
@@ -20748,7 +20748,7 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20761,7 +20761,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closepopup'>
@@ -20819,7 +20819,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -20832,7 +20832,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closetooltip'>
@@ -21724,7 +21724,7 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21737,7 +21737,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closepopup'>
@@ -21795,7 +21795,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -21808,7 +21808,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closetooltip'>
@@ -22086,17 +22086,17 @@ information about the event. For example:</p>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>
@@ -23170,7 +23170,7 @@ of the popup when opening it on some overlays.</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -23183,7 +23183,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closepopup'>
@@ -23241,7 +23241,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</nobr></code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-neccessary event listeners. If a <code>Function</code> is passed it will receive
+necessary event listeners. If a <code>Function</code> is passed it will receive
 the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
@@ -23254,7 +23254,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closetooltip'>

--- a/docs/reference-1.2.0.html
+++ b/docs/reference-1.2.0.html
@@ -1719,7 +1719,7 @@ is a plain javascript object with the following optional components:</div>
 		<td><code><b>watch</b></code></td>
 		<td><code>Boolean</code>
 		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continous watching of location changes (instead of detecting it
+		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
 once) using W3C <code>watchPosition</code> method. You can later stop watching using
 <code>map.stopLocate()</code> method.</td>
 	</tr>
@@ -2597,7 +2597,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closepopup'>
@@ -2668,7 +2668,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='marker-closetooltip'>
@@ -3331,7 +3331,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closepopup'>
@@ -3402,7 +3402,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='popup-closetooltip'>
@@ -3645,7 +3645,7 @@ should adapt this value if you use a custom icon.</li>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Direction where to open the tooltip. Possible values are: <code>right</code>, <code>left</code>,
 <code>top</code>, <code>bottom</code>, <code>center</code>, <code>auto</code>.
-<code>auto</code> will dynamicaly switch between <code>right</code> and <code>left</code> according to the tooltip
+<code>auto</code> will dynamically switch between <code>right</code> and <code>left</code> according to the tooltip
 position on the map.</td>
 	</tr>
 	<tr id='tooltip-permanent'>
@@ -3921,7 +3921,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closepopup'>
@@ -3992,7 +3992,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tooltip-closetooltip'>
@@ -4595,7 +4595,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -4778,7 +4778,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closepopup'>
@@ -4849,7 +4849,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-closetooltip'>
@@ -5537,7 +5537,7 @@ tiles outside the CRS limits.</td>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer&#39;s <a href="#gridlayer-createtile"><code>createTile()</code></a>
-to return an <code>&lt;img&gt;</code> HTML element with the appropiate image URL given <code>coords</code>. The <code>done</code>
+to return an <code>&lt;img&gt;</code> HTML element with the appropriate image URL given <code>coords</code>. The <code>done</code>
 callback is called when the tile has been loaded.</p>
 </td>
 	</tr>
@@ -5699,7 +5699,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closepopup'>
@@ -5770,7 +5770,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-closetooltip'>
@@ -6423,7 +6423,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closepopup'>
@@ -6494,7 +6494,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-closetooltip'>
@@ -7225,7 +7225,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-closepopup'>
@@ -7296,7 +7296,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-closetooltip'>
@@ -7935,7 +7935,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closepopup'>
@@ -8006,7 +8006,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='path-closetooltip'>
@@ -8783,7 +8783,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closepopup'>
@@ -8854,7 +8854,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polyline-closetooltip'>
@@ -9659,7 +9659,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closepopup'>
@@ -9730,7 +9730,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='polygon-closetooltip'>
@@ -10545,7 +10545,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closepopup'>
@@ -10616,7 +10616,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='rectangle-closetooltip'>
@@ -11384,7 +11384,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closepopup'>
@@ -11455,7 +11455,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circle-closetooltip'>
@@ -12172,7 +12172,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closepopup'>
@@ -12243,7 +12243,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-closetooltip'>
@@ -12723,7 +12723,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closepopup'>
@@ -12794,7 +12794,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='svg-closetooltip'>
@@ -13325,7 +13325,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closepopup'>
@@ -13396,7 +13396,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='canvas-closetooltip'>
@@ -13926,7 +13926,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closepopup'>
@@ -13997,7 +13997,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layergroup-closetooltip'>
@@ -14602,7 +14602,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closepopup'>
@@ -14673,7 +14673,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-closetooltip'>
@@ -15386,7 +15386,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closepopup'>
@@ -15457,7 +15457,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='geojson-closetooltip'>
@@ -16131,7 +16131,7 @@ tiles outside the CRS limits.</td>
 	<tr id='gridlayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</nobr></code></td>
 		<td><code>HTMLElement</code></td>
-		<td><p>Called only internally, must be overriden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
+		<td><p>Called only internally, must be overridden by classes extending <a href="#gridlayer"><code>GridLayer</code></a>.
 Returns the <code>HTMLElement</code> corresponding to the given <code>coords</code>. If the <code>done</code> callback
 is specified, it must be called when the tile has finished loading and drawing.</p>
 </td>
@@ -16224,7 +16224,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closepopup'>
@@ -16295,7 +16295,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-closetooltip'>
@@ -16525,7 +16525,7 @@ map.panTo(L.latLng(50, 30));
 	<tr id='latlng-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>otherLatLng</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the given <a href="#latlng"><code>LatLng</code></a> point is at the same position (within a small margin of error). The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlng-tostring'>
@@ -16767,7 +16767,7 @@ bounds = L.latLngBounds(corner1, corner2);
 	<tr id='latlngbounds-equals'>
 		<td><code><b>equals</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>otherBounds</i>, <nobr>&lt;Number&gt;</nobr> <i>maxMargin?</i>)</nobr></code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overriden by setting <code>maxMargin</code> to a small number.</p>
+		<td><p>Returns <code>true</code> if the rectangle is equivalent (within a small margin of error) to the given bounds. The margin of error can be overridden by setting <code>maxMargin</code> to a small number.</p>
 </td>
 	</tr>
 	<tr id='latlngbounds-isvalid'>
@@ -18520,7 +18520,7 @@ Has a <code>L.bind()</code> shortcut.</td>
 	<tr id='util-stamp'>
 		<td><code><b>stamp</b>(<nobr>&lt;Object&gt;</nobr> <i>obj</i>)</nobr></code></td>
 		<td><code>Number</code></td>
-		<td>Returns the unique ID of an object, assiging it one if it doesn&#39;t have it.</td>
+		<td>Returns the unique ID of an object, assigning it one if it doesn&#39;t have it.</td>
 	</tr>
 	<tr id='util-throttle'>
 		<td><code><b>throttle</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Number&gt;</nobr> <i>time</i>, <nobr>&lt;Object&gt;</nobr> <i>context</i>)</nobr></code></td>
@@ -18685,7 +18685,7 @@ the reverse. Used by Leaflet in its projections code.</p>
 	</tr>
 	<tr id='transformation-l-transformation'>
 		<td><code><b>L.transformation</b>(<nobr>&lt;Array&gt;</nobr> <i>coefficients</i>)</nobr></code></td>
-		<td>Expects an coeficients array of the form
+		<td>Expects an coefficients array of the form
 <code>[a: Number, b: Number, c: Number, d: Number]</code>.</td>
 	</tr>
 </tbody></table>
@@ -18727,7 +18727,7 @@ by the given scale. Only accepts actual <a href="#point"><code>L.Point</code></a
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyine points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -18806,7 +18806,7 @@ points that are on the screen or near, increasing performance.</td>
 		<td>Clips the polygon geometry defined by the given <code>points</code> by the given bounds (using the <a href="https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm">Sutherland-Hodgeman algorithm</a>).
 Used by Leaflet to only show polygon points that are on the screen or near, increasing
 performance. Note that polygon points needs different algorithm for clipping
-than polyline, so there&#39;s a seperate method for it.</td>
+than polyline, so there&#39;s a separate method for it.</td>
 	</tr>
 </tbody></table>
 
@@ -20243,7 +20243,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closepopup'>
@@ -20312,7 +20312,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='layer-closetooltip'>
@@ -20776,7 +20776,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closepopup'>
@@ -20847,7 +20847,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-closetooltip'>
@@ -21752,7 +21752,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closepopup'>
@@ -21823,7 +21823,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='renderer-closetooltip'>
@@ -22101,17 +22101,17 @@ information about the event. For example:</p>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>
@@ -23198,7 +23198,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound popup at the specificed <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound popup at the specified <a href="#latlng"><code>latlng</code></a> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closepopup'>
@@ -23269,7 +23269,7 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</nobr></code></td>
 		<td><code>this</code></td>
-		<td><p>Opens the bound tooltip at the specificed <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
+		<td><p>Opens the bound tooltip at the specified <a href="#latlng"><code>latlng</code></a> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-closetooltip'>

--- a/docs/reference-1.3.0.html
+++ b/docs/reference-1.3.0.html
@@ -16570,7 +16570,7 @@ properties. The event can optionally be propagated to event parents.</p>
 map.panTo({lon: 30, lat: 50});
 map.panTo({lat: 50, lng: 30});
 map.panTo(L.latLng(50, 30));
-</code></pre><p>Note that <a href="#latlng"><code>LatLng</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+</code></pre><p>Note that <a href="#latlng"><code>LatLng</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -16717,7 +16717,7 @@ bounds = L.latLngBounds(corner1, corner2);
 ]);
 </code></pre>
 <p>Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners <em>outside</em> the [-180, 180] degrees longitude range.
-Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -16906,7 +16906,7 @@ Negative values will retract the bounds.</p>
 <pre><code class="lang-js">map.panBy([200, 300]);
 map.panBy(L.point(200, 300));
 </code></pre>
-<p>Note that <code>Point</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Point</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17108,7 +17108,7 @@ bounds = L.bounds(p1, p2);
 <p>All Leaflet methods that accept <a href="#bounds"><code>Bounds</code></a> objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:</p>
 <pre><code class="lang-js">otherBounds.intersects([[10, 10], [40, 60]]);
 </code></pre>
-<p>Note that <code>Bounds</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Bounds</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -21377,7 +21377,7 @@ Only accepts actual <a href="#latlng"><code>L.LatLng</code></a> instances, not a
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>The inverse of <code>project</code>. Projects a 2D point into a geographical location.
 Only accepts actual <a href="#point"><code>L.Point</code></a> instances, not arrays.
-Note that the projection instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the projection instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</p>
 </td>
@@ -21637,7 +21637,7 @@ coordinates in other units for <a href="https://en.wikipedia.org/wiki/Web_Map_Se
 Leaflet defines the most usual CRSs by default. If you want to use a
 CRS not defined by default, take a look at the
 <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.
-Note that the CRS instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the CRS instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</td>
 	</tr>
@@ -22315,17 +22315,17 @@ event parent.</td>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>

--- a/docs/reference-1.3.2.html
+++ b/docs/reference-1.3.2.html
@@ -16725,7 +16725,7 @@ bounds = L.latLngBounds(corner1, corner2);
 ]);
 </code></pre>
 <p>Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners <em>outside</em> the [-180, 180] degrees longitude range.
-Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -16914,7 +16914,7 @@ Negative values will retract the bounds.</p>
 <pre><code class="lang-js">map.panBy([200, 300]);
 map.panBy(L.point(200, 300));
 </code></pre>
-<p>Note that <code>Point</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Point</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17116,7 +17116,7 @@ bounds = L.bounds(p1, p2);
 <p>All Leaflet methods that accept <a href="#bounds"><code>Bounds</code></a> objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:</p>
 <pre><code class="lang-js">otherBounds.intersects([[10, 10], [40, 60]]);
 </code></pre>
-<p>Note that <code>Bounds</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Bounds</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -21397,7 +21397,7 @@ Only accepts actual <a href="#latlng"><code>L.LatLng</code></a> instances, not a
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>The inverse of <code>project</code>. Projects a 2D point into a geographical location.
 Only accepts actual <a href="#point"><code>L.Point</code></a> instances, not arrays.
-Note that the projection instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the projection instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</p>
 </td>
@@ -21650,7 +21650,7 @@ coordinates in other units for <a href="https://en.wikipedia.org/wiki/Web_Map_Se
 Leaflet defines the most usual CRSs by default. If you want to use a
 CRS not defined by default, take a look at the
 <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.
-Note that the CRS instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the CRS instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</td>
 	</tr>
@@ -22335,17 +22335,17 @@ event parent.</td>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>

--- a/docs/reference-1.3.4.html
+++ b/docs/reference-1.3.4.html
@@ -16771,7 +16771,7 @@ bounds = L.latLngBounds(corner1, corner2);
 ]);
 </code></pre>
 <p>Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners <em>outside</em> the [-180, 180] degrees longitude range.
-Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -16960,7 +16960,7 @@ Negative values will retract the bounds.</p>
 <pre><code class="lang-js">map.panBy([200, 300]);
 map.panBy(L.point(200, 300));
 </code></pre>
-<p>Note that <code>Point</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Point</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17162,7 +17162,7 @@ bounds = L.bounds(p1, p2);
 <p>All Leaflet methods that accept <a href="#bounds"><code>Bounds</code></a> objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:</p>
 <pre><code class="lang-js">otherBounds.intersects([[10, 10], [40, 60]]);
 </code></pre>
-<p>Note that <code>Bounds</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Bounds</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -21443,7 +21443,7 @@ Only accepts actual <a href="#latlng"><code>L.LatLng</code></a> instances, not a
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>The inverse of <code>project</code>. Projects a 2D point into a geographical location.
 Only accepts actual <a href="#point"><code>L.Point</code></a> instances, not arrays.
-Note that the projection instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the projection instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</p>
 </td>
@@ -21696,7 +21696,7 @@ coordinates in other units for <a href="https://en.wikipedia.org/wiki/Web_Map_Se
 Leaflet defines the most usual CRSs by default. If you want to use a
 CRS not defined by default, take a look at the
 <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.
-Note that the CRS instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the CRS instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</td>
 	</tr>
@@ -22381,17 +22381,17 @@ event parent.</td>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>

--- a/docs/reference-1.4.0.html
+++ b/docs/reference-1.4.0.html
@@ -16784,7 +16784,7 @@ bounds = L.latLngBounds(corner1, corner2);
 ]);
 </code></pre>
 <p>Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners <em>outside</em> the [-180, 180] degrees longitude range.
-Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -16973,7 +16973,7 @@ Negative values will retract the bounds.</p>
 <pre><code class="lang-js">map.panBy([200, 300]);
 map.panBy(L.point(200, 300));
 </code></pre>
-<p>Note that <code>Point</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Point</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17175,7 +17175,7 @@ bounds = L.bounds(p1, p2);
 <p>All Leaflet methods that accept <a href="#bounds"><code>Bounds</code></a> objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:</p>
 <pre><code class="lang-js">otherBounds.intersects([[10, 10], [40, 60]]);
 </code></pre>
-<p>Note that <code>Bounds</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Bounds</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -21456,7 +21456,7 @@ Only accepts actual <a href="#latlng"><code>L.LatLng</code></a> instances, not a
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>The inverse of <code>project</code>. Projects a 2D point into a geographical location.
 Only accepts actual <a href="#point"><code>L.Point</code></a> instances, not arrays.
-Note that the projection instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the projection instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</p>
 </td>
@@ -21709,7 +21709,7 @@ coordinates in other units for <a href="https://en.wikipedia.org/wiki/Web_Map_Se
 Leaflet defines the most usual CRSs by default. If you want to use a
 CRS not defined by default, take a look at the
 <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.
-Note that the CRS instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the CRS instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</td>
 	</tr>
@@ -22394,17 +22394,17 @@ event parent.</td>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>

--- a/docs/reference-1.5.0.html
+++ b/docs/reference-1.5.0.html
@@ -17604,7 +17604,7 @@ bounds = L.latLngBounds(corner1, corner2);
 ]);
 </code></pre>
 <p>Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners <em>outside</em> the [-180, 180] degrees longitude range.
-Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that <a href="#latlngbounds"><code>LatLngBounds</code></a> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17793,7 +17793,7 @@ Negative values will retract the bounds.</p>
 <pre><code class="lang-js">map.panBy([200, 300]);
 map.panBy(L.point(200, 300));
 </code></pre>
-<p>Note that <code>Point</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Point</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -17995,7 +17995,7 @@ bounds = L.bounds(p1, p2);
 <p>All Leaflet methods that accept <a href="#bounds"><code>Bounds</code></a> objects also accept them in a simple Array form (unless noted otherwise), so the bounds example above can be passed like this:</p>
 <pre><code class="lang-js">otherBounds.intersects([[10, 10], [40, 60]]);
 </code></pre>
-<p>Note that <code>Bounds</code> does not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+<p>Note that <code>Bounds</code> does not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 which means new classes can&#39;t inherit from it, and new methods
 can&#39;t be added to it with the <code>include</code> function.</p>
 
@@ -22277,7 +22277,7 @@ Only accepts actual <a href="#latlng"><code>L.LatLng</code></a> instances, not a
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>The inverse of <code>project</code>. Projects a 2D point into a geographical location.
 Only accepts actual <a href="#point"><code>L.Point</code></a> instances, not arrays.
-Note that the projection instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the projection instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</p>
 </td>
@@ -22537,7 +22537,7 @@ coordinates in other units for <a href="https://en.wikipedia.org/wiki/Web_Map_Se
 Leaflet defines the most usual CRSs by default. If you want to use a
 CRS not defined by default, take a look at the
 <a href="https://github.com/kartena/Proj4Leaflet">Proj4Leaflet</a> plugin.
-Note that the CRS instances do not inherit from Leafet&#39;s <a href="#class"><code>Class</code></a> object,
+Note that the CRS instances do not inherit from Leaflet&#39;s <a href="#class"><code>Class</code></a> object,
 and can&#39;t be instantiated. Also, new classes can&#39;t inherit from them,
 and methods can&#39;t be added to them with the <code>include</code> function.</td>
 	</tr>
@@ -23215,17 +23215,17 @@ event parent.</td>
 	<tr id='mouseevent-latlng'>
 		<td><code><b>latlng</b>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td>The geographical point where the mouse event occured.</td>
+		<td>The geographical point where the mouse event occurred.</td>
 	</tr>
 	<tr id='mouseevent-layerpoint'>
 		<td><code><b>layerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map layer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map layer.</td>
 	</tr>
 	<tr id='mouseevent-containerpoint'>
 		<td><code><b>containerPoint</b>
 		<td><code><a href='#point'>Point</a></code></td>
-		<td>Pixel coordinates of the point where the mouse event occured relative to the map сontainer.</td>
+		<td>Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.</td>
 	</tr>
 	<tr id='mouseevent-originalevent'>
 		<td><code><b>originalEvent</b>

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -41,11 +41,11 @@ The original [DOM `KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/
 @miniclass MouseEvent (Event objects)
 @inherits Event
 @property latlng: LatLng
-The geographical point where the mouse event occured.
+The geographical point where the mouse event occurred.
 @property layerPoint: Point
-Pixel coordinates of the point where the mouse event occured relative to the map layer.
+Pixel coordinates of the point where the mouse event occurred relative to the map layer.
 @property containerPoint: Point
-Pixel coordinates of the point where the mouse event occured relative to the map сontainer.
+Pixel coordinates of the point where the mouse event occurred relative to the map сontainer.
 @property originalEvent: DOMEvent
 The original [DOM `MouseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent) or [DOM `TouchEvent`](https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent) that triggered this Leaflet event.
 

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -25,7 +25,7 @@ import {LatLng, toLatLng} from './LatLng';
  *
  * Caution: if the area crosses the antimeridian (often confused with the International Date Line), you must specify corners _outside_ the [-180, 180] degrees longitude range.
  *
- * Note that `LatLngBounds` does not inherit from Leafet's `Class` object,
+ * Note that `LatLngBounds` does not inherit from Leaflet's `Class` object,
  * which means new classes can't inherit from it, and new methods
  * can't be added to it with the `include` function.
  */

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -16,7 +16,7 @@ import * as Util from '../../core/Util';
  * CRS not defined by default, take a look at the
  * [Proj4Leaflet](https://github.com/kartena/Proj4Leaflet) plugin.
  *
- * Note that the CRS instances do not inherit from Leafet's `Class` object,
+ * Note that the CRS instances do not inherit from Leaflet's `Class` object,
  * and can't be instantiated. Also, new classes can't inherit from them,
  * and methods can't be added to them with the `include` function.
  */

--- a/src/geo/projection/index.js
+++ b/src/geo/projection/index.js
@@ -15,7 +15,7 @@
  * The inverse of `project`. Projects a 2D point into a geographical location.
  * Only accepts actual `L.Point` instances, not arrays.
 
- * Note that the projection instances do not inherit from Leafet's `Class` object,
+ * Note that the projection instances do not inherit from Leaflet's `Class` object,
  * and can't be instantiated. Also, new classes can't inherit from them,
  * and methods can't be added to them with the `include` function.
 

--- a/src/geometry/Bounds.js
+++ b/src/geometry/Bounds.js
@@ -20,7 +20,7 @@ import {Point, toPoint} from './Point';
  * otherBounds.intersects([[10, 10], [40, 60]]);
  * ```
  *
- * Note that `Bounds` does not inherit from Leafet's `Class` object,
+ * Note that `Bounds` does not inherit from Leaflet's `Class` object,
  * which means new classes can't inherit from it, and new methods
  * can't be added to it with the `include` function.
  */

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -19,7 +19,7 @@ import {isArray, formatNum} from '../core/Util';
  * map.panBy(L.point(200, 300));
  * ```
  *
- * Note that `Point` does not inherit from Leafet's `Class` object,
+ * Note that `Point` does not inherit from Leaflet's `Class` object,
  * which means new classes can't inherit from it, and new methods
  * can't be added to it with the `include` function.
  */


### PR DESCRIPTION
There was a remarkable amount of misspelling of "Leaflet" (e.g. "Leafet")!
