### PR TITLE
add leaflet-tilelayer-hongkong plugin information

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -234,6 +234,15 @@ Ready-to-go basemaps, with little or no configuration at all.
 			<a href="https://github.com/rkaravia">Roman Karavia</a>
 		</td>
 	</tr>
+	<tr>
+		<td>
+			<a href="https://github.com/spaceflighter/leaflet-tilelayer-hongkong">leaflet-tilelayer-hongkong</a>
+		</td><td>
+			Displays Hong Kong map tiles from <a href="https://geodata.gov.hk">Hong Kong GeoData Store</a> provider.
+		</td><td>
+			<a href="https://github.com/spaceflighter">spaceflighter</a>
+		</td>
+	</tr>
 </table>
 
 


### PR DESCRIPTION
add the plugin for basemap tile provider for Hong Kong region.