### PR TITLE
Fix toLatLngBounds

### DIFF
--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -248,7 +248,7 @@ export function toLatLngBounds(a, b) {
 		return a;
 	}
 	if (a.getSouthWest && a.getNorthEast) {
-		return new LatLngBounds(a.getSouthWest(), a.getNorthEast());	
+		return new LatLngBounds(a.getSouthWest(), a.getNorthEast());
 	}
 	return new LatLngBounds(a, b);
 }

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -247,5 +247,8 @@ export function toLatLngBounds(a, b) {
 	if (a instanceof LatLngBounds) {
 		return a;
 	}
+	if (a.getSouthWest && a.getNorthEast) {
+		return new LatLngBounds(a.getSouthWest(), a.getNorthEast());	
+	}
 	return new LatLngBounds(a, b);
 }

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -247,7 +247,7 @@ export function toLatLngBounds(a, b) {
 	if (a instanceof LatLngBounds) {
 		return a;
 	}
-	if (a.getSouthWest && a.getNorthEast) {
+	if (a && a.getSouthWest && a.getNorthEast) {
 		return new LatLngBounds(a.getSouthWest(), a.getNorthEast());
 	}
 	return new LatLngBounds(a, b);


### PR DESCRIPTION
Fix for https://github.com/Leaflet/Leaflet.markercluster/issues/740


execution gets to this point:

```js
function toLatLngBounds(a, b) {
	if (a instanceof LatLngBounds) {
		return a;
	}
	return new LatLngBounds(a, b);
}
```

where `a` is `LatLngBounds` (it has all the same methods), but it is not instance of `LatLngBounds` (it identifies itself as `B`).

<img width="538" alt="Screenshot 2019-10-14 at 11 44 24" src="https://user-images.githubusercontent.com/179534/66742484-03dfde00-ee78-11e9-94d3-e6ee0af80ab9.png">