### PR TITLE
Correct condition to add zoom limits for Layer

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -235,7 +235,7 @@ Map.include({
 	},
 
 	_addZoomLimit: function (layer) {
-		if (isNaN(layer.options.maxZoom) || !isNaN(layer.options.minZoom)) {
+		if (!isNaN(layer.options.maxZoom) || !isNaN(layer.options.minZoom)) {
 			this._zoomBoundLayers[Util.stamp(layer)] = layer;
 			this._updateZoomLevels();
 		}


### PR DESCRIPTION
Corrected a small mistake which attempts to add zoom limits when maxZoom is NaN while it should be the opposite (when maxZoom is not NaN, as done for minZoom).