### PR TITLE
Tests: remove non-functional Firefox setting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,6 @@ jobs:
         browser:
           [
             Chrome1280x1024,
-            FirefoxPointer,
             FirefoxTouch,
             FirefoxPointerTouch,
           ]

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -102,24 +102,15 @@ module.exports = function (config) {
 				// https://github.com/Leaflet/Leaflet/issues/7113#issuecomment-619528577
 				flags: ['--window-size=1280,1024']
 			},
-			'FirefoxPointer': {
-				base: 'FirefoxHeadless',
-			        prefs: {
-					'dom.w3c_pointer_events.enabled': true,
-					'dom.w3c_touch_events.enabled': 0
-			        }
-			},
 			'FirefoxTouch': {
 				base: 'FirefoxHeadless',
 			        prefs: {
-					'dom.w3c_pointer_events.enabled': false,
 					'dom.w3c_touch_events.enabled': 1
 			        }
 			},
 			'FirefoxPointerTouch': {
 				base: 'FirefoxHeadless',
 			        prefs: {
-					'dom.w3c_pointer_events.enabled': true,
 					'dom.w3c_touch_events.enabled': 1
 			        }
 			},


### PR DESCRIPTION
`dom.w3c_pointer_events.enabled` does not exist in recent Firefox
Anyway, it is not really useful after 0ae68f4658cb1cd85e6e0c67a24b12e5e6282e22

Fix #7728
Ref: #7029