### PR TITLE
More reliable disableClickPropagation

### DIFF
--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -142,25 +142,6 @@ describe('DomEvent', function () {
 
 			map.remove();
 		});
-
-		it('does not interfere with stopPropagation', function () { // test for #1925
-			var child = document.createElement('div');
-			el.appendChild(child);
-			L.DomEvent.disableClickPropagation(child);
-			L.DomEvent.on(child, 'click', L.DomEvent.stopPropagation);
-			var map = L.map(el).setView([0, 0], 0);
-			map.on('click', listener);
-
-			happen.once(child, {type: 'click'});
-
-			expect(listener.notCalled).to.be.ok();
-
-			happen.once(map.getContainer(), {type: 'click'});
-
-			expect(listener.called).to.be.ok();
-
-			map.remove();
-		});
 	});
 
 	describe('#preventDefault', function () {

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -104,9 +104,10 @@ describe('DomEvent', function () {
 			var child = document.createElement('div');
 			el.appendChild(child);
 			L.DomEvent.disableClickPropagation(child);
-			L.DomEvent.on(el, 'dblclick mousedown touchstart', listener);
+			L.DomEvent.on(el, 'dblclick contextmenu mousedown touchstart', listener);
 
 			happen.once(child, {type: 'dblclick'});
+			happen.once(child, {type: 'contextmenu'});
 			happen.once(child, {type: 'mousedown'});
 			happen.once(child, {type: 'touchstart', touches: []});
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -184,7 +184,7 @@ export function disableScrollPropagation(el) {
 // `'mousedown'` and `'touchstart'` events (plus browser variants).
 export function disableClickPropagation(el) {
 	on(el, 'mousedown touchstart dblclick', stopPropagation);
-	addOne(el, 'click', fakeStop);
+	el['_leaflet_disable_click'] = true;
 	return this;
 }
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -179,10 +179,10 @@ export function disableScrollPropagation(el) {
 }
 
 // @function disableClickPropagation(el: HTMLElement): this
-// Adds `stopPropagation` to the element's `'click'`, `'dblclick'`,
+// Adds `stopPropagation` to the element's `'click'`, `'dblclick'`, `'contextmenu'`,
 // `'mousedown'` and `'touchstart'` events (plus browser variants).
 export function disableClickPropagation(el) {
-	on(el, 'mousedown touchstart dblclick', stopPropagation);
+	on(el, 'mousedown touchstart dblclick contextmenu', stopPropagation);
 	el['_leaflet_disable_click'] = true;
 	return this;
 }

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -251,20 +251,6 @@ export function getWheelDelta(e) {
 	       0;
 }
 
-var skipEvents = {};
-
-export function fakeStop(e) {
-	// fakes stopPropagation by setting a special event flag, checked/reset with skipped(e)
-	skipEvents[e.type] = true;
-}
-
-export function skipped(e) {
-	var events = skipEvents[e.type];
-	// reset when checking, as it's only used in map container and propagates outside of the map
-	skipEvents[e.type] = false;
-	return events;
-}
-
 // check if element really left/entered the event target (for mouseenter/mouseleave)
 export function isExternalTarget(el, e) {
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -167,7 +167,6 @@ export function stopPropagation(e) {
 	} else {
 		e.cancelBubble = true;
 	}
-	skipped(e);
 
 	return this;
 }

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -193,7 +193,7 @@ export var Popup = DivOverlay.extend({
 			closeButton.href = '#close';
 			closeButton.innerHTML = '&#215;';
 
-			DomEvent.on(closeButton, 'click', this._onCloseButtonClick, this);
+			DomEvent.on(closeButton, 'click', this._close, this);
 		}
 	},
 
@@ -275,11 +275,6 @@ export var Popup = DivOverlay.extend({
 			    .fire('autopanstart')
 			    .panBy([dx, dy]);
 		}
-	},
-
-	_onCloseButtonClick: function (e) {
-		this._close();
-		DomEvent.stop(e);
 	},
 
 	_getAnchor: function () {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -63,6 +63,7 @@ export var Canvas = Renderer.extend({
 		DomEvent.on(container, 'mousemove', this._onMouseMove, this);
 		DomEvent.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this);
 		DomEvent.on(container, 'mouseout', this._handleMouseOut, this);
+		container['_leaflet_disable_events'] = true;
 
 		this._ctx = container.getContext('2d');
 	},
@@ -355,7 +356,6 @@ export var Canvas = Renderer.extend({
 			}
 		}
 		if (clickedLayer)  {
-			DomEvent.fakeStop(e);
 			this._fireEvent([clickedLayer], e);
 		}
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1377,7 +1377,7 @@ export var Map = Evented.extend({
 
 	_handleDOMEvent: function (e) {
 		var el = (e.target || e.srcElement);
-		if (!this._loaded || DomEvent.skipped(e) || e.type === 'click' && this._isClickDisabled(el)) {
+		if (!this._loaded || el['_leaflet_disable_events'] || e.type === 'click' && this._isClickDisabled(el)) {
 			return;
 		}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1406,8 +1406,6 @@ export var Map = Evented.extend({
 			this._fireDOMEvent(synth, synth.type, targets);
 		}
 
-		if (e._stopped) { return; }
-
 		// Find the layer the event is propagating from and its parents.
 		targets = (targets || []).concat(this._findEventTargets(e, type));
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1368,14 +1368,24 @@ export var Map = Evented.extend({
 		return targets;
 	},
 
+	_isClickDisabled: function (el) {
+		while (el !== this._container) {
+			if (el['_leaflet_disable_click']) { return true; }
+			el = el.parentNode;
+		}
+	},
+
 	_handleDOMEvent: function (e) {
-		if (!this._loaded || DomEvent.skipped(e)) { return; }
+		var el = (e.target || e.srcElement);
+		if (!this._loaded || DomEvent.skipped(e) || e.type === 'click' && this._isClickDisabled(el)) {
+			return;
+		}
 
 		var type = e.type;
 
 		if (type === 'mousedown') {
 			// prevents outline when clicking on keyboard-focusable element
-			DomUtil.preventOutline(e.target || e.srcElement);
+			DomUtil.preventOutline(el);
 		}
 
 		this._fireDOMEvent(e, type);


### PR DESCRIPTION
ATM `DomEvent.disableClickPropagation` is not reliable enough as it relies on shared state (stored in private `skipEvents`).
I can imagine many cases where this approach may fail. E.g. if some external component will use native `stopPropagation` (instead of Leaflet's `DomEvent.stopPropagation`) - the state left set, and next click will be ignored.

This PR makes things simple and straight-forward.

Close #7431, fix #6546 (prevent `contextmenu` as well).
