### PR TITLE
Align documentation reference expander icons with labels texts.

### DIFF
--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -31,6 +31,7 @@ label {
 div.accordion > div.accordion-overflow > div.accordion-content {
     max-height: 0;
     display: none;
+    pointer-events: none;
 }
 
 div.accordion.collapsed > div.accordion-overflow > div.accordion-content {
@@ -48,6 +49,7 @@ div.accordion.expanded > div.accordion-overflow > div.accordion-content {
 /* 		height: auto; */
     max-height: none;
     display: block;
+    pointer-events: fill;
 }
 
 @keyframes collapse {
@@ -72,6 +74,8 @@ div.accordion > label > span.expander {
     transition: transform 0.4s ease-out 0s;
     display: inline-block;
     font-size: 12px;
+    position: relative;
+    top: -2px;
 }
 
 

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -68,14 +68,15 @@ div.accordion.expanded > div.accordion-overflow > div.accordion-content {
 
 div.accordion.expanded > label > span.expander {
     transform: rotate(90deg);
+    top: 1px;
 }
 
 div.accordion > label > span.expander {
-    transition: transform 0.4s ease-out 0s;
+    transition: transform 0.4s ease-out 0s, top 0.4s ease-out 0s;
     display: inline-block;
     font-size: 12px;
     position: relative;
-    top: -2px;
+    top: -3px;
 }
 
 

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -68,7 +68,7 @@ div.accordion.expanded > div.accordion-overflow > div.accordion-content {
 
 div.accordion.expanded > label > span.expander {
     transform: rotate(90deg);
-    top: 1px;
+    top: 0px;
 }
 
 div.accordion > label > span.expander {


### PR DESCRIPTION
## Before

![leaflet-doc-before](https://user-images.githubusercontent.com/23049315/88048746-2bc14800-cb54-11ea-8fc7-c9f39f6cd9ec.gif)

## After

![leaflet-doc-after](https://user-images.githubusercontent.com/23049315/88048761-31b72900-cb54-11ea-9e01-09b65fb3b7f9.gif)
