### PR TITLE
Prevent click on popup tip from firing on map.

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -495,6 +495,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	padding: 1px;
 
 	margin: -10px auto 0;
+	pointer-events: auto;
 
 	-webkit-transform: rotate(45deg);
 	   -moz-transform: rotate(45deg);


### PR DESCRIPTION
Fix #4596 / #5720