### PR TITLE
Support additional map events: touch* [POC]

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -62,7 +62,7 @@ function _addPointerStart(obj, handler, id) {
 			DomEvent.preventDefault(e);
 		}
 
-		_handlePointer(e, handler);
+		_handlePointer(e, 'touchstart', handler);
 	});
 
 	obj['_leaflet_touchstart' + id] = onDown;
@@ -94,14 +94,14 @@ function _globalPointerUp(e) {
 	delete _pointers[e.pointerId];
 }
 
-function _handlePointer(e, handler) {
+function _handlePointer(e, type, handler) {
 	e.touches = [];
 	for (var i in _pointers) {
 		e.touches.push(_pointers[i]);
 	}
 	e.changedTouches = [e];
 
-	handler(e);
+	handler(e, type);
 }
 
 function _addPointerMove(obj, handler, id) {
@@ -111,7 +111,7 @@ function _addPointerMove(obj, handler, id) {
 			return;
 		}
 
-		_handlePointer(e, handler);
+		_handlePointer(e, 'touchmove', handler);
 	};
 
 	obj['_leaflet_touchmove' + id] = onMove;
@@ -120,7 +120,7 @@ function _addPointerMove(obj, handler, id) {
 
 function _addPointerEnd(obj, handler, id) {
 	var onUp = function (e) {
-		_handlePointer(e, handler);
+		_handlePointer(e, e.type === POINTER_UP ? 'touchend' : 'touchcancel', handler);
 	};
 
 	obj['_leaflet_touchend' + id] = onUp;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -82,8 +82,8 @@ function addOne(obj, type, fn, context) {
 
 	if (obj[eventsKey] && obj[eventsKey][id]) { return this; }
 
-	var handler = function (e) {
-		return fn.call(context || obj, e || window.event);
+	var handler = function (e, originalType) {
+		return fn.call(context || obj, e || window.event, originalType);
 	};
 
 	var originalHandler = handler;
@@ -107,7 +107,7 @@ function addOne(obj, type, fn, context) {
 			handler = function (e) {
 				e = e || window.event;
 				if (isExternalTarget(obj, e)) {
-					originalHandler(e);
+					originalHandler(e, type);
 				}
 			};
 			obj.addEventListener(type === 'mouseenter' ? 'mouseover' : 'mouseout', handler, false);

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -60,6 +60,7 @@ export var Canvas = Renderer.extend({
 	_initContainer: function () {
 		var container = this._container = document.createElement('canvas');
 
+		// Todo: touchstart touchend touchcancel
 		DomEvent.on(container, 'mousemove', this._onMouseMove, this);
 		DomEvent.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this);
 		DomEvent.on(container, 'mouseout', this._handleMouseOut, this);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1324,7 +1324,14 @@ export var Map = Evented.extend({
 		// that do not produce a character value.
 		// @event keyup: KeyboardEvent
 		// Fired when the user releases a key from the keyboard while the map is focused.
+		// @event touchstart: TouchEvent
+		// Fired when the user ...to be continued
+		// @event touchend: TouchEvent
+		// Fired when the user ...to be continued
+		// @event touchcancel: TouchEvent
+		// Fired when the user ...to be continued
 		onOff(this._container, 'click dblclick mousedown mouseup ' +
+			'touchstart touchend touchcancel ' +
 			'mouseover mouseout mousemove contextmenu keypress keydown keyup', this._handleDOMEvent, this);
 
 		if (this.options.trackResize) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1384,10 +1384,10 @@ export var Map = Evented.extend({
 		return targets;
 	},
 
-	_handleDOMEvent: function (e) {
+	_handleDOMEvent: function (e, originalType) {
 		if (!this._loaded || DomEvent.skipped(e)) { return; }
 
-		var type = e.type;
+		var type = originalType || e.type;
 
 		if (type === 'mousedown' || type === 'keypress' || type === 'keyup' || type === 'keydown') {
 			// prevents outline when clicking on keyboard-focusable element


### PR DESCRIPTION
(based on #7064)

Currently event types are limited to described in docs: https://leafletjs.com/reference-1.6.0.html#map-event

But there is demand to support more events (#5556).

This PR is created to discuss implementation details.

---
We need to consider **real** use cases.
What is not clear to me:
1. May be more event types needed: shouldn't we make their list customizable?
Or it's up to user code - to define additional handlers?
2. Is it good idea - pass 'original' event type as additional handler argument?
3. Why Map.Drag test failed? Is there real issue or may be test suite itself need some fixes.
---
Todo: there left more places to fix, e.g.:
<details>

https://github.com/Leaflet/Leaflet/blob/d843c3b88486713827d7e860b58bdba75bfbd5a2/src/layer/vector/Canvas.js#L64
</details>

(it may be not needed if we remove that code duplication, see #7049)