### PR TITLE
DomEvent: keep original value of event type for transformed events

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -15,6 +15,12 @@ var pEvent = {
 	touchend    : POINTER_UP,
 	touchcancel : POINTER_CANCEL
 };
+var tEvent = {
+	POINTER_DOWN  : 'touchstart',
+	POINTER_MOVE  : 'touchmove',
+	POINTER_UP    : 'touchend',
+	POINTER_CANCEL:	'touchcancel'
+};
 var handle = {
 	touchstart  : _onPointerStart,
 	touchmove   : _handlePointer,
@@ -76,7 +82,7 @@ function _handlePointer(handler, e) {
 	}
 	e.changedTouches = [e];
 
-	handler(e);
+	handler(e, tEvent[e.type]);
 }
 
 function _onPointerStart(handler, e) {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -81,8 +81,8 @@ function addOne(obj, type, fn, context) {
 
 	if (obj[eventsKey] && obj[eventsKey][id]) { return this; }
 
-	var handler = function (e) {
-		return fn.call(context || obj, e || window.event);
+	var handler = function (e, originalType) {
+		return fn.call(context || obj, e || window.event, originalType);
 	};
 
 	var originalHandler = handler;
@@ -103,7 +103,7 @@ function addOne(obj, type, fn, context) {
 			handler = function (e) {
 				e = e || window.event;
 				if (isExternalTarget(obj, e)) {
-					originalHandler(e);
+					originalHandler(e, type);
 				}
 			};
 			obj.addEventListener(mouseSubst[type], handler, false);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1375,13 +1375,13 @@ export var Map = Evented.extend({
 		}
 	},
 
-	_handleDOMEvent: function (e) {
+	_handleDOMEvent: function (e, originalType) {
 		var el = (e.target || e.srcElement);
 		if (!this._loaded || el['_leaflet_disable_events'] || e.type === 'click' && this._isClickDisabled(el)) {
 			return;
 		}
 
-		var type = e.type;
+		var type = originalType || e.type;
 
 		if (type === 'mousedown') {
 			// prevents outline when clicking on keyboard-focusable element


### PR DESCRIPTION
Currently for compatibility purposes Leaflet substitutes 'touch*' listeners with 'pointer*' ones (~~where available~~ if touch is not available).
And similarly with 'mouseenter' / 'mouseleave'.

It may lead to unexpected consequences, if handler relies on original value of `type` in own code.
That's why it'd better to keep original `type`.

In proposed modification I pass 'original' type as 2nd argument of handler, and this is enough for [events](https://leafletjs.com/reference-1.6.0.html#map-click) dispatched with `map._fireDOMEvent`: handler then has access both to 'original' event type, and to real type (`originalEvent.type`).

But for listeners attached directly with `DomEvent.on(...` it is not so simple, as `type` property is read-only (as a rule). I believe that we should keep things simple: `type` as second argument is smart enough.
Perhaps, that should be documented in https://leafletjs.com/reference-1.6.0.html#domevent.
