### PR TITLE
GridLayer: fix _updateLevels and _removeTilesAtZoom

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -365,6 +365,7 @@ export var GridLayer = Layer.extend({
 		if (zoom === undefined) { return undefined; }
 
 		for (var z in this._levels) {
+			z = Number(z);
 			if (this._levels[z].el.children.length || z === zoom) {
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
 				this._onUpdateLevel(z);
@@ -461,7 +462,7 @@ export var GridLayer = Layer.extend({
 	_invalidateAll: function () {
 		for (var z in this._levels) {
 			DomUtil.remove(this._levels[z].el);
-			this._onRemoveLevel(z);
+			this._onRemoveLevel(Number(z));
 			delete this._levels[z];
 		}
 		this._removeAllTiles();


### PR DESCRIPTION
Because of particular quality of `for ... in` loop, type of `z` is 'string'.
Thus condition `z === zoom` never met in _updateLevels.
Considering wrong arg type, _removeTilesAtZoom also never had any action.

Cleaner solution would be to iterate `Object.keys()` instead, but it is available only since IE 9.

Note: the fix here is pretty same as #6064.
Additionally I've checked all other similar places in Leaflet code and made one more potential fix for `_onRemoveLevel` (is not used in Leaflet's core, but available for overriding).
