### PR TITLE
Fix exception on FeatureGroup getBounds() with LayerGroup/FeatureGroup as child

### DIFF
--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -84,7 +84,7 @@
 			expect(fg.hasLayer(marker)).to.be(false);
 		});
 	});
-	
+
 	describe('getBounds', function () {
 		it('returns the bounds (latlng) of the group', function () {
 			var fg = L.featureGroup([
@@ -96,12 +96,12 @@
 			]);
 
 			var southWest = new L.LatLng(0, 0),
-				northEast = new L.LatLng(4, 4);
-			
-			var bounds = new L.LatLngBounds(southWest, northEast);			
+			    northEast = new L.LatLng(4, 4);
+
+			var bounds = new L.LatLngBounds(southWest, northEast);
 			expect(fg.getBounds()).to.eql(bounds);
 		});
-		
+
 		it('returns the bounds (LatLng) of the group', function () {
 			var fg = L.featureGroup([
 				L.marker([0, 0]),
@@ -112,43 +112,43 @@
 			]);
 
 			var southWest = new L.LatLng(0, 0),
-				northEast = new L.LatLng(4, 4);
-			
-			var bounds = new L.LatLngBounds(southWest, northEast);			
+			    northEast = new L.LatLng(4, 4);
+
+			var bounds = new L.LatLngBounds(southWest, northEast);
 			expect(fg.getBounds()).to.eql(bounds);
 		});
 
-		describe('when a FeatureGroup contains a LayerGroup as children', function(){
-			it("returns the bounds (LatLng) of the group, including group member's child layers", function(){
-				var parentFeatureGroup = L.featureGroup([ L.marker([-23, -102]) ]);
+		describe('when a FeatureGroup contains a LayerGroup as children', function () {
+			it("returns the bounds (LatLng) of the group, including group member's child layers", function () {
+				var parentFeatureGroup = L.featureGroup([L.marker([-23, -102])]);
 
-				var layerGroupWithChildren = L.layerGroup([
+				L.layerGroup([
 					L.marker([39.61, -105.02]),
 					L.marker([39.74, -104.99]),
 					L.marker([39.73, -104.8]),
 					L.marker([39.77, -105.23]),
-				]).addTo(parentFeatureGroup)
+				]).addTo(parentFeatureGroup);
 
 				var bounds = new L.LatLngBounds(
-					new L.LatLng(-23, -105.23), 
+					new L.LatLng(-23, -105.23),
 					new L.LatLng(39.77, -102)
-				);			
+				);
 				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
-			})
+			});
 		});
-		
-		describe('when a FeatureGroup contains nested LayerGroups/FeatureGroups as children', function(){
-			it("returns the bounds (LatLng) of the group, including bounds of nested groups' child layers", function(){
+
+		describe('when a FeatureGroup contains nested LayerGroups/FeatureGroups as children', function () {
+			it("returns the bounds (LatLng) of the group, including bounds of nested groups' child layers", function () {
 				var parentFeatureGroup = L.featureGroup();
 
-				var layerGroupWithChildren = L.layerGroup([
+				L.layerGroup([
 					L.marker([39.61, -105.02]),
 					L.marker([39.74, -104.99]),
 					L.marker([39.73, -104.8]),
 					L.marker([39.77, -105.23]),
-				]).addTo(parentFeatureGroup)
-				
-				var layerGroupWithNestedGroups = L.layerGroup([
+				]).addTo(parentFeatureGroup);
+
+				L.layerGroup([
 					L.marker([39.72, -103.31]),
 					L.layerGroup([
 						L.marker([39.51, -104]),
@@ -160,9 +160,9 @@
 						L.marker([42, -104]),
 					]),
 					L.marker([39.77, -105.32]),
-				]).addTo(parentFeatureGroup)
-				
-				var featureGroupWithNestedGroups = L.layerGroup([
+				]).addTo(parentFeatureGroup);
+
+				L.layerGroup([
 					L.marker([39.72, -103.31]),
 					L.layerGroup([
 						L.marker([39.51, -104]),
@@ -173,16 +173,16 @@
 							L.marker([39, -55]),
 							L.marker([39, -55.6]),
 							L.marker([39.2, -50]),
-						])	
+						])
 					]),
-				]).addTo(parentFeatureGroup)
+				]).addTo(parentFeatureGroup);
 
 				var bounds = new L.LatLngBounds(
-					new L.LatLng(39, -106), 
+					new L.LatLng(39, -106),
 					new L.LatLng(43.5, -50)
 				);
 				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
-			})
+			});
 		});
 	});
 });

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -84,4 +84,105 @@
 			expect(fg.hasLayer(marker)).to.be(false);
 		});
 	});
