### PR TITLE
Fix exception Invalid LatLng object: (NaN, NaN) with the firefox debu…

### DIFF
--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -70,7 +70,7 @@ export var TouchZoom = Handler.extend({
 		var map = this._map,
 		    p1 = map.mouseEventToContainerPoint(e.touches[0]),
 		    p2 = map.mouseEventToContainerPoint(e.touches[1]),
-		    scale = p1.distanceTo(p2) / this._startDist;
+		    scale = this._startDist !== 0 ? : p1.distanceTo(p2) / this._startDist : 1;
 
 		this._zoom = map.getScaleZoom(scale, this._startZoom);
 

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -70,7 +70,7 @@ export var TouchZoom = Handler.extend({
 		var map = this._map,
 		    p1 = map.mouseEventToContainerPoint(e.touches[0]),
 		    p2 = map.mouseEventToContainerPoint(e.touches[1]),
-		    scale = this._startDist !== 0 ? : p1.distanceTo(p2) / this._startDist : 1;
+		    scale = this._startDist !== 0 ? p1.distanceTo(p2) / this._startDist : 1;
 
 		this._zoom = map.getScaleZoom(scale, this._startZoom);
 


### PR DESCRIPTION
…gger in the mobile simluator mode

Fix a problem with the Firefox debugger in simulated mobile mode who pointerdown event received have two touches with the same coordinate which leaflet does not handle correctly.

Fix bug #7566