### PR TITLE
Fix tooltip position

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -143,11 +143,11 @@ export var Tooltip = DivOverlay.extend({
 		    anchor = this._getAnchor();
 
 		if (direction === 'top') {
-			subX = tooltipWidth / 2;
+			subX = tooltipWidth / 2 + anchor.x;
 			subY = tooltipHeight;
 		} else if (direction === 'bottom') {
-			subX = tooltipWidth / 2;
-			subY = 0;
+			subX = tooltipWidth / 2 + anchor.x;
+			subY = anchor.y;
 		} else if (direction === 'center') {
 			subX = tooltipWidth / 2;
 			subY = tooltipHeight / 2;


### PR DESCRIPTION
Hi guys,
I fixed tooltip position when the direction of the tooltip is top or bottom and anchor isn't ` {x : 0, y: 0} ` 
 
**Before**
![image](https://user-images.githubusercontent.com/11555001/111870669-b762d100-898e-11eb-82ff-1518bf733d25.png)

**After**
![image](https://user-images.githubusercontent.com/11555001/111870693-de210780-898e-11eb-8484-d298691f8225.png)
