### PR TITLE
Canvas events handling: do not block events on dragging

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -348,8 +348,10 @@ export var Canvas = Renderer.extend({
 
 		for (var order = this._drawFirst; order; order = order.next) {
 			layer = order.layer;
-			if (layer.options.interactive && layer._containsPoint(point) && !this._map._draggableMoved(layer)) {
-				clickedLayer = layer;
+			if (layer.options.interactive && layer._containsPoint(point)) {
+				if (!(e.type === 'click' || e.type !== 'preclick') || !this._map._draggableMoved(layer)) {
+					clickedLayer = layer;
+				}
 			}
 		}
 		if (clickedLayer)  {


### PR DESCRIPTION
Currently we prevent any event on Canvas during dragging.
AFAIK, the only valuable case where it's useful - suppress false `click`, source: https://github.com/Leaflet/Leaflet/commit/95d5b59c5fdc53ac19575e7e46882b7d7a701f15#diff-5b3512e2ba3d374197128a67b330a0efR256

Fix #7007.
