### PR TITLE
Prevent false map click after fast dragging of marker

### DIFF
--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -41,11 +41,8 @@ describe("Marker.Drag", function () {
 				onStop: function () {
 					expect(marker.getOffset()).to.eql(offset);
 
-					expect(map.getCenter()).to.eql({lat: 0, lng: 0});
-					expect(marker.getLatLng().equals({ // small margin of error allowed
-						lat: -40.979898069620134,
-						lng: 360
-					})).to.be.ok();
+					expect(map.getCenter()).to.be.nearLatLng([0, 0]);
+					expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 360]);
 
 					done();
 				}
@@ -76,11 +73,8 @@ describe("Marker.Drag", function () {
 					onStop: function () {
 						expect(marker.getOffset()).to.eql(offset);
 
-						expect(map.getCenter()).to.eql({lat: 0, lng: 0});
-						expect(marker.getLatLng().equals({ // small margin of error allowed
-							lat: -40.979898069620134,
-							lng: 360
-						})).to.be.ok();
+						expect(map.getCenter()).to.be.nearLatLng([0, 0]);
+						expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 360]);
 
 						done();
 					}
@@ -110,11 +104,8 @@ describe("Marker.Drag", function () {
 					expect(marker.getOffset()).to.eql(offset);
 
 					// small margin of error allowed
-					expect(map.getCenter().equals({lat: 0, lng: 11.25})).to.be.ok();
-					expect(marker.getLatLng().equals({
-						lat: -40.979898069620134,
-						lng: 419.0625
-					})).to.be.ok();
+					expect(map.getCenter()).to.be.nearLatLng([0, 11.25]);
+					expect(marker.getLatLng()).to.be.nearLatLng(-40.979898069620134, 419.0625);
 
 					done();
 				}

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -105,7 +105,7 @@ describe("Marker.Drag", function () {
 
 					// small margin of error allowed
 					expect(map.getCenter()).to.be.nearLatLng([0, 11.25]);
-					expect(marker.getLatLng()).to.be.nearLatLng(-40.979898069620134, 419.0625);
+					expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 419.0625]);
 
 					done();
 				}

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -17,101 +17,112 @@ describe("Marker.Drag", function () {
 		document.body.removeChild(div);
 	});
 
