### PR TITLE
Align overlay and shadow panes order

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1157,11 +1157,11 @@ export var Map = Evented.extend({
 		// Pane for `GridLayer`s and `TileLayer`s
 		this.createPane('tilePane');
 		// @pane overlayPane: HTMLElement = 400
-		// Pane for overlay shadows (e.g. `Marker` shadows)
-		this.createPane('shadowPane');
-		// @pane shadowPane: HTMLElement = 500
 		// Pane for vectors (`Path`s, like `Polyline`s and `Polygon`s), `ImageOverlay`s and `VideoOverlay`s
 		this.createPane('overlayPane');
+		// @pane shadowPane: HTMLElement = 500
+		// Pane for overlay shadows (e.g. `Marker` shadows)
+		this.createPane('shadowPane');
 		// @pane markerPane: HTMLElement = 600
 		// Pane for `Icon`s of `Marker`s
 		this.createPane('markerPane');


### PR DESCRIPTION
The descriptions for the two panes in the docs were switched. Also flipped the pane creation order to align with the z-index order.