### PR TITLE
Make docs headings sticky

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -488,6 +488,10 @@ table.plugins td:first-child a {
 	color: #333;
 	border-bottom: 3px solid #555;
 	transition: border-color .25s ease;
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	background-color: white;
 }
 .api-page #toc ~ h2:target {
 	border-color: #1EB300;

--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -9,6 +9,11 @@ html, body, input, select, button, textarea, table {
 	text-rendering: optimizeLegibility;
 }
 
+html {
+	scroll-padding-top: 5em;
+	overflow: auto;
+}
+
 body {
 	line-height: 1.5;
 	color: black;

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -23,6 +23,15 @@ section > h4 {
     font-weight: 500;
     margin: 1em 0 0.25em;
 }
+div.accordion.expanded label,
+section > h4 {
+    margin: 0.75em 0 0;
+    padding: 0.25em 0;
+    position: sticky;
+    top: 2.8em;
+    background-color: white;
+    border-bottom: 1px solid #eee;
+}
 
 label {
     cursor: pointer;


### PR DESCRIPTION
Every now and again, when I browse the documentation I find myself unsure which namespace I'm on or what options I'm looking at, so using a bit of CSS and `position: sticky` I've the headings stay comfortable put at the top of the screen, both on desktop and mobile.

https://user-images.githubusercontent.com/524259/138038696-a73b4531-8b8e-4825-9236-1ef914684e5c.mp4

Are there any test for docs or did I edit some auto-generated files?

