### PR TITLE
Change undefined argument handling in Layer[Group]/hasLayer()

### DIFF
--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -1,10 +1,14 @@
 ﻿describe('LayerGroup', function () {
 	describe("#hasLayer", function () {
-		it("returns false when passed undefined, null, or false", function () {
+		it("throws when called without proper argument", function () {
 			var lg = L.layerGroup();
-			expect(lg.hasLayer(undefined)).to.equal(false);
-			expect(lg.hasLayer(null)).to.equal(false);
-			expect(lg.hasLayer(false)).to.equal(false);
+			var hasLayer = L.Util.bind(lg.hasLayer, lg);
+			expect(hasLayer).withArgs(new L.Layer()).to.not.throwException(); // control case
+
+			expect(hasLayer).withArgs(undefined).to.throwException();
+			expect(hasLayer).withArgs(null).to.throwException();
+			expect(hasLayer).withArgs(false).to.throwException();
+			expect(hasLayer).to.throwException();
 		});
 	});
 

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -357,12 +357,17 @@ describe("Map", function () {
 	});
 
 	describe("#hasLayer", function () {
-		it("returns false when passed undefined, null, or false", function () {
+		it("throws when called without proper argument", function () {
 			var map = L.map(document.createElement("div"));
+			var hasLayer = L.Util.bind(map.hasLayer, map);
+			expect(hasLayer).withArgs(new L.Layer()).to.not.throwException(); // control case
+
+			expect(hasLayer).withArgs(undefined).to.throwException();
+			expect(hasLayer).withArgs(null).to.throwException();
+			expect(hasLayer).withArgs(false).to.throwException();
+			expect(hasLayer).to.throwException();
+
 			map.remove(); // clean up
-			expect(map.hasLayer(undefined)).to.equal(false);
-			expect(map.hasLayer(null)).to.equal(false);
-			expect(map.hasLayer(false)).to.equal(false);
 		});
 	});
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -208,7 +208,7 @@ Map.include({
 	// @method hasLayer(layer: Layer): Boolean
 	// Returns `true` if the given layer is currently added to the map
 	hasLayer: function (layer) {
-		return !!layer && (Util.stamp(layer) in this._layers);
+		return Util.stamp(layer) in this._layers;
 	},
 
 	/* @method eachLayer(fn: Function, context?: Object): this

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -73,7 +73,6 @@ export var LayerGroup = Layer.extend({
 	// @method hasLayer(id: Number): Boolean
 	// Returns `true` if the given internal ID is currently added to the group.
 	hasLayer: function (layer) {
-		if (!layer) { return false; }
 		var layerId = typeof layer === 'number' ? layer : this.getLayerId(layer);
 		return layerId in this._layers;
 	},


### PR DESCRIPTION
`undefined`/`null`/`false` are not considered as special case anymore,
`layer` argument is always required, as per docs.

Previous excessive tolerance may lead to real errors get masked.

I've tracked the issue down to it's origin: #1282, but found mentioned there reasons weak.
