### PR TITLE
Expand DomEventSpec.js on and off tests

### DIFF
--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -23,13 +23,13 @@ describe('DomEvent', function () {
 		document.body.removeChild(el);
 	});
 
-	describe('#addListener', function () {
+	describe('#on (addListener)', function () {
 		it('adds a listener and calls it on event', function () {
 			var listener1 = sinon.spy(),
 			    listener2 = sinon.spy();
 
-			L.DomEvent.addListener(el, 'click', listener1);
-			L.DomEvent.addListener(el, 'click', listener2);
+			L.DomEvent.on(el, 'click', listener1);
+			L.DomEvent.on(el, 'click', listener2);
 
 			simulateClick(el);
 
@@ -41,7 +41,7 @@ describe('DomEvent', function () {
 			var obj = {foo: 'bar'},
 			    result;
 
-			L.DomEvent.addListener(el, 'click', function () {
+			L.DomEvent.on(el, 'click', function () {
 				result = this;
 			}, obj);
 
@@ -53,7 +53,7 @@ describe('DomEvent', function () {
 		it('passes an event object to the listener', function () {
 			var type;
 
-			L.DomEvent.addListener(el, 'click', function (e) {
+			L.DomEvent.on(el, 'click', function (e) {
 				type = e && e.type;
 			});
 			simulateClick(el);
@@ -62,17 +62,21 @@ describe('DomEvent', function () {
 		});
 
 		it('is chainable', function () {
-			var res = L.DomEvent.addListener(el, 'click', function () {});
-			expect(res.addListener).to.be.a('function');
+			var res = L.DomEvent.on(el, 'click', function () {});
+			expect(res.on).to.be.a('function');
+		});
+
+		it('is aliased to addListener ', function () {
+			expect(L.DomEvent.on).to.be(L.DomEvent.addListener);
 		});
 	});
 
-	describe('#removeListener', function () {
+	describe('#off (removeListener)', function () {
 		it('removes a previously added listener', function () {
 			var listener = sinon.spy();
 
-			L.DomEvent.addListener(el, 'click', listener);
-			L.DomEvent.removeListener(el, 'click', listener);
+			L.DomEvent.on(el, 'click', listener);
+			L.DomEvent.off(el, 'click', listener);
 
 			simulateClick(el);
 
@@ -80,8 +84,12 @@ describe('DomEvent', function () {
 		});
 
 		it('is chainable', function () {
-			var res = L.DomEvent.removeListener(el, 'click', function () {});
-			expect(res.removeListener).to.be.a('function');
+			var res = L.DomEvent.off(el, 'click', function () {});
+			expect(res.off).to.be.a('function');
+		});
+
+		it('is aliased to removeListener ', function () {
+			expect(L.DomEvent.off).to.be(L.DomEvent.removeListener);
 		});
 	});
 
@@ -92,8 +100,8 @@ describe('DomEvent', function () {
 
 			el.appendChild(child);
 
-			L.DomEvent.addListener(child, 'click', L.DomEvent.stopPropagation);
-			L.DomEvent.addListener(el, 'click', listener);
+			L.DomEvent.on(child, 'click', L.DomEvent.stopPropagation);
+			L.DomEvent.on(el, 'click', listener);
 
 			simulateClick(child);
 
@@ -105,7 +113,7 @@ describe('DomEvent', function () {
 
 	describe('#preventDefault', function () {
 		it('prevents the default action of event', function () {
-			L.DomEvent.addListener(el, 'click', L.DomEvent.preventDefault);
+			L.DomEvent.on(el, 'click', L.DomEvent.preventDefault);
 
 			expect(simulateClick(el)).to.be(false);
 		});

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -133,6 +133,25 @@ describe('DomEvent', function () {
 
 			map.remove();
 		});
+
+		it('does not interfere with stopPropagation', function () { // test for #1925
+			var child = document.createElement('div');
+			el.appendChild(child);
+			L.DomEvent.disableClickPropagation(child);
+			L.DomEvent.on(child, 'click', L.DomEvent.stopPropagation);
+			var map = L.map(el).setView([0, 0], 0);
+			map.on('click', listener);
+
+			happen.once(child, {type: 'click'});
+
+			expect(listener.notCalled).to.be.ok();
+
+			happen.once(map.getContainer(), {type: 'click'});
+
+			expect(listener.called).to.be.ok();
+
+			map.remove();
+		});
 	});
 
 	describe('#preventDefault', function () {

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -1,17 +1,6 @@
 describe('DomEvent', function () {
 	var el;
 
-	function simulateClick(el) {
-		if (document.createEvent) {
-			var e = document.createEvent('MouseEvents');
-			e.initMouseEvent('click', true, true, window,
-				0, 0, 0, 0, 0, false, false, false, false, 0, null);
-			return el.dispatchEvent(e);
-		} else if (el.fireEvent) {
-			return el.fireEvent('onclick');
-		}
-	}
-
 	beforeEach(function () {
 		el = document.createElement('div');
 		el.style.position = 'absolute';
@@ -31,7 +20,7 @@ describe('DomEvent', function () {
 			L.DomEvent.on(el, 'click', listener1);
 			L.DomEvent.on(el, 'click', listener2);
 
-			simulateClick(el);
+			happen.click(el);
 
 			expect(listener1.called).to.be.ok();
 			expect(listener2.called).to.be.ok();
@@ -45,7 +34,7 @@ describe('DomEvent', function () {
 				result = this;
 			}, obj);
 
-			simulateClick(el);
+			happen.click(el);
 
 			expect(result).to.eql(obj);
 		});
@@ -56,7 +45,7 @@ describe('DomEvent', function () {
 			L.DomEvent.on(el, 'click', function (e) {
 				type = e && e.type;
 			});
-			simulateClick(el);
+			happen.click(el);
 
 			expect(type).to.eql('click');
 		});
@@ -78,7 +67,7 @@ describe('DomEvent', function () {
 			L.DomEvent.on(el, 'click', listener);
 			L.DomEvent.off(el, 'click', listener);
 
-			simulateClick(el);
+			happen.click(el);
 
 			expect(listener.called).to.not.be.ok();
 		});
@@ -103,7 +92,7 @@ describe('DomEvent', function () {
 			L.DomEvent.on(child, 'click', L.DomEvent.stopPropagation);
 			L.DomEvent.on(el, 'click', listener);
 
-			simulateClick(child);
+			happen.click(child);
 
 			expect(listener.called).to.not.be.ok();
 
@@ -114,8 +103,17 @@ describe('DomEvent', function () {
 	describe('#preventDefault', function () {
 		it('prevents the default action of event', function () {
 			L.DomEvent.on(el, 'click', L.DomEvent.preventDefault);
+			var listener = sinon.spy();
+			L.DomEvent.on(el, 'click', listener);
 
-			expect(simulateClick(el)).to.be(false);
+			happen.click(el);
+
+			var e = listener.lastCall.args[0];
+			if ('defaultPrevented' in e) {
+				expect(e.defaultPrevented).to.be.ok();
+			} else {
+				expect(e.returnValue).not.to.be.ok();
+			}
 		});
 	});
 });

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -49,6 +49,30 @@ describe('DomEvent', function () {
 		it('is aliased to addListener ', function () {
 			expect(L.DomEvent.on).to.be(L.DomEvent.addListener);
 		});
+
+		it('adds listener with multiple events and calls it on every event', function () {
+			L.DomEvent.on(el, 'click dblclick', listener);
+
+			happen.dblclick(el);
+			happen.click(el);
+
+			expect(listener.calledTwice).to.be.ok();
+		});
+
+		it('adds listener with an event map and calls appropriate listener when DOM event type occurs', function () {
+			var listener2 = sinon.spy();
+			var eventMap = {
+				click: listener,
+				dblclick: listener2,
+			};
+
+			L.DomEvent.on(el, eventMap);
+
+			happen.click(el);
+
+			expect(listener.called).to.be.ok();
+			expect(listener2.notCalled).to.be.ok();
+		});
 	});
 
 	describe('#off (removeListener)', function () {
@@ -69,6 +93,43 @@ describe('DomEvent', function () {
 
 		it('is aliased to removeListener ', function () {
 			expect(L.DomEvent.off).to.be(L.DomEvent.removeListener);
+		});
+
+		it('removes a previously added listener with multiple types', function () {
+			L.DomEvent.on(el, 'click dblclick', listener);
+			L.DomEvent.off(el, 'click dblclick', listener);
+
+			happen.click(el);
+			happen.dblclick(el);
+
+			expect(listener.notCalled).to.be.ok();
+		});
+
+		it('removes only specified types from a previously added listener', function () {
+			L.DomEvent.on(el, 'click dblclick', listener);
+			L.DomEvent.off(el, 'click', listener);
+
+			happen.click(el);
+			happen.dblclick(el);
+
+			expect(listener.calledOnce).to.be.ok();
+		});
+
+		it('removes a previously added type/listener pair', function () {
+			var listener2 = sinon.spy();
+			var eventMap = {
+				click: listener,
+				dblclick: listener2,
+			};
+
+			L.DomEvent.on(el, eventMap);
+			L.DomEvent.off(el, eventMap);
+
+			happen.click(el);
+			happen.dblclick(el);
+
+			expect(listener.notCalled).to.be.ok();
+			expect(listener2.notCalled).to.be.ok();
 		});
 	});
 

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -85,6 +85,56 @@ describe('DomEvent', function () {
 		});
 	});
 
+	describe('#disableScrollPropagation', function () {
+		it('stops wheel events from propagation to parent elements', function () {
+			var child = document.createElement('div');
+			el.appendChild(child);
+			var wheel = 'onwheel' in window ? 'wheel' : 'mousewheel';
+			L.DomEvent.on(el, wheel, listener);
+
+			L.DomEvent.disableScrollPropagation(child);
+			happen.once(child, {type: wheel});
+
+			expect(listener.notCalled).to.be.ok();
+		});
+	});
+
+	describe('#disableClickPropagation', function () {
+		it('stops click events from propagation to parent elements', function () { // except 'click'
+			var child = document.createElement('div');
+			el.appendChild(child);
+			L.DomEvent.disableClickPropagation(child);
+			L.DomEvent.on(el, 'dblclick mousedown touchstart', listener);
+
+			happen.once(child, {type: 'dblclick'});
+			happen.once(child, {type: 'mousedown'});
+			happen.once(child, {type: 'touchstart', touches: []});
+
+			expect(listener.notCalled).to.be.ok();
+		});
+
+		it('prevents click event on map object, but propagates to DOM elements', function () { // to solve #301
+			var child = document.createElement('div');
+			el.appendChild(child);
+			L.DomEvent.disableClickPropagation(child);
+			L.DomEvent.on(el, 'click', listener);
+			var map = L.map(el).setView([0, 0], 0);
+			var mapClickListener = sinon.spy();
+			var mapOtherListener = sinon.spy();
+			map.on('click', mapClickListener);
+			map.on('keypress', mapOtherListener); // control case
+
+			happen.once(child, {type: 'click'});
+			happen.once(child, {type: 'keypress'});
+
+			expect(listener.called).to.be.ok();
+			expect(mapOtherListener.called).to.be.ok();
+			expect(mapClickListener.notCalled).to.be.ok();
+
+			map.remove();
+		});
+	});
+
 	describe('#preventDefault', function () {
 		it('prevents the default action of event', function () {
 			L.DomEvent.on(el, 'click', listener);

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -180,7 +180,7 @@ export function disableScrollPropagation(el) {
 }
 
 // @function disableClickPropagation(el: HTMLElement): this
-// Adds `stopPropagation` to the element's `'click'`, `'doubleclick'`,
+// Adds `stopPropagation` to the element's `'click'`, `'dbleclick'`,
 // `'mousedown'` and `'touchstart'` events (plus browser variants).
 export function disableClickPropagation(el) {
 	on(el, 'mousedown touchstart dblclick', stopPropagation);


### PR DESCRIPTION
* Based on #7438
* Adds test cases for the following use cases:
** `on(<HTMLElement> el, <String> types, <Function> fn, <Object> context?) (where types has several events)`
** `on(<HTMLElement> el, <Object> eventMap, <Object> context?)`
** `off(<HTMLElement> el, <String> types, <Function> fn, <Object> context?) (where types has several events)`
** `off(<HTMLElement> el, <Object> eventMap, <Object> context?)`