### PR TITLE
A few improvements in the Docs and on DivOverlay, Tooltip and Popup

### DIFF
--- a/build/docs-index.leafdoc
+++ b/build/docs-index.leafdoc
@@ -6,6 +6,7 @@ This file just defines the order of the classes in the docs.
 @class Map
 
 @class Marker
+@class DivOverlay
 @class Popup
 @class Tooltip
 

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -45,6 +45,7 @@
 			<h4>UI Layers</h4>
 			<ul>
 				<li><a href="#marker">Marker</a></li>
+				<li><a href="#divoverlay">DivOverlay</a></li>
 				<li><a href="#popup">Popup</a></li>
 				<li><a href="#tooltip">Tooltip</a></li>
 			</ul>

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -100,7 +100,8 @@
 .leaflet-overlay-pane { z-index: 400; }
 .leaflet-shadow-pane  { z-index: 500; }
 .leaflet-marker-pane  { z-index: 600; }
-.leaflet-tooltip-pane   { z-index: 650; }
+.leaflet-tooltip-pane   { z-index: 650;}
+.leaflet-rtl .leaflet-tooltip-pane   {direction: ltr;}
 .leaflet-popup-pane   { z-index: 700; }
 
 .leaflet-map-pane canvas { z-index: 100; }
@@ -268,6 +269,10 @@ svg.leaflet-image-layer.leaflet-interactive path {
 /* general typography */
 .leaflet-container {
 	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+	}
+
+.leaflet-rtl{
+	direction: rtl;
 	}
 
 
@@ -638,3 +643,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	margin-left: -12px;
 	border-right-color: #fff;
 	}
+
+.leaflet-rtl .leaflet-tooltip-pane > * {
+	direction: rtl;
+}

