### PR TITLE
Fix some issues related to wrong Browser.pointer value

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -93,7 +93,7 @@ export var msPointer = !window.PointerEvent && window.MSPointerEvent;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
-export var pointer = !webkit && !!(window.PointerEvent || msPointer);
+export var pointer = !!(window.PointerEvent || msPointer);
 
 // @property touch: Boolean
 // `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -9,6 +9,14 @@ var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'point
 var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
 var _pre = '_leaflet_';
 
+function browserFiresNativeDblClick(e) {
+	// See https://github.com/w3c/pointerevents/issues/171
+	if (Browser.edge || Browser.safari) {
+		return e.pointerType === 'mouse'; // fire native dblclick for mouse
+	}
+	return true; // other browsers fire native dblclick for any pointer type
+}
+
 // inspired by Zepto touch code by Thomas Fuchs
 export function addDoubleTapListener(obj, handler, id) {
 	var last, touch,
@@ -19,7 +27,7 @@ export function addDoubleTapListener(obj, handler, id) {
 		var count;
 
 		if (Browser.pointer) {
-			if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+			if (browserFiresNativeDblClick(e)) { return; }
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -38,7 +46,7 @@ export function addDoubleTapListener(obj, handler, id) {
 	function onTouchEnd(e) {
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if ((!Browser.edge) || e.pointerType === 'mouse') { return; }
+				if (browserFiresNativeDblClick(e)) { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -9,14 +9,6 @@ var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'point
 var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
 var _pre = '_leaflet_';
 
-function browserFiresNativeDblClick(e) {
-	// See https://github.com/w3c/pointerevents/issues/171
-	if (Browser.edge || Browser.safari) {
-		return e.pointerType === 'mouse'; // fire native dblclick for mouse
-	}
-	return true; // other browsers fire native dblclick for any pointer type
-}
-
 // inspired by Zepto touch code by Thomas Fuchs
 export function addDoubleTapListener(obj, handler, id) {
 	var last, touch,
@@ -27,7 +19,7 @@ export function addDoubleTapListener(obj, handler, id) {
 		var count;
 
 		if (Browser.pointer) {
-			if (browserFiresNativeDblClick(e)) { return; }
+			if (e.pointerType === 'mouse') { return; } // mouse fires native dblclick
 			count = _pointersCount;
 		} else {
 			count = e.touches.length;
@@ -46,7 +38,7 @@ export function addDoubleTapListener(obj, handler, id) {
 	function onTouchEnd(e) {
 		if (doubleTap && !touch.cancelBubble) {
 			if (Browser.pointer) {
-				if (browserFiresNativeDblClick(e)) { return; }
+				if (e.pointerType === 'mouse') { return; }
 				// work around .type being readonly with MSPointer* events
 				var newTouch = {},
 				    prop, i;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -1,5 +1,4 @@
 import * as Browser from '../core/Browser';
-import {_pointersCount} from './DomEvent.Pointer';
 
 /*
  * Extends the event handling code with double tap support for mobile browsers.
@@ -16,16 +15,13 @@ export function addDoubleTapListener(obj, handler, id) {
 	    delay = 250;
 
 	function onTouchStart(e) {
-		var count;
 
 		if (Browser.pointer) {
+			if (!e.isPrimary) { return; }
 			if (e.pointerType === 'mouse') { return; } // mouse fires native dblclick
-			count = _pointersCount;
-		} else {
-			count = e.touches.length;
+		} else if (e.touches.length > 1) {
+			return;
 		}
-
-		if (count > 1) { return; }
 
 		var now = Date.now(),
 		    delta = now - (last || now);

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -16,9 +16,6 @@ var TAG_WHITE_LIST = ['INPUT', 'SELECT', 'OPTION'];
 var _pointers = {};
 var _pointerDocListener = false;
 
-// DomEvent.DoubleTap needs to know about this
-export var _pointersCount = 0;
-
 // Provides a touch events wrapper for (ms)pointer events.
 // ref http://www.w3.org/TR/pointerevents/ https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
 
@@ -86,7 +83,6 @@ function _addPointerStart(obj, handler, id) {
 
 function _globalPointerDown(e) {
 	_pointers[e.pointerId] = e;
-	_pointersCount++;
 }
 
 function _globalPointerMove(e) {
@@ -97,7 +93,6 @@ function _globalPointerMove(e) {
 
 function _globalPointerUp(e) {
 	delete _pointers[e.pointerId];
-	_pointersCount--;
 }
 
 function _handlePointer(e, handler) {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -70,6 +70,13 @@ export function off(obj, types, fn, context) {
 	return this;
 }
 
+function browserFiresNativeDblClick() {
+	// See https://github.com/w3c/pointerevents/issues/171
+	if (Browser.pointer) {
+		return !(Browser.edge || Browser.safari);
+	}
+}
+
 function addOne(obj, type, fn, context) {
 	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : '');
 
@@ -85,10 +92,7 @@ function addOne(obj, type, fn, context) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && addDoubleTapListener &&
-	           !(Browser.pointer && Browser.chrome)) {
-		// Chrome >55 does not need the synthetic dblclicks from addDoubleTapListener
-		// See #5180
+	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
 		addDoubleTapListener(obj, handler, id);
 
 	} else if ('addEventListener' in obj) {
@@ -132,8 +136,7 @@ function removeOne(obj, type, fn, context) {
 	if (Browser.pointer && type.indexOf('touch') === 0) {
 		removePointerListener(obj, type, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && removeDoubleTapListener &&
-	           !(Browser.pointer && Browser.chrome)) {
+	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
 		removeDoubleTapListener(obj, id);
 
 	} else if ('removeEventListener' in obj) {

--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -131,6 +131,6 @@ export var Tap = Handler.extend({
 // @section Handlers
 // @property tap: Handler
 // Mobile touch hacks (quick tap and touch hold) handler.
-if (Browser.touch && !Browser.pointer) {
+if (Browser.touch && (!Browser.pointer || Browser.safari)) {
 	Map.addInitHook('addHandler', 'tap', Tap);
 }


### PR DESCRIPTION
- Close #6977.
- ~~Introduce `Browser.iOS` property.~~
  <details>

  ```js
  // https://stackoverflow.com/questions/57765958/how-to-detect-ipad-and-ipad-os-version-in-ios-13-and-up
  // @property iOS: Boolean; `true` for iPhone/iPad.
  export var iOS = /iPad|iPhone|iPod/.test(navigator.platform) ||
  		(navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
  ```
  </details>

- Revert #6855, and fix #6817 in more local way.

- Fix #6988, fix #6973, fix #6896, and may be some more similar issues.

Last commits are not strictly belongs here, and it'd made sense to separate them in another PR, but they depend on previous changes, so..
- Supersedes other related PRs (close #5881, close #6815) and make some other issues obsolete (close #5627)

---

Test page: https://gist.githack.com/johnd0e/c7b44648c5b365cd9b2a9662a23180e0/raw/test-fix-pointer.html
