### PR TITLE
fix: Unwanted change of scale when moving horizontally/vertically

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "consistent-return": 0,
       "no-unused-expressions": [
         "error",
-        { 
+        {
           "allowShortCircuit": true
         }
       ]

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -114,7 +114,7 @@ export var Scale = Control.extend({
 	_getRoundNum: function (num) {
 		var pow10 = Math.pow(10, (Math.floor(num) + '').length - 1),
 		    d = num / pow10;
-
+		d = Math.round((d + Number.EPSILON) * 100) / 100;
 		d = d >= 10 ? 10 :
 		    d >= 5 ? 5 :
 		    d >= 3 ? 3 :


### PR DESCRIPTION
# Unwanted change of scale when moving horizontally/vertically
![20200312_155324](https://user-images.githubusercontent.com/28598261/76535272-e93b8080-647a-11ea-8c7b-c8919ac5636c.gif)

By moving at a given scale (10km or 5km for example) vertically or horizontally you can observe a change in the display of the scale. (especially in metric)