### PR TITLE
DomEvent.Pointer: process touch events only

### DIFF
--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -46,6 +46,15 @@ describe('DomEvent.Pointer', function () {
 			});
 		});
 
+		it('ignores events from mouse', function () {
+			pointerEvents.forEach(function (type) {
+				happen.once(el, {type: type, pointerType: 'mouse'});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].notCalled).to.be.ok();
+			});
+		});
+
 		it('ignores native touch events', function () {
 			touchEvents.forEach(function (type) {
 				happen.once(el, {type: type});

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -17,7 +17,7 @@ var pEvent = {
 };
 var handle = {
 	touchstart  : _onPointerStart,
-	touchmove   : _onPointerMove,
+	touchmove   : _handlePointer,
 	touchend    : _handlePointer,
 	touchcancel : _handlePointer
 };
@@ -68,6 +68,8 @@ function _addPointerDocListener() {
 }
 
 function _handlePointer(handler, e) {
+	if (e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) { return; }
+
 	e.touches = [];
 	for (var i in _pointers) {
 		e.touches.push(_pointers[i]);
@@ -81,14 +83,6 @@ function _onPointerStart(handler, e) {
 	// IE10 specific: MsTouch needs preventDefault. See #2000
 	if (e.MSPOINTER_TYPE_TOUCH && e.pointerType === e.MSPOINTER_TYPE_TOUCH) {
 		DomEvent.preventDefault(e);
-	}
-	_handlePointer(handler, e);
-}
-
-function _onPointerMove(handler, e) {
-	// don't fire touch moves when mouse isn't down
-	if ((e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) && e.buttons === 0) {
-		return;
 	}
 	_handlePointer(handler, e);
 }


### PR DESCRIPTION
Fix #7058

Todo:
- [x] Should we reject `mouse` only? Or opposite: process `touch`only?
- [ ] Pass original event type (#7064)?
