### PR TITLE
Updated URL for Zoomify Plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -381,7 +381,7 @@ Sometimes you don't want to load a map, just big custom images. **Really** big o
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 	<tr>
 		<td>
-			<a href="https://github.com/turban/Leaflet.Zoomify">TileLayer.Zoomify</a>
+			<a href="https://github.com/cmulders/Leaflet.Zoomify">TileLayer.Zoomify</a>
 		</td><td>
 			A TileLayer for Zoomify images.
 		</td><td>


### PR DESCRIPTION
Old url for zoomify plugin links to to version that does not work with Leaflet 1+; new fork works with current version of Leaflet (tested 2/15/2021)