### PR TITLE
Feature Dark Mode

### DIFF
--- a/debug/map/darkmode.html
+++ b/debug/map/darkmode.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script src="../dist/leaflet-src.js"></script>
+
+	<style>
+		html, body{
+			background: #333333;
+		}
+
+		#map{
+			border: none;
+		}
+	</style>
+</head>
+<body>
+
+	<div id="map"></div>
+
+	<script>
+
+		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var map = L.map('map')
+				.setView([50.5, 30.51], 15)
+				.addLayer(osm);
+
+		var marker = L.marker(map.getCenter()).addTo(map);
+
+		marker.bindPopup("<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>").addTo(map).openPopup();
+		marker.bindTooltip("This is a Tooltip",{permanent: true}).addTo(map).openTooltip();
+
+		L.control.scale().addTo(map);
+
+
+		var grayscale = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+			streets   = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		var baseMaps = {
+			"Grayscale": grayscale,
+			"Streets": streets
+		};
+
+		var overlayMaps = {
+			"Cities": null
+		};
+
+		L.control.layers(baseMaps, baseMaps, {collapsed: true}).addTo(map);
+		L.control.layers(baseMaps, baseMaps, {collapsed: false}).addTo(map);
+
+		var myIcon = L.divIcon({});
+		L.marker(map.getCenter(), {icon: myIcon}).addTo(map);
+
+	</script>
+</body>
+</html>

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -328,22 +328,21 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 
-@media (prefers-color-scheme: dark) {
-	.leaflet-bar a,
-	.leaflet-bar a:hover{
-		background-color: #333;
-		border-bottom: 1px solid #ddd;
-		color: #fff;
-	}
+/* Dark Mode */
+.leaflet-darkmode .leaflet-bar a,
+.leaflet-darkmode .leaflet-bar a:hover{
+  background-color: #333;
+  border-bottom: 1px solid #ddd;
+  color: #fff;
+}
 
-	.leaflet-bar a:hover {
-		background-color: #444;
-	}
+.leaflet-darkmode .leaflet-bar a:hover {
+  background-color: #444;
+}
 
-	.leaflet-bar a.leaflet-disabled {
-		background-color: #444;
-		color: #bbb;
-	}
+.leaflet-darkmode .leaflet-bar a.leaflet-disabled {
+  background-color: #444;
+  color: #bbb;
 }
 
 
@@ -417,24 +416,20 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	background-image: url(images/marker-icon.png);
 	}
 
