### PR TITLE
Lint all files unless explicitly ignored

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
     "ignorePatterns": [
       "dist",
       "debug",
-      "docs"
+      "docs/docs/highlight",
+      "docs/examples/choropleth",
+      "docs/examples/geojson",
+      "docs/examples/map-panes"
     ],
     "root": true,
     "globals": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "docs": "node ./build/docs.js",
     "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
-    "lint": "eslint src spec/suites docs/docs/js build",
+    "lint": "eslint .",
     "lintfix": "npm run lint -- --fix",
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-watch-config.js",
@@ -49,6 +49,11 @@
     "prepublishOnly": "npm ci && npm run lint && npm run test && NODE_ENV=release npm run build"
   },
   "eslintConfig": {
+    "ignorePatterns": [
+      "dist",
+      "debug",
+      "docs"
+    ],
     "root": true,
     "globals": {
       "L": true

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -131,6 +131,7 @@ module.exports = function (config) {
 
 		client: {
 			mocha: {
+				// eslint-disable-next-line no-undef
 				forbidOnly: process.env.CI || false
 			}
 		}


### PR DESCRIPTION
Lints all files using ESLint unless explicitly ignored using the `ignorePatterns` option. Continuation of the discussion in #7743.