### PR TITLE
Disable tap handler by default, except in mobile Safari

### DIFF
--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -15,10 +15,12 @@ import * as Browser from '../../core/Browser';
 // @section Interaction Options
 Map.mergeOptions({
 	// @section Touch interaction options
-	// @option tap: Boolean = true
+	// @option tap: Boolean
 	// Enables mobile hacks for supporting instant taps (fixing 200ms click
 	// delay on iOS/Android) and touch holds (fired as `contextmenu` events).
-	tap: true,
+	// This is legacy option, by default enabled in mobile Safari only
+	// (because we still need `contextmenu` simulation for iOS).
+	tap: Browser.safari && Browser.mobile,
 
 	// @option tapTolerance: Number = 15
 	// The max number of pixels a user can shift his finger during touch
@@ -131,7 +133,4 @@ export var Tap = Handler.extend({
 // @section Handlers
 // @property tap: Handler
 // Mobile touch hacks (quick tap and touch hold) handler.
-var iOS = Browser.safari && Browser.mobile;
-if (Browser.touch && (!Browser.pointer || iOS)) {
-	Map.addInitHook('addHandler', 'tap', Tap);
-}
+Map.addInitHook('addHandler', 'tap', Tap);


### PR DESCRIPTION
Atm it is still needed to simulate taphold in iOS

Fix #7262, close #7255.

To maintainers: consider alternative #7026.
More context: 6980.
