### PR TITLE
simplify code contributions & reviews by fully automating the dev setup.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+tasks:
+  - name: Rollup
+    init: npm install
+    command: npm run watch
+  - name: Docs
+    init: |
+      gem install jekyll
+      cd docs/
+      bundle install
+    command: jekyll serve --watch
+      
+ports: 
+  - port: 4000
+    onOpen: open-preview

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,16 @@ and ask yourself two questions:
 If your feature or API improvement did get merged into master,
 please consider submitting another pull request with the corresponding [documentation update](#improving-documentation).
 
+### Online one-click Setup for contributing
+
+You can use [Gitpod](https://www.gitpod.io/) (an Online Open Source VS Code-like IDE which is free for Open Source) for working on issues and making PRs to this project online. With a single click it will start a workspace and automatically:
+
+- clone this repo. 
+- install all the dependencies i.e jykell, node modules and all the ruby gems.
+- run `npm run watch` and `jykell serve watch` in isolated terminals.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Setting up the Build System
 
 The Leaflet build system uses [NodeJS](http://nodejs.org/).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Let's make the best mapping library that will ever exist,
 and push the limits of what's possible with online maps!
 
 [![Build Status](https://travis-ci.org/Leaflet/Leaflet.svg?branch=master)](https://travis-ci.org/Leaflet/Leaflet)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 
  [contributors]: https://github.com/Leaflet/Leaflet/graphs/contributors
  [features]: http://leafletjs.com/#features


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone this repo. 
- install all the dependencies i.e jykell, node modules and all the ruby gems.
- run `npm run watch` to start Rollup and `jykell serve watch` to serve the docs in isolated terminals.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/Leaflet

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95290993-ffca7e80-0887-11eb-9ba7-12ef9342487d.png)


 
