### PR TITLE
Fix tiles flickering when maxNativeZoom === maxZoom (and same with min-)

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -544,10 +544,12 @@ export var GridLayer = Layer.extend({
 	},
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
-		var tileZoom = this._clampZoom(Math.round(zoom));
+		var tileZoom = Math.round(zoom);
 		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
 		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
 			tileZoom = undefined;
+		} else {
+			tileZoom = this._clampZoom(tileZoom);
 		}
 
 		var tileZoomChanged = this.options.updateWhenZooming && (tileZoom !== this._tileZoom);


### PR DESCRIPTION
GridLayer/_setView: check max/minZoom before clamping to max/minNativeZoom.

Fix #6259, close #6310 as superseded.

This patch is also based on @IvanSanchez [suggestion](https://github.com/Leaflet/Leaflet/issues/6259#issuecomment-408819449), but slightly differs from #6310: `zoom` value is rounded before any further conditions.

---
Test page with latest leaflet (from unpkg.com): https://codepen.io/johnd0e-the-bashful/full/yLYeeEm

(To fix flicker follow 'apply anti-flicker patch' link)
