### PR TITLE
doc: run hljs on all documentation pages

### DIFF
--- a/docs/docs/js/docs.js
+++ b/docs/docs/js/docs.js
@@ -1,3 +1,6 @@
+/* global hljs */
+hljs.configure({tabReplace: '    '});
+hljs.initHighlighting();
 
 var tocCopy = document.createElement('div');
 tocCopy.id = 'toc-copy';

--- a/docs/docs/js/reference.js
+++ b/docs/docs/js/reference.js
@@ -1,7 +1,3 @@
-/* global hljs */
-hljs.configure({tabReplace: '    '});
-hljs.initHighlighting();
-
 if (document.body.className.indexOf('api-page') !== -1) {
 
 	var elems = document.querySelectorAll('h2, h3, h4, tr');


### PR DESCRIPTION
Run hljs not only on reference pages, but on all documentation pages.

Fixes #6878. Regression of 9a43cf72d768aad58a7a116ad426ace905c64817.

@mourner