### PR TITLE
Move worldCopyJump to L.Map, make it work when zooming.

### DIFF
--- a/debug/leaflet-src.js.map
+++ b/debug/leaflet-src.js.map
@@ -1,0 +1,1 @@
+../dist/leaflet-src.js.map

--- a/debug/tests/dragging_and_copyworldjump.html
+++ b/debug/tests/dragging_and_copyworldjump.html
@@ -19,8 +19,8 @@
 		<button id="foo">
 			Click to enable dragging on the right map, then dragging around and watch copying
 		</button><br>
-		<div id="map1" style="height: 300px;width: 400px; float:left;"></div>
-		<div id="map2" style="height: 300px;width: 400px; float:left; margin-left: 10px;"></div>
+		<div id="map1" style="height: 300px;width: 40vw; float:left;"></div>
+		<div id="map2" style="height: 300px;width: 40vw; float:left; margin-left: 10px;"></div>
 		<div style="clear:both"></div>
 
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -120,7 +120,13 @@ export var Map = Evented.extend({
 
 		// @option trackResize: Boolean = true
 		// Whether the map automatically handles browser window resize to update itself.
-		trackResize: true
+		trackResize: true,
+
+		// @option worldCopyJump: Boolean = false
+		// With this option enabled, the map tracks when you pan/zoom to another
+		// "copy" of the world and seamlessly jumps to the original one so that
+		// all overlays like markers and vector layers are still visible.
+		worldCopyJump: false
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)
@@ -1248,6 +1254,14 @@ export var Map = Evented.extend({
 	},
 
 	_moveEnd: function (zoomChanged) {
+		if (this.options.worldCopyJump) {
+			var center = this.getCenter();
+			var wrappedCenter = this.wrapLatLng(center);
+			if (!center.equals(wrappedCenter)) {
+				this.panTo(wrappedCenter, {animate: false});
+			}
+		}
+
 		// @event zoomend: Event
 		// Fired when the map has changed, after any animations.
 		if (zoomChanged) {

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -37,13 +37,6 @@ Map.mergeOptions({
 	// @option easeLinearity: Number = 0.2
 	easeLinearity: 0.2,
 
-	// TODO refactor, move to CRS
-	// @option worldCopyJump: Boolean = false
-	// With this option enabled, the map tracks when you pan to another "copy"
-	// of the world and seamlessly jumps to the original one so that all overlays
-	// like markers and vector layers are still visible.
-	worldCopyJump: false,
-
 	// @option maxBoundsViscosity: Number = 0.0
 	// If `maxBounds` is set, this option will control how solid the bounds
 	// are when dragging the map around. The default value of `0.0` allows the
@@ -171,7 +164,6 @@ export var Drag = Handler.extend({
 	},
 
 	_onPreDragWrap: function () {
-		// TODO refactor to be able to adjust map pane position after zoom
 		var worldWidth = this._worldWidth,
 		    halfWidth = Math.round(worldWidth / 2),
 		    dx = this._initialWorldOffset,


### PR DESCRIPTION
As prompted by https://stackoverflow.com/questions/62764699/can-leaflet-jump-to-new-world-copy-on-zoom-instead-of-just-on-panning . 

I have tested it with mouse only - at the moment I do lack a tablet (or any other big multipointer input device). I would appreciate a bit of manual testing of this:

- Check out the branch
- Do the build (`npm run rollup`)
- Manually open `debug/tests/dragging_and_copyworldjump.html` in a browser
- Do a bunch of pinch-zoom operations (including one-finger dragging before and after the second finger for the pinch is down)

