### PR TITLE
Zoom/pan not working on Windows 10 Touch in Chrome and Edge #6896

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -100,7 +100,7 @@ export var pointer = !webkit && !!(window.PointerEvent || msPointer);
 // This does not necessarily mean that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
+export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0 ||
 		(window.DocumentTouch && document instanceof window.DocumentTouch));
 
 // @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -81,7 +81,7 @@ function addOne(obj, type, fn, context) {
 
 	var originalHandler = handler;
 
-	if (Browser.pointer && type.indexOf('touch') === 0) {
+	if ((Browser.pointer || Browser.edge) && type.indexOf('touch') === 0) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 


### PR DESCRIPTION
I think the change for `export var touch =` is safe.

Not sure about the change in src/dom/DomEvent.js. Edge is based on webkit and `var pointer =` is not set in 1.6.0.  