### PR TITLE
new plugin "leaflet-geoserver-request"

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4452,6 +4452,16 @@ Ease your development integrating Leaflet into a development framework or automa
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/iamtekson/L.Geoserver">leaflet-geoserver-request</a>
+		</td><td>
+			Geoserver requests in the leaflet map. wms,wfs, legend, wmsImage request on the leaflet. 
+		<a href="https://iamtekson.github.io/L.Geoserver/examples/maps.html">Demo</a>
+		</td><td>
+			<a href="https://github.com/iamtekson">Iamtekson</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/PaulLeCam/react-leaflet">react-leaflet</a>
 		</td><td>
 			<a href="https://facebook.github.io/react/">React</a> components for Leaflet maps.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4452,10 +4452,10 @@ Ease your development integrating Leaflet into a development framework or automa
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/iamtekson/L.Geoserver">leaflet-geoserver-request</a>
+			<a href="https://github.com/iamtekson/leaflet-geoserver-request">leaflet-geoserver-request</a>
 		</td><td>
-			Geoserver requests in the leaflet map. wms,wfs, legend, wmsImage request on the leaflet. 
-		<a href="https://iamtekson.github.io/L.Geoserver/examples/maps.html">Demo</a>
+			Basic geoserver requests in leaflet. Currently supports wms, wfs, legend, wmsImage request on the leaflet. 
+		<a href="https://iamtekson.github.io/leaflet-geoserver-request/examples/maps.html">Demo</a>
 		</td><td>
 			<a href="https://github.com/iamtekson">Iamtekson</a>
 		</td>


### PR DESCRIPTION
This is the plugin for various kind of GeoServer requests on leaflet map. For now, it has only four requests, i.e. wms, wfs, legend, wmsImage.