### PR TITLE
L.GridLayer/onAdd: avoid excessive _update call

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -159,8 +159,7 @@ export var GridLayer = Layer.extend({
 		this._levels = {};
 		this._tiles = {};
 
-		this._resetView();
-		this._update();
+		this._resetView(); // implicit _update() call
 	},
 
 	beforeAdd: function (map) {


### PR DESCRIPTION
..which is already implicitly called earlier by _resetView

`onAdd` ->[`_resetView`](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/layer/tile/GridLayer.js#L526) -> [`_setView`](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/layer/tile/GridLayer.js#L570) -> [`_update`](https://github.com/Leaflet/Leaflet/blob/0f904a515879fcd08f69b7f51799ee7f18f23fd8/src/layer/tile/GridLayer.js#L641)