### PR TITLE
Fix dblclick event when both Pointer Events and Touch Events are available

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -93,7 +93,7 @@ export var msPointer = !window.PointerEvent && window.MSPointerEvent;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
-export var pointer = !!(window.PointerEvent || msPointer);
+export var pointer = !webkit && !!(window.PointerEvent || msPointer);
 
 // @property touch: Boolean
 // `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).


### PR DESCRIPTION
This happens on iOS13, at least.

Tested the fix on an iPhone and an iPad, both with iOS 13, and with and
without "Pointer Events" feature (enabled by default, can be disabled in
Safari Settings). There is still an issue with the iPad.

I tried keeping all other (non-"Safari with Pointer Events") code paths
the same.

Fixes #6817 for non-"iPad on iOS13"