+	
+	describe('getBounds', function () {
+		it('returns the bounds (latlng) of the group', function () {
+			var fg = L.featureGroup([
+				L.marker([0, 0]),
+				L.marker([4, 4]),
+				L.marker([3, 3]),
+				L.marker([2, 2]),
+				L.marker([1, 1]),
+			]);
+
+			var southWest = new L.LatLng(0, 0),
+				northEast = new L.LatLng(4, 4);
+			
+			var bounds = new L.LatLngBounds(southWest, northEast);			
+			expect(fg.getBounds()).to.eql(bounds);
+		});
+		
+		it('returns the bounds (LatLng) of the group', function () {
+			var fg = L.featureGroup([
+				L.marker([0, 0]),
+				L.marker([4, 4]),
+				L.marker([3, 3]),
+				L.marker([2, 2]),
+				L.marker([1, 1]),
+			]);
+
+			var southWest = new L.LatLng(0, 0),
+				northEast = new L.LatLng(4, 4);
+			
+			var bounds = new L.LatLngBounds(southWest, northEast);			
+			expect(fg.getBounds()).to.eql(bounds);
+		});
+
+		describe('when a FeatureGroup contains a LayerGroup as children', function(){
+			it("returns the bounds (LatLng) of the group, including group member's child layers", function(){
+				var parentFeatureGroup = L.featureGroup([ L.marker([-23, -102]) ]);
+
+				var layerGroupWithChildren = L.layerGroup([
+					L.marker([39.61, -105.02]),
+					L.marker([39.74, -104.99]),
+					L.marker([39.73, -104.8]),
+					L.marker([39.77, -105.23]),
+				]).addTo(parentFeatureGroup)
+
+				var bounds = new L.LatLngBounds(
+					new L.LatLng(-23, -105.23), 
+					new L.LatLng(39.77, -102)
+				);			
+				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
+			})
+		});
+		
+		describe('when a FeatureGroup contains nested LayerGroups/FeatureGroups as children', function(){
+			it("returns the bounds (LatLng) of the group, including bounds of nested groups' child layers", function(){
+				var parentFeatureGroup = L.featureGroup();
+
+				var layerGroupWithChildren = L.layerGroup([
+					L.marker([39.61, -105.02]),
+					L.marker([39.74, -104.99]),
+					L.marker([39.73, -104.8]),
+					L.marker([39.77, -105.23]),
+				]).addTo(parentFeatureGroup)
+				
+				var layerGroupWithNestedGroups = L.layerGroup([
+					L.marker([39.72, -103.31]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([39.52, -106]),
+					]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([39.5, -103]),
+						L.marker([42, -104]),
+					]),
+					L.marker([39.77, -105.32]),
+				]).addTo(parentFeatureGroup)
+				
+				var featureGroupWithNestedGroups = L.layerGroup([
+					L.marker([39.72, -103.31]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([43.5, -103]),
+					]),
+					L.featureGroup([
+						L.featureGroup([
+							L.marker([39, -55]),
+							L.marker([39, -55.6]),
+							L.marker([39.2, -50]),
+						])	
+					]),
+				]).addTo(parentFeatureGroup)
+
+				var bounds = new L.LatLngBounds(
+					new L.LatLng(39, -106), 
+					new L.LatLng(43.5, -50)
+				);
+				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
+			})
+		});
+	});
 });

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -184,5 +184,56 @@
 				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
 			});
 		});
