### PR TITLE
add check for map in _onclick handler in canvas

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -344,6 +344,7 @@ export var Canvas = Renderer.extend({
 	// so we emulate that by calculating what's under the mouse on mousemove/click manually
 
 	_onClick: function (e) {
+		if (!this._map) { return; }
 		var point = this._map.mouseEventToLayerPoint(e), layer, clickedLayer;
 
 		for (var order = this._drawFirst; order; order = order.next) {


### PR DESCRIPTION
Really simple PR, adding a check to make sure this._map exists in the _onClick handler in Canvas, similar to the check in _onMouseMove below it.