+	var MyMarker = L.Marker.extend({
+		_getPosition: function () {
+			return L.DomUtil.getPosition(this.dragging._draggable._element);
+		},
+		getOffset: function () {
+			return this._getPosition().subtract(this._initialPos);
+		}
+	}).addInitHook('on', 'add', function () {
+		this._initialPos = this._getPosition();
+	});
+
 	describe("drag", function () {
 		it("drags a marker with mouse", function (done) {
-			var marker = new L.Marker([0, 0], {
-				draggable: true
-			}).addTo(map);
+			var marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
+
+			var start = L.point(300, 280);
+			var offset = L.point(256, 32);
+			var finish = start.add(offset);
 
 			var hand = new Hand({
 				timing: 'fastframe',
 				onStop: function () {
-					var center = map.getCenter();
-					expect(center.lat).to.be(0);
-					expect(center.lng).to.be(0);
+					expect(marker.getOffset()).to.eql(offset);
 
-					var markerPos = marker.getLatLng();
-					// Marker drag is very timing sensitive, so we can't check
-					// exact values here, just verify that the drag is in the
-					// right ballpark
-					expect(markerPos.lat).to.be.within(-50, -30);
-					expect(markerPos.lng).to.be.within(340, 380);
+					expect(map.getCenter()).to.eql({lat: 0, lng: 0});
+					expect(marker.getLatLng().equals({ // small margin of error allowed
+						lat: -40.979898069620134,
+						lng: 360
+					})).to.be.ok();
 
 					done();
 				}
 			});
 			var toucher = hand.growFinger('mouse');
 
-			toucher.wait(100).moveTo(300, 280, 0)
-				.down().moveBy(5, 0, 20).moveBy(256, 32, 1000).wait(100).up().wait(100);
+			toucher.moveTo(start.x, start.y, 0)
+				.down().moveBy(5, 0, 20).moveTo(finish.x, finish.y, 1000).up();
 		});
 
 		describe("in CSS scaled container", function () {
-			var scaleX = 2;
-			var scaleY = 1.5;
+			var scale = L.point(2, 1.5);
 
 			beforeEach(function () {
 				div.style.webkitTransformOrigin = 'top left';
-				div.style.webkitTransform = 'scale(' + scaleX + ', ' + scaleY + ')';
+				div.style.webkitTransform = 'scale(' + scale.x + ', ' + scale.y + ')';
 			});
 
-			// fixme IE
 			(L.Browser.ie ? it.skip : it)("drags a marker with mouse, compensating for CSS scale", function (done) {
-				var marker = new L.Marker([0, 0], {
-					draggable: true
-				}).addTo(map);
+				var marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
+
+				var start = L.point(300, 280);
+				var offset = L.point(256, 32);
+				var finish = start.add(offset);
 
 				var hand = new Hand({
 					timing: 'fastframe',
 					onStop: function () {
-						var center = map.getCenter();
-						expect(center.lat).to.be(0);
-						expect(center.lng).to.be(0);
+						expect(marker.getOffset()).to.eql(offset);
 
-						var markerPos = marker.getLatLng();
-						// Marker drag is very timing sensitive, so we can't check
-						// exact values here, just verify that the drag is in the
-						// right ballpark
-						expect(markerPos.lat).to.be.within(-50, -30);
-						expect(markerPos.lng).to.be.within(340, 380);
+						expect(map.getCenter()).to.eql({lat: 0, lng: 0});
+						expect(marker.getLatLng().equals({ // small margin of error allowed
+							lat: -40.979898069620134,
+							lng: 360
+						})).to.be.ok();
 
 						done();
 					}
 				});
 				var toucher = hand.growFinger('mouse');
 
-				toucher.wait(100).moveTo(scaleX * 300, scaleY * 280, 0)
-					.down().moveBy(5, 0, 20).moveBy(scaleX * 256, scaleY * 32, 1000).wait(100).up().wait(100);
+				var startScaled = start.scaleBy(scale);
+				var finishScaled = finish.scaleBy(scale);
+				toucher.wait(0).moveTo(startScaled.x, startScaled.y, 0)
+					.down().moveBy(5, 0, 20).moveTo(finishScaled.x, finishScaled.y, 1000).up();
 			});
 		});
 
 		it("pans map when autoPan is enabled", function (done) {
-			var marker = new L.Marker([0, 0], {
+			var marker = new MyMarker([0, 0], {
 				draggable: true,
 				autoPan: true
 			}).addTo(map);
 
+			var start = L.point(300, 280);
+			var offset = L.point(290, 32);
+			var finish = start.add(offset);
+
 			var hand = new Hand({
 				timing: 'fastframe',
 				onStop: function () {
-					var center = map.getCenter();
-					expect(center.lat).to.be(0);
-					expect(center.lng).to.be.within(10, 30);
+					expect(marker.getOffset()).to.eql(offset);
 
-					var markerPos = marker.getLatLng();
-					// Marker drag is very timing sensitive, so we can't check
-					// exact values here, just verify that the drag is in the
-					// right ballpark
-					expect(markerPos.lat).to.be.within(-50, -30);
-					expect(markerPos.lng).to.be.within(400, 450);
+					// small margin of error allowed
+					expect(map.getCenter().equals({lat: 0, lng: 11.25})).to.be.ok();
+					expect(marker.getLatLng().equals({
+						lat: -40.979898069620134,
+						lng: 419.0625
+					})).to.be.ok();
 
 					done();
 				}
 			});
 			var toucher = hand.growFinger('mouse');
 
-			toucher.wait(100).moveTo(300, 280, 0)
-				.down().moveBy(5, 0, 20).moveBy(290, 32, 1000).wait(100).up().wait(100);
+			toucher.moveTo(start.x, start.y, 0)
+				.down().moveBy(5, 0, 20).moveTo(finish.x, finish.y, 1000).up();
 		});
 	});
 });

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -146,7 +146,9 @@ describe('Canvas', function () {
 
 		it("does fire mousedown on layer after dragging map", function (done) { // #7775
 			var spy = sinon.spy();
-			var circle = L.circle(p2ll(300, 300)).addTo(map);
+			var center = p2ll(300, 300);
+			var radius = p2ll(200, 200).distanceTo(center);
+			var circle = L.circle(center, {radius: radius}).addTo(map);
 			circle.on('mousedown', spy);
 
 			var hand = new Hand({
@@ -159,9 +161,9 @@ describe('Canvas', function () {
 			var mouse = hand.growFinger('mouse');
 
 			mouse.wait(100)
-				.moveTo(300, 300, 0).down().moveBy(5, 0, 20).up()
-				.moveTo(100, 100, 0).down().moveBy(5, 0, 20).up()
-				.moveTo(300, 300, 0).down().moveBy(5, 0, 20).up();
+				.moveTo(300, 300, 0).down().moveBy(5, 0, 20).up()  // control case
+				.moveTo(100, 100, 0).down().moveBy(5, 0, 20).up()  // drag the map (outside of circle)
+				.moveTo(300, 300, 0).down().moveBy(5, 0, 20).up(); // expect mousedown ok
 		});
 	});
 

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -89,10 +89,7 @@ describe("Map.Drag", function () {
 					expect(map.getOffset()).to.eql(offset);
 
 					expect(map.getZoom()).to.be(1);
-					expect(map.getCenter().equals({ // small margin of error allowed
-						lat: 21.943045533, // 21.94304553343818
-						lng: -180
-					})).to.be.ok();
+					expect(map.getCenter()).to.be.nearLatLng([21.943045533, -180]);
 
 					done();
 				}
@@ -128,10 +125,7 @@ describe("Map.Drag", function () {
 						expect(map.getOffset()).to.eql(offset);
 
 						expect(map.getZoom()).to.be(1);
-						expect(map.getCenter().equals({ // small margin of error allowed
-							lat: 21.943045533, // 21.94304553343818
-							lng: -180
-						})).to.be.ok();
+						expect(map.getCenter()).to.be.nearLatLng([21.943045533, -180]);
 
 						done();
 					}
@@ -354,10 +348,7 @@ describe("Map.Drag", function () {
 					expect(map.getOffset()).to.eql(offset);
 
 					expect(map.getZoom()).to.be(1);
-					expect(map.getCenter().equals({ // small margin of error allowed
-						lat: 21.943045533, // 21.94304553343818
-						lng: -180
-					})).to.be.ok();
+					expect(map.getCenter()).to.be.nearLatLng([21.943045533, -180]);
 
 					done();
 				}

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -82,10 +82,8 @@ describe("Map.Drag", function () {
 			});
 			var mouse = hand.growFinger('mouse');
 
-			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
 			mouse.wait(100).moveTo(200, 200, 0)
-				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
+				.down().moveBy(5, 0, 20).moveTo(200 + 256, 200 + 32, 200).up();
 		});
 
 		describe("in CSS scaled container", function () {
@@ -119,10 +117,8 @@ describe("Map.Drag", function () {
 				});
 				var mouse = hand.growFinger('mouse');
 
-				// We move 5 pixels first to overcome the 3-pixel threshold of
-				// L.Draggable.
 				mouse.wait(100).moveTo(200, 200, 0)
-					.down().moveBy(5, 0, 20).moveBy(scaleX * 256, scaleY * 32, 200).up();
+					.down().moveBy(5, 0, 20).moveTo(200 + scaleX * 256, 200 + scaleY * 32, 200).up();
 			});
 		});
 
@@ -185,10 +181,8 @@ describe("Map.Drag", function () {
 			});
 			var mouse = hand.growFinger('mouse');
 
-			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
 			mouse.wait(100).moveTo(200, 200, 0)
-				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
+				.down().moveBy(5, 0, 20).moveTo(456, 232, 200).up();
 		});
 
 		it("does not trigger preclick nor click when dragging on top of a static marker", function (done) {
@@ -344,10 +338,8 @@ describe("Map.Drag", function () {
 			});
 			var toucher = hand.growFinger(touchEventType);
 
-			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
 			toucher.wait(100).moveTo(200, 200, 0)
-				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
+				.down().moveBy(5, 0, 20).moveTo(200 + 256, 200 + 32, 200).up();
 		});
 
 		it.skipIfNotTouch("does not change the center of the map when finger is moved less than the drag threshold", function (done) {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -100,6 +100,7 @@ export var Draggable = Evented.extend({
 		    sizedParent = DomUtil.getSizedParentNode(this._element);
 
 		this._startPoint = new Point(first.clientX, first.clientY);
+		this._startPos = DomUtil.getPosition(this._element);
 
 		// Cache the scale, so that we can continuously compensate for it during drag (_onMove).
 		this._parentScale = DomUtil.getScale(sizedParent);
@@ -139,7 +140,6 @@ export var Draggable = Evented.extend({
 			this.fire('dragstart');
 
 			this._moved = true;
-			this._startPos = DomUtil.getPosition(this._element).subtract(offset);
 
 			DomUtil.addClass(document.body, 'leaflet-dragging');
 
@@ -198,6 +198,7 @@ export var Draggable = Evented.extend({
 		if (this._moved && this._moving) {
 			// ensure drag is not fired after dragend
 			Util.cancelAnimFrame(this._animRequest);
+			DomUtil.setPosition(this._element, this._newPos);
 
 			// @event dragend: DragEndEvent
 			// Fired when the drag ends.

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -155,9 +155,8 @@ export var Draggable = Evented.extend({
 		this._newPos = this._startPos.add(offset);
 		this._moving = true;
 
-		Util.cancelAnimFrame(this._animRequest);
 		this._lastEvent = e;
-		this._animRequest = Util.requestAnimFrame(this._updatePosition, this, true);
+		this._updatePosition();
 	},
 
 	_updatePosition: function () {
@@ -196,9 +195,6 @@ export var Draggable = Evented.extend({
 		DomUtil.enableTextSelection();
 
 		if (this._moved && this._moving) {
-			// ensure drag is not fired after dragend
-			Util.cancelAnimFrame(this._animRequest);
-			DomUtil.setPosition(this._element, this._newPos);
 
 			// @event dragend: DragEndEvent
 			// Fired when the drag ends.


### PR DESCRIPTION
Fix #4457 (and duplicates).

**Fix final position after dragging**
For unclear reason `_startPos` was set wrong (increasing it for offset of first move event), so we fix that,
like it was in initial implementation (no idea why it was ever changed).
(https://github.com/Leaflet/Leaflet/commit/2d2fc74110f2fe7fbc06d7f6e0a2e90528ce46c6#diff-d8f00e9d1726fd6483110dc44c93d9f8R84)

**Prevent false map click after fast dragging of marker**
To solve this we have to ensure that draggable final position is already set on the time
of mouseup/touchend. Thus we have only option - reject using of `requestAnimationFrame`,
which was originally introduced to fix performance issues of map panning, see
https://github.com/Leaflet/Leaflet/commit/c93d91bfad73483990fd5340ed0db8908ba5a4b6#diff-46eca63ac2c5237cbd2d45c8a60f6ee28ce34231aef53669247ead03f012dff2

Perhaps browsers evolved since then.

**Adapt test to expect exact position values**
(as we do not depend on timings anymore)

**Todo:**
- [ ] Check panning performance.
In case if it is not sufficient we could use `requestAnimationFrame` but for map only.

---
Demo pages:
- Original bug: https://gist.githack.com/johnd0e/279b2c5bd985027fd3f959d8b1cec9ea/raw/bug.html
- Fixed with this PR: https://gist.githack.com/johnd0e/279b2c5bd985027fd3f959d8b1cec9ea/raw/fixed.html
