### PR TITLE
leaflet-geojson-vt plugin added

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -794,6 +794,15 @@ Plugins to display [vector tiles](https://github.com/mapbox/vector-tile-spec).
 	</tr>
 	<tr>
 		<td>
+			<a href="https://github.com/iamtekson/leaflet-geojson-vt">leaflet-geojson-vt</a>
+		</td><td>
+			Displaying the vector tiles of GeoJSON data on the fly on leaflet
+		</td><td>
+			<a href="https://github.com/iamtekson">Tek Kshetri</a>
+		</td>
+	</tr>
+	<tr>
+		<td>
 			<a href="https://github.com/mapbox/geojson-vt">geojson-vt</a>
 		</td><td>
 			Efficient library for slicing GeoJSON data into vector tiles on the fly.


### PR DESCRIPTION
The leaflet plugin helps to render vector tiles for the GeoJSON data on the fly.