### PR TITLE
Tooltip: stop relying on Browser `touch` property

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -1,5 +1,3 @@
-
-import * as Browser from '../core/Browser';
 import {DivOverlay} from './DivOverlay';
 import {toPoint} from '../geometry/Point';
 import {Map} from '../map/Map';
@@ -106,7 +104,7 @@ export var Tooltip = DivOverlay.extend({
 	getEvents: function () {
 		var events = DivOverlay.prototype.getEvents.call(this);
 
-		if (Browser.touch && !this.options.permanent) {
+		if (!this.options.permanent) {
 			events.preclick = this._close;
 		}
 
@@ -312,9 +310,7 @@ Layer.include({
 			if (this._tooltip.options.sticky) {
 				events.mousemove = this._moveTooltip;
 			}
-			if (Browser.touch) {
-				events.click = this._openTooltip;
-			}
+			events.click = this._openTooltip;
 		} else {
 			events.add = this._openTooltip;
 		}


### PR DESCRIPTION
Rationale: #6978
