### PR TITLE
Attach pointer tracker listeners to document (instead of documentElement)

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -71,11 +71,11 @@ function _addPointerStart(obj, handler, id) {
 
 	// need to keep track of what pointers and how many are active to provide e.touches emulation
 	if (!_pointerDocListener) {
-		// we listen documentElement as any drags that end by moving the touch off the screen get fired there
-		document.documentElement.addEventListener(POINTER_DOWN, _globalPointerDown, true);
-		document.documentElement.addEventListener(POINTER_MOVE, _globalPointerMove, true);
-		document.documentElement.addEventListener(POINTER_UP, _globalPointerUp, true);
-		document.documentElement.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
+		// we listen document as any drags that end by moving the touch off the screen get fired there
+		document.addEventListener(POINTER_DOWN, _globalPointerDown, true);
+		document.addEventListener(POINTER_MOVE, _globalPointerMove, true);
+		document.addEventListener(POINTER_UP, _globalPointerUp, true);
+		document.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
 
 		_pointerDocListener = true;
 	}


### PR DESCRIPTION
Otherwise it's not possible to capture events in some cases.

Fix #6419

---

Test page:
https://gist.githack.com/johnd0e/682d8f3f468b5a77b1654e40f573f897/raw/issue-6419.html

Compare with behavior before the fix: https://jsbin.com/sobecabati/edit?output

(easy to check with dev tools in desktop Chrome)