### PR TITLE
Allow to prevent round-off errors, caused by formatNum

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -86,6 +86,7 @@ describe('Util', function () {
 			expect(L.Util.formatNum(13.12325555, 3)).to.eql(13.123);
 			expect(L.Util.formatNum(13.12325555)).to.eql(13.123256);
 			expect(L.Util.formatNum(13.12325555, 0)).to.eql(13);
+			expect(L.Util.formatNum(13.12325555, false)).to.eql(13.12325555);
 			expect(isNaN(L.Util.formatNum(-7.993322e-10))).to.eql(false);
 		});
 	});

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -111,10 +111,11 @@ export function wrapNum(x, range, includeMax) {
 // Returns a function which always returns `false`.
 export function falseFn() { return false; }
 
-// @function formatNum(num: Number, digits?: Number): Number
-// Returns the number `num` rounded to `digits` decimals, or to 6 decimals by default.
-export function formatNum(num, digits) {
-	var pow = Math.pow(10, (digits === undefined ? 6 : digits));
+// @function formatNum(num: Number, precision?: Number): Number
+// Returns the number `num` rounded with specified `precision`.
+// The default `precision` value is 6 decimal places.
+export function formatNum(num, precision) {
+	var pow = Math.pow(10, precision === undefined ? 6 : precision);
 	return Math.round(num * pow) / pow;
 }
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -111,10 +111,12 @@ export function wrapNum(x, range, includeMax) {
 // Returns a function which always returns `false`.
 export function falseFn() { return false; }
 
-// @function formatNum(num: Number, precision?: Number): Number
+// @function formatNum(num: Number, precision?: Number|false): Number
 // Returns the number `num` rounded with specified `precision`.
 // The default `precision` value is 6 decimal places.
+// `false` can be passed to skip any processing (can be useful to avoid round-off errors).
 export function formatNum(num, precision) {
+	if (precision === false) { return num; }
 	var pow = Math.pow(10, precision === undefined ? 6 : precision);
 	return Math.round(num * pow) / pow;
 }

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -253,7 +253,7 @@ export function coordsToLatLngs(coords, levelsDeep, _coordsToLatLng) {
 	return latlngs;
 }
 
-// @function latLngToCoords(latlng: LatLng, precision?: Number): Array
+// @function latLngToCoords(latlng: LatLng, precision?: Number|false): Array
 // Reverse of [`coordsToLatLng`](#geojson-coordstolatlng)
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function.
 export function latLngToCoords(latlng, precision) {
@@ -262,7 +262,7 @@ export function latLngToCoords(latlng, precision) {
 		[Util.formatNum(latlng.lng, precision), Util.formatNum(latlng.lat, precision)];
 }
 
-// @function latLngsToCoords(latlngs: Array, levelsDeep?: Number, closed?: Boolean, precision?: Number): Array
+// @function latLngsToCoords(latlngs: Array, levelsDeep?: Number, closed?: Boolean, precision?: Number|false): Array
 // Reverse of [`coordsToLatLngs`](#geojson-coordstolatlngs)
 // `closed` determines whether the first point should be appended to the end of the array to close the feature, only used when `levelsDeep` is 0. False by default.
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function.
@@ -313,13 +313,13 @@ var PointToGeoJSON = {
 
 // @namespace Marker
 // @section Other methods
-// @method toGeoJSON(precision?: Number): Object
+// @method toGeoJSON(precision?: Number|false): Object
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the marker (as a GeoJSON `Point` Feature).
 Marker.include(PointToGeoJSON);
 
 // @namespace CircleMarker
-// @method toGeoJSON(precision?: Number): Object
+// @method toGeoJSON(precision?: Number|false): Object
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the circle marker (as a GeoJSON `Point` Feature).
 Circle.include(PointToGeoJSON);
@@ -327,7 +327,7 @@ CircleMarker.include(PointToGeoJSON);
 
 
 // @namespace Polyline
-// @method toGeoJSON(precision?: Number): Object
+// @method toGeoJSON(precision?: Number|false): Object
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polyline (as a GeoJSON `LineString` or `MultiLineString` Feature).
 Polyline.include({
@@ -344,7 +344,7 @@ Polyline.include({
 });
 
 // @namespace Polygon
-// @method toGeoJSON(precision?: Number): Object
+// @method toGeoJSON(precision?: Number|false): Object
 // Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polygon (as a GeoJSON `Polygon` or `MultiPolygon` Feature).
 Polygon.include({
@@ -381,7 +381,7 @@ LayerGroup.include({
 		});
 	},
 
-	// @method toGeoJSON(precision?: Number): Object
+	// @method toGeoJSON(precision?: Number|false): Object
 	// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 	// Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the layer group (as a GeoJSON `FeatureCollection`, `GeometryCollection`, or `MultiPoint`).
 	toGeoJSON: function (precision) {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -255,16 +255,17 @@ export function coordsToLatLngs(coords, levelsDeep, _coordsToLatLng) {
 
 // @function latLngToCoords(latlng: LatLng, precision?: Number): Array
 // Reverse of [`coordsToLatLng`](#geojson-coordstolatlng)
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function.
 export function latLngToCoords(latlng, precision) {
-	precision = typeof precision === 'number' ? precision : 6;
 	return latlng.alt !== undefined ?
 		[Util.formatNum(latlng.lng, precision), Util.formatNum(latlng.lat, precision), Util.formatNum(latlng.alt, precision)] :
 		[Util.formatNum(latlng.lng, precision), Util.formatNum(latlng.lat, precision)];
 }
 
-// @function latLngsToCoords(latlngs: Array, levelsDeep?: Number, closed?: Boolean): Array
+// @function latLngsToCoords(latlngs: Array, levelsDeep?: Number, closed?: Boolean, precision?: Number): Array
 // Reverse of [`coordsToLatLngs`](#geojson-coordstolatlngs)
 // `closed` determines whether the first point should be appended to the end of the array to close the feature, only used when `levelsDeep` is 0. False by default.
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function.
 export function latLngsToCoords(latlngs, levelsDeep, closed, precision) {
 	var coords = [];
 
@@ -313,15 +314,13 @@ var PointToGeoJSON = {
 // @namespace Marker
 // @section Other methods
 // @method toGeoJSON(precision?: Number): Object
-// `precision` is the number of decimal places for coordinates.
-// The default value is 6 places.
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the marker (as a GeoJSON `Point` Feature).
 Marker.include(PointToGeoJSON);
 
 // @namespace CircleMarker
 // @method toGeoJSON(precision?: Number): Object
-// `precision` is the number of decimal places for coordinates.
-// The default value is 6 places.
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the circle marker (as a GeoJSON `Point` Feature).
 Circle.include(PointToGeoJSON);
 CircleMarker.include(PointToGeoJSON);
@@ -329,8 +328,7 @@ CircleMarker.include(PointToGeoJSON);
 
 // @namespace Polyline
 // @method toGeoJSON(precision?: Number): Object
-// `precision` is the number of decimal places for coordinates.
-// The default value is 6 places.
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polyline (as a GeoJSON `LineString` or `MultiLineString` Feature).
 Polyline.include({
 	toGeoJSON: function (precision) {
@@ -347,8 +345,7 @@ Polyline.include({
 
 // @namespace Polygon
 // @method toGeoJSON(precision?: Number): Object
-// `precision` is the number of decimal places for coordinates.
-// The default value is 6 places.
+// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 // Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the polygon (as a GeoJSON `Polygon` or `MultiPolygon` Feature).
 Polygon.include({
 	toGeoJSON: function (precision) {
@@ -385,8 +382,7 @@ LayerGroup.include({
 	},
 
 	// @method toGeoJSON(precision?: Number): Object
-	// `precision` is the number of decimal places for coordinates.
-	// The default value is 6 places.
+	// Coordinates values are rounded with [`formatNum`](#util-formatnum) function with given `precision`.
 	// Returns a [`GeoJSON`](http://en.wikipedia.org/wiki/GeoJSON) representation of the layer group (as a GeoJSON `FeatureCollection`, `GeometryCollection`, or `MultiPoint`).
 	toGeoJSON: function (precision) {
 


### PR DESCRIPTION
Especially in GeoJSON converting.

Close #6681.
