### PR TITLE
BoxZoom: Reset _moved flag after cancel with ESC

### DIFF
--- a/spec/suites/map/handler/Map.BoxZoom.js
+++ b/spec/suites/map/handler/Map.BoxZoom.js
@@ -1,0 +1,65 @@
+describe("Map.BoxZoom", function () {
+	var container, map;
+
+	beforeEach(function () {
+		container = document.createElement('div');
+		container.style.width = container.style.height = '600px';
+		container.style.top = container.style.left = 0;
+		container.style.top = container.style.top = 0;
+		container.style.position = 'absolute';
+		document.body.appendChild(container);
+	});
+
+	afterEach(function () {
+		map.remove();
+		document.body.removeChild(container);
+	});
+
+
+	it("cancel boxZoom by pressing ESC and re-enable click event on the map", function () {
+		map = new L.Map(container, {
+			center: [0, 0],
+			zoom: 3
+		});
+
+		var mapClick = false;
+		map.on('click', function () {
+			mapClick = true;
+		});
+
+		// check if click event on the map is fired
+		happen.click(map._container);
+		expect(mapClick).to.be(true);
+
+		// fire mousedown event with shiftKey = true, to start drawing the boxZoom
+		var clientX = 100;
+		var clientY = 100;
+		var event = new CustomEvent("mousedown");
+		event.shiftKey = true;
+		event.clientX = clientX;
+		event.clientY = clientY;
+		event.button = 1;
+		map._container.dispatchEvent(event);
+
+		// fire mousemove event with shiftKey = true, to draw the boxZoom
+		clientX += 100;
+		clientY += 100;
+		event = new CustomEvent("mousemove");
+		event.shiftKey = true;
+		event.clientX = clientX;
+		event.clientY = clientY;
+		event.button = 1;
+		document.dispatchEvent(event);
+
+		// fire keydown event with keyCode = 27 (ESC) to cancel boxZoom
+		event = new CustomEvent("keydown");
+		event.keyCode = 27;
+		document.dispatchEvent(event);
+
+		// check if click event on the map is fired
+		mapClick = false;
+		happen.click(map._container);
+		expect(mapClick).to.be(true);
+	});
+
+});

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -140,6 +140,10 @@ export var BoxZoom = Handler.extend({
 	_onKeyDown: function (e) {
 		if (e.keyCode === 27) {
 			this._finish();
+			// Postpone to next JS tick so internal click event handling
+			// still see it as "moved".
+			this._clearDeferredResetState();
+			this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
 		}
 	}
 });

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -140,10 +140,8 @@ export var BoxZoom = Handler.extend({
 	_onKeyDown: function (e) {
 		if (e.keyCode === 27) {
 			this._finish();
-			// Postpone to next JS tick so internal click event handling
-			// still see it as "moved".
 			this._clearDeferredResetState();
-			this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
+			this._resetState();
 		}
 	}
 });


### PR DESCRIPTION
After cancel the BoxZoom with ESC the `_moved` flag is not reseted and destorys the `click` event on the map. 
The part 
```
this._clearDeferredResetState();
this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
``` 
is missing in the [_onKeyDown](https://github.com/Leaflet/Leaflet/blob/81dc24892a3ffd4b53158bb0b5533ae55c1931c1/src/map/handler/Map.BoxZoom.js#L140) function. [_onMouseUp](https://github.com/Leaflet/Leaflet/blob/master/src/map/handler/Map.BoxZoom.js#L128) Reference


Usage of the `_moved` flag over `boxZoom.moved()` which breaks some functions outside of `boxZoom`:
https://github.com/Leaflet/Leaflet/blob/81dc24892a3ffd4b53158bb0b5533ae55c1931c1/src/map/Map.js#L1430-L1433

Can simply tested with `map.on('click', (e)=>console.log(e));`, it will not be triggered after cancel BoxZoom:

![boxzoom_esc_break](https://user-images.githubusercontent.com/19800037/121820578-f9e93080-cc93-11eb-87c0-620c1c781b6f.gif)
After reuse and finish the boxZoom the `click` event is fired again.
