### PR TITLE
bugfix for permanent tooltips not properly placed within polygons at low zoom levels

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -294,14 +294,12 @@ Layer.include({
 		if (this._tooltip && this._tooltip._isRedraw) {
 			this._initTooltipInteractions(true);
 			this.closeTooltip();
-		  	this._tooltip._isRedraw = false; 
-		} else {
-			  if (this._tooltip) {
+			this._tooltip._isRedraw = false;
+		} else if (this._tooltip) {
 			  this._initTooltipInteractions(true);
 			  this.closeTooltip();
 			  this._tooltip = null;
-			  }  
-		  }
+			  }
 		return this;
 	},
 
@@ -312,9 +310,9 @@ Layer.include({
 			remove: this.closeTooltip,
 			move: this._moveTooltip
 		    };
-		if (this._tooltip.options.permanent) {
-			this._map.on('zoomend', this._redrawTooltip, this)
-		}  	
+		if (this._tooltip.options.permanent && this._map) {
+			this._map.on('zoomend', this._redrawTooltip, this);
+		}
 		if (!this._tooltip.options.permanent) {
 			events.mouseover = this._openTooltip;
 			events.mouseout = this.closeTooltip;
@@ -417,8 +415,8 @@ Layer.include({
 		this._tooltip.setLatLng(latlng);
 	},
 
-	_redrawTooltip: function() {
-		this._tooltip._isRedraw = true;  
+	_redrawTooltip: function () {
+		this._tooltip._isRedraw = true;
 		this.unbindTooltip();
 		this.bindTooltip();
 	}

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -291,11 +291,17 @@ Layer.include({
 	// @method unbindTooltip(): this
 	// Removes the tooltip previously bound with `bindTooltip`.
 	unbindTooltip: function () {
-		if (this._tooltip) {
+		if (this._tooltip && this._tooltip._isRedraw) {
 			this._initTooltipInteractions(true);
 			this.closeTooltip();
-			this._tooltip = null;
-		}
+		  	this._tooltip._isRedraw = false; 
+		} else {
+			  if (this._tooltip) {
+			  this._initTooltipInteractions(true);
+			  this.closeTooltip();
+			  this._tooltip = null;
+			  }  
+		  }
 		return this;
 	},
 
@@ -306,6 +312,9 @@ Layer.include({
 			remove: this.closeTooltip,
 			move: this._moveTooltip
 		    };
+		if (this._tooltip.options.permanent) {
+			this._map.on('zoomend', this._redrawTooltip, this)
+		}  	
 		if (!this._tooltip.options.permanent) {
 			events.mouseover = this._openTooltip;
 			events.mouseout = this.closeTooltip;
@@ -406,5 +415,11 @@ Layer.include({
 			latlng = this._map.layerPointToLatLng(layerPoint);
 		}
 		this._tooltip.setLatLng(latlng);
+	},
+
+	_redrawTooltip: function() {
+		this._tooltip._isRedraw = true;  
+		this.unbindTooltip();
+		this.bindTooltip();
 	}
 });

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -306,7 +306,7 @@ Layer.include({
 			remove: this.closeTooltip,
 			move: this._moveTooltip
 		    };
-		if (this._tooltip.options.permanent && this._map) {
+		if (this._tooltip.options.permanent && this.getCenter && this._map) {
 			this._map[onOff]('zoomend', this._updateTooltipCenter, this);
 		}
 		if (!this._tooltip.options.permanent) {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -291,15 +291,11 @@ Layer.include({
 	// @method unbindTooltip(): this
 	// Removes the tooltip previously bound with `bindTooltip`.
 	unbindTooltip: function () {
-		if (this._tooltip && this._tooltip._isRedraw) {
+		if (this._tooltip) {
 			this._initTooltipInteractions(true);
 			this.closeTooltip();
-			this._tooltip._isRedraw = false;
-		} else if (this._tooltip) {
-			  this._initTooltipInteractions(true);
-			  this.closeTooltip();
-			  this._tooltip = null;
-			  }
+			this._tooltip = null;
+		}
 		return this;
 	},
 
@@ -311,7 +307,7 @@ Layer.include({
 			move: this._moveTooltip
 		    };
 		if (this._tooltip.options.permanent && this._map) {
-			this._map.on('zoomend', this._redrawTooltip, this);
+			this._map[onOff]('zoomend', this._updateTooltipCenter, this);
 		}
 		if (!this._tooltip.options.permanent) {
 			events.mouseover = this._openTooltip;
@@ -415,9 +411,10 @@ Layer.include({
 		this._tooltip.setLatLng(latlng);
 	},
 
-	_redrawTooltip: function () {
-		this._tooltip._isRedraw = true;
-		this.unbindTooltip();
-		this.bindTooltip();
+	_updateTooltipCenter: function () {
+		var latlng = this.getCenter();
+		if (latlng) {
+			this._tooltip.setLatLng(latlng);
+		}
 	}
 });


### PR DESCRIPTION
- Fixes #7492
- Fixes #5216

Problem originates from latlng calculations initialized at low zoom levels being inaccurate at closer zoom levels.

- Added a `zoomend` event listener when a permanent tooltip is initialized. 
- Listener fires  new `_redrawTooltip` function , which just unbinds and rebinds the tooltip. 
- Added `_isRedraw` attribute in the `_redrawTooltip` function to allow use of `unbindTooltip`. 

My first pull request. Let me know how I did! 