### PR TITLE
Allow pass custom function in locate to get coordinates

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -663,24 +663,19 @@ export var Map = Evented.extend({
 					.then(function (locationWatchId) {
 						this._locationWatchId = locationWatchId;
 					});
-
 			} else {
 				options.getCoordinates(options)
 					.then(function (pos) {
 						onResponse(pos);
-
 					}).catch(function (error) {
 						onError(error);
-
 					});
 			}
 		} else if (options.watch) {
 			this._locationWatchId =
 				navigator.geolocation.watchPosition(onResponse, onError, options);
-
 		} else {
 			navigator.geolocation.getCurrentPosition(onResponse, onError, options);
-
 		}
 		return this;
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -655,13 +655,32 @@ export var Map = Evented.extend({
 		}
 
 		var onResponse = Util.bind(this._handleGeolocationResponse, this),
-		    onError = Util.bind(this._handleGeolocationError, this);
+			onError = Util.bind(this._handleGeolocationError, this);
 
-		if (options.watch) {
+		if (options.getCoordinates) {
+			if (options.watch) {
+				options.getCoordinates(options)
+					.then(function (locationWatchId) {
+						this._locationWatchId = locationWatchId;
+					});
+
+			} else {
+				options.getCoordinates(options)
+					.then(function (pos) {
+						onResponse(pos);
+
+					}).catch(function (error) {
+						onError(error);
+
+					});
+			}
+		} else if (options.watch) {
 			this._locationWatchId =
-			        navigator.geolocation.watchPosition(onResponse, onError, options);
+				navigator.geolocation.watchPosition(onResponse, onError, options);
+
 		} else {
 			navigator.geolocation.getCurrentPosition(onResponse, onError, options);
+
 		}
 		return this;
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -655,7 +655,7 @@ export var Map = Evented.extend({
 		}
 
 		var onResponse = Util.bind(this._handleGeolocationResponse, this),
-			onError = Util.bind(this._handleGeolocationError, this);
+		    onError = Util.bind(this._handleGeolocationError, this);
 
 		if (options.getCoordinates) {
 			if (options.watch) {
@@ -673,7 +673,7 @@ export var Map = Evented.extend({
 			}
 		} else if (options.watch) {
 			this._locationWatchId =
-				navigator.geolocation.watchPosition(onResponse, onError, options);
+			    navigator.geolocation.watchPosition(onResponse, onError, options);
 		} else {
 			navigator.geolocation.getCurrentPosition(onResponse, onError, options);
 		}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -659,17 +659,11 @@ export var Map = Evented.extend({
 
 		if (options.getCoordinates) {
 			if (options.watch) {
-				options.getCoordinates(options)
-					.then(function (locationWatchId) {
-						this._locationWatchId = locationWatchId;
-					});
+				this._locationWatchId = options.getCoordinates(options, onResponse);
 			} else {
 				options.getCoordinates(options)
-					.then(function (pos) {
-						onResponse(pos);
-					}).catch(function (error) {
-						onError(error);
-					});
+					.then(onResponse)
+					.catch(onError);
 			}
 		} else if (options.watch) {
 			this._locationWatchId =


### PR DESCRIPTION
Allow to pass a custom function to get coordinates, this allow leaflet to work with Capacitor like this.

The getCoordinates must return a Promise.

```js
this.map.locate({
    getCoordinates: async (options, callback) => {
        return Geolocation.getCurrentPosition(options); // Return the same as navigator.geolocation.getCurrentPosition();
        // return Geolocation.watchPosition(options, callback); // If you want to watch
    },
   // watch: true
})
```

Resolves #7296. 