### PR TITLE
Add toPoint validation

### DIFF
--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -218,5 +218,8 @@ export function toPoint(x, y, round) {
 	if (typeof x === 'object' && 'x' in x && 'y' in x) {
 		return new Point(x.x, x.y);
 	}
+	if (y === undefined || y === null) {
+    		throw new Error('toPoint: Y coordinate must be defined.');
+	}
 	return new Point(x, y, round);
 }


### PR DESCRIPTION
Before creating a new `Point`, check the Y coordinate has been provided. This catches issues where callers only provide a single value by mistake, e.g. when setting a padding value for one of the map functions (see #7372).