--- a/docs/docs/js/reference.js
+++ b/docs/docs/js/reference.js
@@ -11,6 +11,15 @@ if (document.body.className.indexOf('api-page') !== -1) {
 			if (!el.children.length) {
 				// For headers, insert the anchor before.
 				el.parentNode.insertBefore(anchor, el);
+				// Clicking on the row (meaning "the link icon on the ::before)
+				// jumps to the item
+				el.onclick = function () {
+					return function (ev) {
+						if (ev.offsetX < 0) {
+							window.location.hash = '#' + ev.target.id;
+						}
+					};
+				}(el.id);
 			} else {
 				// For table rows, insert the anchor inside the first <td>
 				el.querySelector('td').appendChild(anchor);
@@ -44,6 +53,37 @@ if (document.body.className.indexOf('api-page') !== -1) {
 
 		// 		el.className = 'accordion collapsed';
 		// 		el.querySelector('.accordion-content').style.display = 'none';
+	}
+
+
+	// open accordion of anchor if collapsed
+	var urlAnchor = location.hash;
+	if (urlAnchor) {
+		var fnc = function () {
+			// timeout because the page is not finished loading with collapsed accordions
+			setTimeout(function () {
+				// .closest('.accordion') would be a alternative but is not working in IE
+				var getParentAccordion = function (el) {
+					while (el.parentNode && (' ' + el.parentNode.className + ' ').indexOf(' accordion ') === -1) {
+						el = el.parentNode;
+					}
+					return el.parentNode && (' ' + el.parentNode.className + ' ').indexOf(' accordion ') > -1 ? el.parentNode : null;
+				};
+
+				var elm = document.getElementById(urlAnchor.substr(1));
+				if (elm) {
+					var parent = getParentAccordion(elm);
+					if (parent) {
+						parent.className = 'accordion expanded';
+					}
+					// For Firefox: Accordion have to be expanded before scrolling
+					setTimeout(function () {
+						elm.scrollIntoView();
+					}, 10);
+				}
+			}, 100);
+		};
+		window.addEventListener('load', fnc);
 	}
 
 }

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -9,7 +9,7 @@ import * as DomUtil from '../dom/DomUtil';
  * @class DivOverlay
  * @inherits Layer
  * @aka L.DivOverlay
- * Base model for L.Popup and L.Tooltip. Inherit from it for custom popup like plugins.
+ * Base model for L.Popup and L.Tooltip. Inherit from it for custom overlays like plugins.
  */
 
 // @namespace DivOverlay
@@ -19,17 +19,21 @@ export var DivOverlay = Layer.extend({
 	// @aka DivOverlay options
 	options: {
 		// @option offset: Point = Point(0, 7)
-		// The offset of the popup position. Useful to control the anchor
-		// of the popup when opening it on some overlays.
+		// The offset of the overlay position. Useful to control the anchor
+		// of the overlay when opening it on some overlays.
 		offset: [0, 7],
 
 		// @option className: String = ''
-		// A custom CSS class name to assign to the popup.
+		// A custom CSS class name to assign to the overlay.
 		className: '',
 
 		// @option pane: String = 'popupPane'
-		// `Map pane` where the popup will be added.
-		pane: 'popupPane'
+		// `Map pane` where the overlay will be added.
+		pane: 'popupPane',
+
+		// @option content: String = ''
+		// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
+		content: '',
 	},
 
 	initialize: function (options, source) {
@@ -69,15 +73,15 @@ export var DivOverlay = Layer.extend({
 		}
 	},
 
-	// @namespace Popup
+	// @namespace DivOverlay
 	// @method getLatLng: LatLng
-	// Returns the geographical point of popup.
+	// Returns the geographical point of the overlay.
 	getLatLng: function () {
 		return this._latlng;
 	},
 
 	// @method setLatLng(latlng: LatLng): this
-	// Sets the geographical point where the popup will open.
+	// Sets the geographical point where the overlay will open.
 	setLatLng: function (latlng) {
 		this._latlng = toLatLng(latlng);
 		if (this._map) {
@@ -88,13 +92,13 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// @method getContent: String|HTMLElement
-	// Returns the content of the popup.
+	// Returns the content of the overlay.
 	getContent: function () {
 		return this._content;
 	},
 
 	// @method setContent(htmlContent: String|HTMLElement|Function): this
-	// Sets the HTML content of the popup. If a function is passed the source layer will be passed to the function. The function should return a `String` or `HTMLElement` to be used in the popup.
+	// Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
 	setContent: function (content) {
 		this._content = content;
 		this.update();
@@ -102,13 +106,13 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// @method getElement: String|HTMLElement
-	// Returns the HTML container of the popup.
+	// Returns the HTML container of the overlay.
 	getElement: function () {
 		return this._container;
 	},
 
 	// @method update: null
-	// Updates the popup content, layout and position. Useful for updating the popup after something inside changed, e.g. image loaded.
+	// Updates the overlay content, layout and position. Useful for updating the overlay after something inside changed, e.g. image loaded.
 	update: function () {
 		if (!this._map) { return; }
 
@@ -136,13 +140,13 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// @method isOpen: Boolean
-	// Returns `true` when the popup is visible on the map.
+	// Returns `true` when the overlay is visible on the map.
 	isOpen: function () {
 		return !!this._map && this._map.hasLayer(this);
 	},
 
 	// @method bringToFront: this
-	// Brings this popup in front of other popups (in the same map pane).
+	// Brings this overlay in front of other overlay (in the same map pane).
 	bringToFront: function () {
 		if (this._map) {
 			DomUtil.toFront(this._container);
@@ -151,7 +155,7 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// @method bringToBack: this
-	// Brings this popup to the back of other popups (in the same map pane).
+	// Brings this overlay to the back of other overlay (in the same map pane).
 	bringToBack: function () {
 		if (this._map) {
 			DomUtil.toBack(this._container);
@@ -207,6 +211,10 @@ export var DivOverlay = Layer.extend({
 			}
 			node.appendChild(content);
 		}
+		// @namespace DivOverlay
+		// @section DivOverlay events
+		// @event contentupdate: Event
+		// Fired when the content of the overlay is updated
 		this.fire('contentupdate');
 	},
 
@@ -226,7 +234,7 @@ export var DivOverlay = Layer.extend({
 		var bottom = this._containerBottom = -offset.y,
 		    left = this._containerLeft = -Math.round(this._containerWidth / 2) + offset.x;
 
-		// bottom position the popup in case the height of the popup changes (images loading etc)
+		// bottom position the overlay in case the height of the overlay changes (images loading etc)
 		this._container.style.bottom = bottom + 'px';
 		this._container.style.left = left + 'px';
 	},

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -39,7 +39,14 @@ export var DivOverlay = Layer.extend({
 	initialize: function (options, source) {
 		Util.setOptions(this, options);
 
-		this._source = source;
+		if (source instanceof L.LatLng || Util.isArray(source)) {
+			this._latlng = toLatLng(source);
+		} else {
+			this._source = source;
+		}
+		if (this.options.content) {
+			this._content = this.options.content;
+		}
 	},
 
 	onAdd: function (map) {
@@ -219,7 +226,7 @@ export var DivOverlay = Layer.extend({
 	},
 
 	_updatePosition: function () {
-		if (!this._map) { return; }
+		if (!this._map || !this._latlng) { return; }
 
 		var pos = this._map.latLngToLayerPoint(this._latlng),
 		    offset = toPoint(this.options.offset),

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -23,7 +23,8 @@ import {Path} from './vector/Path';
  * marker.bindPopup(popupContent).openPopup();
  * ```
  * Path overlays like polylines also have a `bindPopup` method.
- * Here's a more complicated way to open a popup on a map:
+ *
+ * Here's a more complicated way to open a standalone popup on a map:
  *
  * ```js
  * var popup = L.popup()
@@ -95,9 +96,6 @@ export var Popup = DivOverlay.extend({
 		// Set it if you want to override the default behavior of the popup closing when user clicks
 		// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
 
-		// @option className: String = ''
-		// A custom CSS class name to assign to the popup.
-		className: ''
 	},
 
 	// @namespace Popup
@@ -116,6 +114,12 @@ export var Popup = DivOverlay.extend({
 		// @event popupopen: PopupEvent
 		// Fired when a popup is opened in the map
 		map.fire('popupopen', {popup: this});
+
+		// @namespace Popup
+		// @section Popup events
+		// @event popupopen: PopupEvent
+		// Fired when the popup is opened
+		this.fire('popupopen', {popup: this}, true);
 
 		if (this._source) {
 			// @namespace Layer
@@ -139,6 +143,13 @@ export var Popup = DivOverlay.extend({
 		// @event popupclose: PopupEvent
 		// Fired when a popup in the map is closed
 		map.fire('popupclose', {popup: this});
+
+
+		// @namespace Popup
+		// @section Popup events
+		// @event popupclose: PopupEvent
+		// Fired when the popup is closed
+		this.fire('popupclose', {popup: this}, true);
 
 		if (this._source) {
 			// @namespace Layer
@@ -292,6 +303,9 @@ export var Popup = DivOverlay.extend({
 // @namespace Popup
 // @factory L.popup(options?: Popup options, source?: Layer)
 // Instantiates a `Popup` object given an optional `options` object that describes its appearance and location and an optional `source` object that is used to tag the popup with a reference to the Layer to which it refers.
+// @alternative
+// @factory L.popup(options?: Popup options, latlng?: LatLng)
+// Instantiates a `Popup` object given an optional `options` object that describes its appearance and location and an optional `LatLng` where the overlay will open.
 export var popup = function (options, source) {
 	return new Popup(options, source);
 };

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -15,9 +15,23 @@ import * as DomUtil from '../dom/DomUtil';
  *
  * @example
  *
+ * If you want to just bind a tooltip to marker:
+ *
  * ```js
  * marker.bindTooltip("my tooltip text").openTooltip();
  * ```
+ * Path overlays like polylines also have a `bindTooltip` method.
+ *
+ * A tooltip can be also standalone:
+ *
+ * ```js
+ * var tooltip = L.tooltip()
+ * 	.setLatLng(latlng)
+ * 	.setContent('Hello world!<br />This is a nice tooltip.')
+ * 	.addTo(map);
+ * ```
+ *
+ *
  * Note about tooltip offset. Leaflet takes two options in consideration
  * for computing tooltip offsetting:
  * - the `offset` Tooltip option: it defaults to [0, 0], and it's specific to one tooltip.
@@ -25,6 +39,8 @@ import * as DomUtil from '../dom/DomUtil';
  *   move it to the bottom. Negatives will move to the left and top.
  * - the `tooltipAnchor` Icon option: this will only be considered for Marker. You
  *   should adapt this value if you use a custom icon.
+ *
+ *
  */
 
 
@@ -178,6 +194,8 @@ export var Tooltip = DivOverlay.extend({
 	},
 
 	_updatePosition: function () {
+		if (!this._map || !this._latlng) { return; }
+
 		var pos = this._map.latLngToLayerPoint(this._latlng);
 		this._setPosition(pos);
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -959,6 +959,17 @@ export var Map = Evented.extend({
 		return this._container;
 	},
 
+	// @method setRTLDirection(rtl: Boolean): this
+	// Support for right-to-left text direction. Adds to the map container the CSS-Class `leaflet-rtl`.
+	// During initialization the style `direction: rtl` is searched on the map container and accordingly `leaflet-rtl` is set
+	setRTLDirection: function (rtl) {
+		if (rtl) {
+			DomUtil.addClass(this._container, 'leaflet-rtl');
+		} else {
+			DomUtil.removeClass(this._container, 'leaflet-rtl');
+		}
+		return this;
+	},
 
 	// @section Conversion Methods
 
@@ -1120,6 +1131,8 @@ export var Map = Evented.extend({
 			(Browser.ielt9 ? ' leaflet-oldie' : '') +
 			(Browser.safari ? ' leaflet-safari' : '') +
 			(this._fadeAnimated ? ' leaflet-fade-anim' : ''));
+
+		this.setRTLDirection(DomUtil.getStyle(container, 'direction') === 'rtl');
 
 		var position = DomUtil.getStyle(container, 'position');
 


### PR DESCRIPTION
**Improvements in the Docs: [Demo](http://falke-design.bplaced.net/leaflet/dist/#popup)**
- DivOverlay is now on the right place in the section `UI Layers`, before it was not added in the menu and placed at the bottom below `Events` [DivOverlay](https://leafletjs.com/reference-1.7.1.html#divoverlay)
- Popup and Tooltip references now to the functions of DivOverlay. Changed also the description Fixes: #6954, #6597
- Now it is possible to create anchor links from headers, when clicking on the link icon
- Anchor links they are in a collapsed accordion are now expanding the accordion if they are requested (tested in Firefox, Chrome, Edge, IE) [#divoverlay-bindpopup](http://falke-design.bplaced.net/leaflet/dist/#divoverlay-bindpopup)

**Added Features:**
- Fires on the popup self the events `popupopen` and `popupclose`
- DivOverlay (Popup & Tooltip) supports now  `content` in the options and as second parameter `latlng`. Very useful for standalone Popups or Tooltips, because the expected behaviour is to pass them on initializing.
Before:
```
var popup = L.popup()
    .setLatLng(latlng)
    .setContent('<p>Hello world!<br />This is a nice popup.</p>')
    .openOn(map);
```
Now:
```
var popup = L.popup({content: '<p>Hello world!<br />This is a nice popup.</p>'},latlng).addTo(map);
```

**Fixed Bugs:**
- Tooltip RTL support: was possible over css changes, explained [here](https://github.com/Leaflet/Leaflet/issues/7201#issuecomment-713112492). New function to the map is added `map.setRTLDirection(boolean)`, it adds the CSS-Class `leaflet-rtl` to the map container . During initialization the style `direction: rtl` is searched on the map container and if is found `setRTLDirection(true)` is called. Fix: #7201
- ~~If Tooltip is Sticky and Permanent it is now following mouse [comment in #7201](https://github.com/Leaflet/Leaflet/issues/7201#issuecomment-655746354)~~ PR: #7563 


**Additional thoughts:**
- DivOverlay has a default `offset: [0,7]` I think this would be better if this is moved to Popup and changed to [0,0] but this is a breaking change ...
- `.setTooltipContent("")` / `.setPopupContent("");` and  `.setContent("")` confuses developers, maybe this can explained better but I don't know how.


Restructured commits of PR: #7398