### PR TITLE
DomEvent: use passive for touchmove (instead of touchend)

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -100,10 +100,10 @@ function addOne(obj, type, fn, context) {
 		if (type === 'mousewheel') {
 			obj.addEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, Browser.passiveEvents ? {passive: false} : false);
 
-		} else if ((type === 'touchstart') || (type === 'touchmove')) {
+		} else if (type === 'touchstart' || type === 'touchmove') {
 			obj.addEventListener(type, handler, Browser.passiveEvents ? {passive: false} : false);
 
-		} else if ((type === 'mouseenter') || (type === 'mouseleave')) {
+		} else if (type === 'mouseenter' || type === 'mouseleave') {
 			handler = function (e) {
 				e = e || window.event;
 				if (isExternalTarget(obj, e)) {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -80,7 +80,7 @@ function browserFiresNativeDblClick() {
 var mouseSubst = {
 	mouseenter: 'mouseover',
 	mouseleave: 'mouseout',
-	mousewheel: 'onwheel' in window && 'wheel'
+	wheel: !('onwheel' in window) && 'mousewheel'
 };
 
 function addOne(obj, type, fn, context) {
@@ -173,9 +173,9 @@ export function stopPropagation(e) {
 }
 
 // @function disableScrollPropagation(el: HTMLElement): this
-// Adds `stopPropagation` to the element's `'mousewheel'` events (plus browser variants).
+// Adds `stopPropagation` to the element's `'wheel'` events (plus browser variants).
 export function disableScrollPropagation(el) {
-	addOne(el, 'mousewheel', stopPropagation);
+	addOne(el, 'wheel', stopPropagation);
 	return this;
 }
 
@@ -236,7 +236,7 @@ var wheelPxFactor =
 	Browser.gecko ? window.devicePixelRatio : 1;
 
 // @function getWheelDelta(ev: DOMEvent): Number
-// Gets normalized wheel delta from a mousewheel DOM event, in vertical
+// Gets normalized wheel delta from a wheel DOM event, in vertical
 // pixels scrolled (negative if scrolling down).
 // Events from pointing devices without precise scrolling are mapped to
 // a best guess of 60 pixels.

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -100,7 +100,7 @@ function addOne(obj, type, fn, context) {
 		if (type === 'mousewheel') {
 			obj.addEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, Browser.passiveEvents ? {passive: false} : false);
 
-		} else if ((type === 'touchstart') || (type === 'touchend')) {
+		} else if ((type === 'touchstart') || (type === 'touchmove')) {
 			obj.addEventListener(type, handler, Browser.passiveEvents ? {passive: false} : false);
 
 		} else if ((type === 'mouseenter') || (type === 'mouseleave')) {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -77,6 +77,12 @@ function browserFiresNativeDblClick() {
 	}
 }
 
+var mouseSubst = {
+	mouseenter: 'mouseover',
+	mouseleave: 'mouseout',
+	mousewheel: 'onwheel' in window && 'wheel'
+};
+
 function addOne(obj, type, fn, context) {
 	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : '');
 
@@ -97,11 +103,8 @@ function addOne(obj, type, fn, context) {
 
 	} else if ('addEventListener' in obj) {
 
-		if (type === 'mousewheel') {
-			obj.addEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, Browser.passiveEvents ? {passive: false} : false);
-
-		} else if (type === 'touchstart' || type === 'touchmove') {
-			obj.addEventListener(type, handler, Browser.passiveEvents ? {passive: false} : false);
+		if (type === 'touchstart' || type === 'touchmove' || type === 'wheel' ||  type === 'mousewheel') {
+			obj.addEventListener(mouseSubst[type] || type, handler, Browser.passiveEvents ? {passive: false} : false);
 
 		} else if (type === 'mouseenter' || type === 'mouseleave') {
 			handler = function (e) {
@@ -110,7 +113,7 @@ function addOne(obj, type, fn, context) {
 					originalHandler(e);
 				}
 			};
-			obj.addEventListener(type === 'mouseenter' ? 'mouseover' : 'mouseout', handler, false);
+			obj.addEventListener(mouseSubst[type], handler, false);
 
 		} else {
 			obj.addEventListener(type, originalHandler, false);
@@ -139,14 +142,7 @@ function removeOne(obj, type, fn, context) {
 
 	} else if ('removeEventListener' in obj) {
 
-		if (type === 'mousewheel') {
-			obj.removeEventListener('onwheel' in obj ? 'wheel' : 'mousewheel', handler, Browser.passiveEvents ? {passive: false} : false);
-
-		} else {
-			obj.removeEventListener(
-				type === 'mouseenter' ? 'mouseover' :
-				type === 'mouseleave' ? 'mouseout' : type, handler, false);
-		}
+		obj.removeEventListener(mouseSubst[type] || type, handler, false);
 
 	} else if ('detachEvent' in obj) {
 		obj.detachEvent('on' + type, handler);

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -10,7 +10,7 @@ import * as Util from '../../core/Util';
 // @namespace Map
 // @section Interaction Options
 Map.mergeOptions({
-	// @section Mousewheel options
+	// @section Mouse wheel options
 	// @option scrollWheelZoom: Boolean|String = true
 	// Whether the map can be zoomed by using the mouse wheel. If passed `'center'`,
 	// it will zoom to the center of the view regardless of where the mouse was.
@@ -30,13 +30,13 @@ Map.mergeOptions({
 
 export var ScrollWheelZoom = Handler.extend({
 	addHooks: function () {
-		DomEvent.on(this._map._container, 'mousewheel', this._onWheelScroll, this);
+		DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
 
 		this._delta = 0;
 	},
 
 	removeHooks: function () {
-		DomEvent.off(this._map._container, 'mousewheel', this._onWheelScroll, this);
+		DomEvent.off(this._map._container, 'wheel', this._onWheelScroll, this);
 	},
 
 	_onWheelScroll: function (e) {


### PR DESCRIPTION
Close #7052.

1. Original code (added in #7008) does not follow docs: https://developers.google.com/web/tools/lighthouse/audits/passive-event-listeners

2. We should not make `touchend` passive, as it does not help with performance: `preventDefault` is used there does not affect touch - it only useful to [prevent simulation of `click`](https://w3c.github.io/touch-events/#event-touchend) (which is also valuable feature).

<!-- Reviewable:start -->
---
Also:
- simplify some conditions and add passive option for `wheel` event listeners
  (previously it was supported for `mousewheel` only)
- prefer `wheel` over `mousewheel`