### PR TITLE
Add module entry point to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "uglify-js": "~3.5.10"
   },
   "main": "dist/leaflet-src.js",
+  "module": "dist/leaflet-src.esm.js",
   "style": "dist/leaflet.css",
   "files": [
     "dist",


### PR DESCRIPTION
With this change projects using rollup plugin can use the ESM
version of Leaflet.

Without `module` entry point (only with `main`), Rollup
Plugin uses the `commonjs` to parse Leaflet JS (`dist/leaflet-src.js`),
which is a bit unneeded round trip:
firstly Leaflet is rolled up, than in projects is un-rolled, to be rolled-up again.

This patch, as well, fixes issues like `Rollup: Missing Export`, or parsing errors
during building more complicated projects with rollup plugin.