### PR TITLE
Fix invalidateSize re-centering pan logic

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -584,7 +584,7 @@ export var Map = Evented.extend({
 		var newSize = this.getSize(),
 		    oldCenter = oldSize.divideBy(2).round(),
 		    newCenter = newSize.divideBy(2).round(),
-		    offset = oldCenter.subtract(newCenter);
+		    offset = newCenter.subtract(oldCenter);
 
 		if (!offset.x && !offset.y) { return this; }
 


### PR DESCRIPTION
The map currently pans in the wrong direction when its size is updated, shifting the center farther away from where it should be, rather than back to where it was originally. This inverts the direction of the `offset` passed to the `panBy`/`_rawPanBy` methods.

Might fix #5008 (and/or #6051, #5030).