### PR TITLE
Support for passive events is not actually checked

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -130,7 +130,7 @@ export var passiveEvents = (function () {
 		// Errors can safely be ignored since this is only a browser support test.
 	}
 	return supportsPassiveOption;
-});
+}());
 
 // @property canvas: Boolean
 // `true` when the browser supports [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).


### PR DESCRIPTION
The `passiveEvents` variable was always a truthy value since it holds a reference to the function, instead of it being self-invokated and thus getting its result.