### PR TITLE
Add documentation for Event Listens Propagate argument.

### DIFF
--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -19773,9 +19773,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</nobr></code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/docs/reference-1.1.0.html
+++ b/docs/reference-1.1.0.html
@@ -19903,9 +19903,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</nobr></code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/docs/reference-1.2.0.html
+++ b/docs/reference-1.2.0.html
@@ -19918,9 +19918,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</nobr></code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/docs/reference-1.3.4.html
+++ b/docs/reference-1.3.4.html
@@ -20120,9 +20120,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</nobr></code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/docs/reference-1.4.0.html
+++ b/docs/reference-1.4.0.html
@@ -20133,9 +20133,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</nobr></code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/docs/reference-1.6.0.html
+++ b/docs/reference-1.6.0.html
@@ -21025,9 +21025,9 @@ properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
 	<tr id='evented-listens'>
-		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>)</code></td>
+		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.</p>
+		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it. The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
 	<tr id='evented-once'>

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -202,8 +202,9 @@ export var Events = {
 		return this;
 	},
 
-	// @method listens(type: String): Boolean
+	// @method listens(type: String, propagate?: Boolean): Boolean
 	// Returns `true` if a particular event type has any listeners attached to it.
+	// The verification can optionally be propagated, it will return `true` if parents have the listener attached to it.
 	listens: function (type, propagate) {
 		var listeners = this._events && this._events[type];
 		if (listeners && listeners.length) { return true; }


### PR DESCRIPTION
Fixes #6912

Original documentation reference: https://leafletjs.com/reference-1.6.0.html#evented-listens

This is the new documentation for `evented-listens` after the change:

<img width="994" alt="Screen Shot 2020-04-19 at 6 27 40 pm" src="https://user-images.githubusercontent.com/5021064/79683176-7a1c2d80-826b-11ea-81ea-a1e40599405f.png">

The original change was introduced since 1.0.0 so past docs had to be updated manually, I'm not 100% sure that's the way since I read this should happen on release of the Leaflet versions