### PR TITLE
Remove legacy click filter, targeted android 4.x

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -106,12 +106,7 @@ function addOne(obj, type, fn, context) {
 			obj.addEventListener(type === 'mouseenter' ? 'mouseover' : 'mouseout', handler, false);
 
 		} else {
-			if (type === 'click' && Browser.android) {
-				handler = function (e) {
-					filterClick(e, originalHandler);
-				};
-			}
-			obj.addEventListener(type, handler, false);
+			obj.addEventListener(type, originalHandler, false);
 		}
 
 	} else if ('attachEvent' in obj) {
@@ -284,27 +279,6 @@ export function isExternalTarget(el, e) {
 		return false;
 	}
 	return (related !== el);
-}
-
-var lastClick;
-
-// this is a horrible workaround for a bug in Android where a single touch triggers two click events
-function filterClick(e, handler) {
-	var timeStamp = (e.timeStamp || (e.originalEvent && e.originalEvent.timeStamp)),
-	    elapsed = lastClick && (timeStamp - lastClick);
-
-	// are they closer together than 500ms yet more than 100ms?
-	// Android typically triggers them ~300ms apart while multiple listeners
-	// on the same event should be triggered far faster;
-	// or check if click is simulated on the element, and if it is, reject any non-simulated events
-
-	if ((elapsed && elapsed > 100 && elapsed < 500) || (e.target._simulatedClick && !e._simulated)) {
-		stop(e);
-		return;
-	}
-	lastClick = timeStamp;
-
-	handler(e);
 }
 
 // @function addListener(…): this


### PR DESCRIPTION
Remove code originally introduced 7 years ago (by #1227, purposed to fix android WebView bug).

Android 4.x market share is low enough and continues to decline rapidly.
https://developer.android.com/about/dashboards

P.S.
TODO:

Perhaps it's time to retire `Browser.android23` as well. At least stop using it in own code.

Occurrences of `Browser.android` and `Browser.androidStock` also should be revised.