### PR TITLE
DivOverlay/Popup/Tooltip refactoring and fixes

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -479,4 +479,31 @@ describe('L.Layer#_popup', function () {
 			done();
 		}).to.not.throwException();
 	});
+
+	it("does not open for empty FeatureGroup", function () {
+		var popup = L.popup();
+		L.featureGroup([])
+		  .addTo(map)
+		  .bindPopup(popup)
+		  .openPopup();
+
+		expect(map.hasLayer(popup)).to.not.be.ok();
+	});
+
+	it("uses only visible layers of FeatureGroup for popup content source", function () {
+		var marker1 = L.marker([1, 1]);
+		var marker2 = L.marker([2, 2]);
+		var marker3 = L.marker([3, 3]);
+		var popup = L.popup();
+		var group = L.featureGroup([marker1, marker2])
+		  .bindPopup(popup)
+		  .addTo(map);
+
+		marker1.remove();
+		marker3.remove();
+		group.openPopup();
+
+		expect(map.hasLayer(popup)).to.be.ok();
+		expect(popup._source).to.be(marker2);
+	});
 });

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -160,13 +160,8 @@ export var DivOverlay = Layer.extend({
 	},
 
 	// prepare bound overlay to open: update latlng pos / content source (for FeatureGroup)
-	_prepareOpen: function (source, latlng) {
-		if (source instanceof Layer) {
-			this._source = source;
-		} else {
-			latlng = source;
-			source = this._source;
-		}
+	_prepareOpen: function (latlng) {
+		var source = this._source;
 		if (!source._map) { return; }
 
 		if (source instanceof FeatureGroup) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -416,10 +416,8 @@ Layer.include({
 
 	// @method openPopup(latlng?: LatLng): this
 	// Opens the bound popup at the specified `latlng` or at the default popup anchor if no `latlng` is passed.
-	openPopup: function (layer, latlng) {
-		if (this._popup && this._map) {
-			latlng = this._popup._prepareOpen(this, layer, latlng);
-
+	openPopup: function (target, latlng) {
+		if (this._popup && this._popup._prepareOpen(target, latlng)) {
 			// open the popup on the map
 			this._map.openPopup(this._popup, latlng);
 		}
@@ -471,7 +469,7 @@ Layer.include({
 	},
 
 	_openPopup: function (e) {
-		var layer = e.layer || e.target;
+		var target = e.layer || e.target;
 
 		if (!this._popup) {
 			return;
@@ -486,17 +484,17 @@ Layer.include({
 
 		// if this inherits from Path its a vector and we can just
 		// open the popup at the new location
-		if (layer instanceof Path) {
-			this.openPopup(e.layer || e.target, e.latlng);
+		if (target instanceof Path) {
+			this.openPopup(target, e.latlng);
 			return;
 		}
 
 		// otherwise treat it like a marker and figure out
 		// if we should toggle it open/closed
-		if (this._map.hasLayer(this._popup) && this._popup._source === layer) {
+		if (this._map.hasLayer(this._popup) && this._popup._source === target) {
 			this.closePopup();
 		} else {
-			this.openPopup(layer, e.latlng);
+			this.openPopup(target, e.latlng);
 		}
 	},
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -324,10 +324,8 @@ Layer.include({
 
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
-	openTooltip: function (layer, latlng) {
-		if (this._tooltip && this._map) {
-			latlng = this._tooltip._prepareOpen(this, layer, latlng);
-
+	openTooltip: function (target, latlng) {
+		if (this._tooltip && this._tooltip._prepareOpen(target, latlng)) {
 			// open the tooltip on the map
 			this._map.openTooltip(this._tooltip, latlng);
 
@@ -390,12 +388,12 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		var layer = e.layer || e.target;
+		var target = e.layer || e.target;
 
 		if (!this._tooltip || !this._map) {
 			return;
 		}
-		this.openTooltip(layer, this._tooltip.options.sticky ? e.latlng : undefined);
+		this.openTooltip(target, this._tooltip.options.sticky ? e.latlng : undefined);
 	},
 
 	_moveTooltip: function (e) {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -324,8 +324,8 @@ Layer.include({
 
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
-	openTooltip: function (target, latlng) {
-		if (this._tooltip && this._tooltip._prepareOpen(target, latlng)) {
+	openTooltip: function (latlng) {
+		if (this._tooltip && this._tooltip._prepareOpen(latlng)) {
 			// open the tooltip on the map
 			this._map.openTooltip(this._tooltip, latlng);
 
@@ -355,12 +355,12 @@ Layer.include({
 
 	// @method toggleTooltip(): this
 	// Opens or closes the tooltip bound to this layer depending on its current state.
-	toggleTooltip: function (target) {
+	toggleTooltip: function () {
 		if (this._tooltip) {
 			if (this._tooltip._map) {
 				this.closeTooltip();
 			} else {
-				this.openTooltip(target);
+				this.openTooltip();
 			}
 		}
 		return this;
@@ -388,12 +388,12 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		var target = e.layer || e.target;
-
 		if (!this._tooltip || !this._map) {
 			return;
 		}
-		this.openTooltip(target, this._tooltip.options.sticky ? e.latlng : undefined);
+		this._tooltip._source = e.layer || e.target;
+
+		this.openTooltip(this._tooltip.options.sticky ? e.latlng : undefined);
 	},
 
 	_moveTooltip: function (e) {


### PR DESCRIPTION
This is continuation of #6613.

- Fix a couple of edge cases
- Make `_prepareOpen`-related code logic more clear
- Allow to prevent overlay opening gracefully on some conditions (like empty `FeatureGroup`)
- Refactor to avoid of undocumented arguments for public methods