### PR TITLE
Tooltip/Popup: remove redundant checks

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -439,13 +439,6 @@ describe('L.Layer#_popup', function () {
 		expect(map.hasLayer(popup)).to.be(true);
 	});
 
-	it("should not give an error when the marker has no popup", function () {
-		expect(function () {
-			marker.isPopupOpen();
-		}).to.not.throwException();
-		expect(marker.isPopupOpen()).to.be(false);
-	});
-
 	it("should show a popup as closed if it's never opened", function () {
 		marker.bindPopup("new layer");
 		expect(marker.isPopupOpen()).to.be(false);
@@ -458,14 +451,6 @@ describe('L.Layer#_popup', function () {
 
 	it("should show a popup as closed if it's opened and closed", function () {
 		marker.bindPopup("new layer").openPopup().closePopup();
-		expect(marker.isPopupOpen()).to.be(false);
-	});
-
-	it("should show the popup as closed if it's unbound", function () {
-		marker.bindPopup("new layer").openPopup().unbindPopup();
-		expect(function () {
-			marker.isPopupOpen();
-		}).to.not.throwException();
 		expect(marker.isPopupOpen()).to.be(false);
 	});
 

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -211,8 +211,6 @@ export var DivOverlay = Layer.extend({
 	},
 
 	_updatePosition: function () {
-		if (!this._map) { return; }
-
 		var pos = this._map.latLngToLayerPoint(this._latlng),
 		    offset = toPoint(this.options.offset),
 		    anchor = this._getAnchor();

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -416,12 +416,10 @@ Layer.include({
 	// @method openPopup(latlng?: LatLng): this
 	// Opens the bound popup at the specified `latlng` or at the default popup anchor if no `latlng` is passed.
 	openPopup: function (layer, latlng) {
-		if (this._map) {
-			latlng = this._popup._prepareOpen(this, layer, latlng);
+		latlng = this._popup._prepareOpen(this, layer, latlng);
 
-			// open the popup on the map
-			this._map.openPopup(this._popup, latlng);
-		}
+		// open the popup on the map
+		this._map.openPopup(this._popup, latlng);
 
 		return this;
 	},
@@ -463,10 +461,6 @@ Layer.include({
 
 	_openPopup: function (e) {
 		var layer = e.layer || e.target;
-
-		if (!this._map) {
-			return;
-		}
 
 		// prevent map click
 		DomEvent.stop(e);

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -401,23 +401,22 @@ Layer.include({
 	// @method unbindPopup(): this
 	// Removes the popup previously bound with `bindPopup`.
 	unbindPopup: function () {
-		if (this._popup) {
-			this.off({
-				click: this._openPopup,
-				keypress: this._onKeyPress,
-				remove: this.closePopup,
-				move: this._movePopup
-			});
-			this._popupHandlersAdded = false;
-			this._popup = null;
-		}
+		this.off({
+			click: this._openPopup,
+			keypress: this._onKeyPress,
+			remove: this.closePopup,
+			move: this._movePopup
+		});
+		this._popupHandlersAdded = false;
+		this._popup = null;
+
 		return this;
 	},
 
 	// @method openPopup(latlng?: LatLng): this
 	// Opens the bound popup at the specified `latlng` or at the default popup anchor if no `latlng` is passed.
 	openPopup: function (layer, latlng) {
-		if (this._popup && this._map) {
+		if (this._map) {
 			latlng = this._popup._prepareOpen(this, layer, latlng);
 
 			// open the popup on the map
@@ -430,21 +429,16 @@ Layer.include({
 	// @method closePopup(): this
 	// Closes the popup bound to this layer if it is open.
 	closePopup: function () {
-		if (this._popup) {
-			this._popup._close();
-		}
-		return this;
+		return this._popup._close();
 	},
 
 	// @method togglePopup(): this
 	// Opens or closes the popup bound to this layer depending on its current state.
 	togglePopup: function (target) {
-		if (this._popup) {
-			if (this._popup._map) {
-				this.closePopup();
-			} else {
-				this.openPopup(target);
-			}
+		if (this._popup._map) {
+			this.closePopup();
+		} else {
+			this.openPopup(target);
 		}
 		return this;
 	},
@@ -452,16 +446,13 @@ Layer.include({
 	// @method isPopupOpen(): boolean
 	// Returns `true` if the popup bound to this layer is currently open.
 	isPopupOpen: function () {
-		return (this._popup ? this._popup.isOpen() : false);
+		return this._popup.isOpen();
 	},
 
 	// @method setPopupContent(content: String|HTMLElement|Popup): this
 	// Sets the content of the popup bound to this layer.
 	setPopupContent: function (content) {
-		if (this._popup) {
-			this._popup.setContent(content);
-		}
-		return this;
+		return this._popup.setContent(content);
 	},
 
 	// @method getPopup(): Popup
@@ -472,10 +463,6 @@ Layer.include({
 
 	_openPopup: function (e) {
 		var layer = e.layer || e.target;
-
-		if (!this._popup) {
-			return;
-		}
 
 		if (!this._map) {
 			return;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -291,11 +291,10 @@ Layer.include({
 	// @method unbindTooltip(): this
 	// Removes the tooltip previously bound with `bindTooltip`.
 	unbindTooltip: function () {
-		if (this._tooltip) {
-			this._initTooltipInteractions(true);
-			this.closeTooltip();
-			this._tooltip = null;
-		}
+		this._initTooltipInteractions(true);
+		this.closeTooltip();
+		this._tooltip = null;
+
 		return this;
 	},
 
@@ -325,7 +324,7 @@ Layer.include({
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
 	openTooltip: function (layer, latlng) {
-		if (this._tooltip && this._map) {
+		if (this._map) {
 			latlng = this._tooltip._prepareOpen(this, layer, latlng);
 
 			// open the tooltip on the map
@@ -338,19 +337,16 @@ Layer.include({
 				this.addInteractiveTarget(this._tooltip._container);
 			}
 		}
-
 		return this;
 	},
 
 	// @method closeTooltip(): this
 	// Closes the tooltip bound to this layer if it is open.
 	closeTooltip: function () {
-		if (this._tooltip) {
-			this._tooltip._close();
-			if (this._tooltip.options.interactive && this._tooltip._container) {
-				DomUtil.removeClass(this._tooltip._container, 'leaflet-clickable');
-				this.removeInteractiveTarget(this._tooltip._container);
-			}
+		this._tooltip._close();
+		if (this._tooltip.options.interactive && this._tooltip._container) {
+			DomUtil.removeClass(this._tooltip._container, 'leaflet-clickable');
+			this.removeInteractiveTarget(this._tooltip._container);
 		}
 		return this;
 	},
@@ -358,12 +354,10 @@ Layer.include({
 	// @method toggleTooltip(): this
 	// Opens or closes the tooltip bound to this layer depending on its current state.
 	toggleTooltip: function (target) {
-		if (this._tooltip) {
-			if (this._tooltip._map) {
-				this.closeTooltip();
-			} else {
-				this.openTooltip(target);
-			}
+		if (this._tooltip._map) {
+			this.closeTooltip();
+		} else {
+			this.openTooltip(target);
 		}
 		return this;
 	},
@@ -377,10 +371,7 @@ Layer.include({
 	// @method setTooltipContent(content: String|HTMLElement|Tooltip): this
 	// Sets the content of the tooltip bound to this layer.
 	setTooltipContent: function (content) {
-		if (this._tooltip) {
-			this._tooltip.setContent(content);
-		}
-		return this;
+		return this._tooltip.setContent(content);
 	},
 
 	// @method getTooltip(): Tooltip
@@ -390,11 +381,9 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		var layer = e.layer || e.target;
+		if (!this._map) { return; }
 
-		if (!this._tooltip || !this._map) {
-			return;
-		}
+		var layer = e.layer || e.target;
 		this.openTooltip(layer, this._tooltip.options.sticky ? e.latlng : undefined);
 	},
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -324,19 +324,18 @@ Layer.include({
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
 	openTooltip: function (layer, latlng) {
-		if (this._map) {
-			latlng = this._tooltip._prepareOpen(this, layer, latlng);
+		latlng = this._tooltip._prepareOpen(this, layer, latlng);
 
-			// open the tooltip on the map
-			this._map.openTooltip(this._tooltip, latlng);
+		// open the tooltip on the map
+		this._map.openTooltip(this._tooltip, latlng);
 
-			// Tooltip container may not be defined if not permanent and never
-			// opened.
-			if (this._tooltip.options.interactive && this._tooltip._container) {
-				DomUtil.addClass(this._tooltip._container, 'leaflet-clickable');
-				this.addInteractiveTarget(this._tooltip._container);
-			}
+		// Tooltip container may not be defined if not permanent and never
+		// opened.
+		if (this._tooltip.options.interactive && this._tooltip._container) {
+			DomUtil.addClass(this._tooltip._container, 'leaflet-clickable');
+			this.addInteractiveTarget(this._tooltip._container);
 		}
+
 		return this;
 	},
 
@@ -381,8 +380,6 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		if (!this._map) { return; }
-
 		var layer = e.layer || e.target;
 		this.openTooltip(layer, this._tooltip.options.sticky ? e.latlng : undefined);
 	},

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -109,7 +109,7 @@ export var MarkerDrag = Handler.extend({
 		this._oldLatLng = this._marker.getLatLng();
 
 		// When using ES6 imports it could not be set when `Popup` was not imported as well
-		this._marker.closePopup && this._marker.closePopup();
+		this._marker._popup && this._marker.closePopup && this._marker.closePopup();
 
 		this._marker
 			.fire('movestart')


### PR DESCRIPTION
Removing all this over-protection we demand user code to be stricter, but with benefit instead - bugs will manifest themselves earlier.