### PR TITLE
switch overlayPane and shadowPane in doc

### DIFF
--- a/docs/reference-1.7.1.html
+++ b/docs/reference-1.7.1.html
@@ -1702,14 +1702,14 @@ can access panes with <a href="#map-getpane"><code>map.getPane</code></a> or
 		<td><code>200</code></td>
 		<td>Pane for <a href="#gridlayer"><code>GridLayer</code></a>s and <a href="#tilelayer"><code>TileLayer</code></a>s</td>
 	</tr>
-	<tr id='map-overlaypane'>
-		<td><code><b>overlayPane</b></code></td>
+	<tr id='map-shadowpane'>
+		<td><code><b>shadowPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>400</code></td>
 		<td>Pane for overlay shadows (e.g. <a href="#marker"><code>Marker</code></a> shadows)</td>
 	</tr>
-	<tr id='map-shadowpane'>
-		<td><code><b>shadowPane</b></code></td>
+	<tr id='map-overlaypane'>
+		<td><code><b>overlayPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>500</code></td>
 		<td>Pane for vectors (<a href="#path"><code>Path</code></a>s, like <a href="#polyline"><code>Polyline</code></a>s and <a href="#polygon"><code>Polygon</code></a>s), <a href="#imageoverlay"><code>ImageOverlay</code></a>s and <a href="#videooverlay"><code>VideoOverlay</code></a>s</td>


### PR DESCRIPTION
switching mistakenly places overlayPane and shadowPane in documentation. #7564 