### PR TITLE
Update Renderer documentation to clarify tolerance option Canvas only

### DIFF
--- a/docs/reference-1.7.1.html
+++ b/docs/reference-1.7.1.html
@@ -22831,7 +22831,7 @@ e.g. 0.1 would be 10% of map view in each direction</td>
 		<td><code><b>tolerance</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0</code></td>
-		<td>How much to extend click tolerance round a path/object on the map</td>
+		<td>How much to extend click tolerance around a path/object on the map. Only for <a href="#canvas"><code>Canvas</code></a>.</td>
 	</tr>
 </tbody></table>
 

--- a/docs/reference-1.7.1.html
+++ b/docs/reference-1.7.1.html
@@ -22831,7 +22831,7 @@ e.g. 0.1 would be 10% of map view in each direction</td>
 		<td><code><b>tolerance</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0</code></td>
-		<td>How much to extend click tolerance around a path/object on the map. Only for <a href="#canvas"><code>Canvas</code></a>.</td>
+		<td>How much to extend click tolerance round a path/object on the map</td>
 	</tr>
 </tbody></table>
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -38,6 +38,15 @@ import {Bounds} from '../../geometry/Bounds';
  */
 
 export var Canvas = Renderer.extend({
+
+	// @section
+	// @aka Canvas options
+	options: {
+		// @option tolerance: Number = 0
+		// How much to extend the click tolerance around a path/object on the map.
+		tolerance: 0
+	},
+
 	getEvents: function () {
 		var events = Renderer.prototype.getEvents.call(this);
 		events.viewprereset = this._onViewPreReset;

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -142,6 +142,7 @@ export var Path = Layer.extend({
 
 	_clickTolerance: function () {
 		// used when doing hit detection for Canvas layers
-		return (this.options.stroke ? this.options.weight / 2 : 0) + this._renderer.options.tolerance;
+		return (this.options.stroke ? this.options.weight / 2 : 0) +
+		(this._renderer.options.tolerance ? this._renderer.options.tolerance : 0);
 	}
 });

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -143,6 +143,6 @@ export var Path = Layer.extend({
 	_clickTolerance: function () {
 		// used when doing hit detection for Canvas layers
 		return (this.options.stroke ? this.options.weight / 2 : 0) +
-		(this._renderer.options.tolerance ? this._renderer.options.tolerance : 0);
+		  (this._renderer.options.tolerance || 0);
 	}
 });

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -34,11 +34,7 @@ export var Renderer = Layer.extend({
 		// @option padding: Number = 0.1
 		// How much to extend the clip area around the map view (relative to its size)
 		// e.g. 0.1 would be 10% of map view in each direction
-		padding: 0.1,
-
-		// @option tolerance: Number = 0
-		// How much to extend click tolerance round a path/object on the map
-		tolerance : 0
+		padding: 0.1
 	},
 
 	initialize: function (options) {


### PR DESCRIPTION
Fixes #7494 

- Renderer documentation does not clarify the [tolerance ](https://leafletjs.com/reference-1.7.1.html#renderer-tolerance ) option is only supported by Canvas (not SVG) renderer.
- Update documentation to reflect this.
- Refer to similar instance in documentation: Path [className](https://leafletjs.com/reference-1.7.1.html#path-classname) option

Close #7494.