### PR TITLE
Run CI on Github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,5 +11,6 @@ jobs:
           check-latest: true
           cache: npm
       - run: npm ci
+      - run: npm run lint
       - run: npm test -- -- --browsers PhantomJSCustom,Chrome1280x1024,FirefoxPointer,FirefoxTouch,FirefoxPointerTouch --reporters
       - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  push:
-    branches: [master]
-  pull_request:
-    branches: [master]
+on: push
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          check-latest: true
+          cache: npm
+      - run: npm ci
+      - run: npm test -- -- --browsers PhantomJSCustom,Chrome1280x1024,FirefoxPointer,FirefoxTouch,FirefoxPointerTouch --reporters
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
   ],
   "scripts": {
     "docs": "node ./build/docs.js",
-    "pretest": "npm run lint",
-    "test": "npm run test-nolint",
-    "test-nolint": "karma start ./spec/karma.conf.js",
+    "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
     "release": "./build/publish.sh",
     "lint": "eslint src spec/suites docs/docs/js",


### PR DESCRIPTION
Depends on #7653 as a `package-lock.json` file is needed to run `npm ci`. Allows running the CI on Github actions instead of Travis, as it looks like the Travis builds are not running. Added benefit is that forks can use the same configuration to run CI without having to set up Travis and change the source.