### PR TITLE
feat(GeoJSON): new option markersInheritOptions

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -31,6 +31,21 @@ describe("L.GeoJSON", function () {
 			layer.addData(geojsonEmpty);
 			expect(layer.getLayers().length).to.eql(0);
 		});
+
+		it("makes default marker inherit group options if explicitly requested", function () {
+			// Check first that it does not inherit group options by default
+			var options = {
+				customOption: "My Custom Option"
+			};
+			var layer = new L.GeoJSON(null, options);
+			layer.addData(geojson);
+			expect(layer.getLayers()[0].options.customOption).to.equal(undefined);
+
+			// Now make it inherit group options
+			layer.options.markersInheritOptions = true;
+			layer.addData(geojson);
+			expect(layer.getLayers()[1].options.customOption).to.eql(options.customOption);
+		});
 	});
 
 	describe('resetStyle', function () {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -78,6 +78,9 @@ export var GeoJSON = FeatureGroup.extend({
 	 * @option coordsToLatLng: Function = *
 	 * A `Function` that will be used for converting GeoJSON coordinates to `LatLng`s.
 	 * The default is the `coordsToLatLng` static method.
+	 *
+	 * @option markersInheritOptions: Boolean = false
+	 * Whether default Markers for "Point" type Features inherit from group options.
 	 */
 
 	initialize: function (geojson, options) {
@@ -181,12 +184,12 @@ export function geometryToLayer(geojson, options) {
 	switch (geometry.type) {
 	case 'Point':
 		latlng = _coordsToLatLng(coords);
-		return pointToLayer ? pointToLayer(geojson, latlng) : new Marker(latlng);
+		return _pointToLayer(pointToLayer, geojson, latlng, options);
 
 	case 'MultiPoint':
 		for (i = 0, len = coords.length; i < len; i++) {
 			latlng = _coordsToLatLng(coords[i]);
-			layers.push(pointToLayer ? pointToLayer(geojson, latlng) : new Marker(latlng));
+			layers.push(_pointToLayer(pointToLayer, geojson, latlng, options));
 		}
 		return new FeatureGroup(layers);
 
@@ -217,6 +220,12 @@ export function geometryToLayer(geojson, options) {
 	default:
 		throw new Error('Invalid GeoJSON object.');
 	}
+}
+
+function _pointToLayer(pointToLayerFn, geojson, latlng, options) {
+	return pointToLayerFn ?
+		pointToLayerFn(geojson, latlng) :
+		new Marker(latlng, options && options.markersInheritOptions && options);
 }
 
 // @function coordsToLatLng(coords: Array): LatLng


### PR DESCRIPTION
Fix #6858 

This PR introduces a new `markersInheritOptions` option to `L.GeoJSON` (default `false`).

It alters the current behaviour by having the default Marker, which is built for "Point" type Geometries, inherit from the options of the GeoJSON Layer Group, as is already the case by default for Path-based (vector) Layers.

I decided to make this new behaviour an opt-in feature in order to avoid changing the current default behaviour (see https://github.com/Leaflet/Leaflet/issues/6858#issuecomment-542867699 for details).

Note: first commit to fail for TDD