### PR TITLE
fix(Map): rm moveend listener from setMaxBounds

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -72,7 +72,7 @@ describe("Map", function () {
 
 		it("does not throw if removed during animation", function () {
 			var container = document.createElement('div'),
-			    map = new L.Map(container).setView([0, 0], 1);
+			    map = new L.Map(container).setView([0, 0], 1).setMaxBounds([[0, 1], [2, 3]]);
 
 			// Force creation of animation proxy,
 			// otherwise browser checks disable it

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -752,6 +752,7 @@ export var Map = Evented.extend({
 	remove: function () {
 
 		this._initEvents(true);
+		this.off('moveend', this._panInsideMaxBounds);
 
 		if (this._containerId !== this._container._leaflet_id) {
 			throw new Error('Map container is being reused by another instance');


### PR DESCRIPTION
Calling `map.setMapBounds`, adds the `"moveend"` event listener `_panInsideMaxBounds`. Previously, this did not get cleaned up via `remove`.

See https://github.com/Leaflet/Leaflet/issues/5774#issuecomment-570953719 for a detailed analysis and a SSCCE.