### PR TITLE
Fix: Tooltips can rely on parent layer getBounds() too, so they work on ImageOverlays

### DIFF
--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -177,6 +177,8 @@ export var DivOverlay = Layer.extend({
 				latlng = layer.getCenter();
 			} else if (layer.getLatLng) {
 				latlng = layer.getLatLng();
+			} else if (layer.getBounds) {
+				latlng = layer.getBounds().getCenter();
 			} else {
 				throw new Error('Unable to get source layer LatLng.');
 			}


### PR DESCRIPTION
Fixes #6780