### PR TITLE
[docs] correct Mapbox examples' tileSize

### DIFF
--- a/debug/map/svgoverlay.html
+++ b/debug/map/svgoverlay.html
@@ -28,7 +28,9 @@
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'mapbox/satellite-v9'
+			id: 'mapbox/satellite-v9',
+			tileSize: 512,
+			zoomOffset: -1
 		}).addTo(map);
 
 		var svgElement = document.querySelector('#image'),

--- a/debug/map/videooverlay.html
+++ b/debug/map/videooverlay.html
@@ -26,7 +26,9 @@
 			attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, ' +
 				'<a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="http://mapbox.com">Mapbox</a>',
-			id: 'mapbox/satellite-v9'
+			id: 'mapbox/satellite-v9',
+			tileSize: 512,
+			zoomOffset: -1
 		}).addTo(map);
 
 		var videoUrls = [

--- a/debug/vector/moving-canvas.html
+++ b/debug/vector/moving-canvas.html
@@ -19,7 +19,7 @@
 
 		var osmUrl = 'https://api.mapbox.com/styles/v1/mapbox/light-v9/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, tileSize: 512, zoomOffset: -1, attribution: osmAttrib});
 
 		var map = L.map('map', {preferCanvas: true})
 				.setView([50.5, 30.51], 15)

--- a/docs/examples/choropleth/example-basic.md
+++ b/docs/examples/choropleth/example-basic.md
@@ -12,7 +12,9 @@ title: Choropleth Tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/light-v9'
+		id: 'mapbox/light-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	var geojson = L.geoJson(statesData).addTo(map);

--- a/docs/examples/choropleth/example-color.md
+++ b/docs/examples/choropleth/example-color.md
@@ -13,7 +13,9 @@ title: Choropleth Tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/light-v9'
+		id: 'mapbox/light-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	// get color depending on population density value

--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -43,7 +43,9 @@ css: "#map {
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/light-v9'
+		id: 'mapbox/light-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -38,7 +38,9 @@ Let's display our states data on a map with a custom Mapbox style for nice grays
 
 	L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + mapboxAccessToken, {
 		id: 'mapbox/light-v9',
-		attribution: ...
+		attribution: ...,
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	L.geoJson(statesData).addTo(map);

--- a/docs/examples/geojson/example.md
+++ b/docs/examples/geojson/example.md
@@ -12,7 +12,9 @@ title: GeoJSON tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/light-v9'
+		id: 'mapbox/light-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	var baseballIcon = L.icon({

--- a/docs/examples/geojson/geojson-example.html
+++ b/docs/examples/geojson/geojson-example.html
@@ -21,7 +21,9 @@
 			attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 				'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 				'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-			id: 'mapbox/light-v9'
+			id: 'mapbox/light-v9',
+			tileSize: 512,
+			zoomOffset: -1
 		}).addTo(map);
 
 		var baseballIcon = L.icon({

--- a/docs/examples/geojson/geojson.html
+++ b/docs/examples/geojson/geojson.html
@@ -16,7 +16,9 @@ title: Using GeoJSON with Leaflet
 
 	L.tileLayer(MB_URL, {
 		attribution: MB_ATTR,
-		id: 'mapbox/light-v9'
+		id: 'mapbox/light-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	var baseballIcon = L.icon({

--- a/docs/examples/layers-control/example.md
+++ b/docs/examples/layers-control/example.md
@@ -16,8 +16,8 @@ title: Layers Control Tutorial
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
 		mbUrl = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
 
-	var grayscale   = L.tileLayer(mbUrl, {id: 'mapbox/light-v9', attribution: mbAttr}),
-		streets  = L.tileLayer(mbUrl, {id: 'mapbox/streets-v11',   attribution: mbAttr});
+	var grayscale   = L.tileLayer(mbUrl, {id: 'mapbox/light-v9', tileSize: 512, zoomOffset: -1, attribution: mbAttr}),
+		streets  = L.tileLayer(mbUrl, {id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mbAttr});
 
 	var map = L.map('map', {
 		center: [39.73, -104.99],

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -32,8 +32,8 @@ There are two types of layers: (1) base layers that are mutually exclusive (only
 
 Now let's create those base layers and add the default ones to the map:
 
-<pre><code>var grayscale = L.tileLayer(mapboxUrl, {id: '<a href="https://mapbox.com">MapID</a>', attribution: mapboxAttribution}),
-	streets   = L.tileLayer(mapboxUrl, {id: '<a href="https://mapbox.com">MapID</a>', attribution: mapboxAttribution});
+<pre><code>var grayscale = L.tileLayer(mapboxUrl, {id: '<a href="https://mapbox.com">MapID</a>', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution}),
+	streets   = L.tileLayer(mapboxUrl, {id: '<a href="https://mapbox.com">MapID</a>', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
 
 var map = L.map('map', {
 	center: [39.73, -104.99],

--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -18,7 +18,9 @@ css: "body {
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/streets-v11'
+		id: 'mapbox/streets-v11',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	function onLocationFound(e) {

--- a/docs/examples/mobile/index.md
+++ b/docs/examples/mobile/index.md
@@ -35,7 +35,9 @@ We'll now initialize the map in the JavaScript code like we did in the [quick st
 
 L.tileLayer('https://api.mapbox.com/styles/v1/{<a href="https://docs.mapbox.com/help/glossary/style-id/">id</a>}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
 	attribution: 'Map data &amp;copy; <span class="text-cut" data-cut="[&hellip;]">&lt;a href="https://www.openstreetmap.org/"&gt;OpenStreetMap&lt;/a&gt; contributors, &lt;a href="https://creativecommons.org/licenses/by-sa/2.0/"&gt;CC-BY-SA&lt;/a&gt;, Imagery &copy; &lt;a href="https://www.mapbox.com/"&gt;Mapbox&lt;/a&gt;</span>',
-	maxZoom: 18
+	maxZoom: 18,
+	tileSize: 512,
+	zoomOffset: -1
 }).addTo(map);</code></pre>
 
 ### Geolocation

--- a/docs/examples/quick-start/example-basic.md
+++ b/docs/examples/quick-start/example-basic.md
@@ -13,7 +13,9 @@ customMapContainer: "true"
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/streets-v11'
+		id: 'mapbox/streets-v11',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(mymap);
 
 </script>

--- a/docs/examples/quick-start/example-overlays.md
+++ b/docs/examples/quick-start/example-overlays.md
@@ -13,7 +13,9 @@ customMapContainer: "true"
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/streets-v11'
+		id: 'mapbox/streets-v11',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(mymap);
 
 	L.marker([51.5, -0.09]).addTo(mymap);

--- a/docs/examples/quick-start/example-popups.md
+++ b/docs/examples/quick-start/example-popups.md
@@ -13,7 +13,9 @@ customMapContainer: "true"
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/streets-v11'
+		id: 'mapbox/streets-v11',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(mymap);
 
 	L.marker([51.5, -0.09]).addTo(mymap)

--- a/docs/examples/quick-start/example.md
+++ b/docs/examples/quick-start/example.md
@@ -13,7 +13,9 @@ customMapContainer: "true"
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/streets-v11'
+		id: 'mapbox/streets-v11',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(mymap);
 
 	L.marker([51.5, -0.09]).addTo(mymap)

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -50,12 +50,14 @@ By default (as we didn't pass any options when creating the map instance), all m
 
 Note that `setView` call also returns the map object --- most Leaflet methods act like this when they don't return an explicit value, which allows convenient jQuery-like method chaining.
 
-Next we'll add a tile layer to add to our map, in this case it's a Mapbox Streets tile layer. Creating a tile layer usually involves setting the [URL template](/reference.html#tilelayer-url-template) for the tile images, the attribution text and the maximum zoom level of the layer. In this example we'll use the `mapbox/streets-v11` tiles from [Mapbox's Static Tiles API](https://docs.mapbox.com/api/maps/#static-tiles) (in order to use tiles from Mapbox, you must also [request an access token](https://www.mapbox.com/studio/account/tokens/)).
+Next we'll add a tile layer to add to our map, in this case it's a Mapbox Streets tile layer. Creating a tile layer usually involves setting the [URL template](/reference.html#tilelayer-url-template) for the tile images, the attribution text and the maximum zoom level of the layer. In this example we'll use the `mapbox/streets-v11` tiles from [Mapbox's Static Tiles API](https://docs.mapbox.com/api/maps/#static-tiles) (in order to use tiles from Mapbox, you must also [request an access token](https://www.mapbox.com/studio/account/tokens/)). Because this API returns 512x512 tiles by default (instead of 256x256), we will also have to explicitly specify this and offset our zoom by a value of -1.
 
 <pre><code class="javascript">L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
 	attribution: 'Map data &amp;copy; <span class="text-cut" data-cut="[&hellip;]">&lt;a href="https://www.openstreetmap.org/"&gt;OpenStreetMap&lt;/a&gt; contributors, &lt;a href="https://creativecommons.org/licenses/by-sa/2.0/"&gt;CC-BY-SA&lt;/a&gt;, Imagery &copy; &lt;a href="https://www.mapbox.com/"&gt;Mapbox&lt;/a&gt;</span>',
 	maxZoom: 18,
 	id: 'mapbox/streets-v11',
+	tileSize: 512,
+	zoomOffset: -1,
 	accessToken: 'your.mapbox.access.token'
 }).addTo(mymap);</code></pre>
 

--- a/docs/examples/video-overlay/example-bounds.md
+++ b/docs/examples/video-overlay/example-bounds.md
@@ -10,7 +10,9 @@ title: Video Overlay Tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/satellite-v9'
+		id: 'mapbox/satellite-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	bounds = L.latLngBounds([[ 32, -130], [ 13, -100]]);

--- a/docs/examples/video-overlay/example-nocontrols.md
+++ b/docs/examples/video-overlay/example-nocontrols.md
@@ -10,7 +10,9 @@ title: Video Overlay Tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/satellite-v9'
+		id: 'mapbox/satellite-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	var videoUrls = [

--- a/docs/examples/video-overlay/example.md
+++ b/docs/examples/video-overlay/example.md
@@ -10,7 +10,9 @@ title: Video Overlay Tutorial
 		attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
 			'<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
-		id: 'mapbox/satellite-v9'
+		id: 'mapbox/satellite-v9',
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 	var videoUrls = [

--- a/docs/examples/video-overlay/index.md
+++ b/docs/examples/video-overlay/index.md
@@ -31,7 +31,9 @@ First of all, create a Leaflet map and add a background `L.TileLayer` in the usu
 
 	L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + mapboxAccessToken, {
 		id: 'mapbox/satellite-v9',
-		attribution: ...
+		attribution: ...,
+		tileSize: 512,
+		zoomOffset: -1
 	}).addTo(map);
 
 Then, we'll define the geographical bounds that the video will cover. This is an instance of [`L.LatLngBounds`](/reference.html#latlngbounds), which is a rectangular shape:


### PR DESCRIPTION
In https://github.com/Leaflet/Leaflet/pull/6905 we updated all the examples that use Mapbox to point to a non-legacy API. However, we failed to account for the fact that the new API returns 512x512 styles by default (instead of the 256x256 that the legacy API returned). The result was that the examples worked correctly, but map labels & features were quite small. 

This PR adds the options `tileSize` & `zoomOffset` to all of the examples to ensure that the result does not cause consumers of the documentation to squint. Here's a quick side-by-side of the difference:

![Screen Shot 2020-02-13 at 6 59 43 PM](https://user-images.githubusercontent.com/16272584/74490148-9f6c7400-4e95-11ea-91b9-57e482cc39af.png)

Note, it's also possible to specify a tilesize of 256 in the API request (ref. [Static Tiles docs](https://docs.mapbox.com/api/maps/#static-tiles)). However, this would result in 4x the amount of requests to the API so I opted for this approach instead. 

cc/ @rmrice @mourner 