### PR TITLE
Split main workflow into multiple parallel jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
 
   deploy:
     needs: setup
-    # if: secrets.AWS_S3_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
+    if: secrets.AWS_S3_BUCKET && secrets.AWS_ACCESS_KEY_ID && secrets.AWS_SECRET_ACCESS_KEY
     runs-on: ubuntu-latest
     steps:
       - name: Restore setup


### PR DESCRIPTION
This changes the main workflow by splitting it out into multiple separate jobs, the following is included in this change:

- ~~NodeJS version is bumped to version 17.~~ (changed back to 16)
- An additional level of caching has been added for dependencies, allowing the `npm ci` step to be skipped if no dependencies were modified.
- Linting (and possible future tasks) now run in a separate job, allowing them to run in parallel.
- Tests now run in a separate job for each individual browser, making it easier to find which is causing failures.
- Deployment of artifacts now runs in a separate job which only runs if the secrets are properly configured.