### PR TITLE
Evented: protect from common errors (+tests)

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -387,6 +387,16 @@ describe('Events', function () {
 			expect(obj.listens('test')).to.be(true);
 		});
 
+		it('ignores non-function listeners passed', function () {
+			var obj = new L.Evented();
+			var off = obj.off.bind(obj);
+			['string', {}, [], true, false, undefined].forEach(function (fn) {
+				obj.on('test', fn);
+				expect(obj.listens('test')).to.be(false);
+				expect(off).withArgs('test', fn).to.not.throwException();
+			});
+		});
+
 		it('works like #addEventListener && #removeEventListener', function () {
 			var obj = new L.Evented(),
 			    spy = sinon.spy();

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -397,6 +397,19 @@ describe('Events', function () {
 			});
 		});
 
+		it('throws with wrong types passed', function () {
+			var obj = new L.Evented();
+			var on = obj.on.bind(obj);
+			var off = obj.off.bind(obj);
+			// todo? make it throw  with []
+			[true, false, undefined, 1].forEach(function (type) {
+				expect(on).withArgs(type, L.Util.falseFn).to.throwException();
+				expect(off).withArgs(type, L.Util.falseFn).to.throwException();
+			});
+
+			// todo? make `fire` and `listen` to throw with wrong type
+		});
+
 		it('works like #addEventListener && #removeEventListener', function () {
 			var obj = new L.Evented(),
 			    spy = sinon.spy();

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -378,6 +378,15 @@ describe('Events', function () {
 	});
 
 	describe('#on, #off & #fire', function () {
+		it('does not remove all listeners when any fn argument specified', function () {
+			var obj = new L.Evented();
+			obj.on('test', L.Util.falseFn);
+			obj.off('test', undefined);
+			obj.off({test: undefined});
+
+			expect(obj.listens('test')).to.be(true);
+		});
+
 		it('works like #addEventListener && #removeEventListener', function () {
 			var obj = new L.Evented(),
 			    spy = sinon.spy();

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -81,8 +81,13 @@ export var Events = {
 		} else {
 			types = Util.splitWords(types);
 
+			var removeAll = arguments.length === 1;
 			for (var i = 0, len = types.length; i < len; i++) {
-				this._off(types[i], fn, context);
+				if (removeAll) {
+					this._off(types[i]);
+				} else {
+					this._off(types[i], fn, context);
+				}
 			}
 		}
 
@@ -130,7 +135,7 @@ export var Events = {
 			return;
 		}
 
-		if (!fn) {
+		if (arguments.length === 1) { // remove all
 			if (this._firingCount) {
 				// Set all removed listeners to noop
 				// so they are not called if remove happens in fire

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -96,6 +96,9 @@ export var Events = {
 
 	// attach listener (without syntactic sugar now)
 	_on: function (type, fn, context) {
+		if (typeof fn !== 'function') {
+			return;
+		}
 		this._events = this._events || {};
 
 		/* get/init listeners for type */
@@ -152,6 +155,9 @@ export var Events = {
 			context = undefined;
 		}
 
+		if (typeof fn !== 'function') {
+			return;
+		}
 		// find fn and remove it
 		for (i = 0, len = listeners.length; i < len; i++) {
 			var l = listeners[i];

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -69,7 +69,7 @@ export var Events = {
 	 */
 	off: function (types, fn, context) {
 
-		if (!types) {
+		if (!arguments.length) {
 			// clear all listeners if called without arguments
 			delete this._events;
 

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -131,9 +131,12 @@ export var Events = {
 		}
 
 		if (!fn) {
-			// Set all removed listeners to noop so they are not called if remove happens in fire
-			for (i = 0, len = listeners.length; i < len; i++) {
-				listeners[i].fn = Util.falseFn;
+			if (this._firingCount) {
+				// Set all removed listeners to noop
+				// so they are not called if remove happens in fire
+				for (i = 0, len = listeners.length; i < len; i++) {
+					listeners[i].fn = Util.falseFn;
+				}
 			}
 			// clear all listeners for a type if function isn't specified
 			delete this._events[type];
@@ -149,11 +152,10 @@ export var Events = {
 			var l = listeners[i];
 			if (l.ctx !== context) { continue; }
 			if (l.fn === fn) {
-
-				// set the removed listener to noop so that's not called if remove happens in fire
-				l.fn = Util.falseFn;
-
 				if (this._firingCount) {
+					// set the removed listener to noop so that's not called if remove happens in fire
+					l.fn = Util.falseFn;
+
 					/* copy array in case events are being fired */
 					this._events[type] = listeners = listeners.slice();
 				}

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -97,6 +97,7 @@ export var Events = {
 	// attach listener (without syntactic sugar now)
 	_on: function (type, fn, context) {
 		if (typeof fn !== 'function') {
+			console.warn('wrong listener type: ' + typeof fn);
 			return;
 		}
 		this._events = this._events || {};
@@ -156,6 +157,7 @@ export var Events = {
 		}
 
 		if (typeof fn !== 'function') {
+			console.warn('wrong listener type: ' + typeof fn);
 			return;
 		}
 		// find fn and remove it
@@ -174,6 +176,7 @@ export var Events = {
 
 				return;
 			}
+			console.warn('listener not found');
 		}
 	},
 
@@ -215,6 +218,9 @@ export var Events = {
 	// @method listens(type: String): Boolean
 	// Returns `true` if a particular event type has any listeners attached to it.
 	listens: function (type, propagate) {
+		if (typeof type !== 'string') {
+			console.warn('"string" type argument expected');
+		}
 		var listeners = this._events && this._events[type];
 		if (listeners && listeners.length) { return true; }
 

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -144,25 +144,22 @@ export var Events = {
 			context = undefined;
 		}
 
-		if (listeners) {
+		// find fn and remove it
+		for (i = 0, len = listeners.length; i < len; i++) {
+			var l = listeners[i];
+			if (l.ctx !== context) { continue; }
+			if (l.fn === fn) {
 
-			// find fn and remove it
-			for (i = 0, len = listeners.length; i < len; i++) {
-				var l = listeners[i];
-				if (l.ctx !== context) { continue; }
-				if (l.fn === fn) {
+				// set the removed listener to noop so that's not called if remove happens in fire
+				l.fn = Util.falseFn;
 
-					// set the removed listener to noop so that's not called if remove happens in fire
-					l.fn = Util.falseFn;
-
-					if (this._firingCount) {
-						/* copy array in case events are being fired */
-						this._events[type] = listeners = listeners.slice();
-					}
-					listeners.splice(i, 1);
-
-					return;
+				if (this._firingCount) {
+					/* copy array in case events are being fired */
+					this._events[type] = listeners = listeners.slice();
 				}
+				listeners.splice(i, 1);
+
+				return;
 			}
 		}
 	},


### PR DESCRIPTION
Such as:
1. wrong value passed as listener `fn`
   - in `on/once`: errors will throw too late (in fire), and it may be tricky to find exact source
   - in `off`: wrong (false) value may lead to removing all the listeners, this case is also not easy to debug
2. wrong value passed as `types`
    - in `off`: wrong (false) value may lead to removing all the listeners at once too

All such cases now handled gracefully and without much overhead: either exception is thrown, or a warning is printed in console.
Warnings approach was chosen for compatibility reasons, but may be we should prefer stricter handling in some cases - throw exceptions (this is approach that I preferred in similar #7125 about `DomEvent`).

So I'm waiting for maintainers' advice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/7518)
<!-- Reviewable:end -->
