### PR TITLE
New plugin: Add Leaflet.Mask

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -638,6 +638,18 @@ The following plugins change the way that tile or image layers are displayed in 
 			<a href="https://github.com/thor85">Thorbjørn Horgen</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/ptma/Leaflet.Mask">Leaflet.Mask
+			</a>
+		</td>
+		<td>
+			Load polygons from geojson to masking the rest of the map(<a href="https://ptma.github.io/Leaflet.Mask/examples/mask.html">Demo</a>).
+		</td>
+		<td>
+			<a href="https://github.com/ptma">JJ Jin</a>
+		</td>
+	</tr>
 </table>
 
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -4002,6 +4002,18 @@ Buttons, sliders, toolbars, sidebars, and panels.
 			<a href="https://github.com/publiclab">Public Lab</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/ptma/Leaflet.Legend">Leaflet.Legend
+			</a>
+		</td>
+		<td>
+			Display legend symbols and toggle overlays(<a href="https://ptma.github.io/Leaflet.Legend/examples/legend.html">Demo</a>).
+		</td>
+		<td>
+			<a href="https://github.com/ptma">JJ Jin</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
Hi,
    Leaflet.Mask is a plugin that loads polygons from geojson to mask the rest of the map.

   THX.