### PR TITLE
Refactor vmlCreate() so that it does not leak closure to `TypeError`

### DIFF
--- a/src/layer/vector/SVG.VML.js
+++ b/src/layer/vector/SVG.VML.js
@@ -14,10 +14,12 @@ export var vmlCreate = (function () {
 			return document.createElement('<lvml:' + name + ' class="lvml">');
 		};
 	} catch (e) {
-		return function (name) {
-			return document.createElement('<' + name + ' xmlns="urn:schemas-microsoft.com:vml" class="lvml">');
-		};
+		// Do not return fn from catch block so `e` can be garbage collected
+		// See https://github.com/Leaflet/Leaflet/pull/7279
 	}
+	return function (name) {
+		return document.createElement('<' + name + ' xmlns="urn:schemas-microsoft.com:vml" class="lvml">');
+	};
 })();
 
 


### PR DESCRIPTION
When `document.namespaces.add()` throws `TypeError: Cannot read property 'add' of undefined`, the `TypeError` persists in the memory heap snapshot.  

I am not sure why Google Chrome does not garbage collect this `TypeError` because clearly it is not used in the returned fn. But if you look at memory Heap snapshot, you can see it persists after garbage collection.
* Try it with any leaflet map such as https://leafletjs.com/ and search heap snapshot for 'TypeError' and you will see it was never garbage collected after this simple feature test was performed.
![image](https://user-images.githubusercontent.com/945058/93382421-19038080-f830-11ea-9292-3567818ac1e5.png)

With this change, the `TypeError` is garbage collected and not in memory heap snapshot.

I don't think it's serious... but the change is simple and with the change I can easily see the `TypeError` is removed from the heap snapshot in my application.