### PR TITLE
Add move event to setLatLngs and addLatLng

### DIFF
--- a/debug/tests/move_event.html
+++ b/debug/tests/move_event.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script src="../leaflet-include.js"></script>
+	<script src="../../dist/leaflet-src.js"></script>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script>
+
+		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {attribution: osmAttrib});
+
+		var map = L.map('map')
+				.setView([51.505, -0.09], 12)
+				.addLayer(osm);
+
+		var marker = L.marker([51.5, -0.09]).addTo(map);
+
+		var circle = L.circle([51.508, -0.11], 500).addTo(map);
+
+		var circleMarker = L.circleMarker([51.518, -0.05], 10).addTo(map);
+
+		var polygon = L.polygon([
+			[51.509, -0.08],
+			[51.503, -0.06],
+			[51.51, -0.047]
+		]).addTo(map);
+
+		var polyline = L.polyline([
+			[51.5095, -0.085],
+			[51.5035, -0.075]
+		]).addTo(map);
+
+		var rectangle = L.rectangle([
+			[51.519, -0.18],
+			[51.513, -0.16],
+		]).addTo(map);
+
+
+		function logEvent(e) { console.log(e);
+
+		marker.on('move', logEvent);
+		circle.on('move', logEvent);
+		circleMarker.on('move', logEvent);
+		polygon.on('move', logEvent);
+		polyline.on('move', logEvent);
+		rectangle.on('move', logEvent);
+
+		console.log('marker');
+		marker.setLatLng(marker.getLatLng());
+		console.log('circle');
+		circle.setLatLng(circle.getLatLng());
+		console.log('circleMarker');
+		circleMarker.setLatLng(circleMarker.getLatLng());
+		console.log('polyline setLatLngs');
+		polyline.setLatLngs(polyline.getLatLngs());
+		console.log('polyline addLatLng');
+		polyline.addLatLng([51.5035, -0.077]);
+		console.log('polygon');
+		polygon.setLatLngs(polygon.getLatLngs());
+		console.log('rectangle setLatLngs');
+		rectangle.setLatLngs(rectangle.getLatLngs());
+		console.log('rectangle setBounds');
+		rectangle.setBounds(rectangle.getBounds());
+
+	</script>
+</body>
+</html>

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -167,7 +167,7 @@ export var Polyline = Path.extend({
 	// the polyline in case of a multi-polyline, but can be overridden by passing
 	// a specific ring as a LatLng array (that you can earlier access with [`getLatLngs`](#polyline-getlatlngs)).
 	addLatLng: function (latlng, latlngs) {
-		var oldLatLngs = this._latlngs;
+		var oldLatLngs = this._convertLatLngs(this._latlngs);
 		latlngs = latlngs || this._defaultShape();
 		latlng = toLatLng(latlng);
 		latlngs.push(latlng);

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -74,7 +74,9 @@ export var Polyline = Path.extend({
 	// @method setLatLngs(latlngs: LatLng[]): this
 	// Replaces all the points in the polyline with the given array of geographical points.
 	setLatLngs: function (latlngs) {
+		var oldLatLngs = this._latlngs;
 		this._setLatLngs(latlngs);
+		this.fire('move', {oldLatLngs: oldLatLngs, latlngs: this._latlngs});
 		return this.redraw();
 	},
 
@@ -165,10 +167,12 @@ export var Polyline = Path.extend({
 	// the polyline in case of a multi-polyline, but can be overridden by passing
 	// a specific ring as a LatLng array (that you can earlier access with [`getLatLngs`](#polyline-getlatlngs)).
 	addLatLng: function (latlng, latlngs) {
+		var oldLatLngs = this._latlngs;
 		latlngs = latlngs || this._defaultShape();
 		latlng = toLatLng(latlng);
 		latlngs.push(latlng);
 		this._bounds.extend(latlng);
+		this.fire('move', {oldLatLngs: oldLatLngs, latlngs: this._latlngs});
 		return this.redraw();
 	},
 


### PR DESCRIPTION
Adding the `move` event to the `setLatLngs` and `addLatLng` function.
Added because of inconsistent `move` event on `setLatLng`. For more information read #6492

Fixed Issues:
#2235
#6214 
#6492