### PR TITLE
add source to movestart, move, moveend, zoomstart, zoom and zoomend events

### DIFF
--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -69,13 +69,13 @@ export var Zoom = Control.extend({
 
 	_zoomIn: function (e) {
 		if (!this._disabled && this._map._zoom < this._map.getMaxZoom()) {
-			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1), 'user.zoomin');
 		}
 	},
 
 	_zoomOut: function (e) {
 		if (!this._disabled && this._map._zoom > this._map.getMinZoom()) {
-			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
+			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1), 'user.zoomout');
 		}
 	},
 

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -22,12 +22,12 @@ import * as DomUtil from '../dom/DomUtil';
 
 export var PosAnimation = Evented.extend({
 
-	// @method run(el: HTMLElement, newPos: Point, duration?: Number, easeLinearity?: Number)
+	// @method run(el: HTMLElement, newPos: Point, duration?: Number, easeLinearity?: Number, source?: String)
 	// Run an animation of a given element to a new position, optionally setting
 	// duration in seconds (`0.25` by default) and easing linearity factor (3rd
 	// argument of the [cubic bezier curve](http://cubic-bezier.com/#0,0,.5,1),
 	// `0.5` by default).
-	run: function (el, newPos, duration, easeLinearity) {
+	run: function (el, newPos, duration, easeLinearity, source) {
 		this.stop();
 
 		this._el = el;
@@ -38,10 +38,11 @@ export var PosAnimation = Evented.extend({
 		this._startPos = DomUtil.getPosition(el);
 		this._offset = newPos.subtract(this._startPos);
 		this._startTime = +new Date();
+		this._source = source || 'imperative';
 
 		// @event start: Event
 		// Fired when the animation starts
-		this.fire('start');
+		this.fire('start', {source: this._source});
 
 		this._animate();
 	},
@@ -82,7 +83,7 @@ export var PosAnimation = Evented.extend({
 
 		// @event step: Event
 		// Fired continuously during the animation.
-		this.fire('step');
+		this.fire('step', {source: this._source});
 	},
 
 	_complete: function () {
@@ -91,7 +92,7 @@ export var PosAnimation = Evented.extend({
 		this._inProgress = false;
 		// @event end: Event
 		// Fired when the animation ends.
-		this.fire('end');
+		this.fire('end', {source: this._source});
 	},
 
 	_easeOut: function (t) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -172,10 +172,10 @@ export var Map = Evented.extend({
 
 	// @section Methods for modifying map state
 
-	// @method setView(center: LatLng, zoom: Number, options?: Zoom/pan options): this
+	// @method setView(center: LatLng, zoom: Number, options?: Zoom/pan options, source?: String): this
 	// Sets the view of the map (geographical center and zoom) with the given
 	// animation options.
-	setView: function (center, zoom, options) {
+	setView: function (center, zoom, options, source) {
 
 		zoom = zoom === undefined ? this._zoom : this._limitZoom(zoom);
 		center = this._limitCenter(toLatLng(center), zoom, this.options.maxBounds);
@@ -192,8 +192,8 @@ export var Map = Evented.extend({
 
 			// try animating pan or zoom
 			var moved = (this._zoom !== zoom) ?
-				this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom, options.zoom) :
-				this._tryAnimatedPan(center, options.pan);
+				this._tryAnimatedZoom && this._tryAnimatedZoom(center, zoom, options.zoom, source) :
+				this._tryAnimatedPan(center, options.pan, source);
 
 			if (moved) {
 				// prevent resize handler call, the view will refresh after animation anyway
@@ -203,42 +203,42 @@ export var Map = Evented.extend({
 		}
 
 		// animation didn't start, just reset the map view
-		this._resetView(center, zoom);
+		this._resetView(center, zoom, source);
 
 		return this;
 	},
 
-	// @method setZoom(zoom: Number, options?: Zoom/pan options): this
+	// @method setZoom(zoom: Number, options?: Zoom/pan options, source?: String): this
 	// Sets the zoom of the map.
-	setZoom: function (zoom, options) {
+	setZoom: function (zoom, options, source) {
 		if (!this._loaded) {
 			this._zoom = zoom;
 			return this;
 		}
-		return this.setView(this.getCenter(), zoom, {zoom: options});
+		return this.setView(this.getCenter(), zoom, {zoom: options}, source);
 	},
 
-	// @method zoomIn(delta?: Number, options?: Zoom options): this
+	// @method zoomIn(delta?: Number, options?: Zoom options, source?: String): this
 	// Increases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
-	zoomIn: function (delta, options) {
+	zoomIn: function (delta, options, source) {
 		delta = delta || (Browser.any3d ? this.options.zoomDelta : 1);
-		return this.setZoom(this._zoom + delta, options);
+		return this.setZoom(this._zoom + delta, options, source);
 	},
 
-	// @method zoomOut(delta?: Number, options?: Zoom options): this
+	// @method zoomOut(delta?: Number, options?: Zoom options, source?: String): this
 	// Decreases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
-	zoomOut: function (delta, options) {
+	zoomOut: function (delta, options, source) {
 		delta = delta || (Browser.any3d ? this.options.zoomDelta : 1);
-		return this.setZoom(this._zoom - delta, options);
+		return this.setZoom(this._zoom - delta, options, source);
 	},
 
-	// @method setZoomAround(latlng: LatLng, zoom: Number, options: Zoom options): this
+	// @method setZoomAround(latlng: LatLng, zoom: Number, options: Zoom options, source?: String): this
 	// Zooms the map while keeping a specified geographical point on the map
 	// stationary (e.g. used internally for scroll zoom and double-click zoom).
 	// @alternative
 	// @method setZoomAround(offset: Point, zoom: Number, options: Zoom options): this
 	// Zooms the map while keeping a specified pixel on the map (relative to the top-left corner) stationary.
-	setZoomAround: function (latlng, zoom, options) {
+	setZoomAround: function (latlng, zoom, options, source) {
 		var scale = this.getZoomScale(zoom),
 		    viewHalf = this.getSize().divideBy(2),
 		    containerPoint = latlng instanceof Point ? latlng : this.latLngToContainerPoint(latlng),
@@ -246,7 +246,7 @@ export var Map = Evented.extend({
 		    centerOffset = containerPoint.subtract(viewHalf).multiplyBy(1 - 1 / scale),
 		    newCenter = this.containerPointToLatLng(viewHalf.add(centerOffset));
 
-		return this.setView(newCenter, zoom, {zoom: options});
+		return this.setView(newCenter, zoom, {zoom: options}, source);
 	},
 
 	_getBoundsCenterZoom: function (bounds, options) {
@@ -280,10 +280,10 @@ export var Map = Evented.extend({
 		};
 	},
 
-	// @method fitBounds(bounds: LatLngBounds, options?: fitBounds options): this
+	// @method fitBounds(bounds: LatLngBounds, options?: fitBounds options, source?: String): this
 	// Sets a map view that contains the given geographical bounds with the
 	// maximum zoom level possible.
-	fitBounds: function (bounds, options) {
+	fitBounds: function (bounds, options, source) {
 
 		bounds = toLatLngBounds(bounds);
 
@@ -292,35 +292,36 @@ export var Map = Evented.extend({
 		}
 
 		var target = this._getBoundsCenterZoom(bounds, options);
-		return this.setView(target.center, target.zoom, options);
+		return this.setView(target.center, target.zoom, options, source);
 	},
 
-	// @method fitWorld(options?: fitBounds options): this
+	// @method fitWorld(options?: fitBounds options, source?: source): this
 	// Sets a map view that mostly contains the whole world with the maximum
 	// zoom level possible.
-	fitWorld: function (options) {
-		return this.fitBounds([[-90, -180], [90, 180]], options);
+	fitWorld: function (options, source) {
+		return this.fitBounds([[-90, -180], [90, 180]], options, source);
 	},
 
-	// @method panTo(latlng: LatLng, options?: Pan options): this
+	// @method panTo(latlng: LatLng, options?: Pan options, source?: String): this
 	// Pans the map to a given center.
-	panTo: function (center, options) { // (LatLng)
-		return this.setView(center, this._zoom, {pan: options});
+	panTo: function (center, options, source) { // (LatLng)
+		return this.setView(center, this._zoom, {pan: options}, source);
 	},
 
-	// @method panBy(offset: Point, options?: Pan options): this
+	// @method panBy(offset: Point, options?: Pan options, source:? String): this
 	// Pans the map by a given number of pixels (animated).
-	panBy: function (offset, options) {
+	panBy: function (offset, options, source) {
 		offset = toPoint(offset).round();
 		options = options || {};
+		source = source || 'imperative';
 
 		if (!offset.x && !offset.y) {
-			return this.fire('moveend');
+			return this.fire('moveend', {source: source});
 		}
 		// If we pan too far, Chrome gets issues with tiles
 		// and makes them disappear or appear in the wrong place (slightly offset) #2602
 		if (options.animate !== true && !this.getSize().contains(offset)) {
-			this._resetView(this.unproject(this.project(this.getCenter()).add(offset)), this.getZoom());
+			this._resetView(this.unproject(this.project(this.getCenter()).add(offset)), this.getZoom(), source);
 			return this;
 		}
 
@@ -335,7 +336,7 @@ export var Map = Evented.extend({
 
 		// don't fire movestart if animating inertia
 		if (!options.noMoveStart) {
-			this.fire('movestart');
+			this.fire('movestart', {source: source});
 		}
 
 		// animate pan unless animate: false specified
@@ -343,10 +344,10 @@ export var Map = Evented.extend({
 			DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
 
 			var newPos = this._getMapPanePos().subtract(offset).round();
-			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
+			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity, source);
 		} else {
 			this._rawPanBy(offset);
-			this.fire('move').fire('moveend');
+			this.fire('move', {source: source}).fire('moveend', {source: source});
 		}
 
 		return this;
@@ -422,7 +423,7 @@ export var Map = Evented.extend({
 
 			} else {
 				this
-					._move(targetCenter, targetZoom)
+					._move(targetCenter, targetZoom, null)
 					._moveEnd(true);
 			}
 		}
@@ -498,13 +499,13 @@ export var Map = Evented.extend({
 
 	// @method panInsideBounds(bounds: LatLngBounds, options?: Pan options): this
 	// Pans the map to the closest view that would lie inside the given bounds (if it's not already), controlling the animation using the options specific, if any.
-	panInsideBounds: function (bounds, options) {
+	panInsideBounds: function (bounds, options, source) {
 		this._enforcingBounds = true;
 		var center = this.getCenter(),
 		    newCenter = this._limitCenter(center, this._zoom, toLatLngBounds(bounds));
 
 		if (!center.equals(newCenter)) {
-			this.panTo(newCenter, options);
+			this.panTo(newCenter, options, source);
 		}
 
 		this._enforcingBounds = false;
@@ -565,11 +566,11 @@ export var Map = Evented.extend({
 	// times in a row.
 
 	// @alternative
-	// @method invalidateSize(animate: Boolean): this
+	// @method invalidateSize(animate: Boolean, source?: String): this
 	// Checks if the map container size changed and updates the map if so —
 	// call it after you've changed the map size dynamically, also animating
 	// pan by default.
-	invalidateSize: function (options) {
+	invalidateSize: function (options, source) {
 		if (!this._loaded) { return this; }
 
 		options = Util.extend({
@@ -589,20 +590,20 @@ export var Map = Evented.extend({
 		if (!offset.x && !offset.y) { return this; }
 
 		if (options.animate && options.pan) {
-			this.panBy(offset);
+			this.panBy(offset, null, source);
 
 		} else {
 			if (options.pan) {
-				this._rawPanBy(offset);
+				this._rawPanBy(offset, source);
 			}
 
-			this.fire('move');
+			this.fire('move', {source: source});
 
 			if (options.debounceMoveend) {
 				clearTimeout(this._sizeTimer);
-				this._sizeTimer = setTimeout(Util.bind(this.fire, this, 'moveend'), 200);
+				this._sizeTimer = setTimeout(Util.bind(this.fire, this, 'moveend', {source: source}), 200);
 			} else {
-				this.fire('moveend');
+				this.fire('moveend', {source: source});
 			}
 		}
 
@@ -611,7 +612,8 @@ export var Map = Evented.extend({
 		// Fired when the map is resized.
 		return this.fire('resize', {
 			oldSize: oldSize,
-			newSize: newSize
+			newSize: newSize,
+			source: source
 		});
 	},
 
@@ -687,7 +689,7 @@ export var Map = Evented.extend({
 		            (c === 2 ? 'position unavailable' : 'timeout'));
 
 		if (this._locateOptions.setView && !this._loaded) {
-			this.fitWorld();
+			this.fitWorld(null, 'imperative.geolocation');
 		}
 
 		// @section Location events
@@ -708,7 +710,7 @@ export var Map = Evented.extend({
 
 		if (options.setView) {
 			var zoom = this.getBoundsZoom(bounds);
-			this.setView(latlng, options.maxZoom ? Math.min(zoom, options.maxZoom) : zoom);
+			this.setView(latlng, options.maxZoom ? Math.min(zoom, options.maxZoom) : zoom, null, 'imperative.geolocation');
 		}
 
 		var data = {
@@ -1181,7 +1183,8 @@ export var Map = Evented.extend({
 	// private methods that modify map state
 
 	// @section Map state change events
-	_resetView: function (center, zoom) {
+	_resetView: function (center, zoom, source) {
+		source = source || 'imperative';
 		DomUtil.setPosition(this._mapPane, new Point(0, 0));
 
 		var loading = !this._loaded;
@@ -1192,9 +1195,9 @@ export var Map = Evented.extend({
 
 		var zoomChanged = this._zoom !== zoom;
 		this
-			._moveStart(zoomChanged, false)
-			._move(center, zoom)
-			._moveEnd(zoomChanged);
+			._moveStart(zoomChanged, false, source)
+			._move(center, zoom, null, source)
+			._moveEnd(zoomChanged, source);
 
 		// @event viewreset: Event
 		// Fired when the map needs to redraw its content (this usually happens
@@ -1209,21 +1212,22 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_moveStart: function (zoomChanged, noMoveStart) {
+	_moveStart: function (zoomChanged, noMoveStart, source) {
+		source = source || 'imperative';
 		// @event zoomstart: Event
 		// Fired when the map zoom is about to change (e.g. before zoom animation).
 		// @event movestart: Event
 		// Fired when the view of the map starts changing (e.g. user starts dragging the map).
 		if (zoomChanged) {
-			this.fire('zoomstart');
+			this.fire('zoomstart', {source: source});
 		}
 		if (!noMoveStart) {
-			this.fire('movestart');
+			this.fire('movestart', {source: source});
 		}
 		return this;
 	},
 
-	_move: function (center, zoom, data) {
+	_move: function (center, zoom, data, source) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -1232,6 +1236,9 @@ export var Map = Evented.extend({
 		this._zoom = zoom;
 		this._lastCenter = center;
 		this._pixelOrigin = this._getNewPixelOrigin(center);
+
+		data = data || {};
+		data.source = source || 'imperative';
 
 		// @event zoom: Event
 		// Fired repeatedly during any change in zoom level, including zoom
@@ -1246,17 +1253,17 @@ export var Map = Evented.extend({
 		return this.fire('move', data);
 	},
 
-	_moveEnd: function (zoomChanged) {
+	_moveEnd: function (zoomChanged, source) {
 		// @event zoomend: Event
 		// Fired when the map has changed, after any animations.
 		if (zoomChanged) {
-			this.fire('zoomend');
+			this.fire('zoomend', {source: source});
 		}
 
 		// @event moveend: Event
 		// Fired when the center of the map stops changing (e.g. user stopped
 		// dragging the map).
-		return this.fire('moveend');
+		return this.fire('moveend', {source: source});
 	},
 
 	_stop: function () {
@@ -1338,7 +1345,7 @@ export var Map = Evented.extend({
 	_onResize: function () {
 		Util.cancelAnimFrame(this._resizeRequest);
 		this._resizeRequest = Util.requestAnimFrame(
-		        function () { this.invalidateSize({debounceMoveend: true}); }, this);
+		        function () { this.invalidateSize({debounceMoveend: true}, 'imperative.resize'); }, this);
 	},
 
 	_onScroll: function () {
@@ -1578,23 +1585,23 @@ export var Map = Evented.extend({
 		return Math.max(min, Math.min(max, zoom));
 	},
 
-	_onPanTransitionStep: function () {
-		this.fire('move');
+	_onPanTransitionStep: function (event) {
+		this.fire('move', {source: event.source});
 	},
 
-	_onPanTransitionEnd: function () {
+	_onPanTransitionEnd: function (event) {
 		DomUtil.removeClass(this._mapPane, 'leaflet-pan-anim');
-		this.fire('moveend');
+		this.fire('moveend', {source: event.source});
 	},
 
-	_tryAnimatedPan: function (center, options) {
+	_tryAnimatedPan: function (center, options, source) {
 		// difference between the new and current centers in pixels
 		var offset = this._getCenterOffset(center)._trunc();
 
 		// don't animate too far unless animate: true specified in options
 		if ((options && options.animate) !== true && !this.getSize().contains(offset)) { return false; }
 
-		this.panBy(offset, options);
+		this.panBy(offset, options, source);
 
 		return true;
 	},
@@ -1643,7 +1650,7 @@ export var Map = Evented.extend({
 		return !this._container.getElementsByClassName('leaflet-zoom-animated').length;
 	},
 
-	_tryAnimatedZoom: function (center, zoom, options) {
+	_tryAnimatedZoom: function (center, zoom, options, source) {
 
 		if (this._animatingZoom) { return true; }
 
@@ -1662,15 +1669,17 @@ export var Map = Evented.extend({
 
 		Util.requestAnimFrame(function () {
 			this
-			    ._moveStart(true, false)
-			    ._animateZoom(center, zoom, true);
+			    ._moveStart(true, false, source)
+			    ._animateZoom(center, zoom, true, null, source);
 		}, this);
 
 		return true;
 	},
 
-	_animateZoom: function (center, zoom, startAnim, noUpdate) {
+	_animateZoom: function (center, zoom, startAnim, noUpdate, source) {
 		if (!this._mapPane) { return; }
+
+		source = source || 'imperative';
 
 		if (startAnim) {
 			this._animatingZoom = true;
@@ -1688,8 +1697,11 @@ export var Map = Evented.extend({
 		this.fire('zoomanim', {
 			center: center,
 			zoom: zoom,
-			noUpdate: noUpdate
+			noUpdate: noUpdate,
+			source: source
 		});
+
+		this._zoomTransitionSource = source;
 
 		// Work around webkit not firing 'transitionend', see https://github.com/Leaflet/Leaflet/issues/3689, 2693
 		setTimeout(Util.bind(this._onZoomTransitionEnd, this), 250);
@@ -1698,17 +1710,20 @@ export var Map = Evented.extend({
 	_onZoomTransitionEnd: function () {
 		if (!this._animatingZoom) { return; }
 
+		var source = this._zoomTransitionSource;
+		this._zoomTransitionSource = null;
+
 		if (this._mapPane) {
 			DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
 		}
 
 		this._animatingZoom = false;
 
-		this._move(this._animateToCenter, this._animateToZoom);
+		this._move(this._animateToCenter, this._animateToZoom, null, source);
 
 		// This anim frame should prevent an obscure iOS webkit tile loading race condition.
 		Util.requestAnimFrame(function () {
-			this._moveEnd(true);
+			this._moveEnd(true, source);
 		}, this);
 	}
 });

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -133,7 +133,7 @@ export var BoxZoom = Handler.extend({
 		        this._map.containerPointToLatLng(this._point));
 
 		this._map
-			.fitBounds(bounds)
+			.fitBounds(bounds, null, 'user.boxzoom')
 			.fire('boxzoomend', {boxZoomBounds: bounds});
 	},
 

--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -33,9 +33,9 @@ export var DoubleClickZoom = Handler.extend({
 		    zoom = e.originalEvent.shiftKey ? oldZoom - delta : oldZoom + delta;
 
 		if (map.options.doubleClickZoom === 'center') {
-			map.setZoom(zoom);
+			map.setZoom(zoom, null, 'user.doubleclickzoom');
 		} else {
-			map.setZoomAround(e.containerPoint, zoom);
+			map.setZoomAround(e.containerPoint, zoom, null, 'user.doubleclickzoom');
 		}
 	}
 });

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -112,7 +112,7 @@ export var Drag = Handler.extend({
 		}
 
 		map
-		    .fire('movestart')
+		    .fire('movestart', {source: 'user.drag'})
 		    .fire('dragstart');
 
 		if (map.options.inertia) {
@@ -131,6 +131,8 @@ export var Drag = Handler.extend({
 
 			this._prunePositions(time);
 		}
+
+		e.source = 'user.drag';
 
 		this._map
 		    .fire('move', e)
@@ -193,7 +195,7 @@ export var Drag = Handler.extend({
 		map.fire('dragend', e);
 
 		if (noInertia) {
-			map.fire('moveend');
+			map.fire('moveend', {source: 'user.drag'});
 
 		} else {
 			this._prunePositions(+new Date());
@@ -212,7 +214,7 @@ export var Drag = Handler.extend({
 			    offset = limitedSpeedVector.multiplyBy(-decelerationDuration / 2).round();
 
 			if (!offset.x && !offset.y) {
-				map.fire('moveend');
+				map.fire('moveend', {source: 'user.drag'});
 
 			} else {
 				offset = map._limitOffset(offset, map.options.maxBounds);
@@ -223,7 +225,7 @@ export var Drag = Handler.extend({
 						easeLinearity: ease,
 						noMoveStart: true,
 						animate: true
-					});
+					}, 'user.drag');
 				});
 			}
 		}

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -151,14 +151,14 @@ export var Keyboard = Handler.extend({
 					offset = toPoint(offset).multiplyBy(3);
 				}
 
-				map.panBy(offset);
+				map.panBy(offset, null, 'user.keyboard');
 
 				if (map.options.maxBounds) {
-					map.panInsideBounds(map.options.maxBounds);
+					map.panInsideBounds(map.options.maxBounds, null, 'user.keyboard');
 				}
 			}
 		} else if (key in this._zoomKeys) {
-			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key]);
+			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key], null, 'user.keyboard');
 
 		} else if (key === 27 && map._popup && map._popup.options.closeOnEscapeKey) {
 			map.closePopup();

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -78,9 +78,9 @@ export var ScrollWheelZoom = Handler.extend({
 		if (!delta) { return; }
 
 		if (map.options.scrollWheelZoom === 'center') {
-			map.setZoom(zoom + delta);
+			map.setZoom(zoom + delta, null, 'user.scrollwheelzoom');
 		} else {
-			map.setZoomAround(this._lastMousePos, zoom + delta);
+			map.setZoomAround(this._lastMousePos, zoom + delta, null, 'user.scrollwheelzoom');
 		}
 	}
 });

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -97,7 +97,7 @@ export var TouchZoom = Handler.extend({
 
 		Util.cancelAnimFrame(this._animRequest);
 
-		var moveFn = Util.bind(map._move, map, this._center, this._zoom, {pinch: true, round: false});
+		var moveFn = Util.bind(map._move, map, this._center, this._zoom, {pinch: true, round: false}, 'user.touchzoom');
 		this._animRequest = Util.requestAnimFrame(moveFn, this, true);
 
 		DomEvent.preventDefault(e);
@@ -117,9 +117,9 @@ export var TouchZoom = Handler.extend({
 
 		// Pinch updates GridLayers' levels only when zoomSnap is off, so zoomSnap becomes noUpdate.
 		if (this._map.options.zoomAnimation) {
-			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.zoomSnap);
+			this._map._animateZoom(this._center, this._map._limitZoom(this._zoom), true, this._map.options.zoomSnap, 'user.touchzoom');
 		} else {
-			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
+			this._map._resetView(this._center, this._map._limitZoom(this._zoom), 'user.touchzoom');
 		}
 	}
 });


### PR DESCRIPTION
It would be very useful to know when the map is moved or zoomed due to user interaction.

So here‘s a pull request which adds a 'source' property to movestart, move, moveend, zoomstart, zoom, and zoomend events.
The source is either `user(.[a-z]+)?` or `imperative(.[a-z]+)?`, depending on how was triggered the event.

This pull request is mostly based on this one #5247 which is three years old and was never merged for some unknown reason.