### PR TITLE
Control.Layers: stop relying on Browser `android` and `touch` properties

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -189,6 +189,13 @@ describe("Control.Layers", function () {
 	});
 
 	describe("collapse when collapsed: true", function () {
+		it('expands on toggle focus', function () {
+			var layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			var toggle = layersCtrl._container.querySelector('.leaflet-control-layers-toggle');
+			happen.once(toggle, {type:'focus'});
+			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok();
+		});
+
 		it('expands when mouse is over', function () {
 			var layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
 			happen.once(layersCtrl._container, {type:'mouseover'});

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -187,7 +187,13 @@ export var Layers = Control.extend({
 			this._map.on('click', this.collapse, this);
 
 			DomEvent.on(container, {
-				mouseenter: this.expand,
+				mouseenter: function () {
+					DomEvent.on(section, 'click', DomEvent.preventDefault);
+					this.expand();
+					setTimeout(function () {
+						DomEvent.off(section, 'click', DomEvent.preventDefault);
+					});
+				},
 				mouseleave: this.collapse
 			}, this);
 		}

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -409,16 +409,6 @@ export var Layers = Control.extend({
 			this.expand();
 		}
 		return this;
-	},
-
-	_expand: function () {
-		// Backward compatibility, remove me in 1.1.
-		return this.expand();
-	},
-
-	_collapse: function () {
-		// Backward compatibility, remove me in 1.1.
-		return this.collapse();
 	}
 
 });

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -1,7 +1,6 @@
 
 import {Control} from './Control';
 import * as Util from '../core/Util';
-import * as Browser from '../core/Browser';
 import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
 
@@ -187,24 +186,18 @@ export var Layers = Control.extend({
 		if (collapsed) {
 			this._map.on('click', this.collapse, this);
 
-			if (!Browser.android) {
-				DomEvent.on(container, {
-					mouseenter: this.expand,
-					mouseleave: this.collapse
-				}, this);
-			}
+			DomEvent.on(container, {
+				mouseenter: this.expand,
+				mouseleave: this.collapse
+			}, this);
 		}
 
 		var link = this._layersLink = DomUtil.create('a', className + '-toggle', container);
 		link.href = '#';
 		link.title = 'Layers';
 
-		if (Browser.touch) {
-			DomEvent.on(link, 'click', DomEvent.stop);
-			DomEvent.on(link, 'click', this.expand, this);
-		} else {
-			DomEvent.on(link, 'focus', this.expand, this);
-		}
+		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
+		DomEvent.on(link, 'focus', this.expand, this);
 
 		if (!collapsed) {
 			this.expand();


### PR DESCRIPTION
Control.Layers: stop relying on Browser `android` and `touch` properties
<details>

- `android` is useless here, as there are a lot of non-android touch devices (including desktop ones)
- `touch` is useless, as mouse can be used on touch-screen too

Now these use cases are covered:
- `mouseenter/leave` are handled on touch devices too
   <details>

  With this PR mouse attached to device with touch support behaves as it should: reacts on `mouseover/out` events.
  But that is up on browser support, e.g. Chrome on android does not produce `mousemove/over/out` events.
  (But Firefox does)
   </details>
- If Layers control created with `{collapsed:false}`, and than it collapsed explicitly
  [using .collapse() method], it's now possible to expand it back with click.
</details>

Fix #6579.
Fix unexpected layer switching when expanding control on touch
<details>

Most browsers produce compatibility `mouseenter` for touch event, but not all,
so we listen for click also.

The problem is that these compatibility events come all in single batch, so
same touch induces expand and then immediate input switching.

To avoid this we temporarily prevent click on layers section.
Note: more straight-forward way would be relying on `e.sourceCapabilities.firesTouchEvents`,
      but atm it has rather low support: https://caniuse.com/#feat=mdn-api_inputdevicecapabilities_firestouchevents
</details>

---
Related discussions: #6978, #7022.

---
Test page: https://gist.githack.com/johnd0e/a854f95019bb1a4c1ae909fbc6769d35/raw/pr-7057.html