### PR TITLE
Add scripts in 'build' directory to linting config

### DIFF
--- a/build/docs.js
+++ b/build/docs.js
@@ -13,7 +13,7 @@ function buildDocs() {
 
 	// Note to Vladimir: Iván's never gonna uncomment the following line. He's
 	// too proud of the little leaves around the code.
-	//doc.setLeadingChar('@');
+	// doc.setLeadingChar('@');
 
 	// Leaflet uses a couple of non-standard documentable things. They are not
 	// important enough to be classes/namespaces of their own, and should

--- a/build/integrity.js
+++ b/build/integrity.js
@@ -17,11 +17,11 @@ console.log('dist/leaflet.css:    ', integrityCss.toString());
 
 var docConfig = fs.readFileSync('docs/_config.yml').toString();
 
-docConfig = docConfig.
-	replace(/latest_leaflet_version:.*/,  'latest_leaflet_version: ' + version).
-	replace(/integrity_hash_source:.*/,   'integrity_hash_source: "' +   integritySrc.toString() + '"').
-	replace(/integrity_hash_uglified:.*/, 'integrity_hash_uglified: "' + integrityUglified.toString() + '"').
-	replace(/integrity_hash_css:.*/,      'integrity_hash_css: "' +      integrityCss.toString() + '"');
+docConfig = docConfig
+	.replace(/latest_leaflet_version:.*/,  'latest_leaflet_version: ' + version)
+	.replace(/integrity_hash_source:.*/,   'integrity_hash_source: "' +   integritySrc.toString() + '"')
+	.replace(/integrity_hash_uglified:.*/, 'integrity_hash_uglified: "' + integrityUglified.toString() + '"')
+	.replace(/integrity_hash_css:.*/,      'integrity_hash_css: "' +      integrityCss.toString() + '"');
 
 // console.log('New jekyll docs config: \n', docConfig);
 

--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -1,9 +1,9 @@
 // Config file for running Rollup in "normal" mode (non-watch)
 
-import rollupGitVersion from 'rollup-plugin-git-version'
-import json from 'rollup-plugin-json'
-import gitRev from 'git-rev-sync'
-import pkg from '../package.json'
+import rollupGitVersion from 'rollup-plugin-git-version';
+import json from 'rollup-plugin-json';
+import gitRev from 'git-rev-sync';
+import pkg from '../package.json';
 
 let {version} = pkg;
 let release;

--- a/build/rollup-watch-config.js
+++ b/build/rollup-watch-config.js
@@ -1,8 +1,8 @@
 // Config file for running Rollup in "watch" mode
 // This adds a sanity check to help ourselves to run 'rollup -w' as needed.
 
-import rollupGitVersion from 'rollup-plugin-git-version'
-import gitRev from 'git-rev-sync'
+import rollupGitVersion from 'rollup-plugin-git-version';
+import gitRev from 'git-rev-sync';
 
 const branch = gitRev.branch();
 const rev = gitRev.short();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
     "release": "./build/publish.sh",
-    "lint": "eslint src spec/suites docs/docs/js",
+    "lint": "eslint src spec/suites docs/docs/js build",
     "lintfix": "npm run lint -- --fix",
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-watch-config.js",
@@ -93,7 +93,18 @@
           "allowShortCircuit": true
         }
       ]
-    }
+    },
+    "overrides": [
+      {
+        "files": ["build/**/*"],
+        "env": {
+          "node": true
+        },
+        "rules": {
+          "global-require": 0
+        }
+      }
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Wanted to work on these files and my IDE started complaining about the linting. Turns out this directory wasn't part of the linting task. This PR adds the 'build' directory to the linting task and fixes the issues that were encountered.