### PR TITLE
Fix permanent opened tooltips for layers inside a LayerGroup.

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -184,6 +184,55 @@ describe('Tooltip', function () {
 		expect(group._tooltip._container.innerHTML).to.be("I'm marker 2.");
 	});
 
+	it("it should use a tooltip with a string as content with a FeatureGroup", function () {
+		var marker1 = new L.Marker([55.8, 37.6]);
+		var marker2 = new L.Marker([54.6, 38.2]);
+		var group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+
+		group.bindTooltip("hello");
+
+		// toggle popup on marker1
+		happen.mouseover(marker1._icon, {relatedTarget: map._container});
+		expect(map.hasLayer(group._tooltip)).to.be(true);
+		expect(group._tooltip._container.innerHTML).to.be("hello");
+
+		// toggle popup on marker2
+		happen.mouseover(marker2._icon, {relatedTarget: map._container});
+		expect(map.hasLayer(group._tooltip)).to.be(true);
+		expect(group._tooltip._container.innerHTML).to.be("hello");
+	});
+
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip before add to map", function () {
+		var group = new L.FeatureGroup();
+		group.bindTooltip("hello", {permanent: true});
+		group.addTo(map);
+
+		var marker1 = new L.Marker([55.8, 37.6]);
+		marker1.addTo(group);
+		expect(map.hasLayer(marker1._tooltip)).to.be(true);
+		expect(marker1._tooltip._container.innerHTML).to.be("hello");
+
+		var marker2 = new L.Marker([55.8, 37.6]);
+		marker2.addTo(group);
+		expect(map.hasLayer(marker2._tooltip)).to.be(true);
+		expect(marker2._tooltip._container.innerHTML).to.be("hello");
+	});
+
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip after add to map", function () {
+		var group = new L.FeatureGroup().addTo(map);
+		group.bindTooltip("hello", {permanent: true});
+
+		var marker1 = new L.Marker([55.8, 37.6]);
+		marker1.addTo(group);
+		expect(map.hasLayer(marker1._tooltip)).to.be(true);
+		expect(marker1._tooltip._container.innerHTML).to.be("hello");
+
+		var marker2 = new L.Marker([55.8, 37.6]);
+		marker2.addTo(group);
+		expect(map.hasLayer(marker2._tooltip)).to.be(true);
+		expect(marker2._tooltip._container.innerHTML).to.be("hello");
+	});
+
 	it("opens on polygon mouseover and close on mouseout", function () {
 		var layer = new L.Polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -206,6 +206,7 @@ describe('Tooltip', function () {
 		var group = new L.FeatureGroup();
 		group.bindTooltip("hello", {permanent: true});
 		group.addTo(map);
+		expect(group._tooltip._container).to.be(undefined);
 
 		var marker1 = new L.Marker([55.8, 37.6]);
 		marker1.addTo(group);
@@ -221,6 +222,7 @@ describe('Tooltip', function () {
 	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip after add to map", function () {
 		var group = new L.FeatureGroup().addTo(map);
 		group.bindTooltip("hello", {permanent: true});
+		expect(group._tooltip._container).to.be(undefined);
 
 		var marker1 = new L.Marker([55.8, 37.6]);
 		marker1.addTo(group);

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -202,7 +202,7 @@ describe('Tooltip', function () {
 		expect(group._tooltip._container.innerHTML).to.be("hello");
 	});
 
-	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip before add to map", function () {
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip string before add to map", function () {
 		var group = new L.FeatureGroup();
 		group.bindTooltip("hello", {permanent: true});
 		group.addTo(map);
@@ -219,7 +219,26 @@ describe('Tooltip', function () {
 		expect(marker2._tooltip._container.innerHTML).to.be("hello");
 	});
 
-	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip after add to map", function () {
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip container before add to map", function () {
+		var group = new L.FeatureGroup();
+		var container = L.DomUtil.create("div");
+
+		group.bindTooltip(container, {permanent: true});
+		group.addTo(map);
+
+		var marker1 = new L.Marker([55.8, 37.6]);
+		marker1.addTo(group);
+		expect(map.hasLayer(marker1._tooltip)).to.be(true);
+		expect(marker1._tooltip._container.innerHTML).to.be(container.outerHTML);
+
+		var marker2 = new L.Marker([55.8, 37.6]);
+		marker2.addTo(group);
+		expect(map.hasLayer(marker2._tooltip)).to.be(true);
+		expect(marker2._tooltip._container.innerHTML).to.be(container.outerHTML);
+	});
+
+
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip string after add to map", function () {
 		var group = new L.FeatureGroup().addTo(map);
 		group.bindTooltip("hello", {permanent: true});
 		expect(group._tooltip._container).to.be(undefined);
@@ -233,6 +252,22 @@ describe('Tooltip', function () {
 		marker2.addTo(group);
 		expect(map.hasLayer(marker2._tooltip)).to.be(true);
 		expect(marker2._tooltip._container.innerHTML).to.be("hello");
+	});
+
+	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip container after add to map", function () {
+		var container = L.DomUtil.create("div");
+		var group = new L.FeatureGroup().addTo(map);
+		group.bindTooltip(container, {permanent: true});
+
+		var marker1 = new L.Marker([55.8, 37.6]);
+		marker1.addTo(group);
+		expect(map.hasLayer(marker1._tooltip)).to.be(true);
+		expect(marker1._tooltip._container.innerHTML).to.be(container.outerHTML);
+
+		var marker2 = new L.Marker([55.8, 37.6]);
+		marker2.addTo(group);
+		expect(map.hasLayer(marker2._tooltip)).to.be(true);
+		expect(marker2._tooltip._container.innerHTML).to.be(container.outerHTML);
 	});
 
 	it("opens on polygon mouseover and close on mouseout", function () {

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -211,11 +211,9 @@ describe('Tooltip', function () {
 			return layer.options.description;
 		}, {permanent: true});
 
-		// toggle popup on marker1
 		expect(map.hasLayer(marker1._tooltip)).to.be(true);
 		expect(marker1._tooltip._container.innerHTML).to.be("I'm marker 1.");
 
-		// toggle popup on marker2
 		expect(map.hasLayer(marker2._tooltip)).to.be(true);
 		expect(marker2._tooltip._container.innerHTML).to.be("I'm marker 2.");
 	});

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -202,6 +202,24 @@ describe('Tooltip', function () {
 		expect(group._tooltip._container.innerHTML).to.be("hello");
 	});
 
+	it("it should use a permanent tooltip with a function as content with a FeatureGroup", function () {
+		var marker1 = new L.Marker([55.8, 37.6], {description: "I'm marker 1."});
+		var marker2 = new L.Marker([54.6, 38.2], {description: "I'm marker 2."});
+		var group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+
+		group.bindTooltip(function (layer) {
+			return layer.options.description;
+		}, {permanent: true});
+
+		// toggle popup on marker1
+		expect(map.hasLayer(marker1._tooltip)).to.be(true);
+		expect(marker1._tooltip._container.innerHTML).to.be("I'm marker 1.");
+
+		// toggle popup on marker2
+		expect(map.hasLayer(marker2._tooltip)).to.be(true);
+		expect(marker2._tooltip._container.innerHTML).to.be("I'm marker 2.");
+	});
+
 	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip string before add to map", function () {
 		var group = new L.FeatureGroup();
 		group.bindTooltip("hello", {permanent: true});
@@ -236,7 +254,6 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(marker2._tooltip)).to.be(true);
 		expect(marker2._tooltip._container.innerHTML).to.be(container.outerHTML);
 	});
