### PR TITLE
TileLayer feature: Add failover for subdomains

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -227,7 +227,10 @@ export var TileLayer = GridLayer.extend({
 		return zoom + zoomOffset;
 	},
 
-	_getSubdomain: function (tilePoint, failoverOffset = 0) {
+	_getSubdomain: function (tilePoint, failoverOffset) {
+		if (failoverOffset === undefined) {
+			failoverOffset = 0;
+		}
 		var index = Math.abs(tilePoint.x + tilePoint.y + failoverOffset) % this.options.subdomains.length;
 		return this.options.subdomains[index];
 	},


### PR DESCRIPTION
If one of the subdomains fails, currently the tiles for this will not be rendered. With this PR it now tries to get the tile from the next subdomain until all servers were tried.