### PR TITLE
fix: Don't call potentially undefined closePopup function

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,13 @@
       "strict": 0,
       "wrap-iife": 0,
       "key-spacing": 0,
-      "consistent-return": 0
+      "consistent-return": 0,
+      "no-unused-expressions": [
+        "error",
+        { 
+          "allowShortCircuit": true
+        }
+      ]
     }
   },
   "repository": {

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -107,10 +107,13 @@ export var MarkerDrag = Handler.extend({
 		// Fired when the marker starts moving (because of dragging).
 
 		this._oldLatLng = this._marker.getLatLng();
+
+		// When using ES6 imports it could not be set when `Popup` was not imported as well
+		this._marker.closePopup && this._marker.closePopup();
+
 		this._marker
-		    .closePopup()
-		    .fire('movestart')
-		    .fire('dragstart');
+			.fire('movestart')
+			.fire('dragstart');
 	},
 
 	_onPreDrag: function (e) {


### PR DESCRIPTION
As a result of using importing Marker as ES6 module and *not* importing Popup the function `closePopup` does not exist on the marker object.

This is a quick fix. A better approach would be to make the popup register a move listener on the marker, while its open. And then close itself when the marker is moved.

Closes #6961