### PR TITLE
Fix `this._icon` undefined on `clearLayers()`

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -272,9 +272,11 @@ export var Marker = Layer.extend({
 				mouseout: this._resetZIndex
 			});
 		}
-
-		DomUtil.remove(this._icon);
-		this.removeInteractiveTarget(this._icon);
+		
+		if (this._icon) {
+			DomUtil.remove(this._icon);
+			this.removeInteractiveTarget(this._icon);
+		}
 
 		this._icon = null;
 	},


### PR DESCRIPTION
Bugfixed - Error on clearLayers - this._icon is undefined fixes #7429
