### PR TITLE
Adds a Map option to set the timeout for firing the contextmenu event.

### DIFF
--- a/src/map/handler/Map.Tap.js
+++ b/src/map/handler/Map.Tap.js
@@ -25,7 +25,12 @@ Map.mergeOptions({
 	// @option tapTolerance: Number = 15
 	// The max number of pixels a user can shift his finger during touch
 	// for it to be considered a valid tap.
-	tapTolerance: 15
+	tapTolerance: 15,
+
+	// @option contextMenuTimeout: Number = 1000
+	// The amount of time that needs to elapse before the contextmenu
+	// event is fired on a long press.
+	contextMenuTimeout: 1000
 });
 
 export var Tap = Handler.extend({
@@ -68,7 +73,7 @@ export var Tap = Handler.extend({
 				this._onUp();
 				this._simulateEvent('contextmenu', first);
 			}
-		}, this), 1000);
+		}, this), this._map.options.contextMenuTimeout);
 
 		this._simulateEvent('mousedown', first);
 


### PR DESCRIPTION
The current timeout in Map.Tap.js is set to 1000 ms. iOS provides tactile feedback at around 600ms on a long touch. Users are likely to end their long touch after receiving the tactile feedback and wonder why the context menu did not appear.

This PR does not change the current value but does allow application developers to change the timeout to something that is reasonable for their purposes.
