### PR TITLE
Fix map display on larger screens

### DIFF
--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -19,8 +19,8 @@
 			margin: 0;
 		}
 		#map {
-			width: 600px;
-			height: 400px;
+			max-width: 100%;
+			height: 100vw;
 		}
 	</style>
 {% endunless %}


### PR DESCRIPTION
Fixes map displaying on desktop screens, while remaining responsive on mobile devices.

Fix #7420