-
-@media (prefers-color-scheme: dark) {
-	.leaflet-control-layers {
-		box-shadow: 0 1px 5px rgba(0,0,0,0.4);
-		background: #333;
-	}
-	.leaflet-control-layers-expanded {
-		color: #fff;
-		background: #333;
-	}
-	.leaflet-control-layers-separator {
-		border-top: 1px solid #ddd;
-	}
+/* Dark Mode */
+.leaflet-darkmode .leaflet-control-layers {
+  box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+  background: #333;
+}
+.leaflet-darkmode .leaflet-control-layers-expanded {
+  color: #fff;
+  background: #333;
+}
+.leaflet-darkmode .leaflet-control-layers-separator {
+  border-top: 1px solid #ddd;
 }
 
-
 /* attribution and scale controls */
-
 .leaflet-container .leaflet-control-attribution {
 	background: rgba(255, 255, 255, 0.7);
 	margin: 0;
@@ -492,31 +487,30 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	background-clip: padding-box;
 	}
 
-@media (prefers-color-scheme: dark) {
-	.leaflet-container .leaflet-control-attribution {
-		background: rgba(51, 51, 51, 0.7);
-	}
-	.leaflet-container .leaflet-control-attribution a{
-		color: #70D6FF;
-	}
-	.leaflet-control-attribution,
-	.leaflet-control-scale-line {
-		color: #fff;
-	}
-	.leaflet-control-scale-line {
-		border: 2px solid #444;
-		background: rgba(51, 51, 51, 0.5);
-	}
-	.leaflet-control-scale-line:not(:first-child) {
-		border-top: 2px solid #444;
-	}
-	.leaflet-control-scale-line:not(:first-child):not(:last-child) {
-		border-bottom: 2px solid #444;
-	}
-	.leaflet-touch .leaflet-control-layers,
-	.leaflet-touch .leaflet-bar {
-		border: 2px solid rgba(0,0,0,0.2);
-	}
+/* Dark Mode */
+.leaflet-darkmode.leaflet-container .leaflet-control-attribution {
+  background: rgba(51, 51, 51, 0.7);
+}
+.leaflet-darkmode.leaflet-container .leaflet-control-attribution a{
+  color: #70D6FF;
+}
+.leaflet-darkmode .leaflet-control-attribution,
+.leaflet-darkmode .leaflet-control-scale-line {
+  color: #fff;
+}
+.leaflet-darkmode .leaflet-control-scale-line {
+  border: 2px solid #444;
+  background: rgba(51, 51, 51, 0.5);
+}
+.leaflet-darkmode .leaflet-control-scale-line:not(:first-child) {
+  border-top: 2px solid #444;
+}
+.leaflet-darkmode .leaflet-control-scale-line:not(:first-child):not(:last-child) {
+  border-bottom: 2px solid #444;
+}
+.leaflet-darkmode .leaflet-touch .leaflet-control-layers,
+.leaflet-darkmode .leaflet-touch .leaflet-bar {
+  border: 2px solid rgba(0,0,0,0.2);
 }
 
 /* popup */
@@ -610,30 +604,28 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border: 1px solid #999;
 	}
 
-@media (prefers-color-scheme: dark) {
-
-	.leaflet-popup-content-wrapper,
-	.leaflet-popup-tip {
-		background: #333;
-		color: #fff;
-		box-shadow: 0 3px 14px rgba(0,0,0,0.4);
-	}
-	.leaflet-container a.leaflet-popup-close-button{
-		color: #ddd;
-	}
-	.leaflet-container a.leaflet-popup-close-button:hover {
-		color: #999;
-	}
-	.leaflet-popup-scrolled {
-		border-bottom: 1px solid #ddd;
-		border-top: 1px solid #ddd;
-	}
-	.leaflet-oldie .leaflet-control-zoom,
-	.leaflet-oldie .leaflet-control-layers,
-	.leaflet-oldie .leaflet-popup-content-wrapper,
-	.leaflet-oldie .leaflet-popup-tip {
-		border: 1px solid #999;
-	}
+/* Dark Mode */
+.leaflet-darkmode .leaflet-popup-content-wrapper,
+.leaflet-darkmode .leaflet-popup-tip {
+  background: #333;
+  color: #fff;
+  box-shadow: 0 3px 14px rgba(0,0,0,0.4);
+}
+.leaflet-darkmode.leaflet-container a.leaflet-popup-close-button{
+  color: #ddd;
+}
+.leaflet-darkmode.leaflet-container a.leaflet-popup-close-button:hover {
+  color: #999;
+}
+.leaflet-darkmode .leaflet-popup-scrolled {
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+}
+.leaflet-darkmode.leaflet-oldie .leaflet-control-zoom,
+.leaflet-darkmode.leaflet-oldie .leaflet-control-layers,
+.leaflet-darkmode.leaflet-oldie .leaflet-popup-content-wrapper,
+.leaflet-darkmode.leaflet-oldie .leaflet-popup-tip {
+  border: 1px solid #999;
 }
 
 
@@ -724,24 +716,23 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-right-color: #fff;
 	}
 
-@media (prefers-color-scheme: dark) {
-	.leaflet-tooltip {
-		background-color: #333;
-		border: 1px solid #333;
-		color: #fff;
-		box-shadow: 0 1px 3px rgba(0,0,0,0.4);
-	}
+/* Dark Mode */
+.leaflet-darkmode .leaflet-tooltip {
+  background-color: #333;
+  border: 1px solid #333;
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+}
 
-	.leaflet-tooltip-top:before {
-		border-top-color: #333;
-	}
-	.leaflet-tooltip-bottom:before {
-		border-bottom-color: #333;
-	}
-	.leaflet-tooltip-left:before {
-		border-left-color: #333;
-	}
-	.leaflet-tooltip-right:before {
-		border-right-color: #333;
-	}
+.leaflet-darkmode .leaflet-tooltip-top:before {
+  border-top-color: #333;
+}
+.leaflet-darkmode .leaflet-tooltip-bottom:before {
+  border-bottom-color: #333;
+}
+.leaflet-darkmode .leaflet-tooltip-left:before {
+  border-left-color: #333;
+}
+.leaflet-darkmode .leaflet-tooltip-right:before {
+  border-right-color: #333;
 }

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -500,10 +500,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
 }
 .leaflet-darkmode .leaflet-control-scale-line {
   border: 2px solid #444;
-  background: rgba(51, 51, 51, 0.5);
+  border-top: none;
+  background: rgba(51, 51, 51, 0.6);
 }
+
 .leaflet-darkmode .leaflet-control-scale-line:not(:first-child) {
   border-top: 2px solid #444;
+  border-bottom: none;
 }
 .leaflet-darkmode .leaflet-control-scale-line:not(:first-child):not(:last-child) {
   border-bottom: 2px solid #444;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -327,6 +327,26 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-bottom-right-radius: 2px;
 	}
 
+
+@media (prefers-color-scheme: dark) {
+	.leaflet-bar a,
+	.leaflet-bar a:hover{
+		background-color: #333;
+		border-bottom: 1px solid #ddd;
+		color: #fff;
+	}
+
+	.leaflet-bar a:hover {
+		background-color: #444;
+	}
+
+	.leaflet-bar a.leaflet-disabled {
+		background-color: #444;
+		color: #bbb;
+	}
+}
+
+
 /* zoom control */
 
 .leaflet-control-zoom-in,
@@ -398,10 +418,24 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 
+@media (prefers-color-scheme: dark) {
+	.leaflet-control-layers {
+		box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+		background: #333;
+	}
+	.leaflet-control-layers-expanded {
+		color: #fff;
+		background: #333;
+	}
+	.leaflet-control-layers-separator {
+		border-top: 1px solid #ddd;
+	}
+}
+
+
 /* attribution and scale controls */
 
 .leaflet-container .leaflet-control-attribution {
-	background: #fff;
 	background: rgba(255, 255, 255, 0.7);
 	margin: 0;
 	}
@@ -436,8 +470,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	overflow: hidden;
 	-moz-box-sizing: border-box;
 	     box-sizing: border-box;
-
-	background: #fff;
 	background: rgba(255, 255, 255, 0.5);
 	}
 .leaflet-control-scale-line:not(:first-child) {
@@ -460,6 +492,32 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	background-clip: padding-box;
 	}
 
