### PR TITLE
Update dev dependencies, fix most of vulnerabilities

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -42,16 +42,18 @@ export default {
 			name: 'L',
 			banner: banner,
 			outro: outro,
-			sourcemap: true
+			sourcemap: true,
+			legacy: true, // Needed to create files loadable by IE8
+			freeze: false
 		},
 		{
 			file: 'dist/leaflet-src.esm.js',
 			format: 'es',
 			banner: banner,
-			sourcemap: true
+			sourcemap: true,
+			freeze: false
 		}
 	],
-	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
 		release ? json() : rollupGitVersion()
 	]

--- a/build/rollup-watch-config.js
+++ b/build/rollup-watch-config.js
@@ -20,9 +20,10 @@ export default {
 		format: 'umd',
 		name: 'L',
 		banner: banner,
-		sourcemap: true
+		sourcemap: true,
+		legacy: true, // Needed to create files loadable by IE8
+		freeze: false,
 	},
-	legacy: true, // Needed to create files loadable by IE8
 	plugins: [
 		rollupGitVersion()
 	]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://leafletjs.com/",
   "description": "JavaScript library for mobile-friendly interactive maps",
   "devDependencies": {
-    "eslint": "^4.19.1",
+    "eslint": "^5.16.0",
     "eslint-config-mourner": "^2.0.1",
     "git-rev-sync": "^2.0.0",
     "happen": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "phantomjs-prebuilt": "^2.1.16",
     "prosthetic-hand": "^1.3.1",
     "rollup": "0.51.8",
-    "rollup-plugin-git-version": "0.2.1",
+    "rollup-plugin-git-version": "^0.3.1",
     "rollup-plugin-json": "^4.0.0",
     "sinon": "^7.5.0",
     "ssri": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rollup-plugin-git-version": "^0.3.1",
     "rollup-plugin-json": "^4.0.0",
     "sinon": "^7.5.0",
-    "ssri": "^6.0.1",
+    "ssri": "^8.0.0",
     "uglify-js": "^3.9.2"
   },
   "main": "dist/leaflet-src.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://leafletjs.com/",
   "description": "JavaScript library for mobile-friendly interactive maps",
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^6.8.0",
     "eslint-config-mourner": "^2.0.1",
     "git-rev-sync": "^2.0.0",
     "happen": "~0.3.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-json": "^4.0.0",
     "sinon": "^7.5.0",
     "ssri": "^6.0.1",
-    "uglify-js": "~3.5.10"
+    "uglify-js": "^3.9.2"
   },
   "main": "dist/leaflet-src.js",
   "style": "dist/leaflet.css",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-mourner": "^2.0.1",
-    "git-rev-sync": "^1.12.0",
+    "git-rev-sync": "^2.0.0",
     "happen": "~0.3.2",
     "karma": "^5.0.3",
     "karma-chrome-launcher": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mocha": "^7.1.2",
     "phantomjs-prebuilt": "^2.1.16",
     "prosthetic-hand": "^1.3.1",
-    "rollup": "0.51.8",
+    "rollup": "^0.59.4",
     "rollup-plugin-git-version": "^0.3.1",
     "rollup-plugin-json": "^4.0.0",
     "sinon": "^7.5.0",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -62,9 +62,13 @@ module.exports = function (config) {
 			plugins: [
 				json()
 			],
-			format: 'umd',
-			name: 'L',
-			outro: outro
+			output: {
+				format: 'umd',
+				name: 'L',
+				outro: outro,
+				legacy: true, // Needed to create files loadable by IE8
+				freeze: false,
+			},
 		},
 
 		// test results reporter to use

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -144,12 +144,12 @@ describe('Canvas', function () {
 		    layerId = L.stamp(layer),
 		    canvas = map.getRenderer(layer);
 
-		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+		expect(canvas._layers).to.have.property(layerId);
 
 		map.removeLayer(layer);
 		// Defer check due to how Canvas renderer manages layer removal.
 		L.Util.requestAnimFrame(function () {
-			expect(canvas._layers.hasOwnProperty(layerId)).to.be(false);
+			expect(canvas._layers).to.not.have.property(layerId);
 			done();
 		}, this);
 	});
