### PR TITLE
Get rid of android legacy hacks

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -40,7 +40,7 @@ export var android23 = userAgentContains('android 2') || userAgentContains('andr
 
 /* See https://stackoverflow.com/a/17961266 for details on detecting stock Android */
 var webkitVer = parseInt(/WebKit\/([0-9]+)|$/.exec(navigator.userAgent)[1], 10); // also matches AppleWebKit
-// @property androidStock: Boolean; `true` for the Android stock browser (i.e. not Chrome)
+// @property androidStock: Boolean; **Deprecated.** `true` for the Android stock browser (i.e. not Chrome)
 export var androidStock = android && userAgentContains('Google') && webkitVer < 537 && !('AudioNode' in window);
 
 // @property opera: Boolean; `true` for the Opera browser

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -35,7 +35,7 @@ export var webkit = userAgentContains('webkit');
 // `true` for any browser running on an Android platform.
 export var android = userAgentContains('android');
 
-// @property android23: Boolean; `true` for browsers running on Android 2 or Android 3.
+// @property android23: Boolean; **Deprecated.** `true` for browsers running on Android 2 or Android 3.
 export var android23 = userAgentContains('android 2') || userAgentContains('android 3');
 
 /* See https://stackoverflow.com/a/17961266 for details on detecting stock Android */

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -797,7 +797,7 @@ export var GridLayer = Layer.extend({
 
 		// without this hack, tiles disappear after zoom on Chrome for Android
 		// https://github.com/Leaflet/Leaflet/issues/2078
-		if (Browser.android && !Browser.android23) {
+		if (Browser.android) {
 			tile.style.WebkitBackfaceVisibility = 'hidden';
 		}
 	},

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -248,11 +248,7 @@ export var TileLayer = GridLayer.extend({
 		if (!tile) { return; }
 
 		// Cancels any pending http requests associated with the tile
-		// unless we're on Android's stock browser,
-		// see https://github.com/Leaflet/Leaflet/issues/137
-		if (!Browser.androidStock) {
-			tile.el.setAttribute('src', Util.emptyImageUrl);
-		}
+		tile.el.setAttribute('src', Util.emptyImageUrl);
 
 		return GridLayer.prototype._removeTile.call(this, key);
 	},

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -23,8 +23,8 @@ Map.mergeOptions({
 	// If enabled, panning of the map will have an inertia effect where
 	// the map builds momentum while dragging and continues moving in
 	// the same direction for some time. Feels especially nice on touch
-	// devices. Enabled by default unless running on old Android devices.
-	inertia: !Browser.android23,
+	// devices. Enabled by default.
+	inertia: true,
 
 	// @option inertiaDeceleration: Number = 3000
 	// The rate with which the inertial movement slows down, in pixels/second².

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -17,8 +17,8 @@ Map.mergeOptions({
 	// Whether the map can be zoomed by touch-dragging with two fingers. If
 	// passed `'center'`, it will zoom to the center of the view regardless of
 	// where the touch events (fingers) were. Enabled for touch-capable web
-	// browsers except for old Androids.
-	touchZoom: Browser.touch && !Browser.android23,
+	// browsers.
+	touchZoom: Browser.touch,
 
 	// @option bounceAtZoomLimits: Boolean = true
 	// Set it to false if you don't want the map to zoom beyond min/max zoom


### PR DESCRIPTION
Continue #7013 

- [x] Remove internal usage of `Browser.android23`/`.androidStock`.
Keep properties for now, but mark as deprecated.
- [ ] check if `Browser.android` is still needed.
<details><summary>Currently we have only 3 occurrences</summary>

https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/layer/tile/TileLayer.js#L109-L112

https://github.com/Leaflet/Leaflet/blob/983092a4975e5a4ab74e8665b38e31a17f38ddb5/src/control/Control.Layers.js#L190-L195

https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/layer/tile/GridLayer.js#L798-L802
</details>
