### PR TITLE
New plugin: Add Leaflet.Legend

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4002,6 +4002,18 @@ Buttons, sliders, toolbars, sidebars, and panels.
 			<a href="https://github.com/publiclab">Public Lab</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/ptma/Leaflet.Legend">Leaflet.Legend
+			</a>
+		</td>
+		<td>
+			Display legend symbols and toggle overlays(<a href="https://ptma.github.io/Leaflet.Legend/examples/legend.html">Demo</a>).
+		</td>
+		<td>
+			<a href="https://github.com/ptma">JJ Jin</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Leaflet.Legend is a plugin for Leaflet that display legend symbols and toggle overlays.