### PR TITLE
Buttons and inputs usability and accessibility improvements

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -295,9 +295,19 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	background-repeat: no-repeat;
 	display: block;
 	}
+.leaflet-bar a {
+	transition: 0.3s ease-out;
+	}
 .leaflet-bar a:hover {
 	background-color: #f4f4f4;
 	}
+.leaflet-bar a:focus {
+	border-radius: 4px;
+	box-shadow: 0 0 0 3px #0078A8;
+	outline: none;
+	position: relative;
+	z-index: 1;
+  }
 .leaflet-bar a:first-child {
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
@@ -326,6 +336,9 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-bottom-left-radius: 2px;
 	border-bottom-right-radius: 2px;
 	}
+.leaflet-touch .leaflet-bar a:focus {
+	border-radius: 4px;
+  }
 
 /* zoom control */
 
@@ -381,7 +394,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-control-layers-selector {
 	margin-top: 2px;
 	position: relative;
+	transition: 0.3s ease-out;
 	top: 1px;
+	}
+.leaflet-control-layers-selector:focus {
+	border-radius: 2px;
+	box-shadow: 0 0 0 2px #0078A8;
+	outline: none;
 	}
 .leaflet-control-layers label {
 	display: block;


### PR DESCRIPTION
This PR try to solve some usability and accessibility issues for both buttons (like zoom controls) and inputs (like layers controls).

It contains a set of changes I'm applying again and again to every Leaflet project so I was wondering if this can be useful to be integrated in the core.

# Make zoom buttons to be more like a button

Currently there's a wrong semantic use of links instead of real buttons for zoom-in/zoom-out controls, but this change would be more complex and I'm not sure about how many issue this will generate in plugins.

Using a simple link had some accessibility drawbacks while using keyboard navigation and focus on elements as some browsers default outline is difficult to be seen:

Firefox default outline | IE 11 default outline
---------------------- | --------------------
![firefox-default-outline](https://user-images.githubusercontent.com/284924/119641096-951b8280-be19-11eb-98eb-251037bcb812.png) | ![IE11-default-outline](https://user-images.githubusercontent.com/284924/119641098-964caf80-be19-11eb-8acf-eb3a67e81c18.png)

Plus: often the CSS of the host page remove the default outline on links (maybe adding another kind of effect) but this can be a major issue for zoom control.

The introduced change: a visible CSS outline triggered on focus that works down to IE 11.

![ie11-new-outline](https://user-images.githubusercontent.com/284924/119641781-4d492b00-be1a-11eb-9b00-66538e4ada16.gif)

Another common cosmetic CSS effect applied by modern framework on buttons is the hover animation.
Leaflet already applies a background color while hovering on zoom controls, but the background is changed immediately. In this change there's a 0.3s transition applied.

# Port same accessibility changes to input too

Modern browsers are good enough on using keyboard navigation on input elements but:

- IE 11 uses an hard to see dotted outline on focus
- Relying on default input outline with changes discussed above makes tab navigation to looks different when focusing input and zoom controls (different color, not animation).

IE 11 input outline | Chrome tabbing from zoom to inputs
------------------ | -------------------------------------
![ie11-input-outine](https://user-images.githubusercontent.com/284924/119645004-d877f000-be1d-11eb-83be-17fc07d4f10c.gif) | ![chrome-tabbing](https://user-images.githubusercontent.com/284924/119644605-55569a00-be1d-11eb-9695-6c62f8e8425c.gif)

For this reason the tabbing effect has been extended to input keyboard navigation too.

![chrome-tabbing-new](https://user-images.githubusercontent.com/284924/119644701-761eef80-be1d-11eb-833c-8992f1a0ed33.gif)

