### PR TITLE
Improve Evented.off performance by using the Map class (fixes #6914)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1782,6 +1782,15 @@ These plugins provide new markers or news ways of converting abstract data into 
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/henrythasler/Leaflet.Geodesic">Leaflet.Geodesic</a>
+		</td><td>
+			Draw geodesic lines and circles. A geodesic line is the shortest path between two given points on the earth surface. It uses Vincenty's formulae for highest precision and distance calculation. Written in Typescript and available via CDN. <a href="https://blog.cyclemap.link/Leaflet.Geodesic/complex-interactive.html">Demo</a>
+		</td><td>
+			<a href="https://github.com/henrythasler">Henry Thasler</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/nuclearsecrecy/Leaflet.greatCircle">Leaflet.greatCircle</a>
 		</td>
 		<td>
@@ -4094,15 +4103,6 @@ The following plugins perform several sorts of geoprocessing (mathematical and t
 		</td>
 		<td>
 			<a href="https://github.com/w8r">Alexander Milevski</a>
-		</td>
-	</tr>
-	<tr>
-		<td>
-			<a href="https://github.com/henrythasler/Leaflet.Geodesic">Leaflet.Geodesic</a>
-		</td><td>
-			Draw geodesic (poly)lines. A geodesic line is the shortest path between two given positions on the earth surface. and You can also calculate the exact distance between two given points on the map.
-		</td><td>
-			<a href="https://github.com/henrythasler">Henry Thasler</a>
 		</td>
 	</tr>
 	<tr>

--- a/src/core/Dictionary.js
+++ b/src/core/Dictionary.js
@@ -1,0 +1,50 @@
+import {Class} from './Class';
+
+var _Dictionary = Class.extend({
+	initialize: function () {
+		this.map = {};
+		this.ordering = [];
+		this.size = 0;
+	},
+
+	get: function (key) {
+		return this.map[key];
+	},
+
+	set: function (key, value) {
+		if (!this.map[key]) {
+			this.map[key] = value;
+			this.size = this.ordering.push(key);
+		}
+	},
+
+	delete: function (key) {
+		delete this.map[key];
+		var indexToRemove = this.ordering.indexOf(key);
+		this.ordering.splice(indexToRemove, 1);
+		this.size = this.ordering.length;
+	},
+
+	forEach: function (delegate, ctx) {
+
+		if (!ctx) {
+			ctx = this;
+		}
+
+		this.ordering.forEach(function (e) {
+			var element = this.map[e];
+			delegate.call(ctx, element);
+		}, this);
+
+	}
+});
+
+// Check if map gets implemented nativly (ecma6 implementation)
+// otherwise use slower onw implementation
+export function Dictionary() {
+	if (window.Map) {
+		return new Map();
+	} else {
+		return new _Dictionary();
+	}
+}

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -1,5 +1,6 @@
 import {Class} from './Class';
 import * as Util from './Util';
+import {Dictionary} from './Dictionary';
 
 /*
  * @class Evented
@@ -91,13 +92,13 @@ export var Events = {
 
 	// attach listener (without syntactic sugar now)
 	_on: function (type, fn, context) {
-		this._events = this._events || {};
+		this._events = this._events || new Dictionary();
 
 		/* get/init listeners for type */
-		var typeListeners = this._events[type];
+		var typeListeners = this._events.get(type);
 		if (!typeListeners) {
-			typeListeners = [];
-			this._events[type] = typeListeners;
+			typeListeners = new Dictionary();
+			this._events.set(type, typeListeners);
 		}
 
 		if (context === this) {
@@ -107,24 +108,22 @@ export var Events = {
 		var newListener = {fn: fn, ctx: context},
 		    listeners = typeListeners;
 
-		// check if fn already there
-		for (var i = 0, len = listeners.length; i < len; i++) {
-			if (listeners[i].fn === fn && listeners[i].ctx === context) {
-				return;
-			}
+		var fullId = this._getListenerFullId(fn, context);
+
+		// Return if entry already exsits
+		if (listeners.get(fullId)) {
+			return;
 		}
 
-		listeners.push(newListener);
+		listeners.set(fullId, newListener);
 	},
 
 	_off: function (type, fn, context) {
-		var listeners,
-		    i,
-		    len;
+		var listeners;
 
 		if (!this._events) { return; }
 
-		listeners = this._events[type];
+		listeners = this._events.get(type);
 
 		if (!listeners) {
 			return;
@@ -132,11 +131,11 @@ export var Events = {
 
 		if (!fn) {
 			// Set all removed listeners to noop so they are not called if remove happens in fire
-			for (i = 0, len = listeners.length; i < len; i++) {
-				listeners[i].fn = Util.falseFn;
-			}
+			listeners.forEach(function (l) {
+				l.fn = Util.falseFn;
+			}, this);
 			// clear all listeners for a type if function isn't specified
-			delete this._events[type];
+			delete this._events.delete(type);
 			return;
 		}
 
@@ -144,26 +143,10 @@ export var Events = {
 			context = undefined;
 		}
 
+		var fullId = this._getListenerFullId(fn, context);
+
 		if (listeners) {
-
-			// find fn and remove it
-			for (i = 0, len = listeners.length; i < len; i++) {
-				var l = listeners[i];
-				if (l.ctx !== context) { continue; }
-				if (l.fn === fn) {
-
-					// set the removed listener to noop so that's not called if remove happens in fire
-					l.fn = Util.falseFn;
-
-					if (this._firingCount) {
-						/* copy array in case events are being fired */
-						this._events[type] = listeners = listeners.slice();
-					}
-					listeners.splice(i, 1);
-
-					return;
-				}
-			}
+			listeners.delete(fullId);
 		}
 	},
 
@@ -180,15 +163,15 @@ export var Events = {
 			sourceTarget: data && data.sourceTarget || this
 		});
 
+		// Call every listener
 		if (this._events) {
-			var listeners = this._events[type];
+			var listeners = this._events.get(type);
 
 			if (listeners) {
 				this._firingCount = (this._firingCount + 1) || 1;
-				for (var i = 0, len = listeners.length; i < len; i++) {
-					var l = listeners[i];
+				listeners.forEach(function (l) {
 					l.fn.call(l.ctx || this, event);
-				}
+				}, this);
 
 				this._firingCount--;
 			}
@@ -205,8 +188,14 @@ export var Events = {
 	// @method listens(type: String): Boolean
 	// Returns `true` if a particular event type has any listeners attached to it.
 	listens: function (type, propagate) {
-		var listeners = this._events && this._events[type];
-		if (listeners && listeners.length) { return true; }
+		var listeners = this._events && this._events.get(type);
+
+		if (listeners) {
+			var size = typeof (listeners.size) == 'function' ? listeners.size() : listeners.size; // Fix for older firefox versions
+			if (size > 0) {
+				return true;
+			}
+		}
 
 		if (propagate) {
 			// also check parents for listeners if event propagates
@@ -264,6 +253,20 @@ export var Events = {
 				propagatedFrom: e.target
 			}, e), true);
 		}
+	},
+
+	// Stamps the function and context and returns a combined unique id
+	// as a result
+	_getListenerFullId: function (fn, ctx) {
+
+		var fnId, ctxId;
+
+		fnId = Util.stamp(fn);
+		if (ctx) {
+			ctxId = Util.stamp(ctx);
+		}
+
+		return fnId + '*' + ctxId;
 	}
 };
 


### PR DESCRIPTION
Added the Dictionary Class:
Added a new class called Dictionary (name borrowed from c#). The dictionary adds the ability to store key/value pairs with high performance ([Spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size))
To make the class compatible with older java script versions  it evaluates if Map gets implemented and if not uses a fallback version which I created (The fallback version currently only contains the methods I needed for my implementation and not the full spec, which could be added later)  

Changed the implementation of Evented to use the Dictionary Class
Evented now uses the new Dictionary class. As a result the performance of Off() is greatly improved (from O(n) to O(1))

Considerations:
- I'm unsure how the Comment/Doumentation system works if somone can provide an explenation I will add the documentation for the Dictionary class.

- Eventhough all tests for the Evented Class where successfull a few tests failed, but they seem unrelated to my changes (Maybe my local testing enviroment is setup wrong?):

> Chrome 78.0.3904 (Windows 10.0.0) CRS #zoom && #scale convert zoom to scale and viceversa and return the same values FAILED
>         Error: expected 2.4999999999999996 to sort of equal 2.5
>             at Assertion.assert (node_modules/expect.js/index.js:96:13)
>             at Assertion.eql (node_modules/expect.js/index.js:230:10)
>             at Context.<anonymous> (spec/suites/geo/CRSSpec.js:233:31)
> ................................................................................
> ................................................................................
> ........................................................................
> Chrome 78.0.3904 (Windows 10.0.0) Tooltip is opened when tapping on touch FAILED
>         Error: expected false to equal true
>             at Assertion.assert (node_modules/expect.js/index.js:96:13)
>             at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
>             at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
>             at Context.<anonymous> (spec/suites/layer/TooltipSpec.js:262:43)
> Chrome 78.0.3904 (Windows 10.0.0) Tooltip is closed if not permanent when clicking on the map elsewhere on touch FAILED
>         Error: expected false to equal true
>             at Assertion.assert (node_modules/expect.js/index.js:96:13)
>             at Assertion.be.Assertion.equal (node_modules/expect.js/index.js:216:10)
>             at Assertion.<computed> [as be] (node_modules/expect.js/index.js:69:24)
>             at Context.<anonymous> (spec/suites/layer/TooltipSpec.js:270:43)
> ......
> Chrome 78.0.3904 (Windows 10.0.0) Marker.Drag drag in CSS scaled container drags a marker with mouse, compensating for CSS scale FAILED
>         Error: Uncaught TypeError: Cannot read property 'dispatchEvent' of null (node_modules/prosthetic-hand/dist/prosthetic-hand.js:1071)
> .............................................
> Chrome 78.0.3904 (Windows 10.0.0) GridLayer number of 256px tiles loaded in synchronous animated grid @800x600px Loads 32, unloads 16 tiles zooming out 11-10 FAILED
>         Error: Uncaught Error: expected 20 to equal 32 (node_modules/expect.js/index.js:102)
> ...
> Chrome 78.0.3904 (Windows 10.0.0) GridLayer configurable tile pruning Loads map, moves forth and back by 512 px, keepBuffer = 0 FAILED
>         Error: Uncaught Error: expected 16 to equal 28 (node_modules/expect.js/index.js:102)
> ............................
> Chrome 78.0.3904 (Windows 10.0.0) Canvas #events should not fire click when dragging the map on top of it FAILED
>         Error: Uncaught Error: expected true to equal false (node_modules/expect.js/index.js:102)
> ............................................................
> WARN: 'Deprecated use of _flat, please use L.LineUtil.isFlat instead.'
> .
> WARN: 'Deprecated use of _flat, please use L.LineUtil.isFlat instead.'
> ................................................................................
> ...................................................
> Chrome 78.0.3904 (Windows 10.0.0) Map.Drag mouse events change the center of the map FAILED
>         Error: Uncaught Error: expected 0 to be within 21.943..21.9431 (node_modules/expect.js/index.js:102)
> ......
> Chrome 78.0.3904 (Windows 10.0.0) Map.Drag touch events change the center of the map FAILED
>         Error: Uncaught Error: expected 0 to be within 21.943..21.9431 (node_modules/expect.js/index.js:102)
> .
> Chrome 78.0.3904 (Windows 10.0.0) Map.Drag touch events reset itself after touchend FAILED
>         Error: Uncaught Error: expected { lat: 0, lng: 0 } to sort of not equal { lat: 0, lng: 0 } (node_modules/expect.js/index.js:102)

