### PR TITLE
Map/closeTooltip: make argument not optional

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -234,13 +234,10 @@ Map.include({
 		return this.addLayer(tooltip);
 	},
 
-	// @method closeTooltip(tooltip?: Tooltip): this
+	// @method closeTooltip(tooltip: Tooltip): this
 	// Closes the tooltip given as parameter.
 	closeTooltip: function (tooltip) {
-		if (tooltip) {
-			this.removeLayer(tooltip);
-		}
-		return this;
+		return this.removeLayer(tooltip);
 	}
 
 });


### PR DESCRIPTION
..as there are no useful cases when we should allow omitting tooltip

https://leafletjs.com/reference-1.7.1.html#map-closetooltip