### PR TITLE
Distinguishes zoom event and zoom option in the docs (#6660).

### DIFF
--- a/docs/reference-1.5.0.html
+++ b/docs/reference-1.5.0.html
@@ -329,7 +329,7 @@ sure what it means.</td>
 		<td><code>undefined</code></td>
 		<td>Initial geographic center of the map</td>
 	</tr>
-	<tr id='map-zoom'>
+	<tr id='map-zoom-option'>
 		<td><code><b>zoom</b></code></td>
 		<td><code>Number</code>
 		<td><code>undefined</code></td>
@@ -692,7 +692,7 @@ for the first time).</td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the view of the map starts changing (e.g. user starts dragging the map).</td>
 	</tr>
-	<tr id='map-zoom'>
+	<tr id='map-zoom-event'>
 		<td><code><b>zoom</b>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired repeatedly during any change in zoom level, including zoom


### PR DESCRIPTION
Just a quick PR to fix the duplicate IDs for 'zoom' event & option.

:wave: 