### PR TITLE
Utils.formatNum: better rounding for some edge cases

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -86,6 +86,10 @@ describe('Util', function () {
 			expect(L.Util.formatNum(13.12325555)).to.eql(13.123256);
 			expect(L.Util.formatNum(13.12325555, 0)).to.eql(13);
 			expect(isNaN(L.Util.formatNum(-7.993322e-10))).to.eql(false);
+			// some edge cases (to be continued)
+			expect(L.Util.formatNum(1.005, 2)).to.eql(1.01);   // instead of 1
+			expect(L.Util.formatNum(-1.005, 2)).to.eql(-1.01); //           -1
+			expect(L.Util.formatNum(-1.555, 2)).to.eql(-1.56); //           -1.55
 		});
 	});
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -111,11 +111,17 @@ export function wrapNum(x, range, includeMax) {
 // Returns a function which always returns `false`.
 export function falseFn() { return false; }
 
+// compatibility polyfills for IE
+var EPSILON = Number.EPSILON || Math.pow(2, -52);
+var sign = Math.sign || function (x) {
+	return ((x > 0) - (x < 0)) || +x;
+};
+
 // @function formatNum(num: Number, digits?: Number): Number
 // Returns the number `num` rounded to `digits` decimals, or to 6 decimals by default.
 export function formatNum(num, digits) {
 	var pow = Math.pow(10, (digits === undefined ? 6 : digits));
-	return Math.round(num * pow) / pow;
+	return Math.round((num + sign(num) * EPSILON) * pow) / pow;
 }
 
 // @function trim(str: String): String


### PR DESCRIPTION
Samples of edge cases are in `UtilSpec.js`

This is rather proof-of-concept.
Implementation details inspired by some stackoverflow discussions.

While searching for a more authoritative source, I found that it's just impossible to write any all-purpose function.
Floating numbers math is really hard.
<details><summary>Some random sources from brief googling</summary>

- http://realtimecollisiondetection.net/blog/?p=89
- https://dev.to/alldanielscott/how-to-compare-numbers-correctly-in-javascript-1l4i
- https://floating-point-gui.de/errors/comparison/
</details>

---
**This is not intended for merge!**
More (edge-)case samples needed to be checked. We must make sure that while fixing just some random cases we do not brake others.