### PR TITLE
Continue running tests even if one fails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
   test:
     needs: setup
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         browser:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,8 @@ jobs:
   test:
     needs: setup
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         browser:
           [


### PR DESCRIPTION
Sets the `fail-fast` option for the tests on the CI to `false`. This will prevent Github Actions from cancelling other test jobs if one of them fails, which allows us to see the result of all the tests runs.