### PR TITLE
Better icon image path detection

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -396,7 +396,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 /* Default icon URLs */
-.leaflet-default-icon-path {
+.leaflet-default-icon-path { /* used only in path-guessing heuristic, see L.Icon.Default */
 	background-image: url(images/marker-icon.png);
 	}
 

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -23,6 +23,19 @@ describe("Icon.Default", function () {
 		expect(L.Icon.Default.imagePath).to.not.be.ok();
 		marker.addTo(map);
 		expect(L.Icon.Default.imagePath).to.equal(document.location.origin + origPath);
+
+		var stripUrl = L.Icon.Default.prototype._stripUrl;
+		var properPath = 'http://localhost:8000/base/dist/images/';
+		[ // valid
+			'url("http://localhost:8000/base/dist/images/marker-icon.png")',  // Firefox
+			"url('http://localhost:8000/base/dist/images/marker-icon.png')",
+			'url(http://localhost:8000/base/dist/images/marker-icon.png)',    // IE, Edge
+		].map(stripUrl).forEach(function (str) { expect(str).to.be(properPath); });
+
+		[ // invalid
+			'url("http://localhost:8000/base/dist/images/marker-icon.png?2x)"',
+			'url("data:image/png;base64,iVBORw...")',                         // inline image (bundlers)
+		].map(stripUrl).forEach(function (str) { expect(str).not.to.be.ok(); });
 	});
 
 	it("icon measures 25x41px", function () {

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -14,6 +14,17 @@ describe("Icon.Default", function () {
 		document.body.removeChild(div);
 	});
 
+	it("detect icon images path", function () {
+		var origPath = L.Icon.Default.imagePath; // set in after.js
+		expect(origPath).to.be.ok();
+		delete L.Icon.Default.imagePath;
+		var marker = new L.Marker([0, 0]);
+
+		expect(L.Icon.Default.imagePath).to.not.be.ok();
+		marker.addTo(map);
+		expect(L.Icon.Default.imagePath).to.equal(document.location.origin + origPath);
+	});
+
 	it("icon measures 25x41px", function () {
 		var img = map.getPane('markerPane').querySelector('img');
 		expect(img.clientHeight).to.be(41);

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -22,7 +22,10 @@ describe("Icon.Default", function () {
 
 		expect(L.Icon.Default.imagePath).to.not.be.ok();
 		marker.addTo(map);
-		expect(L.Icon.Default.imagePath).to.equal(document.location.origin + origPath);
+
+		// polyfill for IE<11
+		var origin = document.location.origin || window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '');
+		expect(L.Icon.Default.imagePath).to.equal(origin + origPath);
 
 		var stripUrl = L.Icon.Default.prototype._stripUrl;
 		var properPath = 'http://localhost:8000/base/dist/images/';

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -31,7 +31,7 @@ export var IconDefault = Icon.extend({
 	},
 
 	_getIconUrl: function (name) {
-		if (!IconDefault.imagePath) {	// Deprecated, backwards-compatibility only
+		if (typeof IconDefault.imagePath !== 'string') {	// Deprecated, backwards-compatibility only
 			IconDefault.imagePath = this._detectIconPath();
 		}
 
@@ -42,19 +42,21 @@ export var IconDefault = Icon.extend({
 		return (this.options.imagePath || IconDefault.imagePath) + Icon.prototype._getIconUrl.call(this, name);
 	},
 
+	_stripUrl: function (path) {	// separate function to use in tests
+		var strip = function (str, re, idx) {
+			var match = re.exec(str);
+			return match && match[idx];
+		};
+		path = strip(path, /^url\((['"])?(.+)\1\)$/, 2);
+		return path && strip(path, /^(.*)marker-icon\.png$/, 1);
+	},
+
 	_detectIconPath: function () {
 		var el = DomUtil.create('div',  'leaflet-default-icon-path', document.body);
 		var path = DomUtil.getStyle(el, 'background-image') ||
 		           DomUtil.getStyle(el, 'backgroundImage');	// IE8
 
 		document.body.removeChild(el);
-
-		if (path === null || path.indexOf('url') !== 0) {
-			path = '';
-		} else {
-			path = path.replace(/^url\(["']?/, '').replace(/marker-icon\.png["']?\)$/, '');
-		}
-
-		return path;
+		return this._stripUrl(path) || '';
 	}
 });

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -57,6 +57,10 @@ export var IconDefault = Icon.extend({
 		           DomUtil.getStyle(el, 'backgroundImage');	// IE8
 
 		document.body.removeChild(el);
-		return this._stripUrl(path) || '';
+		path = this._stripUrl(path);
+		if (path) { return path; }
+		var link = document.querySelector('link[href$="leaflet.css"]');
+		if (!link) { return ''; }
+		return link.href.substring(0, link.href.length - 'leaflet.css'.length - 1);
 	}
 });


### PR DESCRIPTION
Icon.Default/imagePath: more strict detect rules

Reject paths not ending on 'marker-icon.png'.
This should solve issues with images bundled into data-uri (webpack etc).

Add tests.

Close #6804 (superseded), fix #6496, fix (presumably) #7424.
