### PR TITLE
Remove plugin leaflet-echarts

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2263,15 +2263,6 @@ Powerful multi-purpose libraries for data visualization.
 	</tr>
 	<tr>
 		<td>
-			<a href="https://github.com/wandergis/leaflet-echarts">leaflet-echarts</a>
-		</td><td>
-			A plugin for Leaflet to load <a href="https://github.com/ecomfe/echarts">echarts</a> map and make big data visualization easier.
-		</td><td>
-			<a href="https://github.com/wandergis">wandergis</a>
-		</td>
-	</tr>
-	<tr>
-		<td>
 			<a href="https://github.com/atlefren/storymap">jquery-storymap</a>
 		</td><td>
 			A jQuery plugin to display several map locations as the user scrolls through paragraphs.


### PR DESCRIPTION
`leaflet-echarts` isn't an open source project and is impossible to act as a plugin, as the repo only provides minified source, which packed all echarts, leaflet and some others stuffs we don't know. 