### PR TITLE
Fix invalid condition in _addPointerStart

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -55,15 +55,14 @@ export function removePointerListener(obj, type, id) {
 
 function _addPointerStart(obj, handler, id) {
 	var onDown = Util.bind(function (e) {
-		if (e.pointerType !== 'mouse' && e.MSPOINTER_TYPE_MOUSE && e.pointerType !== e.MSPOINTER_TYPE_MOUSE) {
+		if (e.pointerType !== (e.MSPOINTER_TYPE_MOUSE || 'mouse')) {
 			// In IE11, some touch events needs to fire for form controls, or
 			// the controls will stop working. We keep a whitelist of tag names that
 			// need these events. For other target tags, we prevent default on the event.
-			if (TAG_WHITE_LIST.indexOf(e.target.tagName) < 0) {
-				DomEvent.preventDefault(e);
-			} else {
+			if (Browser.ie && TAG_WHITE_LIST.indexOf(e.target.tagName)) {
 				return;
 			}
+			DomEvent.preventDefault(e);
 		}
 
 		_handlePointer(e, handler);
@@ -113,7 +112,9 @@ function _handlePointer(e, handler) {
 function _addPointerMove(obj, handler, id) {
 	var onMove = function (e) {
 		// don't fire touch moves when mouse isn't down
-		if ((e.pointerType === e.MSPOINTER_TYPE_MOUSE || e.pointerType === 'mouse') && e.buttons === 0) { return; }
+		if ((e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) && e.buttons === 0) {
+			return;
+		}
 
 		_handlePointer(e, handler);
 	};

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -59,7 +59,7 @@ function _addPointerStart(obj, handler, id) {
 			// In IE11, some touch events needs to fire for form controls, or
 			// the controls will stop working. We keep a whitelist of tag names that
 			// need these events. For other target tags, we prevent default on the event.
-			if (Browser.ie && TAG_WHITE_LIST.indexOf(e.target.tagName)) {
+			if (Browser.ie && TAG_WHITE_LIST.indexOf(e.target.tagName) >= 0) {
 				return;
 			}
 			DomEvent.preventDefault(e);
@@ -132,4 +132,3 @@ function _addPointerEnd(obj, handler, id) {
 	obj.addEventListener(POINTER_UP, onUp, false);
 	obj.addEventListener(POINTER_CANCEL, onUp, false);
 }
-


### PR DESCRIPTION
https://github.com/Leaflet/Leaflet/blob/e213469a296ea00e6f9e6e6beb49d081e8d1c4fe/src/dom/DomEvent.Pointer.js#L58

The condition is invalid as it's never met in any browser newer that IE10.
To work as intended there must be brackets:
```js
if (e.pointerType !== 'mouse' && (e.MSPOINTER_TYPE_MOUSE && e.pointerType !== e.MSPOINTER_TYPE_MOUSE)) {
```

This PR even more simplifies the condition (and another one, just for consistency).

Some considerations:
1. The bug was introduced by 19d2bd027ec1616f05759224f3c53081b6fad6af more than 3 years ago, but I see only one bug report (#5898)
2. That issue is about IE11/Edge only, and that is strange, 'cause broken condition should affect other browsers too.
So I suspect that we may not really need that `preventDefault(e)` call for modern browsers.

Anyway, current code has no sense and should be fixed.
