### PR TITLE
Add linting to examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-mourner": "^2.0.1",
+    "eslint-plugin-script-tags": "^0.5.0",
     "git-rev-sync": "^1.12.0",
     "happen": "~0.3.2",
     "karma": "^4.1.0",
@@ -42,7 +43,7 @@
     "test-nolint": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
     "release": "./build/publish.sh",
-    "lint": "eslint src spec/suites docs/docs/js",
+    "lint": "eslint src docs/examples/**/*.md spec/suites docs/docs/js",
     "lintfix": "npm run lint -- --fix",
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-watch-config.js",
@@ -54,6 +55,9 @@
     "globals": {
       "L": true
     },
+    "plugins": [
+      "script-tags"
+    ],
     "env": {
       "commonjs": true,
       "amd": true,


### PR DESCRIPTION
To avoid issues like the one in https://github.com/Leaflet/Leaflet/commit/7882015ee883b394f6c4de69b10fed39c1f5d4db (an accidentally broken example), we should lint code in the examples too. This PR adds a plugin to do so, but there are a few hundred errors now — we need to setup a simplified ESLint configuration just for the examples, and fix minor linting issues before merging.