### PR TITLE
Future-proof L.Browser.any3d via CSS.supports(translate3d)

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -75,7 +75,7 @@ export var gecko3d = 'MozPerspective' in style;
 
 // @property any3d: Boolean
 // `true` for all browsers supporting CSS transforms.
-export var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
+export var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d || (CSS && CSS.supports('transform', 'translate3d(0,0,0)'))) && !opera12 && !phantom;
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 export var mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');


### PR DESCRIPTION
As per #7385 - `L.Browser.any3d` should be `true` for any browser that supports `transform3D` CSS rules (except PhantomJS - we depend on that for the unit tests).