### PR TITLE
Remove tooltips outside screen bounds. Resolves #6734

### DIFF
--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -131,14 +131,18 @@ export var Polygon = Polyline.extend({
 		this._parts = [];
 		if (!this._pxBounds || !this._pxBounds.intersects(bounds)) {
 			for (const lyr in this._eventParents) {
-				this._eventParents[lyr].closeTooltip();
+				if (this._eventParents[lyr].getTooltip()) {
+					this._eventParents[lyr].closeTooltip();
+				}
 			}
 			return;
 		}
 
 		for (const lyr in this._eventParents) {
-			if (!this._eventParents[lyr].isTooltipOpen()) {
-				this._eventParents[lyr].openTooltip();
+			if (this._eventParents[lyr].getTooltip()) {
+				if (!this._eventParents[lyr].isTooltipOpen()) {
+					this._eventParents[lyr].openTooltip();
+				}
 			}
 		}
 		if (this.options.noClip) {

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -130,9 +130,17 @@ export var Polygon = Polyline.extend({
 
 		this._parts = [];
 		if (!this._pxBounds || !this._pxBounds.intersects(bounds)) {
+			for (const lyr in this._eventParents) {
+				this._eventParents[lyr].closeTooltip();
+			}
 			return;
 		}
 
+		for (const lyr in this._eventParents) {
+			if (!this._eventParents[lyr].isTooltipOpen()) {
+				this._eventParents[lyr].openTooltip();
+			}
+		}
 		if (this.options.noClip) {
 			this._parts = this._rings;
 			return;


### PR DESCRIPTION
Removes the tooltip of a polygon layer when the polygon bounds does not intersect with the renderer bounds.

Resolves #6734

![Screen_20](https://user-images.githubusercontent.com/6735870/71224693-3c91ad00-232a-11ea-8a9e-37f0a13fbb55.gif)

