### PR TITLE
Correct Browser.touch (and more related changes)

### DIFF
--- a/spec/before.js
+++ b/spec/before.js
@@ -1,2 +1,0 @@
-// Trick Leaflet into believing we have a touchscreen (for desktop)
-if (window.TouchEvent) { window.ontouchstart = function(){} };

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -62,8 +62,7 @@ it.skipIf3d = L.Browser.any3d ? it.skip : it;
 // A couple of tests need the browser to be touch-capable
 it.skipIfNotTouch = L.Browser.touch ? it : it.skip;
 
-// ATM Leaflet prefers pointer events even for touch (see #7077)
-var touchEventType = L.Browser.pointer ? 'pointer' : 'touch'; // eslint-disable-line no-unused-vars
+var touchEventType = L.Browser.touchNative ? 'touch' : 'pointer'; // eslint-disable-line no-unused-vars
 // Note: this override is needed to workaround prosthetic-hand fail,
 //       see https://github.com/Leaflet/prosthetic-hand/issues/14
 

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -60,7 +60,7 @@ it.skipIfNo3d = L.Browser.any3d ? it : it.skip;
 it.skipIf3d = L.Browser.any3d ? it.skip : it;
 
 // A couple of tests need the browser to be touch-capable
-it.skipIfNotTouch = (L.Browser.touch || L.Browser.pointer) ? it : it.skip;
+it.skipIfNotTouch = L.Browser.touch ? it : it.skip;
 
 // ATM Leaflet prefers pointer events even for touch (see #7077)
 var touchEventType = L.Browser.pointer ? 'pointer' : 'touch'; // eslint-disable-line no-unused-vars

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -95,12 +95,17 @@ export var msPointer = !window.PointerEvent && window.MSPointerEvent;
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
 export var pointer = !!(window.PointerEvent || msPointer);
 
-// @property touch: Boolean
+// @property touchNative: Boolean
 // `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).
-// This does not necessarily mean that the browser is running in a computer with
+// **This does not necessarily mean** that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window || window.TouchEvent);
+export var touchNative = 'ontouchstart' in window || !!window.TouchEvent;
+
+// @property touch: Boolean
+// `true` for all browsers supporting either [touch](#browser-touch) or [pointer](#browser-pointer) events.
+// Note: pointer events will be preferred (if available), and processed for all `touch*` listeners.
+export var touch = !window.L_NO_TOUCH && (touchNative || pointer);
 
 // @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
 export var mobileOpera = mobile && opera;

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -100,8 +100,7 @@ export var pointer = !!(window.PointerEvent || msPointer);
 // This does not necessarily mean that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window ||
-		(window.DocumentTouch && document instanceof window.DocumentTouch));
+export var touch = !window.L_NO_TOUCH && (pointer || 'ontouchstart' in window || window.TouchEvent);
 
 // @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
 export var mobileOpera = mobile && opera;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -94,7 +94,7 @@ function addOne(obj, type, fn, context) {
 
 	var originalHandler = handler;
 
-	if (Browser.pointer && type.indexOf('touch') === 0) {
+	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
 		// Needs DomEvent.Pointer.js
 		addPointerListener(obj, type, handler, id);
 
@@ -134,7 +134,7 @@ function removeOne(obj, type, fn, context) {
 
 	if (!handler) { return this; }
 
-	if (Browser.pointer && type.indexOf('touch') === 0) {
+	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
 		removePointerListener(obj, type, id);
 
 	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {


### PR DESCRIPTION
https://github.com/Leaflet/Leaflet/blob/e213469a296ea00e6f9e6e6beb49d081e8d1c4fe/src/core/Browser.js#L98-L104

Leaflet's own code does not correspond to documentation: instead of detecting **touch** capabilities we detect also **pointer** capabilities. It's always bad when any property value deviates from it's 'physical' meaning, as eventually we get code that nobody can understand, and it's hard to fix anything without breaking something else.

So I propose:
1. Explicitly document **actual** meaning of this flag. 
Alternative: retire it completely (but not in this PR, related discussion: #6978)

2. Consider changes in modern browsers:
   - `window.TouchEvent` should trigger `Browser.touch` (as per recommendation https://www.chromestatus.com/feature/4764225348042752)
     E.g. desktop (with no touch screen) may be connected with aux touch panel (even in runtime).
   - Drop support for [legacy touch](https://developer.mozilla.org/en-US/docs/Web/API/DocumentTouch) Firefox versions (<25), because of their insignificant market share.

3. Stop simulating touch via `DomEvent.Pointer.js` when native touch events are available.
   Close #7077, fix #5745, fix #5969, fix #6632.
   May also fix* #6401 (not confirmed yet).

---

[test (tap:false)](https://gist.githack.com/johnd0e/3ad393c73b12b24af7e947711a87b7a4/raw/test.html)

[test (tap:true)](https://gist.githack.com/johnd0e/3ad393c73b12b24af7e947711a87b7a4/raw/test_tap_true.html)
