### PR TITLE
Handle touchcancel separately from touchend

### DIFF
--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -26,7 +26,10 @@ export function addPointerListener(obj, type, handler, id) {
 		_addPointerMove(obj, handler, id);
 
 	} else if (type === 'touchend') {
-		_addPointerEnd(obj, handler, id);
+		_addPointerEnd(obj, type, handler, id);
+
+	} else if (type === 'touchcancel') {
+		_addPointerCancel(obj, type, handler, id);
 	}
 
 	return this;
@@ -43,6 +46,8 @@ export function removePointerListener(obj, type, id) {
 
 	} else if (type === 'touchend') {
 		obj.removeEventListener(POINTER_UP, handler, false);
+
+	} else if (type === 'touchcancel') {
 		obj.removeEventListener(POINTER_CANCEL, handler, false);
 	}
 
@@ -112,12 +117,20 @@ function _addPointerMove(obj, handler, id) {
 	obj.addEventListener(POINTER_MOVE, onMove, false);
 }
 
-function _addPointerEnd(obj, handler, id) {
+function _addPointerEnd(obj, type, handler, id) {
 	var onUp = function (e) {
 		_handlePointer(e, handler);
 	};
 
-	obj['_leaflet_touchend' + id] = onUp;
+	obj['_leaflet_' + type + id] = onUp;
 	obj.addEventListener(POINTER_UP, onUp, false);
-	obj.addEventListener(POINTER_CANCEL, onUp, false);
+}
+
+function _addPointerCancel(obj, type, handler, id) {
+	var onCancel = function (e) {
+		_handlePointer(e, handler);
+	};
+
+	obj['_leaflet_' + type + id] = onCancel;
+	obj.addEventListener(POINTER_CANCEL, onCancel, false);
 }

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -96,7 +96,7 @@ function addOne(obj, type, fn, context) {
 
 	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
 		// Needs DomEvent.Pointer.js
-		addPointerListener(obj, type, handler, id);
+		handler = addPointerListener(obj, type, handler);
 
 	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
 		addDoubleTapListener(obj, handler, id);
@@ -135,7 +135,7 @@ function removeOne(obj, type, fn, context) {
 	if (!handler) { return this; }
 
 	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
-		removePointerListener(obj, type, id);
+		removePointerListener(obj, type, handler);
 
 	} else if (Browser.touch && (type === 'dblclick') && !browserFiresNativeDblClick()) {
 		removeDoubleTapListener(obj, id);

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -22,19 +22,6 @@ import {Point} from '../geometry/Point';
  */
 
 var START = Browser.touch ? 'touchstart mousedown' : 'mousedown';
-var END = {
-	mousedown: 'mouseup',
-	touchstart: 'touchend',
-	pointerdown: 'touchend',
-	MSPointerDown: 'touchend'
-};
-var MOVE = {
-	mousedown: 'mousemove',
-	touchstart: 'touchmove',
-	pointerdown: 'touchmove',
-	MSPointerDown: 'touchmove'
-};
-
 
 export var Draggable = Evented.extend({
 
@@ -120,8 +107,9 @@ export var Draggable = Evented.extend({
 		// Cache the scale, so that we can continuously compensate for it during drag (_onMove).
 		this._parentScale = DomUtil.getScale(sizedParent);
 
-		DomEvent.on(document, MOVE[e.type], this._onMove, this);
-		DomEvent.on(document, END[e.type], this._onUp, this);
+		var mouseevent = e.type === 'mousedown';
+		DomEvent.on(document, mouseevent ? 'mousemove' : 'touchmove', this._onMove, this);
+		DomEvent.on(document, mouseevent ? 'mouseup' : 'touchend touchcancel', this._onUp, this);
 	},
 
 	_onMove: function (e) {
@@ -210,10 +198,8 @@ export var Draggable = Evented.extend({
 			this._lastTarget = null;
 		}
 
-		for (var i in MOVE) {
-			DomEvent.off(document, MOVE[i], this._onMove, this);
-			DomEvent.off(document, END[i], this._onUp, this);
-		}
+		DomEvent.off(document, 'mousemove touchmove', this._onMove, this);
+		DomEvent.off(document, 'mouseup touchend touchcancel', this._onUp, this);
 
 		DomUtil.enableImageDrag();
 		DomUtil.enableTextSelection();

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -59,7 +59,7 @@ export var TouchZoom = Handler.extend({
 		map._stop();
 
 		DomEvent.on(document, 'touchmove', this._onTouchMove, this);
-		DomEvent.on(document, 'touchend', this._onTouchEnd, this);
+		DomEvent.on(document, 'touchend touchcancel', this._onTouchEnd, this);
 
 		DomEvent.preventDefault(e);
 	},
@@ -113,7 +113,7 @@ export var TouchZoom = Handler.extend({
 		Util.cancelAnimFrame(this._animRequest);
 
 		DomEvent.off(document, 'touchmove', this._onTouchMove, this);
-		DomEvent.off(document, 'touchend', this._onTouchEnd, this);
+		DomEvent.off(document, 'touchend touchcancel', this._onTouchEnd, this);
 
 		// Pinch updates GridLayers' levels only when zoomSnap is off, so zoomSnap becomes noUpdate.
 		if (this._map.options.zoomAnimation) {


### PR DESCRIPTION
The things were mixed up, and touchcancel was not handled at all
in case if `Browser.pointer` is `false`.

Close #7062.

Todo:
- [x] continue refactoring, add tests (will be done [separately](https://github.com/johnd0e/Leaflet/tree/refactor-pointer))