### PR TITLE
DomEvent.Pointer: simplify and cover by tests

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -58,6 +58,7 @@
 	<!-- /dom -->
 	<script src="suites/dom/DomEventSpec.js"></script>
 	<script src="suites/dom/DomEvent.DoubleTapSpec.js"></script>
+	<script src="suites/dom/DomEvent.PointerSpec.js"></script>
 	<script src="suites/dom/DomUtilSpec.js"></script>
 
 	<!-- /layer -->

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -53,6 +53,17 @@ happen.at = function (what, x, y, props) {
 	}, props || {}));
 };
 
+happen.makeEvent = (function (makeEvent) {
+	return function (o) {
+		var evt = makeEvent(o);
+		if (o.type.substring(0, 7) === 'pointer') {
+			evt.pointerId = o.pointerId;
+			evt.pointerType = o.pointerType;
+		}
+		return evt;
+	};
+})(happen.makeEvent);
+
 // We'll want to skip a couple of things when in PhantomJS, due to lack of CSS animations
 it.skipIfNo3d = L.Browser.any3d ? it : it.skip;
 

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -78,4 +78,4 @@ var touchEventType = L.Browser.touchNative ? 'touch' : 'pointer'; // eslint-disa
 //       see https://github.com/Leaflet/prosthetic-hand/issues/14
 
 console.log('L.Browser.pointer', L.Browser.pointer);
