### PR TITLE
Draggable: option `shiftDisable` controls whether prevent dragging when Shift pressed

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -44,7 +44,12 @@ export var Draggable = Evented.extend({
 		// @option clickTolerance: Number = 3
 		// The max number of pixels a user can shift the mouse pointer during a click
 		// for it to be considered a valid click (as opposed to a mouse drag).
-		clickTolerance: 3
+		clickTolerance: 3,
+
+		// @option shiftDisable: Boolean = true
+		// Whether dragging should be disabled when Shift key is down.
+		// Should be `true` to allow [`boxZoom` handler](#map-boxzoom) to function properly.
+		shiftDisable: true
 	},
 
 	// @constructor L.Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
@@ -96,7 +101,9 @@ export var Draggable = Evented.extend({
 
 		if (DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 
-		if (Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
+		if (e.shiftKey && this.options.shiftDisable) { return; }
+
+		if (Draggable._dragging || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 		Draggable._dragging = this;  // Prevent dragging multiple objects at once.
 
 		if (this._preventOutline) {


### PR DESCRIPTION
Fix #2772.

To ignore Shift state defaults should be changed:

`L.Draggable.mergeOptions({shiftDisable:false});`

Some considerations:
- May be someone can propose better name/description for `shiftDisable` option.
- May be we need more versatile solution, like `toDisableFn` function, to react on arbitrary conditions.
- It would be more convenient to have higher level functionality, like detecting `boxZoom` handler state on map creation (for marker: on map add), and that can be implemented in future, using introduced here option.
  Though, it will be too tricky to cover cases with dynamic `boxZoom` handler enabling/disabling.