### PR TITLE
Map: fix contextmenu default-preventing when there are >1 target candidates

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1249,6 +1249,37 @@ describe("Map", function () {
 			happen.click(layer._icon);
 			expect(called).to.eql(4);
 		});
+
+		it("prevents default action of contextmenu if there is any listener", function () {
+			if (!L.Browser.canvas) { this.skip(); }
+
+			map.remove();
+			var container = document.createElement('div');
+			container.style.width = container.style.height = '300px';
+			container.style.top = container.style.left = 0;
+			container.style.position = 'absolute';
+			document.body.appendChild(container);
+
+			map = L.map(container, {
+				renderer: L.canvas(),
+				center: [0, 0],
+				zoom: 0
+			});
+			map.setView(L.latLng([0, 0]), 12);
+			var spy = sinon.spy();
+			map.on('contextmenu', spy);
+			var marker = L.circleMarker([0, 0]).addTo(map);
+
+			happen.at('contextmenu', 0, 0); // first
+
+			happen.at('contextmenu', marker._point.x, marker._point.y); // second  (#5995)
+
+			document.body.removeChild(container); // cleanup
+
+			expect(spy.callCount).to.be(2);
+			expect(spy.firstCall.lastArg.originalEvent.defaultPrevented).to.be.ok();
+			expect(spy.secondCall.lastArg.originalEvent.defaultPrevented).to.be.ok();
+		});
 	});
 
 	describe("#getScaleZoom && #getZoomScale", function () {

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1267,7 +1267,9 @@ describe("Map", function () {
 			});
 			map.setView(L.latLng([0, 0]), 12);
 			var spy = sinon.spy();
-			map.on('contextmenu', spy);
+			map.on('contextmenu', function (e) {
+				spy(e.originalEvent.defaultPrevented);
+			});
 			var marker = L.circleMarker([0, 0]).addTo(map);
 
 			happen.at('contextmenu', 0, 0); // first
@@ -1277,8 +1279,8 @@ describe("Map", function () {
 			document.body.removeChild(container); // cleanup
 
 			expect(spy.callCount).to.be(2);
-			expect(spy.firstCall.lastArg.originalEvent.defaultPrevented).to.be.ok();
-			expect(spy.secondCall.lastArg.originalEvent.defaultPrevented).to.be.ok();
+			expect(spy.firstCall.lastArg).to.be.ok();
+			expect(spy.secondCall.lastArg).to.be.ok();
 		});
 	});
 


### PR DESCRIPTION
_fireDOMEvent gets 2 separate targets lists
- from _findEventTargets - has only targets with listeners
- from canvas (passed in argument) - may contain targets without listeners too

Previous code was incorrect as it checked random (first) target, and if happened not to have listeners -
the issue was triggered: preventDefault was not called (despite existing listeners on other targets in list).

Fix #5995.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet/7544)
<!-- Reviewable:end -->
