### PR TITLE
Implement touchpad based pan and zoom gestures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ Gemfile.lock
 package-lock.json
 yarn.lock
 *.log
+*.swp
+

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -30,18 +30,23 @@ Map.mergeOptions({
 
 export var ScrollWheelZoom = Handler.extend({
 	addHooks: function () {
-		DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
+		DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
 
 		this._delta = 0;
 	},
 
 	removeHooks: function () {
-		DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll, this);
+		DomEvent.off(this._map._container, 'wheel', this._onWheelScroll, this);
 	},
 
 	_onWheelScroll: function (e) {
-		var delta = DomEvent.getWheelDelta(e);
 
+		// detect gesture
+		if (e.deltaMode === e.DOM_DELTA_PIXEL) {
+			return;
+		}
+
+		var delta = e.deltaY;
 		var debounce = this._map.options.wheelDebounceTime;
 
 		this._delta += delta;

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -9,6 +9,8 @@ import {Keyboard} from './handler/Map.Keyboard';
 Map.Keyboard = Keyboard;
 import {ScrollWheelZoom} from './handler/Map.ScrollWheelZoom';
 Map.ScrollWheelZoom = ScrollWheelZoom;
+import {Gesture} from './handler/Map.Gesture';
+Map.Gesture = Gesture;
 import {Tap} from './handler/Map.Tap';
 Map.Tap = Tap;
 import {TouchZoom} from './handler/Map.TouchZoom';


### PR DESCRIPTION
Some devices, like  MacBooks allow two finger touchpad gestures simulating multidimensional pixel-precision scroll wheels.
This patch implements pixel-precision zoom and pan for such devices.
Tested on MacBook Pro with Firefox.

Closes #7046