### PR TITLE
fix setting of touch capability flag of browsers - closes #6896 #6897

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -89,7 +89,7 @@ export var mobileWebkit3d = mobile && webkit3d;
 
 // @property msPointer: Boolean
 // `true` for browsers implementing the Microsoft touch events model (notably IE10).
-export var msPointer = !window.PointerEvent && window.MSPointerEvent;
+export var msPointer = window.PointerEvent || window.MSPointerEvent;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
@@ -100,7 +100,7 @@ export var pointer = !webkit && !!(window.PointerEvent || msPointer);
 // This does not necessarily mean that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
+export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0 ||
 		(window.DocumentTouch && document instanceof window.DocumentTouch));
 
 // @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.


### PR DESCRIPTION
With this small changes we try to flag the Browser as being able to understand touch events.
With this fix its is now able to open the [leaflet quickstart](https://leafletjs.com/examples/quick-start/) and interact with touch events using chrome 78 and Edge.