### PR TITLE
Upload artifacts from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,14 +3,47 @@ on: [push, pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      # Only deploy artifacts from the main repo if on master, or when a version is tagged.
+      DEPLOY_ARTIFACTS: ${{ github.repository_owner == 'Leaflet' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
         with:
           node-version: 16
           check-latest: true
           cache: npm
-      - run: npm ci
+
+      - name: Install dependencies
+        run: npm ci
+
       - run: npm run lint
       - run: npm test -- --browsers PhantomJSCustom,Chrome1280x1024,FirefoxPointer,FirefoxTouch,FirefoxPointerTouch
       - run: npm run build
+
+      - name: Compress artifacts
+        if: env.DEPLOY_ARTIFACTS == 'true'
+        working-directory: dist
+        run: zip -r leaflet.zip .
+
+      - name: Determine directory for artifacts
+        if: env.DEPLOY_ARTIFACTS == 'true'
+        id: artifacts-directory
+        run: |
+          VERSION=$(git tag --points-at HEAD)
+          echo "::set-output name=path::content/leaflet/${VERSION:-master}"
+
+      - name: Deploy artifacts
+        if: env.DEPLOY_ARTIFACTS == 'true'
+        uses: jakejarvis/s3-sync-action@v0.5.1
+        with:
+          args: --acl public-read --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: dist
+          DEST_DIR: ${{ steps.artifacts-directory.outputs.path }}


### PR DESCRIPTION
Allows artifacts from the build to be uploaded to an S3 bucket, same as Travis would do. This change is needed to facilitate the switch from Travis to Github Actions as described in #7611.

The artifacts will be uploaded for any commit that is made on the `master` branch, or if a version is tagged. In order for this change to work the following [secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) will have to be added to the repository:

- `AWS_S3_BUCKET`
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`

More information about these variables can be found in the [documentation](https://github.com/jakejarvis/s3-sync-action#configuration) of the action used to upload the artifacts.