### PR TITLE
Doc leaflet description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ Leaflet is the leading open-source JavaScript library for **mobile-friendly inte
 Weighing just about 39 KB of gzipped JS plus 4 KB of gzipped CSS code, it has all the mapping [features][] most developers ever need.
 
 Leaflet is designed with *simplicity*, *performance* and *usability* in mind.
-It works efficiently across all major desktop and mobile platforms out of the box,
-taking advantage of HTML5 and CSS3 on modern browsers while being accessible on older ones too.
-It can be extended with a huge amount of [plugins][],
-has a beautiful, easy to use and [well-documented][] API
+It works efficiently across all major desktop and mobile platforms;
+can be extended with lots of [plugins][];
+has a beautiful, easy to use and [well-documented][] API;
 and a simple, readable [source code][] that is a joy to [contribute][] to.
 
 For more info, docs and tutorials, check out the [official website][].<br>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,9 +9,9 @@ Weighing just about <abbr title="39 KB gzipped &mdash; that's 142 KB minified an
 it&nbsp;has all the mapping <a href="#features">features</a> most developers ever need.</p>
 
 <p>Leaflet is designed with <em>simplicity</em>, <em>performance</em> and <em>usability</em> in mind.
-It works efficiently across all major desktop and mobile platforms,
-can be extended with lots of <a href="plugins.html">plugins</a>,
-has a beautiful, easy to use and <a title="Leaflet API reference" href="reference.html">well-documented API</a>
+It works efficiently across all major desktop and mobile platforms;
+can be extended with lots of <a href="plugins.html">plugins</a>;
+has a beautiful, easy to use and <a title="Leaflet API reference" href="reference.html">well-documented API</a>;
 and a simple, readable&nbsp;<a title="Leaflet source code repository on GitHub" href="https://github.com/Leaflet/Leaflet">source code</a> that is a&nbsp;joy to
 <a title="A guide to contributing to Leaflet" href="https://github.com/Leaflet/Leaflet/blob/master/CONTRIBUTING.md">contribute</a> to.</p>
 


### PR DESCRIPTION
The list describing Leaflet contains two nested commas (after beautiful and simple), making it difficult to separate the items in the list:

- works across all major desktop and mobile platforms
- can be extended with lots of plugins
- has a beautiful, easy to use and well documented API
- (has) a simple, readable source code that is a joy to contribute to

The convention is to use a semicolon as the list separator when there are nested commas within the items of the list.