+@media (prefers-color-scheme: dark) {
+	.leaflet-container .leaflet-control-attribution {
+		background: rgba(51, 51, 51, 0.7);
+	}
+	.leaflet-container .leaflet-control-attribution a{
+		color: #70D6FF;
+	}
+	.leaflet-control-attribution,
+	.leaflet-control-scale-line {
+		color: #fff;
+	}
+	.leaflet-control-scale-line {
+		border: 2px solid #444;
+		background: rgba(51, 51, 51, 0.5);
+	}
+	.leaflet-control-scale-line:not(:first-child) {
+		border-top: 2px solid #444;
+	}
+	.leaflet-control-scale-line:not(:first-child):not(:last-child) {
+		border-bottom: 2px solid #444;
+	}
+	.leaflet-touch .leaflet-control-layers,
+	.leaflet-touch .leaflet-bar {
+		border: 2px solid rgba(0,0,0,0.2);
+	}
+}
 
 /* popup */
 
@@ -552,6 +610,32 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border: 1px solid #999;
 	}
 
+@media (prefers-color-scheme: dark) {
+
+	.leaflet-popup-content-wrapper,
+	.leaflet-popup-tip {
+		background: #333;
+		color: #fff;
+		box-shadow: 0 3px 14px rgba(0,0,0,0.4);
+	}
+	.leaflet-container a.leaflet-popup-close-button{
+		color: #ddd;
+	}
+	.leaflet-container a.leaflet-popup-close-button:hover {
+		color: #999;
+	}
+	.leaflet-popup-scrolled {
+		border-bottom: 1px solid #ddd;
+		border-top: 1px solid #ddd;
+	}
+	.leaflet-oldie .leaflet-control-zoom,
+	.leaflet-oldie .leaflet-control-layers,
+	.leaflet-oldie .leaflet-popup-content-wrapper,
+	.leaflet-oldie .leaflet-popup-tip {
+		border: 1px solid #999;
+	}
+}
+
 
 /* div icon */
 