@@ -159,14 +159,14 @@ describe('Canvas', function () {
 		    layerId = L.stamp(layer),
 		    canvas = map.getRenderer(layer);
 
-		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+		expect(canvas._layers).to.have.property(layerId);
 
 		map.removeLayer(layer);
 		map.addLayer(layer);
-		expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+		expect(canvas._layers).to.have.property(layerId);
 		// Re-perform a deferred check due to how Canvas renderer manages layer removal.
 		L.Util.requestAnimFrame(function () {
-			expect(canvas._layers.hasOwnProperty(layerId)).to.be(true);
+			expect(canvas._layers).to.have.property(layerId);
 			done();
 		}, this);
 	});

--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -22,6 +22,3 @@ export * from './layer/index';
 
 // map
 export * from './map/index';
-
-import {freeze} from './core/Util';
-Object.freeze = freeze;

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -120,7 +120,7 @@ export var passiveEvents = (function () {
 	var supportsPassiveOption = false;
 	try {
 		var opts = Object.defineProperty({}, 'passive', {
-			get: function () {
+			get: function () { // eslint-disable-line getter-return
 				supportsPassiveOption = true;
 			}
 		});

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -35,7 +35,7 @@ Class.extend = function (props) {
 
 	// inherit parent's statics
 	for (var i in this) {
-		if (this.hasOwnProperty(i) && i !== 'prototype' && i !== '__super__') {
+		if (Object.prototype.hasOwnProperty.call(this, i) && i !== 'prototype' && i !== '__super__') {
 			NewClass[i] = this[i];
 		}
 	}

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -130,7 +130,7 @@ export function splitWords(str) {
 // @function setOptions(obj: Object, options: Object): Object
 // Merges the given properties to the `options` of the `obj` object, returning the resulting options. See `Class options`. Has an `L.setOptions` shortcut.
 export function setOptions(obj, options) {
-	if (!obj.hasOwnProperty('options')) {
+	if (!Object.prototype.hasOwnProperty.call(obj, 'options')) {
 		obj.options = obj.options ? create(obj.options) : {};
 	}
 	for (var i in options) {

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -4,9 +4,6 @@
  * Various utility functions, used by Leaflet internally.
  */
 
-export var freeze = Object.freeze;
-Object.freeze = function (obj) { return obj; };
-
 // @function extend(dest: Object, src?: Object): Object
 // Merges the properties of the `src` object (or multiple objects) into `dest` object and returns the latter. Has an `L.extend` shortcut.
 export function extend(dest) {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -164,7 +164,7 @@ export var Draggable = Evented.extend({
 			this._lastTarget = e.target || e.srcElement;
 			// IE and Edge do not give the <use> element, so fetch it
 			// if necessary
-			if ((window.SVGElementInstance) && (this._lastTarget instanceof SVGElementInstance)) {
+			if (window.SVGElementInstance && this._lastTarget instanceof window.SVGElementInstance) {
 				this._lastTarget = this._lastTarget.correspondingUseElement;
 			}
 			DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -72,7 +72,9 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		if (!Util.isArray(this._url)) { this._url = [this._url]; }
 
-		if (!this.options.keepAspectRatio && vid.style.hasOwnProperty('objectFit')) { vid.style['objectFit'] = 'fill'; }
+		if (!this.options.keepAspectRatio && Object.prototype.hasOwnProperty.call(vid.style, 'objectFit')) {
+			vid.style['objectFit'] = 'fill';
+		}
 		vid.autoplay = !!this.options.autoplay;
 		vid.loop = !!this.options.loop;
 		vid.muted = !!this.options.muted;

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -105,7 +105,7 @@ export var Path = Layer.extend({
 		Util.setOptions(this, style);
 		if (this._renderer) {
 			this._renderer._updateStyle(this);
-			if (this.options.stroke && style && style.hasOwnProperty('weight')) {
+			if (this.options.stroke && style && Object.prototype.hasOwnProperty.call(style, 'weight')) {
 				this._updateBounds();
 			}
 		}


### PR DESCRIPTION
```
    "eslint": "^6.8.0",
    "git-rev-sync": "^2.0.0",
    "rollup": "^0.59.4",
    "rollup-plugin-git-version": "^0.3.1",
    "ssri": "^8.0.0",
    "uglify-js": "^3.9.2"
```

Keep `rollup` < 0.60.0 for compatibility with IE 8 (see #6647)
