### PR TITLE
Fixes #6605 regarding API docs

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -302,6 +302,7 @@ var PointToGeoJSON = {
 };
 
 // @namespace Marker
+// @section Other methods
 // @method toGeoJSON(precision?: Number): Object
 // `precision` is the number of decimal places for coordinates.
 // The default value is 6 places.

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1681,7 +1681,7 @@ export var Map = Evented.extend({
 
 			DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 		}
-		
+
 		// @section Other Events
 		// @event zoomanim: ZoomAnimEvent
 		// Fired at least once per zoom animation. For continuous zoom, like pinch zooming, fired once per frame during zoom.

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1681,7 +1681,8 @@ export var Map = Evented.extend({
 
 			DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
 		}
-
+		
+		// @section Other Events
 		// @event zoomanim: ZoomAnimEvent
 		// Fired at least once per zoom animation. For continuous zoom, like pinch zooming, fired once per frame during zoom.
 		this.fire('zoomanim', {


### PR DESCRIPTION
Fixes #6605. Moves intro paragraph that refers to methods from Marker>Events to Marker>Methods. The issue seems to have been caused by GeoJSON and the fix was applied there.
Also renames header Map>Events>Other Methods to Other Events.