### PR TITLE
Add npm scripts `test-all` and `pre-commit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   "scripts": {
     "docs": "node ./build/docs.js",
     "test": "karma start ./spec/karma.conf.js",
+    "test-all": "karma start ./spec/karma.conf.js --browsers Chrome1280x1024,FirefoxPointer,FirefoxTouch,FirefoxPointerTouch",
+    "pre-commit": "npm run build && npm run lint && npm run test-all -- --forbidOnly",
     "build": "npm run rollup && npm run uglify",
     "release": "./build/publish.sh",
     "lint": "eslint src spec/suites docs/docs/js build",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -165,7 +165,7 @@ module.exports = function (config) {
 
 		client: {
 			 mocha: {
-			 	forbidOnly: process.env.CI || false
+			 	forbidOnly: process.env.CI || config.forbidOnly || false
 			 }
 		}
 	});


### PR DESCRIPTION
New npm scripts which should it make easier for contributers to test and push valid code.

- With `npm run test-all` all tests can be run in all browsers (same as Github CI)
- With `npm run pre-commit` all scripts that should be made before commiting / pushing can be done with one call. First building, then linting and then run all tests in all browsers and check if there is no `.only` test