### PR TITLE
Use a legible `font-size` in the attribution

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -418,7 +418,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-container .leaflet-control-attribution {
 	font-size: 12px;
-  }
+	}
 .leaflet-container .leaflet-control-scale {
 	font-size: 11px;
 	}

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -416,9 +416,11 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-control-attribution a:hover {
 	text-decoration: underline;
 	}
-.leaflet-container .leaflet-control-attribution,
-.leaflet-container .leaflet-control-scale {
+.leaflet-container .leaflet-control-attribution {
 	font-size: 12px;
+}
+.leaflet-container .leaflet-control-scale {
+	font-size: 11px;
 	}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
@@ -431,7 +433,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-top: none;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
-	font-size: 12px;
+	font-size: 11px;
 	white-space: nowrap;
 	overflow: hidden;
 	-moz-box-sizing: border-box;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -418,7 +418,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-container .leaflet-control-attribution {
 	font-size: 12px;
-}
+  }
 .leaflet-container .leaflet-control-scale {
 	font-size: 11px;
 	}

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -418,7 +418,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-container .leaflet-control-attribution,
 .leaflet-container .leaflet-control-scale {
-	font-size: 11px;
+	font-size: 12px;
 	}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
@@ -431,7 +431,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-top: none;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
-	font-size: 11px;
+	font-size: 12px;
 	white-space: nowrap;
 	overflow: hidden;
 	-moz-box-sizing: border-box;


### PR DESCRIPTION
Fix Lighthouse audit failure "Document doesn't use legible font sizes" by increasing the font-size by 1px.

See [the report](https://lighthouse-dot-webdotdevsite.appspot.com//lh/html?url=https%3A%2F%2Fleafletjs.com%2Fexamples%2Fquick-start%2Fexample.html#seo) from auditing the URL: https://leafletjs.com/examples/quick-start/example.html (generated from https://web.dev/measure).

This is an accessibility improvement, although Lighthouse categorizes it as an SEO audit.