### PR TITLE
Prevent misfiring dblclick events on touch devices

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -49,6 +49,7 @@ export function addDoubleTapListener(obj, handler, id) {
 			touch.button = 0;
 			handler(touch);
 			last = null;
+			doubleTap = false;
 		}
 	}
 


### PR DESCRIPTION
Fixes #7422 

Existing code assumes that `touchend` events can only occur after `touchstart` events. This assumption is flawed because `touchstart` event can be cancelled or propagation stopped. This PR removes this assumption.

**Additional context:**

DoubleTap handler listens for `touchstart` events and uses a timer to determine if two `touchstart` events occur within a specified `delta`. If they happen within a `delta`, a `doubleTap` flag is set to true. On a `touchend` event, if the `doubleTap` flag is set to true a `dblclick` event is dispatched and the timer is reset, HOWEVER, the `doubleTap` flag remains true until another `touchstart` event occurs. 

The assumption here is that there CANNOT be a `touchend` event that's not preceded with be a `touchstart`.

Unfortunately, if an element has `disableClickPropagation` enabled, the element no longer propagates `mousedown touchstart dblclick` but will still propagate `touchend` to the map.

The other way to fix this is to modify `disableClickPropagation` to prevent all `mousedown touchstart touchend dblclick` events from propagating but I think this approach is safer.