### PR TITLE
Quote strings in url()

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -348,12 +348,12 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-radius: 5px;
 	}
 .leaflet-control-layers-toggle {
-	background-image: url(images/layers.png);
+	background-image: url("images/layers.png");
 	width: 36px;
 	height: 36px;
 	}
 .leaflet-retina .leaflet-control-layers-toggle {
-	background-image: url(images/layers-2x.png);
+	background-image: url("images/layers-2x.png");
 	background-size: 26px 26px;
 	}
 .leaflet-touch .leaflet-control-layers-toggle {
@@ -394,7 +394,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 /* Default icon URLs */
 .leaflet-default-icon-path {
-	background-image: url(images/marker-icon.png);
+	background-image: url("images/marker-icon.png");
 	}
 
 


### PR DESCRIPTION
I'm having problems with a CSS postprocessor. It unwraps the CSS file and adds a hash to each of the referred images to assure that those images will be reloaded after a change. That hash value is appended using a `?somehashvalue` which causes trouble when loaded by the browser.

By quoting the 3 `url()` statements in CSS, this problem can easily be fixed.