### PR TITLE
Fix excessive click in desktop Safari

### DIFF
--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -131,6 +131,7 @@ export var Tap = Handler.extend({
 // @section Handlers
 // @property tap: Handler
 // Mobile touch hacks (quick tap and touch hold) handler.
-if (Browser.touch && (!Browser.pointer || Browser.safari)) {
+var iOS = Browser.safari && Browser.mobile;
+if (Browser.touch && (!Browser.pointer || iOS)) {
 	Map.addInitHook('addHandler', 'tap', Tap);
 }


### PR DESCRIPTION
Tap handler is useful only in iOS

Fix #7255
