### PR TITLE
Adding a new plugin info (Segment Edit) to the docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2289,7 +2289,6 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 			<a href="https://github.com/scripter-co">Nathan Mahdavi</a>
 		</td>
 	</tr>
-
 	<tr>
 		<td>
 			<a href="https://github.com/tkrajina/leaflet-editable-polyline">Leaflet.Editable.Polyline</a>
@@ -2420,7 +2419,7 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 			<a href="https://github.com/manleyjster">Justin Manley</a>
 		</td>
 	</tr>
-        <tr>
+	<tr>
 		<td>
 			<a href="https://github.com/kklimczak/Leaflet.Pin">Leaflet.Pin</a>
 		</td><td>
@@ -2429,7 +2428,7 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 			<a href="https://github.com/kklimczak">Konrad Klimczak</a>
 		</td>
 	</tr>
-        <tr>
+	<tr>
 		<td>
 			<a href="https://github.com/tcoupin/leaflet-paintpolygon">L.Control.PaintPolygon</a>
 		</td><td>
@@ -2445,6 +2444,15 @@ Allows users to create, draw, edit and/or delete points, lines and polygons.
 			Extends Leaflet.FreeDraw and gives extended features like Undo-Redo, deleting markers,dynamic area calculation of polygons ,various hooks/events and in-build control bars, etc.
 		</td><td>
 			<a href="https://github.com/sagarpreet-chadha">Sagarpreet Chadha</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/Lemaf/leaflet-polyline-segment-edit">Leaflet.SegmentEdit</a>
+		</td><td>
+			An extension to Leaflet.draw to allow editing large polylines one chunk at the time.
+		</td><td>
+			<a href="https://github.com/Lemaf">Lemaf</a>
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Adding the entry for [a new plugin](https://github.com/Lemaf/leaflet-polyline-segment-edit) on the docs.