+
+		describe('when a FeatureGroup contains nested LayerGroups/FeatureGroups as children with self references (circular structure)', function () {
+			it("returns the bounds (LatLng) of the group, including bounds of nested groups' child layers, while avoiding circular references", function () {
+				var parentFeatureGroup = L.featureGroup();
+
+				L.layerGroup([
+					L.marker([39.61, -105.02]),
+					L.marker([39.74, -104.99]),
+					L.marker([39.73, -104.8]),
+					L.marker([39.77, -105.23]),
+				]).addTo(parentFeatureGroup);
+
+				var nestedGroup = L.layerGroup([
+					L.marker([39.72, -103.31]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([39.52, -106]),
+					]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([39.5, -103]),
+						L.marker([42, -104]),
+					]),
+					L.marker([39.77, -105.32]),
+				]);
+
+				nestedGroup.addTo(parentFeatureGroup);
+				parentFeatureGroup.addTo(nestedGroup);
+
+				L.layerGroup([
+					L.marker([39.72, -103.31]),
+					L.layerGroup([
+						L.marker([39.51, -104]),
+						L.marker([43.5, -103]),
+					]),
+					L.featureGroup([
+						L.featureGroup([
+							L.marker([39, -55]),
+							L.marker([39, -55.6]),
+							L.marker([39.2, -50]),
+						])
+					]),
+				]).addTo(parentFeatureGroup);
+
+				var bounds = new L.LatLngBounds(
+					new L.LatLng(39, -106),
+					new L.LatLng(43.5, -50)
+				);
+				expect(parentFeatureGroup.getBounds()).to.eql(bounds);
+			});
+		});
 	});
 });

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -81,7 +81,7 @@ export var FeatureGroup = LayerGroup.extend({
 
 		for (var id in this._layers) {
 			var layer = this._layers[id];
-			if (layer instanceof LayerGroup){
+			if (layer instanceof LayerGroup) {
 				bounds.extend(FeatureGroup.prototype.getBounds.call(layer));
 			} else {
 				bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -81,7 +81,11 @@ export var FeatureGroup = LayerGroup.extend({
 
 		for (var id in this._layers) {
 			var layer = this._layers[id];
-			bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());
+			if (layer instanceof LayerGroup){
+				bounds.extend(FeatureGroup.prototype.getBounds.call(layer));
+			} else {
+				bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());
+			}
 		}
 		return bounds;
 	}

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -77,12 +77,17 @@ export var FeatureGroup = LayerGroup.extend({
 	// @method getBounds(): LatLngBounds
 	// Returns the LatLngBounds of the Feature Group (created from bounds and coordinates of its children).
 	getBounds: function () {
+		var traversedIds = arguments.length ? arguments[0] : [this._leaflet_id.toString()];
 		var bounds = new LatLngBounds();
 
 		for (var id in this._layers) {
+			if (traversedIds.indexOf(id) !== -1) {
+				continue;
+			}
+			traversedIds.push(id);
 			var layer = this._layers[id];
 			if (layer instanceof LayerGroup) {
-				bounds.extend(FeatureGroup.prototype.getBounds.call(layer));
+				bounds.extend(FeatureGroup.prototype.getBounds.call(layer, traversedIds));
 			} else {
 				bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());
 			}


### PR DESCRIPTION
Added logic to handle groups (LayerGroup/FeatureGroup) as children of a FeatureGroup. It will also work with nested groups.
Unit tests were also added to check the new logic. There was no need to modify the documentation, since the current one already expected such behaviour.

This PR fixes #7228.