### PR TITLE
Restore DomEvent.off(el) functionality when calling with one arg

### DIFF
--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -11,6 +11,20 @@ describe('DomEvent', function () {
 		document.body.removeChild(el);
 	});
 
+	describe('#arguments check', function () {
+		it('throws when el is not HTMLElement', function () {
+			expect(L.DomEvent.on).withArgs({}, 'click', L.Util.falseFn)
+				.to.throwException();
+			expect(L.DomEvent.disableScrollPropagation).withArgs({})
+				.to.throwException();
+			expect(L.DomEvent.disableClickPropagation).withArgs({})
+				.to.throwException();
+			expect(L.DomEvent.getMousePosition).withArgs({clientX: 0, clientY: 0}, {})
+				.to.throwException();
+			// .off and .isExternalTarget do not throw atm
+		});
+	});
+
 	describe('#on (addListener)', function () {
 		it('throws when types/fn are undefined/null/false', function () {
 			expect(L.DomEvent.on).withArgs(el, undefined, L.Util.falseFn)

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -12,6 +12,21 @@ describe('DomEvent', function () {
 	});
 
 	describe('#on (addListener)', function () {
+		it('throws when types/fn are undefined/null/false', function () {
+			expect(L.DomEvent.on).withArgs(el, undefined, L.Util.falseFn)
+				.to.throwException();
+			expect(L.DomEvent.on).withArgs(el, null, L.Util.falseFn)
+				.to.throwException();
+			expect(L.DomEvent.on).withArgs(el, false, L.Util.falseFn)
+				.to.throwException();
+			expect(L.DomEvent.on).withArgs(el, 'click', undefined)
+				.to.throwException();
+			expect(L.DomEvent.on).withArgs(el, 'click', null)
+				.to.throwException();
+			expect(L.DomEvent.on).withArgs(el, 'click', false)
+				.to.throwException();
+		});
+
 		it('adds a listener and calls it on event', function () {
 			var listener2 = sinon.spy();
 			L.DomEvent.on(el, 'click', listener);
@@ -190,6 +205,26 @@ describe('DomEvent', function () {
 
 			expect(listenerA.called).to.not.be.ok();
 			expect(listenerB.called).to.not.be.ok();
+		});
+
+		it('throws when types is undefined/null/false', function () {
+			expect(L.DomEvent.off).withArgs(el, undefined)
+				.to.throwException();
+			expect(L.DomEvent.off).withArgs(el, null)
+				.to.throwException();
+			expect(L.DomEvent.off).withArgs(el, false)
+				.to.throwException();
+		});
+
+		it('removes listener when passed an event map', function () {
+			var listener = sinon.spy();
+
+			L.DomEvent.on(el, 'click', listener);
+			L.DomEvent.off(el, {'click': listener});
+
+			happen.click(el);
+
+			expect(listener.called).to.not.be.ok();
 		});
 
 		it('is chainable', function () {

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -82,6 +82,20 @@ describe('DomEvent', function () {
 			expect(listener.notCalled).to.be.ok();
 		});
 
+		it('only removes the specified listener', function () {
+			var listenerA = sinon.spy(),
+			listenerB = sinon.spy();
+
+			L.DomEvent.on(el, 'click', listenerA);
+			L.DomEvent.on(el, 'click', listenerB);
+			L.DomEvent.off(el, 'click', listenerA);
+
+			happen.click(el);
+
+			expect(listenerA.called).to.not.be.ok();
+			expect(listenerB.called).to.be.ok();
+		});
+
 		it('removes a previously added listener when passed an event map', function () {
 			var listener = sinon.spy(),
 			    events = {click: listener};
@@ -162,6 +176,20 @@ describe('DomEvent', function () {
 			happen.click(el);
 
 			sinon.assert.called(listener);
+		});
+
+		it('removes all listeners when only passed the HTMLElement', function () {
+			var listenerA = sinon.spy(),
+			listenerB = sinon.spy();
+
+			L.DomEvent.on(el, 'click', listenerA);
+			L.DomEvent.on(el, 'click', listenerB, {});
+			L.DomEvent.off(el);
+
+			happen.click(el);
+
+			expect(listenerA.called).to.not.be.ok();
+			expect(listenerB.called).to.not.be.ok();
 		});
 
 		it('is chainable', function () {

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -207,12 +207,33 @@ describe('DomEvent', function () {
 			expect(listenerB.called).to.not.be.ok();
 		});
 
-		it('throws when types is undefined/null/false', function () {
+		it('only removes specified listeners type', function () {
+			var listenerClick = sinon.spy(),
+			listenerDblClick = sinon.spy();
+
+			L.DomEvent.on(el, 'click', listenerClick);
+			L.DomEvent.on(el, 'dblclick', listenerDblClick);
+			L.DomEvent.off(el, 'click');
+			happen.click(el);
+			happen.dblclick(el);
+
+			sinon.assert.notCalled(listenerClick);
+			sinon.assert.called(listenerDblClick);
+		});
+
+		it('throws when types/fn are undefined/null/false', function () {
 			expect(L.DomEvent.off).withArgs(el, undefined)
 				.to.throwException();
 			expect(L.DomEvent.off).withArgs(el, null)
 				.to.throwException();
 			expect(L.DomEvent.off).withArgs(el, false)
+				.to.throwException();
+
+			expect(L.DomEvent.off).withArgs(el, 'click', undefined)
+				.to.throwException();
+			expect(L.DomEvent.off).withArgs(el, 'click', null)
+				.to.throwException();
+			expect(L.DomEvent.off).withArgs(el, 'click', false)
 				.to.throwException();
 		});
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -23,7 +23,7 @@ import {getScale} from './DomUtil';
 // Adds a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
 export function on(obj, types, fn, context) {
 
-	if (typeof types === 'object') {
+	if (types && typeof types === 'object') {
 		for (var type in types) {
 			addOne(obj, type, types[type], fn);
 		}
@@ -54,22 +54,24 @@ var eventsKey = '_leaflet_events';
 // Removes all previously added listeners from given HTMLElement
 export function off(obj, types, fn, context) {
 	var type;
-	if (typeof types === 'object') {
-		for (type in types) {
-			removeOne(obj, type, types[type], fn);
-		}
-	} else if (types) {
-		types = Util.splitWords(types);
-
-		for (var i = 0, len = types.length; i < len; i++) {
-			removeOne(obj, types[i], fn, context);
-		}
-	} else {
+	if (arguments.length === 1) {
 		for (var id in obj[eventsKey]) {
 			type = id.split(/\d/)[0];
 			removeOne(obj, type, null, null, id);
 		}
 		delete obj[eventsKey];
+
+	} else if (types && typeof types === 'object') {
+		for (type in types) {
+			removeOne(obj, type, types[type], fn);
+		}
+
+	} else {
+		types = Util.splitWords(types);
+
+		for (var i = 0, len = types.length; i < len; i++) {
+			removeOne(obj, types[i], fn, context);
+		}
 	}
 
 	return this;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -50,31 +50,47 @@ var eventsKey = '_leaflet_events';
 // Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
 
 // @alternative
+// @function off(el: HTMLElement, types: String): this
+// Removes all previously added listeners of given types.
+
+// @alternative
 // @function off(el: HTMLElement): this
 // Removes all previously added listeners from given HTMLElement
 export function off(obj, types, fn, context) {
-	var type;
+
 	if (arguments.length === 1) {
-		for (var id in obj[eventsKey]) {
-			type = id.split(/\d/)[0];
-			removeOne(obj, type, null, null, id);
-		}
+		batchRemove(obj);
 		delete obj[eventsKey];
 
 	} else if (types && typeof types === 'object') {
-		for (type in types) {
+		for (var type in types) {
 			removeOne(obj, type, types[type], fn);
 		}
 
 	} else {
 		types = Util.splitWords(types);
 
-		for (var i = 0, len = types.length; i < len; i++) {
-			removeOne(obj, types[i], fn, context);
+		if (arguments.length === 2) {
+			batchRemove(obj, function (type) {
+				return Util.indexOf(types, type) !== -1;
+			});
+		} else {
+			for (var i = 0, len = types.length; i < len; i++) {
+				removeOne(obj, types[i], fn, context);
+			}
 		}
 	}
 
 	return this;
+}
+
+function batchRemove(obj, filterFn) {
+	for (var id in obj[eventsKey]) {
+		var type = id.split(/\d/)[0];
+		if (!filterFn || filterFn(type)) {
+			removeOne(obj, type, null, null, id);
+		}
+	}
 }
 
 var mouseSubst = {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -48,10 +48,14 @@ var eventsKey = '_leaflet_events';
 // @alternative
 // @function off(el: HTMLElement, eventMap: Object, context?: Object): this
 // Removes a set of type/listener pairs, e.g. `{click: onClick, mousemove: onMouseMove}`
-export function off(obj, types, fn, context) {
 
+// @alternative
+// @function off(el: HTMLElement): this
+// Removes all previously added listeners from given HTMLElement
+export function off(obj, types, fn, context) {
+	var type;
 	if (typeof types === 'object') {
-		for (var type in types) {
+		for (type in types) {
 			removeOne(obj, type, types[type], fn);
 		}
 	} else if (types) {
@@ -61,8 +65,9 @@ export function off(obj, types, fn, context) {
 			removeOne(obj, types[i], fn, context);
 		}
 	} else {
-		for (var j in obj[eventsKey]) {
-			removeOne(obj, j, obj[eventsKey][j]);
+		for (var id in obj[eventsKey]) {
+			type = id.split(/\d/)[0];
+			removeOne(obj, type, null, null, id);
 		}
 		delete obj[eventsKey];
 	}
@@ -120,10 +125,9 @@ function addOne(obj, type, fn, context) {
 	obj[eventsKey][id] = handler;
 }
 
-function removeOne(obj, type, fn, context) {
-
-	var id = type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : ''),
-	    handler = obj[eventsKey] && obj[eventsKey][id];
+function removeOne(obj, type, fn, context, id) {
+	id = id || type + Util.stamp(fn) + (context ? '_' + Util.stamp(context) : '');
+	var handler = obj[eventsKey] && obj[eventsKey][id];
 
 	if (!handler) { return this; }
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -135,7 +135,7 @@ function addOne(obj, type, fn, context) {
 			obj.addEventListener(type, originalHandler, false);
 		}
 
-	} else if ('attachEvent' in obj) {
+	} else {
 		obj.attachEvent('on' + type, handler);
 	}
 
@@ -159,7 +159,7 @@ function removeOne(obj, type, fn, context, id) {
 
 		obj.removeEventListener(mouseSubst[type] || type, handler, false);
 
-	} else if ('detachEvent' in obj) {
+	} else {
 		obj.detachEvent('on' + type, handler);
 	}
 


### PR DESCRIPTION
Currently we have code (unsuccessfully) trying to handle this case, see https://github.com/Leaflet/Leaflet/issues/6013#issuecomment-623954835

This PR (originally based on #6032) fixes this case.

1. Two more variations of `off` added:

```js
// @alternative
// @function off(el: HTMLElement, types: String): this
// Removes all previously added listeners of given types.
```
```js
// @alternative
// @function off(el: HTMLElement): this
// Removes all previously added listeners from given HTMLElement
```

2. More strict arguments check to catch common bugs

3. All cases are covered by tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/7125)
<!-- Reviewable:end -->
