### PR TITLE
Rely on CSS backgrounds for the default icon images

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -393,8 +393,14 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 /* Default icon URLs */
-.leaflet-default-icon-path {
+.leaflet-marker-icon.leaflet-default-icon {
 	background-image: url(images/marker-icon.png);
+	}
+.leaflet-retina .leaflet-marker-icon.leaflet-default-icon {
+	background-image: url(images/marker-icon-2x.png);
+	}
+.leaflet-marker-shadow.leaflet-default-icon{
+	background-image: url(images/marker-shadow.png);
 	}
 
 

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -1,6 +1,8 @@
 import {Icon} from './Icon';
 import * as DomUtil from '../../dom/DomUtil';
 
+var emptyImageUrl = 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==';
+
 /*
  * @miniclass Icon.Default (Icon)
  * @aka L.Icon.Default
@@ -20,41 +22,14 @@ import * as DomUtil from '../../dom/DomUtil';
 export var IconDefault = Icon.extend({
 
 	options: {
-		iconUrl:       'marker-icon.png',
-		iconRetinaUrl: 'marker-icon-2x.png',
-		shadowUrl:     'marker-shadow.png',
+		iconUrl:     emptyImageUrl,
+		shadowUrl:   emptyImageUrl,
 		iconSize:    [25, 41],
 		iconAnchor:  [12, 41],
 		popupAnchor: [1, -34],
 		tooltipAnchor: [16, -28],
-		shadowSize:  [41, 41]
+		shadowSize:  [41, 41],
+		className:   'leaflet-default-icon'
 	},
 
-	_getIconUrl: function (name) {
-		if (!IconDefault.imagePath) {	// Deprecated, backwards-compatibility only
-			IconDefault.imagePath = this._detectIconPath();
-		}
-
-		// @option imagePath: String
-		// `Icon.Default` will try to auto-detect the location of the
-		// blue icon images. If you are placing these images in a non-standard
-		// way, set this option to point to the right path.
-		return (this.options.imagePath || IconDefault.imagePath) + Icon.prototype._getIconUrl.call(this, name);
-	},
-
-	_detectIconPath: function () {
-		var el = DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-		var path = DomUtil.getStyle(el, 'background-image') ||
-		           DomUtil.getStyle(el, 'backgroundImage');	// IE8
-
-		document.body.removeChild(el);
-
-		if (path === null || path.indexOf('url') !== 0) {
-			path = '';
-		} else {
-			path = path.replace(/^url\(["']?/, '').replace(/marker-icon\.png["']?\)$/, '');
-		}
-
-		return path;
-	}
 });


### PR DESCRIPTION
Another approach for #7202, taking inspiration in how the image for the layers control is loaded only via CSS.

This has the advantage that smartypants bundlers (webpack and the like) might be able to pick references to external assets from the `background-image: url(foo)` CSS rules and automagically copy them around.

This was a quick test, so I haven't given much thought on the compatibility issues of (now missing) `L.Icon.Default.imagePath` :confused: 