### PR TITLE
Add lineToLayer and polygonToLayer options to GeoJSON layer

### DIFF
--- a/docs/examples/geojson/example.md
+++ b/docs/examples/geojson/example.md
@@ -65,7 +65,16 @@ title: GeoJSON tutorial
 			return false;
 		},
 
-		onEachFeature: onEachFeature
+		onEachFeature: onEachFeature,
+
+		lineToLayer: function (feature, latlngs) {
+			console.log('lineToLayer');
+	    	return L.polyline(latlngs, {
+	    		color: "#FF00FF",
+	    		weight: 4,
+				opacity: 1
+		    })
+		}
 	}).addTo(map);
 
 	var coorsLayer = L.geoJSON(coorsField, {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -104,6 +104,12 @@ export var GeoJSON = FeatureGroup.extend({
 	 *
 	 * @option markersInheritOptions: Boolean = false
 	 * Whether default Markers for "Point" type Features inherit from group options.
+   *
+   * @option linesInheritOptions: Boolean = true
+	 * Whether default Markers for "Polyline" type Features inherit from group options.
+   *
+   * @option polygonsInheritOptions: Boolean = true
+	 * Whether default Markers for "Polygon" type Features inherit from group options.
 	 */
 
 	initialize: function (geojson, options) {
@@ -257,13 +263,13 @@ function _pointToLayer(pointToLayerFn, geojson, latlng, options) {
 function _lineToLayer(lineToLayerFn, geojson, latlngs, options) {
 	return lineToLayerFn ?
 		lineToLayerFn(geojson, latlngs) :
-		new Polyline(latlngs, options && options.markersInheritOptions && options);
+		new Polyline(latlngs, options && options.linesInheritOptions && options);
 }
 
 function _polygonToLayer(polygonToLayerFn, geojson, latlngs, options) {
 	return polygonToLayerFn ?
 		polygonToLayerFn(geojson, latlngs) :
-		new Polygon(latlngs, options && options.markersInheritOptions && options);
+		new Polygon(latlngs, options && options.polygonsInheritOptions && options);
 }
 
 // @function coordsToLatLng(coords: Array): LatLng

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -46,26 +46,26 @@ export var GeoJSON = FeatureGroup.extend({
 	 * 	return L.marker(latlng);
 	 * }
 	 * ```
-	 * 
+	 *
 	 * @option lineToLayer: Function = *
 	 * A `Function` defining how GeoJSON LineString and MultiLineString geometry types
 	 * spawn Leaflet layers. It is internally called when data is added,
 	 * passing the GeoJSON line feature and its `LatLngs`.
-	 * The default is to spawn a default `Marker`:
+	 * The default is to spawn a default `Polyline`:
 	 * ```js
 	 * function(geoJsonLine, latlngs) {
-	 * 	return L.marker(latlng);
+	 * 	return L.polyline(latlng);
 	 * }
 	 * ```
-	 * 
+	 *
 	 * @option polygonToLayer: Function = *
 	 * A `Function` defining how GeoJSON Polygon and MultiPolygon geometry types
 	 * spawn Leaflet layers. It is internally called when data is added,
 	 * passing the GeoJSON polygon feature and its `LatLngs`.
-	 * The default is to spawn a default `Marker`:
+	 * The default is to spawn a default `Polygon`:
 	 * ```js
 	 * function(geoJsonPolygon, latlngs) {
-	 * 	return L.marker(latlngs);
+	 * 	return L.polygon(latlngs);
 	 * }
 	 * ```
 	 *
@@ -199,6 +199,7 @@ export function geometryToLayer(geojson, options) {
 	    layers = [],
 	    pointToLayer = options && options.pointToLayer,
 	    lineToLayer = options && options.lineToLayer,
+	    polygonToLayer = options && options.polygonToLayer,
 	    _coordsToLatLng = options && options.coordsToLatLng || coordsToLatLng,
 	    latlng, latlngs, i, len;
 
@@ -221,12 +222,12 @@ export function geometryToLayer(geojson, options) {
 	case 'LineString':
 	case 'MultiLineString':
 		latlngs = coordsToLatLngs(coords, geometry.type === 'LineString' ? 0 : 1, _coordsToLatLng);
-	  return _lineToLayer(lineToLayer, geojson, latlngs, options);
+		return _lineToLayer(lineToLayer, geojson, latlngs, options);
 
 	case 'Polygon':
 	case 'MultiPolygon':
 		latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, _coordsToLatLng);
-	  return _polygonToLayer(polygonToLayer, geojson, latlngs, options);
+		return _polygonToLayer(polygonToLayer, geojson, latlngs, options);
 
 	case 'GeometryCollection':
 		for (i = 0, len = geometry.geometries.length; i < len; i++) {
@@ -256,7 +257,7 @@ function _pointToLayer(pointToLayerFn, geojson, latlng, options) {
 function _lineToLayer(lineToLayerFn, geojson, latlngs, options) {
 	return lineToLayerFn ?
 		lineToLayerFn(geojson, latlngs) :
-	  new Polyline(latlngs, options && options.markersInheritOptions && options);
+		new Polyline(latlngs, options && options.markersInheritOptions && options);
 }
 
 function _polygonToLayer(polygonToLayerFn, geojson, latlngs, options) {


### PR DESCRIPTION
# Summary

This change adds two new options to the GeoJSON layer. These provide similar functionality to the `pointToLayer` function. However, where `pointToLayer` allows an override in behavior in the creation of Markers, `lineToLayer` and `polygonToLayer` override the creation of Polylines/Multipolylines and Polygons/Multipolygons, respectively:

> **lineToLayer**
A Function defining how GeoJSON LineString and MultiLineString geometry types spawn Leaflet layers. It is internally called when data is added, passing the GeoJSON line feature and its LatLngs. The default is to spawn a default Polyline: 
> ```
> function(geoJsonLine, latlngs) {
>     return L.polyline(latlngs);
> }
> ```

> **polygonToLayer**
A Function defining how GeoJSON Polygon and MultiPolygon geometry types spawn Leaflet layers. It is internally called when data is added, passing the GeoJSON polygon feature and its LatLngs. The default is to spawn a default Polygon: 
> ```
> function(geoJsonPolygon, latlngs) {
>     return L.polygon(latlngs);
> }
> ```

# Use Case

This code allows users to use their own objects to define how polylines and polygons are rendered from GeoJSON data onto a Leaflet map.

As an example: If you wanted the GeoJSON line to be rendered as a [L.multiOptionsPolyline](https://github.com/hgoebl/Leaflet.MultiOptionsPolyline) instead of an `L.polyline`, the existing code base did not provide this option to developers.

I encountered this case, and found it odd that only point markers had the option to override in this manner.

# Changes Made

I implemented the relevant code, modified the relevant documentation comments to reflect the new properties, and ensured that code spacing/linting matched that of the surrounding code. I also tested the code functions as intended by adding an example of `lineToLayer` to the documentation, by changing the rendered lines in `docs/examples/geojson` to create polylines with a magenta color.