### PR TITLE
Check maxBounds, which may be undefined

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1261,7 +1261,7 @@ export var Map = Evented.extend({
 	},
 
 	_panInsideMaxBounds: function () {
-		if (!this._enforcingBounds) {
+		if (!this._enforcingBounds && this.options.maxBounds) {
 			this.panInsideBounds(this.options.maxBounds);
 		}
 	},


### PR DESCRIPTION
options.maxBounds could be initially set, but removed by the moment when the event is fired (with l.fn.call(l.ctx || this, event), inside of fire method). If maxBounds already cleared, calling the _panInsideMaxBounds may produce chain of calls with undefined parameter and "Uncaught TypeError: latlng is undefined" at the end, in "project" method.