### PR TITLE
Popup: fix event propagation to popup._container

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -181,9 +181,9 @@ export var Popup = DivOverlay.extend({
 		var wrapper = this._wrapper = DomUtil.create('div', prefix + '-content-wrapper', container);
 		this._contentNode = DomUtil.create('div', prefix + '-content', wrapper);
 
-		DomEvent.disableClickPropagation(wrapper);
+		DomEvent.disableClickPropagation(container);
 		DomEvent.disableScrollPropagation(this._contentNode);
-		DomEvent.on(wrapper, 'contextmenu', DomEvent.stopPropagation);
+		DomEvent.on(container, 'contextmenu', DomEvent.stopPropagation);
 
 		this._tipContainer = DomUtil.create('div', prefix + '-tip-container', container);
 		this._tip = DomUtil.create('div', prefix + '-tip', this._tipContainer);


### PR DESCRIPTION
Fix #6044, close #6844 as obsolete.

---
Test page: https://gist.githack.com/johnd0e/259dc6da189ae1653987fbf1876dc2ee/raw/fix-6044.html