### PR TITLE
fix tooltipAnchor behavior for different directions

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -131,7 +131,8 @@ export var Tooltip = DivOverlay.extend({
 	_adjustPan: function () {},
 
 	_setPosition: function (pos) {
-		var map = this._map,
+		var subX, subY,
+		    map = this._map,
 		    container = this._container,
 		    centerPoint = map.latLngToContainerPoint(map.getCenter()),
 		    tooltipPoint = map.layerPointToContainerPoint(pos),
@@ -142,18 +143,31 @@ export var Tooltip = DivOverlay.extend({
 		    anchor = this._getAnchor();
 
 		if (direction === 'top') {
-			pos = pos.add(toPoint(-tooltipWidth / 2 + offset.x, -tooltipHeight + offset.y + anchor.y, true));
+			subX = tooltipWidth / 2;
+			subY = tooltipHeight;
 		} else if (direction === 'bottom') {
-			pos = pos.subtract(toPoint(tooltipWidth / 2 - offset.x, -offset.y, true));
+			subX = tooltipWidth / 2;
+			subY = 0;
 		} else if (direction === 'center') {
-			pos = pos.subtract(toPoint(tooltipWidth / 2 + offset.x, tooltipHeight / 2 - anchor.y + offset.y, true));
-		} else if (direction === 'right' || direction === 'auto' && tooltipPoint.x < centerPoint.x) {
+			subX = tooltipWidth / 2;
+			subY = tooltipHeight / 2;
+		} else if (direction === 'right') {
+			subX = 0;
+			subY = tooltipHeight / 2;
+		} else if (direction === 'left') {
+			subX = tooltipWidth;
+			subY = tooltipHeight / 2;
+		} else if (tooltipPoint.x < centerPoint.x) {
 			direction = 'right';
-			pos = pos.add(toPoint(offset.x + anchor.x, anchor.y - tooltipHeight / 2 + offset.y, true));
+			subX = 0;
+			subY = tooltipHeight / 2;
 		} else {
 			direction = 'left';
-			pos = pos.subtract(toPoint(tooltipWidth + anchor.x - offset.x, tooltipHeight / 2 - anchor.y - offset.y, true));
+			subX = tooltipWidth + (offset.x + anchor.x) * 2;
+			subY = tooltipHeight / 2;
 		}
+
+		pos = pos.subtract(toPoint(subX, subY, true)).add(offset).add(anchor);
 
 		DomUtil.removeClass(container, 'leaflet-tooltip-right');
 		DomUtil.removeClass(container, 'leaflet-tooltip-left');


### PR DESCRIPTION
This commit fixes issue #6764, see the discussion and examples there.
It's an alternative implementation for pull request #6116.

It makes `tooltipAnchor` behave the same like `popupAnchor` regardless of the tooltip's direction. With one exception: the `auto` direction flips the `x` axis of `tooltipAnchor` and the tooltip's `offset` when it switches to `left` depending on the position on the screen. `auto` therefore assumes that the icon is somewhat symmetrical to the left and the right of the y axis, which is the case for the default icon.

### Example with this pull request applied

https://jsfiddle.net/emwbsr9j/

#### `auto` to the right
![NEW: auto to the right](https://user-images.githubusercontent.com/8825444/82565084-193d8900-9b7a-11ea-8c5e-0619eab300bd.png)

#### `auto` to the left
![NEW: auto to the left](https://user-images.githubusercontent.com/8825444/82565076-1773c580-9b7a-11ea-9d0d-21705f60edc9.png)

### Old behavior

https://jsfiddle.net/5nycvLez/

#### `auto` to the right
![OLD: auto to the right](https://user-images.githubusercontent.com/8825444/82565575-f2338700-9b7a-11ea-90c5-eeb2a812ee68.png)

#### `auto` to the left
![OLD: auto to the left](https://user-images.githubusercontent.com/8825444/82565588-f790d180-9b7a-11ea-8d4e-3e6a6d4176cf.png)

### Example Code

```js
const map = L.map('map').setView([0.0, 0.0], 12)

const iconBase = {
  iconUrl: 'https://leafletjs.com/docs/images/logo.png',
  iconSize: [120, 31.8], // (600 x 159)/5
  iconAnchor: [60, 15.9], // center
}

const icons = {
  top: L.icon(Object.assign({
    popupAnchor   : [50, -15.9], // top right
    tooltipAnchor : [50, -15.9], // top right
  }, iconBase)),
  bottom: L.icon(Object.assign({
    popupAnchor   : [-3, 15.9], // bottom center
    tooltipAnchor : [-3, 15.9], // bottom center
  }, iconBase)),
  left: L.icon(Object.assign({
    popupAnchor   : [-60, 8], // bottom left
    tooltipAnchor : [-60, 8], // bottom left
  }, iconBase)),
  right: L.icon(Object.assign({
    popupAnchor   : [60, 0], // right
    tooltipAnchor : [60, 0], // right
  }, iconBase)),
  center: L.icon(Object.assign({
    popupAnchor   : [50, -15.9], // top right
    tooltipAnchor : [50, -15.9], // top right
  }, iconBase)),
  auto: L.icon(Object.assign({
    popupAnchor   : [60, 0], // right
    tooltipAnchor : [60, 0], // right
  }, iconBase)),
}

let offset = 0.06
L.marker([offset, 0])
  .bindPopup("default")
  .bindTooltip("default")
  .addTo(map)
  .openTooltip()
for (const k in icons) {
  L.marker([offset -= 0.02, 0], { icon: icons[k] } )
    .bindPopup("popup " + k)
    .bindTooltip("tooltip " + k, { direction: k })
    .addTo(map)
    .openTooltip()
}
```
