### PR TITLE
add space to character regex for template

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -229,9 +229,10 @@ describe('Util', function () {
 			}).to.throwError();
 		});
 
-		it('allows underscores and dashes in placeholders', function () {
+		it('allows underscores, dashes and spaces in placeholders', function () {
 			expect(L.Util.template('{nice_stuff}', {'nice_stuff': 'foo'})).to.eql('foo');
 			expect(L.Util.template('{-y}', {'-y': 1})).to.eql('1');
+			expect(L.Util.template('{Day Of Month}', {'Day Of Month': 30})).to.eql('30');
 		});
 	});
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -152,7 +152,7 @@ export function getParamString(obj, existingUrl, uppercase) {
 	return ((!existingUrl || existingUrl.indexOf('?') === -1) ? '?' : '&') + params.join('&');
 }
 
-var templateRe = /\{ *([\w_-]+) *\}/g;
+var templateRe = /\{ *([\w_ -]+) *\}/g;
 
 // @function template(str: String, data: Object): String
 // Simple templating facility, accepts a template string of the form `'Hello {a}, {b}'`


### PR DESCRIPTION
In order to allow substitution of Object keys containing spaces (can be external JSON data outside of control) to be used for templating of URLs