### PR TITLE
Fix default icon path detection for Rails asset pipelines

### DIFF
--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -52,7 +52,7 @@ export var IconDefault = Icon.extend({
 		if (path === null || path.indexOf('url') !== 0) {
 			path = '';
 		} else {
-			path = path.replace(/^url\(["']?/, '').replace(/marker-icon\.png["']?\)$/, '');
+			path = path.replace(/^url\(["']?/, '').replace(/marker-icon(-[A-Za-z0-9]+)?\.png["']?\)$/, '');
 		}
 
 		return path;


### PR DESCRIPTION
In Rails applications you would usually use the asset pipeline or the webpacker gem  for bundling assets together. As all assets are fingerprinted with a SHA hash to enable effective caching, which results in output files that are named differently than in the project structure. This also applies to image files. When importing/requiring leaflet over yarn (npm), the bundling process also affects the default icon files in `dist/images` as these also need to be imported due to the reference in the stylesheet. Webpacker then adds the fingerprint to the filename, resulting in e.g. `marker-icon-2273e3d8.png` instead of `marker-icon`. It also replaces the corresponding URL occurences in the stylesheet which define the default icon paths over styles. This breaks line 55 of `src/layer/marker/Icon.Default.js` because the RegExp replaces the hardcoded filename with an empty string. In case of a fingerprinted file, it consequently doesn't match, leading to a broken path which errors in the console.

The fix introduces support for Webpacker and the Rails asset pipeline (Sprockets) without breaking the detection of the initial filename (without any fingerprints).