### PR TITLE
Add crs property to LatLng

### DIFF
--- a/spec/suites/geo/CRSSpec.js
+++ b/spec/suites/geo/CRSSpec.js
@@ -221,6 +221,16 @@ describe("CRS.Simple", function () {
 			expect(crs.wrapLatLng(new L.LatLng(300, -250))).nearLatLng(new L.LatLng(-100, 150));
 		});
 	});
+
+	describe("extendLatLng", function () {
+		it("should extend a given LatLng by the number of units in all directions", function () {
+			var bounds = crs.extendLatLng(new L.LatLng(100, 100), 50);
+			expect(bounds.getNorth()).to.be(125);
+			expect(bounds.getEast()).to.be(125);
+			expect(bounds.getSouth()).to.be(75);
+			expect(bounds.getWest()).to.be(75);
+		});
+	});
 });
 
 describe("CRS", function () {
@@ -264,6 +274,8 @@ describe("CRS.ZoomNotPowerOfTwo", function () {
 });
 
 describe("CRS.Earth", function () {
+	var crs = L.CRS.Earth;
+
 	describe("#distance", function () {
 		// Test values from http://rosettacode.org/wiki/Haversine_formula,
 		// we assume using mean earth radius (https://en.wikipedia.org/wiki/Earth_radius#Mean_radius)
@@ -271,6 +283,15 @@ describe("CRS.Earth", function () {
 		// and that sounds serious.
 		var p1 = L.latLng(36.12, -86.67);
 		var p2 = L.latLng(33.94, -118.40);
-		expect(L.CRS.Earth.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
+		expect(crs.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
+	});
+
+	describe("extendLatLng", function () {
+		it("should extend a given LatLng by half of the number of meters in all directions", function () {
+			var bounds = crs.extendLatLng(new L.LatLng(50, 30), 400);
+
+			expect(bounds.getSouthWest()).nearLatLng(new L.LatLng(49.99820, 29.99720));
+			expect(bounds.getNorthEast()).nearLatLng(new L.LatLng(50.00179, 30.00279));
+		});
 	});
 });

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -29,6 +29,15 @@ describe('LatLng', function () {
 			expect(b.alt).to.eql(-50);
 		});
 
+		it('has a default crs of earth', function () {
+			var a = new L.LatLng(25, 74, 50);
+			expect(a.crs).to.eql(L.CRS.Earth);
+		});
+
+		it('sets crs', function () {
+			var a = new L.LatLng(25, 74, 50, L.CRS.Simple);
+			expect(a.crs).to.eql(L.CRS.Simple);
+		});
 	});
 
 	describe('#equals', function () {
@@ -112,6 +121,21 @@ describe('LatLng', function () {
 			expect(L.latLng(50, 30, 100)).to.eql(new L.LatLng(50, 30, 100));
 		});
 
+		it('accepts crs as fourth parameter', function () {
+			var latLng = new L.LatLng(25, 74, 50, L.CRS.Simple);
+			expect(latLng.crs).to.eql(L.CRS.Simple);
+		});
+
+		it('accepts an object with crs', function () {
+			var latLng = L.latLng({
+				lat: 25,
+				lng: 74,
+				alt: 50,
+				crs: L.CRS.Simple
+			});
+			expect(latLng.crs).to.eql(L.CRS.Simple);
+		});
+
 		it('accepts an object with alt', function () {
 			expect(L.latLng({lat: 50, lng: 30, alt: 100})).to.eql(new L.LatLng(50, 30, 100));
 			expect(L.latLng({lat: 50, lon: 30, alt: 100})).to.eql(new L.LatLng(50, 30, 100));
@@ -121,12 +145,13 @@ describe('LatLng', function () {
 	describe('#clone', function () {
 
 		it('should clone attributes', function () {
-			var a = new L.LatLng(50.5, 30.5, 100);
+			var a = new L.LatLng(50.5, 30.5, 100, L.CRS.Simple);
 			var b = a.clone();
 
 			expect(b.lat).to.equal(50.5);
 			expect(b.lng).to.equal(30.5);
 			expect(b.alt).to.equal(100);
+			expect(b.crs).to.equal(L.CRS.Simple);
 		});
 
 		it('should create another reference', function () {
@@ -135,7 +160,6 @@ describe('LatLng', function () {
 
 			expect(a === b).to.be(false);
 		});
-
 	});
 
 });

--- a/src/geo/crs/CRS.Earth.js
+++ b/src/geo/crs/CRS.Earth.js
@@ -1,5 +1,6 @@
 import {CRS} from './CRS';
 import * as Util from '../../core/Util';
+import {toLatLngBounds} from '../LatLngBounds';
 
 /*
  * @namespace CRS
@@ -29,5 +30,16 @@ export var Earth = Util.extend({}, CRS, {
 		    a = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon,
 		    c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 		return this.R * c;
+	},
+
+	// @method extendLatLng(latLng: LatLng, sizeInMeters: Number): LatLngBounds
+	// Returns a new `LatLngBounds` object in which each boundary is `sizeInMeters/2` meters apart from the `LatLng`.
+	extendLatLng: function (latLng, sizeInMeters) {
+		var latAccuracy = 180 * sizeInMeters / 40075017,
+		    lngAccuracy = latAccuracy / Math.cos((Math.PI / 180) * latLng.lat);
+
+		return toLatLngBounds(
+			[latLng.lat - latAccuracy, latLng.lng - lngAccuracy],
+			[latLng.lat + latAccuracy, latLng.lng + lngAccuracy]);
 	}
 });

--- a/src/geo/crs/CRS.Simple.js
+++ b/src/geo/crs/CRS.Simple.js
@@ -2,6 +2,7 @@ import {CRS} from './CRS';
 import {LonLat} from '../projection/Projection.LonLat';
 import {toTransformation} from '../../geometry/Transformation';
 import * as Util from '../../core/Util';
+import {toLatLngBounds} from '../LatLngBounds';
 
 /*
  * @namespace CRS
@@ -30,6 +31,16 @@ export var Simple = Util.extend({}, CRS, {
 		    dy = latlng2.lat - latlng1.lat;
 
 		return Math.sqrt(dx * dx + dy * dy);
+	},
+
+	// @method extendLatLng(latLng: LatLng, size: Number): LatLngBounds
+	// Returns a new `LatLngBounds` object in which each boundary is `size/2` meters apart from the `LatLng`.
+	extendLatLng: function (latLng, size) {
+		var halfSize = size / 2;
+
+		return toLatLngBounds(
+			[latLng.lat - halfSize, latLng.lng - halfSize],
+			[latLng.lat + halfSize, latLng.lng + halfSize]);
 	},
 
 	infinite: true

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -112,7 +112,7 @@ export var CRS = {
 		    lat = this.wrapLat ? Util.wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat,
 		    alt = latlng.alt;
 
-		return new LatLng(lat, lng, alt);
+		return new LatLng(lat, lng, alt, this);
 	},
 
 	// @method wrapLatLngBounds(bounds: LatLngBounds): LatLngBounds
@@ -131,8 +131,8 @@ export var CRS = {
 
 		var sw = bounds.getSouthWest(),
 		    ne = bounds.getNorthEast(),
-		    newSw = new LatLng(sw.lat - latShift, sw.lng - lngShift),
-		    newNe = new LatLng(ne.lat - latShift, ne.lng - lngShift);
+		    newSw = new LatLng(sw.lat - latShift, sw.lng - lngShift, undefined, this),
+		    newNe = new LatLng(ne.lat - latShift, ne.lng - lngShift, undefined, this);
 
 		return new LatLngBounds(newSw, newNe);
 	}


### PR DESCRIPTION
`LatLng` currently assumes the Earth CRS for functions like: `distanceTo`, `wrap`, `toBounds` which is not always correct (See #4978 for example).

This pull request adds a `crs`-property to `LatLng` which enables offloading these functions to the CRS instance. The default remains the Earth CRS.