### PR TITLE
Fix: listeners were not removed because of missed context

### DIFF
--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -112,8 +112,8 @@ export var TouchZoom = Handler.extend({
 		this._zooming = false;
 		Util.cancelAnimFrame(this._animRequest);
 
-		DomEvent.off(document, 'touchmove', this._onTouchMove);
-		DomEvent.off(document, 'touchend', this._onTouchEnd);
+		DomEvent.off(document, 'touchmove', this._onTouchMove, this);
+		DomEvent.off(document, 'touchend', this._onTouchEnd, this);
 
 		// Pinch updates GridLayers' levels only when zoomSnap is off, so zoomSnap becomes noUpdate.
 		if (this._map.options.zoomAnimation) {


### PR DESCRIPTION
Close #6572, close #6578.

See https://github.com/Leaflet/Leaflet/pull/6578#issuecomment-601234792

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/7036)
<!-- Reviewable:end -->