@@ -593,7 +677,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	content: "";
 	}
 
-/* Directions */
+
+/* Tooltip Directions */
 
 .leaflet-tooltip-bottom {
 	margin-top: 6px;
@@ -638,3 +723,25 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	margin-left: -12px;
 	border-right-color: #fff;
 	}
+
+@media (prefers-color-scheme: dark) {
+	.leaflet-tooltip {
+		background-color: #333;
+		border: 1px solid #333;
+		color: #fff;
+		box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+	}
+
+	.leaflet-tooltip-top:before {
+		border-top-color: #333;
+	}
+	.leaflet-tooltip-bottom:before {
+		border-bottom-color: #333;
+	}
+	.leaflet-tooltip-left:before {
+		border-left-color: #333;
+	}
+	.leaflet-tooltip-right:before {
+		border-right-color: #333;
+	}
+}

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1279,4 +1279,122 @@ describe("Map", function () {
 			expect(map.getZoom()).to.be(undefined);
 		});
 	});
+
+	describe("#Map Options", function () {
+
+		beforeEach(function () {
+			container.style.width = "800px";
+			container.style.height = "600px";
+			container.style.visibility = "hidden";
+		});
+
+		describe("#Dark Mode", function () {
+			window.matchMediaOrg = window.matchMedia;
+
+			function toHex(rgb) {
+				rgb = rgb.match(/\d+/g);
+				var r = parseInt(rgb[0]).toString(16);
+				var g = parseInt(rgb[1]).toString(16);
+				var b = parseInt(rgb[2]).toString(16);
+				return '#' + r + g + b;
+			}
+
+			it("Force Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+				expect(L.DomUtil.hasClass(container, 'leaflet-darkmode')).to.be(true);
+			});
+
+			it.skipIfNo3d("Checks if User use Color Schema - Enabled Light Mode (Default)", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				// we need to overwrite matchMedia to simulate the color-schema
+
+				window.matchMedia = function (query) {
+					if (query === '(prefers-color-scheme: light)') {
+						return window.matchMediaOrg('');
+					}
+					return window.matchMediaOrg(query);
+				};
+
+				map = L.map(container, {useUserColorScheme: true});
+				expect(L.DomUtil.hasClass(container, 'leaflet-darkmode')).to.be(false);
+			});
+
+			it.skipIfNo3d("Checks if User use Color Schema - Enabled Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+
+				// we need to overwrite matchMedia to simulate the color-schema
+				window.matchMedia = function (query) {
+					if (query === '(prefers-color-scheme: dark)') {
+						return window.matchMediaOrg('');
+					}
+					return window.matchMediaOrg(query);
+				};
+
+				map = L.map(container, {useUserColorScheme: true});
+				expect(L.DomUtil.hasClass(container, 'leaflet-darkmode')).to.be(true);
+			});
+
+			it("Checks if Zoom Control is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+
+				var zoomControl = container.querySelectorAll('.leaflet-control-zoom-out')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+
+			it("Checks if Attribution is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+
+				var zoomControl = container.querySelectorAll('.leaflet-control-attribution.leaflet-control')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+
+			it("Checks if Layer Control is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+
+				L.control.layers(null, null).addTo(map);
+
+				var zoomControl = container.querySelectorAll('.leaflet-control-layers.leaflet-control')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+
+			it("Checks if Scale Control is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+				map.setView([0, 0], 1);
+
+				L.control.scale().addTo(map);
+
+				var zoomControl = container.querySelectorAll('.leaflet-control-scale-line')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+
+			it("Checks if Popup is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+				map.setView([0, 0], 1);
+
+				var marker = L.marker(map.getCenter()).addTo(map);
+				marker.bindPopup("<p>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Donec odio. Quisque volutpat mattis eros. Nullam malesuada erat ut turpis. Suspendisse urna nibh, viverra non, semper suscipit, posuere a, pede.</p><p>Donec nec justo eget felis facilisis fermentum. Aliquam porttitor mauris sit amet orci. Aenean dignissim pellentesque.</p>").addTo(map).openPopup();
+
+				var zoomControl = container.querySelectorAll('.leaflet-popup-content-wrapper')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+
+			it("Checks if Tooltip is in Dark Mode", function () {
+				map.remove(); // remove the generated Map to re-created it with options
+				map = L.map(container, {darkMode: true});
+				map.setView([0, 0], 1);
+
+				var marker = L.marker(map.getCenter()).addTo(map);
+				marker.bindTooltip("This is a Tooltip", {permanent: true}).addTo(map).openTooltip();
+
+				var zoomControl = container.querySelectorAll('.leaflet-tooltip')[0];
+				expect(toHex(window.getComputedStyle(zoomControl).backgroundColor)).to.be("#333333");
+			});
+		});
+	});
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -120,7 +120,15 @@ export var Map = Evented.extend({
 
 		// @option trackResize: Boolean = true
 		// Whether the map automatically handles browser window resize to update itself.
-		trackResize: true
+		trackResize: true,
+
+		// @option darkMode: Boolean = false
+		// Force Dark Mode of Leaflet
+		darkMode: false,
+
+		// @option useUserColorScheme: Boolean = true
+		// Use the user color scheme to switch between Light and Dark Mode
+		useUserColorScheme: true
 	},
 
 	initialize: function (id, options) { // (HTMLElement or String, Object)
@@ -1109,6 +1117,11 @@ export var Map = Evented.extend({
 
 		if (position !== 'absolute' && position !== 'relative' && position !== 'fixed') {
 			container.style.position = 'relative';
+		}
+
+		var userPrefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+		if (this.options.darkMode || (this.options.useUserColorScheme && userPrefersDark)) {
+			DomUtil.addClass(container, 'leaflet-darkmode');
 		}
 
 		this._initPanes();


### PR DESCRIPTION
# Adds Dark Mode to Leaflet

If the Browser settings of the user is in Dark Mode, Leaflet will automatically change it too. The information comes from [prefers-color-scheme](prefers-color-scheme). This automation can also disabled while map creation with `useUserColorScheme: false` -> `L.map("map",{useUserColorScheme: false});`

Dark Mode can also be forced with the map option `darkMode: true`. 

@Malvoz maybe you can take a look into it about accessibility / contrast

Fix: #7577 

![grafik](https://user-images.githubusercontent.com/19800037/124032087-6b491300-d9f8-11eb-9670-3f9797ebaa9a.png)
![grafik](https://user-images.githubusercontent.com/19800037/124166784-9177bd00-daa3-11eb-93e2-a4b07eae5d6a.png)
