### PR TITLE
Reimplement DoubleTap simulation in more simple and reliable way

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -57,6 +57,7 @@
 
 	<!-- /dom -->
 	<script src="suites/dom/DomEventSpec.js"></script>
+	<script src="suites/dom/DomEvent.DoubleTapSpec.js"></script>
 	<script src="suites/dom/DomUtilSpec.js"></script>
 
 	<!-- /layer -->

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -89,4 +89,28 @@ describe('DomEvent.DoubleTapSpec.js', function () {
 		}
 		expect(event.isTrusted).not.to.be.ok();
 	});
+
+	it('respects disableClickPropagation', function () {
+		var spyMap = sinon.spy();
+		var map = L.map(el).setView([51.505, -0.09], 13);
+		map.on('dblclick', spyMap);
+
+		var spyCtrl = sinon.spy();
+		var ctrl = L.DomUtil.create('div');
+		L.DomEvent.disableClickPropagation(ctrl);
+		var MyControl = L.Control.extend({
+			onAdd: function () {
+				return ctrl;
+			}
+		});
+		map.addControl(new MyControl());
+		L.DomEvent.on(ctrl, 'dblclick', spyCtrl);
+
+		happen.click(ctrl, {detail: 1});
+		clock.tick(100);
+		happen.click(ctrl, {detail: 1});
+
+		expect(spyCtrl.called).to.be.ok();
+		expect(spyMap.notCalled).to.be.ok();
+	});
 });

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -1,0 +1,92 @@
+describe('DomEvent.DoubleTapSpec.js', function () {
+	var el, clock, spy;
+
+	beforeEach(function () {
+		el = document.createElement('div');
+		document.body.appendChild(el);
+
+		clock = sinon.useFakeTimers();
+		clock.tick(1000);
+		spy = sinon.spy();
+		L.DomEvent.on(el, 'dblclick', spy);
+	});
+
+	afterEach(function () {
+		clock.restore();
+		document.body.removeChild(el);
+	});
+
+	it('fires synthetic dblclick after two clicks with delay<200', function () {
+		happen.click(el, {detail: 1});
+		clock.tick(100);
+		happen.click(el, {detail: 1});
+
+		expect(spy.called).to.be.ok();
+		expect(spy.calledOnce).to.be.ok();
+		expect(spy.lastCall.args[0]._simulated).to.be.ok();
+	});
+
+	it('does not fire dblclick when delay>200', function () {
+		happen.click(el, {detail: 1});
+		clock.tick(300);
+		happen.click(el, {detail: 1});
+
+		expect(spy.notCalled).to.be.ok();
+	});
+
+	it('does not fire dblclick when detail !== 1', function () {
+		happen.click(el, {detail: 0}); // like in IE
+		clock.tick(100);
+		happen.click(el, {detail: 0});
+		clock.tick(100);
+
+		expect(spy.notCalled).to.be.ok();
+	});
+
+	it('does not fire dblclick after removeListener', function () {
+		L.DomEvent.off(el, 'dblclick', spy);
+
+		happen.click(el, {detail: 1});
+		clock.tick(100);
+		happen.click(el, {detail: 1});
+		clock.tick(100);
+
+		expect(spy.notCalled).to.be.ok();
+	});
+
+	it('does not conflict with native dblclick', function () {
+		happen.click(el, {detail: 1});
+		clock.tick(100);
+		happen.click(el, {detail: 2}); // native dblclick expected
+		happen.dblclick(el);
+		expect(spy.called).to.be.ok();
+		expect(spy.calledOnce).to.be.ok();
+		expect(spy.lastCall.args[0]._simulated).not.to.be.ok();
+	});
+
+	it('synthetic dblclick event has expected properties', function () {
+		var click = {
+			detail: 1,
+			clientX: 2,
+			clientY: 3,
+			screenX: 4,
+			screenY: 5
+		};
+		happen.click(el, click);
+		clock.tick(100);
+		happen.click(el, click);
+
+		var event = spy.lastCall.args[0];
+		var expectedProps = L.extend(click, {
+			type: 'dblclick',
+			// bubbles: true,    // not important, as we do not actually dispatch the event
+			// cancelable: true, //
+			detail: 2,
+			target: el
+		});
+		for (var prop in expectedProps) {
+			expect(event[prop]).to.be(expectedProps[prop]);
+		}
+		expect(event.isTrusted).not.to.be.ok();
+	});
+});

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -5,7 +5,6 @@
  * (see https://github.com/Leaflet/Leaflet/issues/7012#issuecomment-595087386)
  */
 
-var _pre = '_leaflet_';
 function makeDblclick(event) {
 	// in modern browsers `type` cannot be just overridden:
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only
@@ -24,7 +23,7 @@ function makeDblclick(event) {
 }
 
 var delay = 200;
-export function addDoubleTapListener(obj, handler, id) {
+export function addDoubleTapListener(obj, handler) {
 	// Most browsers handle double tap natively
 	obj.addEventListener('dblclick', handler);
 
@@ -59,11 +58,13 @@ export function addDoubleTapListener(obj, handler, id) {
 
 	obj.addEventListener('click', simDblclick);
 
-	obj[_pre + 'dblclick' + id] = handler;
-	obj[_pre + 'simDblclick' + id] = simDblclick;
+	return {
+		dblclick: handler,
+		simDblclick: simDblclick
+	};
 }
 
-export function removeDoubleTapListener(obj, id) {
-	obj.removeEventListener('dblclick', obj[_pre + 'dblclick' + id]);
-	obj.removeEventListener('click', obj[_pre + 'simDblclick' + id]);
+export function removeDoubleTapListener(obj, handlers) {
+	obj.removeEventListener('dblclick', handlers.dblclick);
+	obj.removeEventListener('click', handlers.simDblclick);
 }

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -1,81 +1,69 @@
-import * as Browser from '../core/Browser';
-
 /*
  * Extends the event handling code with double tap support for mobile browsers.
+ *
+ * Note: currently most browsers fire native dblclick, with only a few exceptions
+ * (see https://github.com/Leaflet/Leaflet/issues/7012#issuecomment-595087386)
  */
 
-var _touchstart = Browser.msPointer ? 'MSPointerDown' : Browser.pointer ? 'pointerdown' : 'touchstart';
-var _touchend = Browser.msPointer ? 'MSPointerUp' : Browser.pointer ? 'pointerup' : 'touchend';
 var _pre = '_leaflet_';
+function makeDblclick(event) {
+	// in modern browsers `type` cannot be just overridden:
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only
+	var newEvent = {},
+	    prop, i;
+	for (i in event) {
+		prop = event[i];
+		newEvent[i] = prop && prop.bind ? prop.bind(event) : prop;
+	}
+	event = newEvent;
+	newEvent.type = 'dblclick';
+	newEvent.detail = 2;
+	newEvent.isTrusted = false;
+	newEvent._simulated = true; // for debug purposes
+	return newEvent;
+}
 
-// inspired by Zepto touch code by Thomas Fuchs
+var delay = 200;
 export function addDoubleTapListener(obj, handler, id) {
-	var last, touch,
-	    doubleTap = false,
-	    delay = 250;
+	// Most browsers handle double tap natively
+	obj.addEventListener('dblclick', handler);
 
-	function onTouchStart(e) {
-
-		if (Browser.pointer) {
-			if (!e.isPrimary) { return; }
-			if (e.pointerType === 'mouse') { return; } // mouse fires native dblclick
-		} else if (e.touches.length > 1) {
+	// On some platforms the browser doesn't fire native dblclicks for touch events.
+	// It seems that in all such cases `detail` property of `click` event is always `1`.
+	// So here we rely on that fact to avoid excessive 'dblclick' simulation when not needed.
+	var last = 0,
+	    detail;
+	function simDblclick(e) {
+		if (e.detail !== 1) {
+			detail = e.detail; // keep in sync to avoid false dblclick in some cases
 			return;
 		}
 
-		var now = Date.now(),
-		    delta = now - (last || now);
+		if (e.pointerType === 'mouse' ||
+			(e.sourceCapabilities && !e.sourceCapabilities.firesTouchEvents)) {
 
-		touch = e.touches ? e.touches[0] : e;
-		doubleTap = (delta > 0 && delta <= delay);
+			return;
+		}
+
+		var now = Date.now();
+		if (now - last <= delay) {
+			detail++;
+			if (detail === 2) {
+				handler(makeDblclick(e));
+			}
+		} else {
+			detail = 1;
+		}
 		last = now;
 	}
 
-	function onTouchEnd(e) {
-		if (doubleTap && !touch.cancelBubble) {
-			if (Browser.pointer) {
-				if (e.pointerType === 'mouse') { return; }
-				// work around .type being readonly with MSPointer* events
-				var newTouch = {},
-				    prop, i;
+	obj.addEventListener('click', simDblclick);
 
-				for (i in touch) {
-					prop = touch[i];
-					newTouch[i] = prop && prop.bind ? prop.bind(touch) : prop;
-				}
-				touch = newTouch;
-			}
-			touch.type = 'dblclick';
-			touch.button = 0;
-			handler(touch);
-			last = null;
-		}
-	}
-
-	obj[_pre + _touchstart + id] = onTouchStart;
-	obj[_pre + _touchend + id] = onTouchEnd;
 	obj[_pre + 'dblclick' + id] = handler;
-
-	obj.addEventListener(_touchstart, onTouchStart, Browser.passiveEvents ? {passive: false} : false);
-	obj.addEventListener(_touchend, onTouchEnd, Browser.passiveEvents ? {passive: false} : false);
-
-	// On some platforms (notably, chrome<55 on win10 + touchscreen + mouse),
-	// the browser doesn't fire touchend/pointerup events but does fire
-	// native dblclicks. See #4127.
-	// Edge 14 also fires native dblclicks, but only for pointerType mouse, see #5180.
-	obj.addEventListener('dblclick', handler, false);
-
-	return this;
+	obj[_pre + 'simDblclick' + id] = simDblclick;
 }
 
 export function removeDoubleTapListener(obj, id) {
-	var touchstart = obj[_pre + _touchstart + id],
-	    touchend = obj[_pre + _touchend + id],
-	    dblclick = obj[_pre + 'dblclick' + id];
-
-	obj.removeEventListener(_touchstart, touchstart, Browser.passiveEvents ? {passive: false} : false);
-	obj.removeEventListener(_touchend, touchend, Browser.passiveEvents ? {passive: false} : false);
-	obj.removeEventListener('dblclick', dblclick, false);
-
-	return this;
+	obj.removeEventListener('dblclick', obj[_pre + 'dblclick' + id]);
+	obj.removeEventListener('click', obj[_pre + 'simDblclick' + id]);
 }

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -92,7 +92,7 @@ function addOne(obj, type, fn, context) {
 		addPointerListener(obj, type, handler, id);
 
 	} else if (Browser.touch && (type === 'dblclick')) {
-		addDoubleTapListener(obj, handler, id);
+		handler = addDoubleTapListener(obj, handler);
 
 	} else if ('addEventListener' in obj) {
 
@@ -131,7 +131,7 @@ function removeOne(obj, type, fn, context) {
 		removePointerListener(obj, type, id);
 
 	} else if (Browser.touch && (type === 'dblclick')) {
-		removeDoubleTapListener(obj, id);
+		removeDoubleTapListener(obj, handler);
 
 	} else if ('removeEventListener' in obj) {
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -70,13 +70,6 @@ export function off(obj, types, fn, context) {
 	return this;
 }
 
-function browserFiresNativeDblClick() {
-	// See https://github.com/w3c/pointerevents/issues/171
-	if (Browser.pointer) {
-		return !(Browser.edge || Browser.safari);
-	}
-}
-
 var mouseSubst = {
 	mouseenter: 'mouseover',
 	mouseleave: 'mouseout',
@@ -98,7 +91,7 @@ function addOne(obj, type, fn, context) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
+	} else if (Browser.touch && (type === 'dblclick')) {
 		addDoubleTapListener(obj, handler, id);
 
 	} else if ('addEventListener' in obj) {
@@ -137,7 +130,7 @@ function removeOne(obj, type, fn, context) {
 	if (Browser.pointer && type.indexOf('touch') === 0) {
 		removePointerListener(obj, type, id);
 
-	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
+	} else if (Browser.touch && (type === 'dblclick')) {
 		removeDoubleTapListener(obj, id);
 
 	} else if ('removeEventListener' in obj) {


### PR DESCRIPTION
Take advantage of observations from #7012:

Base handler on 'click' event instead of 'touch*' / 'pointer*'.
Ensure that simulated 'dblclick's are fired only when needed.

ATM it's safe to use in any known browser, with or without touch support,
and it is equally efficient with or without pointer events.

Additionally: reduce `delay` value to 200, as it is closer to actually observed.

Fix #7106, fix #7419, fix #7422.
Also new approach can easily fix issues like #6777.

---
Test page: https://gist.githack.com/johnd0e/12cb0d6c2aead30ea7f2e17c5f9991be/raw/test-doubletap.html