### PR TITLE
Fix DivOverlay.getElement function documentation

### DIFF
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -102,7 +102,7 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// @method getElement: String|HTMLElement
-	// Alias for [getContent()](#popup-getcontent)
+	// Returns the HTML container of the popup.
 	getElement: function () {
 		return this._container;
 	},


### PR DESCRIPTION
Closes #6926. Related to #6597.