### PR TITLE
fix (Keyboard): Allow WCAG21 focus visible criteria for keyboard navigation - fixes #6986

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1389,7 +1389,7 @@ export var Map = Evented.extend({
 
 		var type = e.type;
 
-		if (type === 'mousedown' || type === 'keypress' || type === 'keyup' || type === 'keydown') {
+		if (type === 'mousedown') {
 			// prevents outline when clicking on keyboard-focusable element
 			DomUtil.preventOutline(e.target || e.srcElement);
 		}


### PR DESCRIPTION
Allow WCAG21 focus visible criteria for keyboard navigation by not stripping outline on focus for keyboard events, only mouse events.

For issue #6986 

https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html
