### PR TITLE
L.Point parse string to number, because polygon disapears sometimes

### DIFF
--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -26,9 +26,10 @@ import {isArray, formatNum} from '../core/Util';
 
 export function Point(x, y, round) {
 	// @property x: Number; The `x` coordinate of the point
-	this.x = (round ? Math.round(x) : x);
+	this.x = (round ? Math.round(x) : parseFloat(x));
 	// @property y: Number; The `y` coordinate of the point
-	this.y = (round ? Math.round(y) : y);
+	this.y = (round ? Math.round(y) : parseFloat(y));
+
 }
 
 var trunc = Math.trunc || function (v) {
@@ -163,7 +164,7 @@ Point.prototype = {
 		point = toPoint(point);
 
 		var x = point.x - this.x,
-		    y = point.y - this.y;
+		y = point.y - this.y;
 
 		return Math.sqrt(x * x + y * y);
 	},
@@ -174,7 +175,7 @@ Point.prototype = {
 		point = toPoint(point);
 
 		return point.x === this.x &&
-		       point.y === this.y;
+			point.y === this.y;
 	},
 
 	// @method contains(otherPoint: Point): Boolean
@@ -183,15 +184,15 @@ Point.prototype = {
 		point = toPoint(point);
 
 		return Math.abs(point.x) <= Math.abs(this.x) &&
-		       Math.abs(point.y) <= Math.abs(this.y);
+			Math.abs(point.y) <= Math.abs(this.y);
 	},
 
 	// @method toString(): String
 	// Returns a string representation of the point for debugging purposes.
 	toString: function () {
 		return 'Point(' +
-		        formatNum(this.x) + ', ' +
-		        formatNum(this.y) + ')';
+			formatNum(this.x) + ', ' +
+			formatNum(this.y) + ')';
 	}
 };
 
@@ -210,13 +211,13 @@ export function toPoint(x, y, round) {
 		return x;
 	}
 	if (isArray(x)) {
-		return new Point(x[0], x[1]);
+		return new Point(parseFloat(x[0]), parseFloat(x[1]));
 	}
 	if (x === undefined || x === null) {
 		return x;
 	}
 	if (typeof x === 'object' && 'x' in x && 'y' in x) {
-		return new Point(x.x, x.y);
+		return new Point(parseFloat(x.x), parseFloat(x.y));
 	}
-	return new Point(x, y, round);
+	return new Point(parseFloat(x), parseFloat(y), round);
 }


### PR DESCRIPTION
This fixes a bug that is very hard to reproduce.

Polygons disappearing sometimes while zooming and moving.

The OP from SO found out that it only happens when the weight of the polygon is set as a string: `{weight: "10"}` instead of `{weight: 10}`

Then I looked in the code and I think I found the problem in the function `_clipPoints` at line 126 and 129.
The weight is a string and the point is create out of the weight value --> `L.Point("10","10")`
And then it is added and subtracted to the bounds. And we all know that in JS when we add a string to a number it retuns a string: `3 + "10" = "310"` and not `13`. You can see this while debugging, look into the bounds value before and after adding the "weight" point.
https://github.com/Leaflet/Leaflet/blob/436430db4203a350601e002c8de6a41fae15a4bf/src/layer/vector/Polygon.js#L121-L130


SO: https://stackoverflow.com/q/65829340/8283938
Video from SO: 

https://user-images.githubusercontent.com/19800037/105766896-99fb2300-5f5a-11eb-9f57-5b74f8c18b20.mp4



