### PR TITLE
Fix exception when calling LayerGroup/hasLayer() with wrong layerId

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -73,7 +73,9 @@ export var LayerGroup = Layer.extend({
 	// @method hasLayer(id: Number): Boolean
 	// Returns `true` if the given internal ID is currently added to the group.
 	hasLayer: function (layer) {
-		return !!layer && (layer in this._layers || this.getLayerId(layer) in this._layers);
+		if (!layer) { return false; }
+		var layerId = typeof layer === 'number' ? layer : this.getLayerId(layer);
+		return layerId in this._layers;
 	},
 
 	// @method clearLayers(): this


### PR DESCRIPTION
Now `false` returned, as per docs
fix #6472
