### PR TITLE
Draggable: allow single-touch drag only

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -96,6 +96,14 @@ export var Draggable = Evented.extend({
 
 		if (DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 
+		if (e.touches && e.touches.length !== 1) {
+			// Finish dragging to avoid conflict with touchZoom
+			if (Draggable._dragging === this) {
+				this.finishDrag();
+			}
+			return;
+		}
+
 		if (Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 		Draggable._dragging = this;  // Prevent dragging multiple objects at once.
 


### PR DESCRIPTION
Finish drag if more than 1 touch detected to avoid conflict with touchZoom.
Fix #6395.

Note: alternatively this could be fixed in `Map.TouchZoom.js` / `_onTouchStart`:
```js
   if (map.dragging && map.dragging.moving()) {
       map.dragging._draggable.finishDrag();
   }
```