-
 
 	it("permanent opened tooltips for layers inside a FeatureGroup with binded tooltip string after add to map", function () {
 		var group = new L.FeatureGroup().addTo(map);

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -99,6 +99,16 @@ export var Layer = Evented.extend({
 		this._map = map;
 		this._zoomAnimated = map._zoomAnimated;
 
+		if (this._eventParents) {
+			for (var parentId in this._eventParents) {
+				var parent = this._eventParents[parentId];
+				if (parent._tooltip && parent._tooltip.options.permanent) {
+					this.bindTooltip(parent._tooltip._content,
+						               parent._tooltip.options);
+				}
+			}
+		}
+
 		if (this.getEvents) {
 			var events = this.getEvents();
 			map.on(events, this);

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -1,6 +1,7 @@
 
 import * as Browser from '../core/Browser';
 import {DivOverlay} from './DivOverlay';
+import {FeatureGroup} from './FeatureGroup';
 import {toPoint} from '../geometry/Point';
 import {Map} from '../map/Map';
 import {Layer} from './Layer';
@@ -262,12 +263,11 @@ Layer.include({
 				this._tooltip = new Tooltip(options, this);
 			}
 			this._tooltip.setContent(content);
-
 		}
 
 		this._initTooltipInteractions();
 
-		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this)) {
+		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this) && !(this instanceof FeatureGroup)) {
 			this.openTooltip();
 		}
 
@@ -301,7 +301,7 @@ Layer.include({
 			if (Browser.touch) {
 				events.click = this._openTooltip;
 			}
-		} else {
+		} else if (!(this instanceof FeatureGroup)) {
 			events.add = this._openTooltip;
 		}
 		this[onOff](events);

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -1,7 +1,7 @@
 
 import * as Browser from '../core/Browser';
 import {DivOverlay} from './DivOverlay';
-import {FeatureGroup} from './FeatureGroup';
+import {LayerGroup} from './LayerGroup';
 import {toPoint} from '../geometry/Point';
 import {Map} from '../map/Map';
 import {Layer} from './Layer';
@@ -267,7 +267,7 @@ Layer.include({
 
 		this._initTooltipInteractions();
 
-		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this) && !(this instanceof FeatureGroup)) {
+		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this) && !(this instanceof LayerGroup)) {
 			this.openTooltip();
 		}
 
@@ -301,7 +301,7 @@ Layer.include({
 			if (Browser.touch) {
 				events.click = this._openTooltip;
 			}
-		} else if (!(this instanceof FeatureGroup)) {
+		} else if (!(this instanceof LayerGroup)) {
 			events.add = this._openTooltip;
 		}
 		this[onOff](events);

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -267,8 +267,14 @@ Layer.include({
 
 		this._initTooltipInteractions();
 
-		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this) && !(this instanceof LayerGroup)) {
-			this.openTooltip();
+		if (this._tooltip.options.permanent && this._map && this._map.hasLayer(this)) {
+			if (!(this instanceof LayerGroup)) {
+				this.openTooltip();
+			} else {
+				this.eachLayer(function (layer) {
+					layer.bindTooltip(content, options);
+				});
+			}
 		}
 
 		return this;


### PR DESCRIPTION
As was reported in #6938, when `bindTooltip` is called with `permanent: true` option on a `FeatureGroup` that doesn't have layers inside it, the tooltip tries to open itself and produces an `Unable to get source layer LatLng` error.

This pull fix the bug adding checks that prevents the tooltips open for layers that are instance of `LayerGroup` when `permanent: true` has been defined. The tooltips, in this case, are binded to `Layer` instances on `_layerAdd` methods. I think that this isn't the correct place to handle this exceptions. If so, consider this pull as a POC to fix this issue. 

Closes #6938.