### PR TITLE
fix: add module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "uglify-js": "^3.9.2"
   },
   "main": "dist/leaflet-src.js",
+  "module": "dist/leaflet-src.esm.js",
   "style": "dist/leaflet.css",
   "files": [
     "dist",


### PR DESCRIPTION
Adds support for rollup, es-dev-server, and more.

closes #7055 