### PR TITLE
Remove Disqus integration

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -13,18 +13,3 @@ bodyclass: post-page
 
 {{ content }}
 
-<div id="disqus_thread"></div>
-
-<script>
-	var disqus_shortname = 'leafletjs';
-//	var disqus_developer = 1;
-
-	(function() {
-		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-		dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
-		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-	})();
-</script>
-
-<a href="https://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-

--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -1083,10 +1083,6 @@ iframe[src*='youtube.com'] {
 	max-width: 100% !important;
 }
 
-#disqus_thread {
-	margin-top: 3em;
-}
-
 .no-break {
 	display: inline-block;
 	width: 100%;


### PR DESCRIPTION
We started getting a lot of spam through the Disqus comments on the Leaflet blog. Since these comments don't serve a lot of purpose in recent years, let's just remove them. Most people comment on the releases in Twitter anyway.