### PR TITLE
fix(Map): properly unbind animation proxy events when removing map

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -70,6 +70,19 @@ describe("Map", function () {
 			expect(spy.called).to.not.be.ok();
 		});
 
+		it("does not throw if removed during animation", function () {
+			var container = document.createElement('div'),
+			    map = new L.Map(container).setView([0, 0], 1);
+
+			// Force creation of animation proxy,
+			// otherwise browser checks disable it
+			map._createAnimProxy();
+
+			// #6775 Remove the map in the middle of the animation
+			map.on("zoom", map.remove);
+			map.setZoom(2);
+		});
+
 		it("throws error if container is reused by other instance", function () {
 			var container = document.createElement('div'),
 			    map = L.map(container),

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1616,18 +1616,21 @@ export var Map = Evented.extend({
 			}
 		}, this);
 
-		this.on('load moveend', function () {
-			var c = this.getCenter(),
-			    z = this.getZoom();
-			DomUtil.setTransform(this._proxy, this.project(c, z), this.getZoomScale(z, 1));
-		}, this);
+		this.on('load moveend', this._animMoveEnd, this);
 
 		this._on('unload', this._destroyAnimProxy, this);
 	},
 
 	_destroyAnimProxy: function () {
 		DomUtil.remove(this._proxy);
+		this.off('load moveend', this._animMoveEnd, this);
 		delete this._proxy;
+	},
+
+	_animMoveEnd: function () {
+		var c = this.getCenter(),
+		    z = this.getZoom();
+		DomUtil.setTransform(this._proxy, this.project(c, z), this.getZoomScale(z, 1));
 	},
 
 	_catchTransitionEnd: function (e) {


### PR DESCRIPTION
Fix #6775

This PR ensures that events bound for animation proxy are properly unbound when the map is removed, so that in the edge case when the removal occurs in the middle of an animation, no callback tries to still access some map data.

Note: test to fail on first commit for TDD, to be resolved on next commit.