### PR TITLE
Remove attribution if tiles not visible

### DIFF
--- a/spec/suites/control/Control.AttributionSpec.js
+++ b/spec/suites/control/Control.AttributionSpec.js
@@ -121,4 +121,11 @@ describe("Control.Attribution", function () {
 			expect(container.innerHTML).to.eql('prefix');
 		});
 	});
+
+	describe('#getAttributionText', function () {
+		it('reads out the attribution text', function () {
+			control.addAttribution('foo');
+			expect(control.getAttributionText()).to.eql('prefix | foo');
+		});
+	});
 });

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -1095,4 +1095,73 @@ describe('GridLayer', function () {
 		grid.redraw();
 		expect(wrapped.neverCalledWith(sinon.match.any, null)).to.be(true);
 	});
+
+	describe("Attribution adding / removing", function () {
+		var clock;
+		beforeEach(function () {
+			map.setView([0, 0], 1);
+			clock = sinon.useFakeTimers();
+		});
+
+		it("shows attribution only when layer is between min and maxZoom", function () {
+
+			L.gridLayer({
+				attribution: 'Grid 1',
+				maxZoom: 20,
+				minZoom: 1
+			}).addTo(map);
+
+			L.gridLayer({
+				attribution: 'Grid 2',
+				maxZoom: 10,
+				minZoom: 5
+			}).addTo(map);
+
+			// Grid 2 should be hidden on Zoom 1
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 2') > -1).to.be(false);
+
+			// Grid 2 should be visible on Zoom 10
+			map.setZoom(10, {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 2') > -1).to.be(true);
+
+			// Grid 2 should be hidden on Zoom 11
+			map.setZoom(11, {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 2') > -1).to.be(false);
+
+			// Grid 2 should be visible on Zoom 5
+			map.setZoom(5, {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 2') > -1).to.be(true);
+
+			// Grid 2 should be hidden on Zoom 4
+			map.setZoom(4, {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 2') > -1).to.be(false);
+		});
+
+		it("shows attribution only when visible tile bounds overlaps with map bounds", function () {
+			L.gridLayer({
+				attribution: 'Grid 1',
+				bounds: [[47.521, 9.813], [47.454, 9.676]]
+			}).addTo(map);
+
+			// moves to position where tile is visible
+			map.setView([47.5832810257206, 9.747963094401658],12);
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 1') > -1).to.be(true);
+
+			// Zoom in -> Tile vanish because of bounds
+			map.setZoom(13, {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 1') > -1).to.be(false);
+
+			// move map to show tiles
+			map.panTo([47.561818868642106, 9.740236583855408 ], {animate: false});
+			clock.tick(250);
+			expect(map.attributionControl.getAttributionText().indexOf('Grid 1') > -1).to.be(true);
+		});
+
+	});
 });

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -27,7 +27,7 @@ export var Attribution = Control.extend({
 
 	initialize: function (options) {
 		Util.setOptions(this, options);
-
+		this._attributionText = '';
 		this._attributions = {};
 	},
 
@@ -104,7 +104,13 @@ export var Attribution = Control.extend({
 			prefixAndAttribs.push(attribs.join(', '));
 		}
 
-		this._container.innerHTML = prefixAndAttribs.join(' | ');
+		this._attributionText = this._container.innerHTML = prefixAndAttribs.join(' | ');
+	},
+
+	// @method getAttributionText(): String
+	// Returns the generated attribution text.
+	getAttributionText: function () {
+		return this._attributionText;
 	}
 });
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -552,6 +552,8 @@ export var GridLayer = Layer.extend({
 			tileZoom = this._clampZoom(tileZoom);
 		}
 
+		this._attributionCheck();
+
 		var tileZoomChanged = this.options.updateWhenZooming && (tileZoom !== this._tileZoom);
 
 		if (!noUpdate || tileZoomChanged) {
@@ -643,7 +645,11 @@ export var GridLayer = Layer.extend({
 		var zoom = this._clampZoom(map.getZoom());
 
 		if (center === undefined) { center = map.getCenter(); }
-		if (this._tileZoom === undefined) { return; }	// if out of minzoom/maxzoom
+		if (this._tileZoom === undefined) {
+			// if out of minzoom/maxzoom
+			this._attributionCheck();
+			return;
+		}
 
 		var pixelBounds = this._getTiledPixelBounds(center),
 		    tileRange = this._pxBoundsToTileRange(pixelBounds),
@@ -670,6 +676,8 @@ export var GridLayer = Layer.extend({
 		// from the map's, let _setView reset levels and prune old tiles.
 		if (Math.abs(zoom - this._tileZoom) > 1) { this._setView(center, zoom); return; }
 
+		var visibleTileBounds = this.options.bounds ? latLngBounds() : this._map.getBounds();
+
 		// create a queue of coordinates to load tiles from
 		for (var j = tileRange.min.y; j <= tileRange.max.y; j++) {
 			for (var i = tileRange.min.x; i <= tileRange.max.x; i++) {
@@ -677,6 +685,10 @@ export var GridLayer = Layer.extend({
 				coords.z = this._tileZoom;
 
 				if (!this._isValidTile(coords)) { continue; }
+
+				if (this.options.bounds) {
+					visibleTileBounds.extend(this._tileCoordsToBounds(coords));
+				}
 
 				var tile = this._tiles[this._tileCoordsToKey(coords)];
 				if (tile) {
@@ -686,6 +698,7 @@ export var GridLayer = Layer.extend({
 				}
 			}
 		}
+		this._visibleTileBounds = visibleTileBounds;
 
 		// sort tile queue to load tiles in order of their distance to center
 		queue.sort(function (a, b) {
@@ -710,6 +723,7 @@ export var GridLayer = Layer.extend({
 
 			this._level.el.appendChild(fragment);
 		}
+		this._attributionCheck();
 	},
 
 	_isValidTile: function (coords) {
@@ -914,6 +928,36 @@ export var GridLayer = Layer.extend({
 			if (!this._tiles[key].loaded) { return false; }
 		}
 		return true;
+	},
+	_layerAdd: function(e){
+		Layer.prototype._layerAdd.call(this,e);
+		this._attributionAdded = true; // attribution is already added over Layer._layerAdd
+		this._attributionCheck();
+	},
+	_attributionCheck(){
+		if (this.getAttribution && this._map.attributionControl) {
+			var tileZoom = Math.round(this._map.getZoom());
+
+			var removeAttribution = false;
+			// remove attribution if layer is hidden because of min-/maxZoom
+			if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
+				(this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
+				removeAttribution = true;
+			}
+
+			// remove attribution if layer is out of the map bounds
+			if (this.options.bounds && this._visibleTileBounds && (!this._visibleTileBounds.getNorthEast() || !this._visibleTileBounds.overlaps(this._map.getBounds()))) {
+				removeAttribution = true;
+			}
+
+			if(removeAttribution){
+				this._map.attributionControl.removeAttribution(this.getAttribution());
+				this._attributionAdded = false;
+			}else if (this.getAttribution && this._map.attributionControl && this._attributionAdded === false) {
+				this._attributionAdded = true;
+				this._map.attributionControl.addAttribution(this.getAttribution());
+			}
+		}
 	}
 });
 


### PR DESCRIPTION
Fix: #5253

Attributions are now removed if tiles not visible. This can be because of `minZoom`, `maxZoom` and `bounds`.

Also added the option `getAttributionText` to `Control.Attribution`.
![attribution_tiles](https://user-images.githubusercontent.com/19800037/139558493-ff54f682-8fdd-4b8f-9778-87a016ec96bb.gif)
![attribution_tiles_move](https://user-images.githubusercontent.com/19800037/139558497-3ca2f6ed-0640-4a8e-aa2c-ffe3ec3c6c5d.gif)