-console.log('L.Browser.touch', L.Browser.touch);
+console.log('L.Browser.touchNative', L.Browser.touchNative);

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -1,0 +1,50 @@
+describe('DomEvent.Pointer', function () {
+	var el, listener;
+
+	beforeEach(function () {
+		el = document.createElement('div');
+		document.body.appendChild(el);
+		listener = sinon.spy();
+		L.DomEvent.on(el, 'touchstart', listener);
+	});
+
+	afterEach(function () {
+		happen.once(el, {type: 'pointercancel'}); // to reset prosphetic-hand
+		happen.once(el, {type: 'touchcancel'});   //
+		document.body.removeChild(el);
+	});
+
+	var skip = describe.skip;
+
+	(L.Browser.pointer ? describe : skip)('#Simulates touch based on pointer events', function () {
+		it('adds a listener and calls it on pointer event', function () {
+			happen.once(el, {type: 'pointerdown'});
+			 expect(listener.called).to.be.ok();
+		});
+
+		it('does not call removed listener', function () {
+			L.DomEvent.off(el, 'touchstart', listener);
+
+			happen.once(el, {type: 'pointerdown'});
+			expect(listener.notCalled).to.be.ok();
+		});
+
+		it('ignores native touch events', function () {
+			happen.once(el, {type: 'touchstart'});
+			expect(listener.notCalled).to.be.ok();
+		});
+	});
+
+	(L.Browser.pointer ? skip : describe)('#Does not intrude if pointer events are not available', function () {
+		it('adds a listener and calls it on touch event', function () {
+			happen.once(el, {type: 'touchstart'});
+			expect(listener.called).to.be.ok();
+		});
+
+		it('ignores pointer events', function () {
+			happen.once(el, {type: 'pointerdown'});
+			expect(listener.notCalled).to.be.ok();
+		});
+	});
+
+});

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -1,11 +1,17 @@
 describe('DomEvent.Pointer', function () {
-	var el, listener;
+	var el,
+	    listeners = {};
+
+	var pointerEvents = ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'];
+	var touchEvents = ['touchstart', 'touchmove', 'touchend', 'touchcancel'];
 
 	beforeEach(function () {
 		el = document.createElement('div');
 		document.body.appendChild(el);
-		listener = sinon.spy();
-		L.DomEvent.on(el, 'touchstart', listener);
+		touchEvents.forEach(function (type) {
+			listeners[type] = sinon.spy();
+			L.DomEvent.on(el, type, listeners[type]);
+		});
 	});
 
 	afterEach(function () {
@@ -18,32 +24,53 @@ describe('DomEvent.Pointer', function () {
 
 	(L.Browser.pointer ? describe : skip)('#Simulates touch based on pointer events', function () {
 		it('adds a listener and calls it on pointer event', function () {
-			happen.once(el, {type: 'pointerdown'});
-			 expect(listener.called).to.be.ok();
+			pointerEvents.forEach(function (type) {
+				happen.once(el, {type: type});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].calledOnce).to.be.ok();
+			});
 		});
 
 		it('does not call removed listener', function () {
-			L.DomEvent.off(el, 'touchstart', listener);
-
-			happen.once(el, {type: 'pointerdown'});
-			expect(listener.notCalled).to.be.ok();
+			touchEvents.forEach(function (type) {
+				L.DomEvent.off(el, type, listeners[type]);
+			});
+			pointerEvents.forEach(function (type) {
+				happen.once(el, {type: type});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].notCalled).to.be.ok();
+			});
 		});
 
 		it('ignores native touch events', function () {
-			happen.once(el, {type: 'touchstart'});
-			expect(listener.notCalled).to.be.ok();
+			touchEvents.forEach(function (type) {
+				happen.once(el, {type: type});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].notCalled).to.be.ok();
+			});
 		});
 	});
 
 	(L.Browser.pointer ? skip : describe)('#Does not intrude if pointer events are not available', function () {
 		it('adds a listener and calls it on touch event', function () {
-			happen.once(el, {type: 'touchstart'});
-			expect(listener.called).to.be.ok();
+			touchEvents.forEach(function (type) {
+				happen.once(el, {type: type});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].calledOnce).to.be.ok();
+			});
 		});
 
 		it('ignores pointer events', function () {
-			happen.once(el, {type: 'pointerdown'});
-			expect(listener.notCalled).to.be.ok();
+			pointerEvents.forEach(function (type) {
+				happen.once(el, {type: type});
+			});
+			touchEvents.forEach(function (type) {
+				expect(listeners[type].notCalled).to.be.ok();
+			});
 		});
 	});
 

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -22,7 +22,8 @@ describe('DomEvent.Pointer', function () {
 
 	var skip = describe.skip;
 
-	(L.Browser.pointer ? describe : skip)('#Simulates touch based on pointer events', function () {
+	var pointerToTouch = L.Browser.pointer && !L.Browser.touchNative;
+	(pointerToTouch ? describe : skip)('#Simulates touch based on pointer events', function () {
 		it('adds a listener and calls it on pointer event', function () {
 			pointerEvents.forEach(function (type) {
 				happen.once(el, {type: type});

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -5,12 +5,22 @@ import * as Browser from '../core/Browser';
  * Extends L.DomEvent to provide touch support for Internet Explorer and Windows-based devices.
  */
 
-
 var POINTER_DOWN =   Browser.msPointer ? 'MSPointerDown'   : 'pointerdown';
 var POINTER_MOVE =   Browser.msPointer ? 'MSPointerMove'   : 'pointermove';
 var POINTER_UP =     Browser.msPointer ? 'MSPointerUp'     : 'pointerup';
 var POINTER_CANCEL = Browser.msPointer ? 'MSPointerCancel' : 'pointercancel';
-
+var pEvent = {
+	touchstart  : POINTER_DOWN,
+	touchmove   : POINTER_MOVE,
+	touchend    : POINTER_UP,
+	touchcancel : POINTER_CANCEL
+};
+var handle = {
+	touchstart  : _onPointerStart,
+	touchmove   : _onPointerMove,
+	touchend    : _handlePointer,
+	touchcancel : _handlePointer
+};
 var _pointers = {};
 var _pointerDocListener = false;
 
@@ -19,57 +29,15 @@ var _pointerDocListener = false;
 
 export function addPointerListener(obj, type, handler) {
 	if (type === 'touchstart') {
-		return _addPointerStart(obj, handler);
-
-	} else if (type === 'touchmove') {
-		return _addPointerMove(obj, handler);
-
-	} else if (type === 'touchend') {
-		return _addPointerEnd(obj, handler);
-
-	} else if (type === 'touchcancel') {
-		return _addPointerCancel(obj, handler);
+		_addPointerDocListener();
 	}
+	handler = handle[type].bind(this, handler);
+	obj.addEventListener(pEvent[type], handler, false);
+	return handler;
 }
 
 export function removePointerListener(obj, type, handler) {
-	if (type === 'touchstart') {
-		obj.removeEventListener(POINTER_DOWN, handler, false);
-
-	} else if (type === 'touchmove') {
-		obj.removeEventListener(POINTER_MOVE, handler, false);
-
-	} else if (type === 'touchend') {
-		obj.removeEventListener(POINTER_UP, handler, false);
-
-	} else if (type === 'touchcancel') {
-		obj.removeEventListener(POINTER_CANCEL, handler, false);
-	}
-}
-
-function _addPointerStart(obj, handler) {
-	var onDown = function (e) {
-		// IE10 specific: MsTouch needs preventDefault. See #2000
-		if (e.MSPOINTER_TYPE_TOUCH && e.pointerType === e.MSPOINTER_TYPE_TOUCH) {
-			DomEvent.preventDefault(e);
-		}
-
-		_handlePointer(e, handler);
-	};
-
-	// need to keep track of what pointers and how many are active to provide e.touches emulation
-	if (!_pointerDocListener) {
-		// we listen document as any drags that end by moving the touch off the screen get fired there
-		document.addEventListener(POINTER_DOWN, _globalPointerDown, true);
-		document.addEventListener(POINTER_MOVE, _globalPointerMove, true);
-		document.addEventListener(POINTER_UP, _globalPointerUp, true);
-		document.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
-
-		_pointerDocListener = true;
-	}
-
-	obj.addEventListener(POINTER_DOWN, onDown, false);
-	return onDown;
+	obj.removeEventListener(pEvent[type], handler, false);
 }
 
 function _globalPointerDown(e) {
@@ -86,7 +54,20 @@ function _globalPointerUp(e) {
 	delete _pointers[e.pointerId];
 }
 
-function _handlePointer(e, handler) {
+function _addPointerDocListener() {
+	// need to keep track of what pointers and how many are active to provide e.touches emulation
+	if (!_pointerDocListener) {
+		// we listen document as any drags that end by moving the touch off the screen get fired there
+		document.addEventListener(POINTER_DOWN, _globalPointerDown, true);
+		document.addEventListener(POINTER_MOVE, _globalPointerMove, true);
+		document.addEventListener(POINTER_UP, _globalPointerUp, true);
+		document.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
+
+		_pointerDocListener = true;
+	}
+}
+
+function _handlePointer(handler, e) {
 	e.touches = [];
 	for (var i in _pointers) {
 		e.touches.push(_pointers[i]);
@@ -96,34 +77,18 @@ function _handlePointer(e, handler) {
 	handler(e);
 }
 
-function _addPointerMove(obj, handler) {
-	var onMove = function (e) {
-		// don't fire touch moves when mouse isn't down
-		if ((e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) && e.buttons === 0) {
-			return;
-		}
-
-		_handlePointer(e, handler);
-	};
-
-	obj.addEventListener(POINTER_MOVE, onMove, false);
-	return onMove;
+function _onPointerStart(handler, e) {
+	// IE10 specific: MsTouch needs preventDefault. See #2000
+	if (e.MSPOINTER_TYPE_TOUCH && e.pointerType === e.MSPOINTER_TYPE_TOUCH) {
+		DomEvent.preventDefault(e);
+	}
+	_handlePointer(handler, e);
 }
 
-function _addPointerEnd(obj, handler) {
-	var onUp = function (e) {
-		_handlePointer(e, handler);
-	};
-
-	obj.addEventListener(POINTER_UP, onUp, false);
-	return onUp;
-}
-
-function _addPointerCancel(obj, handler) {
-	var onCancel = function (e) {
-		_handlePointer(e, handler);
-	};
-
-	obj.addEventListener(POINTER_CANCEL, onCancel, false);
-	return onCancel;
+function _onPointerMove(handler, e) {
+	// don't fire touch moves when mouse isn't down
+	if ((e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) && e.buttons === 0) {
+		return;
+	}
+	_handlePointer(handler, e);
 }


### PR DESCRIPTION
Built on top of #7084.

Simplify DomEvent.Pointer.js and cover it by tests.
Close #7411.

Todo:
- [x] Add more complex test, inspecting resulted `touches` and `changedTouches`.