### PR TITLE
License BSD-2 Missing Fix #7426

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img width="600" src="https://rawgit.com/Leaflet/Leaflet/master/src/images/logo.svg" alt="Leaflet" />
 
-Leaflet is the leading open-source JavaScript library for **mobile-friendly interactive maps**.
+Leaflet is the leading open-source ([BSD 2-Clause license][]) JavaScript library for **mobile-friendly interactive maps**.
 Weighing just about 39 KB of gzipped JS plus 4 KB of gzipped CSS code, it has all the mapping [features][] most developers ever need.
 
 Leaflet is designed with *simplicity*, *performance* and *usability* in mind.
@@ -20,6 +20,7 @@ and push the limits of what's possible with online maps!
 
 [![Build Status](https://travis-ci.org/Leaflet/Leaflet.svg?branch=master)](https://travis-ci.org/Leaflet/Leaflet)
 
+ [BSD 2-Clause license]: https://github.com/Leaflet/Leaflet/blob/master/LICENSE
  [contributors]: https://github.com/Leaflet/Leaflet/graphs/contributors
  [features]: http://leafletjs.com/#features
  [plugins]: http://leafletjs.com/plugins.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@ layout: v2
 
 <div class="announcement">Sep 4, 2020 — <a href="/2020/09/04/leaflet-1.7.1.html">Leaflet 1.7.1</a> has been released!</div>
 
-<p>Leaflet is the leading open-source (<a title="Leaflet's open-source license, BSD 2-Clause" href="https://github.com/Leaflet/Leaflet/blob/master/LICENSE">BSD 2-Clause license</a>) JavaScript library for mobile-friendly interactive maps.
+<p>Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps.
 Weighing just about <abbr title="39 KB gzipped &mdash; that's 142 KB minified and 431 KB in the source form, with 14 KB of CSS (2 KB gzipped) and 11 KB of images.">39 KB of JS</abbr>,
 it&nbsp;has all the mapping <a href="#features">features</a> most developers ever need.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@ layout: v2
 
 <div class="announcement">Sep 4, 2020 — <a href="/2020/09/04/leaflet-1.7.1.html">Leaflet 1.7.1</a> has been released!</div>
 
-<p>Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps.
+<p>Leaflet is the leading open-source (<a title="Leaflet's open-source license, BSD 2-Clause" href="https://github.com/Leaflet/Leaflet/blob/master/LICENSE">BSD 2-Clause license</a>) JavaScript library for mobile-friendly interactive maps.
 Weighing just about <abbr title="39 KB gzipped &mdash; that's 142 KB minified and 431 KB in the source form, with 14 KB of CSS (2 KB gzipped) and 11 KB of images.">39 KB of JS</abbr>,
 it&nbsp;has all the mapping <a href="#features">features</a> most developers ever need.</p>
 


### PR DESCRIPTION
Added BSD-2 Clause licence reference in the docs (index.html) as well as in the github README.md linking to the LICENSE github markdown file. fixes #7426