### PR TITLE
Fix DomUtil getPosition when provided EL is undefined

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -23,6 +23,16 @@ describe('DomUtil', function () {
 		});
 	});
 
+	describe('#getPosition', function () {
+		it('returns x0 y0 as position when provided el is undefined', function () {
+			expect(L.DomUtil.getPosition(undefined)).to.eql({x:0, y:0});
+		});
+
+		it('returns x0 y0 as position when provided el doesnt have position', function () {
+			expect(L.DomUtil.getPosition(el)).to.eql({x:0, y:0});
+		});
+	});
+
 	describe('#addClass, #removeClass, #hasClass', function () {
 		it('has defined class for test element', function () {
 			el.className = 'bar foo baz ';

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -244,7 +244,7 @@ export function getPosition(el) {
 	// this method is only used for elements previously positioned using setPosition,
 	// so it's safe to cache the position for performance
 
-	return el._leaflet_pos || new Point(0, 0);
+	return (!!el && el._leaflet_pos) || new Point(0, 0);
 }
 
 // @function disableTextSelection()


### PR DESCRIPTION
Hello, 

I faced an issue with map.flyTo(position, zoom), after a quick investigation I found that getPosition try to call an attribute en undefined HtmlElement.


An extract from my code
```ts
  onMapReady(map: Map): void {
    this.map = map;
   map.flyTo([countryLocation.lat, countryLocation.lng], 7);
  }
```

Logs
```
TypeError: Cannot read property '_leaflet_pos' of undefined
    at getPosition (leaflet-src.js:2450)
    at NewClass._getMapPanePos (leaflet-src.js:4439)
    at NewClass._moved (leaflet-src.js:4443)
    at NewClass.getCenter (leaflet-src.js:3798)
    at NewClass.flyTo (leaflet-src.js:3330)
    at SafeSubscriber._next (map-shipment.component.ts:85)
    at SafeSubscriber.__tryOrUnsub (Subscriber.js:183)
    at SafeSubscriber.next (Subscriber.js:122)
    at Subscriber._next (Subscriber.js:72)
    at Subscriber.next (Subscriber.js:49)
```