### PR TITLE
Added 'FeatureCollection' case to geoJSON decoder

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -202,6 +202,20 @@ export function geometryToLayer(geojson, options) {
 	case 'MultiPolygon':
 		latlngs = coordsToLatLngs(coords, geometry.type === 'Polygon' ? 1 : 2, _coordsToLatLng);
 		return new Polygon(latlngs, options);
+			
+	case 'FeatureCollection':
+		for (i = 0, len = geometry.features.length; i < len; i++) {
+			var layer = geometryToLayer({
+				geometry: geometry.features[i].geometry,
+				type: 'Feature',
+				properties: geojson.properties
+			}, options);
+
+			if (layer) {
+				layers.push(layer);
+			}
+		}
+		return new FeatureGroup(layers)
 
 	case 'GeometryCollection':
 		for (i = 0, len = geometry.geometries.length; i < len; i++) {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -207,7 +207,7 @@ export function geometryToLayer(geojson, options) {
 		for (i = 0, len = geometry.features.length; i < len; i++) {
 			var layer = geometryToLayer({
 				geometry: geometry.features[i].geometry,
-				type: 'Feature',
+				type: geometry.features[i].type,
 				properties: geojson.properties
 			}, options);
 


### PR DESCRIPTION
Hi everyone. I'm trying to convert the featureGroup object to geoJSON and get the layer again from geoJSON, but it doesn't work:

```js
this.map.on('draw:created', geometryCreate)

geometryCreate(event) {
  this.featureOverlay.addLayer(event.layer)

  let geoJSON = this.featureOverlay.toGeoJSON()

  console.log('geoJSON', geoJSON)

  let layer = L.GeoJSON.geometryToLayer(geoJSON)
}
```
I get this error:

![image](https://user-images.githubusercontent.com/20097205/104178583-44c7f900-5413-11eb-8c95-fbda9b03401d.png)

The problem is that the FeatureCollection object is not supported.

```js
case 'FeatureCollection':
    for (i = 0, len = geometry.features.length; i < len; i++) {
	    var layer = geometryToLayer({
		    geometry: geometry.features[i].geometry,
		    type: geometry.features[i].type,
		    properties: geojson.properties
	    }, options);
    
	    if (layer) {
		    layers.push(layer);
	    }
    }
    return new FeatureGroup(layers)
```