### PR TITLE
iOS: prevent selection of controls text on drag/hold

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -24,6 +24,7 @@
 	   -moz-user-select: none;
 	        user-select: none;
 	  -webkit-user-drag: none;
+	  -webkit-touch-callout: none; /* #6865 */
 	}
 /* Prevents IE11 from highlighting tiles in blue */
 .leaflet-tile::selection {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -166,7 +166,7 @@
 
 /* iOS-specific: prevent selection on drag/hold (#6872) */
 
-.leaflet-control a {
+.leaflet-control:first-child {
 	-webkit-user-select: none;
 	}
 

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -163,6 +163,11 @@
 	margin-right: 10px;
 	}
 
+/* iOS-specific: prevent selection on drag/hold (#6872) */
+
+.leaflet-control a {
+	-webkit-user-select: none;
+	}
 
 /* zoom and fade animations */
 


### PR DESCRIPTION
Workaround to fix #6872, and also fix #6865.

Test page: https://output.jsbin.com/zagowek

Note: I propose to add only prefixed (-webkit) version of the property, as this issue is specific to iOS / Safari.

https://caniuse.com/#feat=user-select-none
