### PR TITLE
Bugfix min/maxZoom & detectRetina

### DIFF
--- a/spec/before.js
+++ b/spec/before.js
@@ -1,2 +1,5 @@
 // Trick Leaflet into believing we have a touchscreen (for desktop)
-if (window.TouchEvent) { window.ontouchstart = function(){} };
+if (window.TouchEvent) { window.ontouchstart = function () {}; }
+
+// allow tests for `detectRetina`
+window.devicePixelRatio = 2;

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -430,6 +430,28 @@ describe('TileLayer', function () {
 				});
 			});
 		}
+
+		it('loads tiles with matching min/maxZoom and detectRetina', function (done) {
+			const kittenLayer = kittenLayerFactory({
+				minZoom: 1,
+				maxZoom: 1,
+				detectRetina: true,
+			});
+
+			var tilesLoaded = 0;
+
+			kittenLayer.on('tileload', function () {
+				tilesLoaded += 1;
+			});
+
+			kittenLayer.on('load', function () {
+				// copied from loads 8 kittens zoom 1 above
+				expect(tilesLoaded).to.be(8 * 4);
+				done();
+			});
+
+			map.addLayer(kittenLayer).setView([0, 0], 1);
+		});
 	});
 
 	describe('#setUrl', function () {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -93,10 +93,10 @@ export var TileLayer = GridLayer.extend({
 
 			if (!options.zoomReverse) {
 				options.zoomOffset++;
-				options.maxZoom--;
+				options.maxZoom = Math.max(options.minZoom, options.maxZoom - 1);
 			} else {
 				options.zoomOffset--;
-				options.minZoom++;
+				options.minZoom = Math.min(options.maxZoom, options.minZoom + 1);
 			}
 
 			options.minZoom = Math.max(0, options.minZoom);


### PR DESCRIPTION
if detectRetina is true, maxZoom was being set to a value less than minZoom.  This PR adds a test, and fixes the logic for setting min/maxZoom in L.TileLayer.