### PR TITLE
Added tooltip rotate option

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -210,28 +210,29 @@ export function testProp(props) {
 // Resets the 3D CSS transform of `el` so it is translated by `offset` pixels
 // and optionally scaled by `scale`. Does not have an effect if the
 // browser doesn't support 3D CSS transforms.
-export function setTransform(el, offset, scale) {
+export function setTransform(el, offset, scale, rotate) {
 	var pos = offset || new Point(0, 0);
 
 	el.style[TRANSFORM] =
 		(Browser.ie3d ?
 			'translate(' + pos.x + 'px,' + pos.y + 'px)' :
 			'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
-		(scale ? ' scale(' + scale + ')' : '');
+		(scale ? ' scale(' + scale + ')' : '') +
+		(rotate ? ' rotate(' + rotate + 'deg)' : '');
 }
 
 // @function setPosition(el: HTMLElement, position: Point)
 // Sets the position of `el` to coordinates specified by `position`,
 // using CSS translate or top/left positioning depending on the browser
 // (used by Leaflet internally to position its layers).
-export function setPosition(el, point) {
+export function setPosition(el, point, rotate) {
 
 	/*eslint-disable */
 	el._leaflet_pos = point;
 	/* eslint-enable */
 
 	if (Browser.any3d) {
-		setTransform(el, point);
+		setTransform(el, point, null, rotate);
 	} else {
 		el.style.left = point.x + 'px';
 		el.style.top = point.y + 'px';

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -63,7 +63,11 @@ export var Tooltip = DivOverlay.extend({
 
 		// @option opacity: Number = 0.9
 		// Tooltip container opacity.
-		opacity: 0.9
+		opacity: 0.9,
+
+		// @option rotate: Number = 0
+		// Tooltip label rotation angle, in degrees.
+		rotate: 0
 	},
 
 	onAdd: function (map) {


### PR DESCRIPTION
Provide the option for a user to define a rotate angle in degrees as part of the standard tooltip options object and, using the existing transform function, will apply a CSS rotate that will provide for vertical or angled tooltip labels.