### PR TITLE
LatLng: stricter arguments validation

### DIFF
--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -10,13 +10,25 @@ describe('LatLng', function () {
 			expect(b.lng).to.eql(-74);
 		});
 
-		it('throws an error if invalid lat or lng', function () {
-			expect(function () {
-				L.latLng(NaN, NaN);
-			}).to.throwError();
+		it('throws an error if invalid lat, lng, alt', function () {
+			expect(L.latLng).withArgs(0, 0, undefined).to.throwError();
+			expect(L.latLng).withArgs(0).to.throwError();
+			expect(L.latLng).withArgs(NaN, 0).to.throwError();
+			expect(L.latLng).withArgs(Infinity, 0).to.throwError();
+			expect(L.latLng).withArgs(-Infinity, 0).to.throwError();
+			expect(L.latLng).withArgs(true, 0).to.throwError();
+			expect(L.latLng).withArgs(false, 0).to.throwError();
+			expect(L.latLng).withArgs(undefined, 0).to.throwError();
+			expect(L.latLng).withArgs(null, 0).to.throwError();
+			expect(L.latLng).withArgs('', 0).to.throwError();
+			expect(L.latLng).withArgs('\n', 0).to.throwError();
+			expect(L.latLng).withArgs('1px', 0).to.throwError();
+			expect(L.latLng).withArgs([]).to.throwError();
+			expect(L.latLng).withArgs([50]).to.throwError();
+			// expect(L.latLng).withArgs('1e5', 0).to.throwError();
 		});
 
-		it('does not set altitude if undefined', function () {
+		it('does not set altitude if not specified', function () {
 			var a = new L.LatLng(25, 74);
 			expect(typeof a.alt).to.eql('undefined');
 		});
@@ -80,15 +92,8 @@ describe('LatLng', function () {
 		});
 
 		it('accepts an array of coordinates', function () {
-			expect(L.latLng([])).to.eql(null);
-			expect(L.latLng([50])).to.eql(null);
 			expect(L.latLng([50, 30])).to.eql(new L.LatLng(50, 30));
 			expect(L.latLng([50, 30, 100])).to.eql(new L.LatLng(50, 30, 100));
-		});
-
-		it('passes null or undefined as is', function () {
-			expect(L.latLng(undefined)).to.eql(undefined);
-			expect(L.latLng(null)).to.eql(null);
 		});
 
 		it('creates a LatLng object from two coordinates', function () {
@@ -101,10 +106,6 @@ describe('LatLng', function () {
 
 		it('accepts an object with lat/lon', function () {
 			expect(L.latLng({lat: 50, lon: 30})).to.eql(new L.LatLng(50, 30));
-		});
-
-		it('returns null if lng not specified', function () {
-			expect(L.latLng(50)).to.be(null);
 		});
 
 		it('accepts altitude as third parameter', function () {

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -28,23 +28,34 @@ import {toLatLngBounds} from './LatLngBounds';
  */
 
 export function LatLng(lat, lng, alt) {
-	if (isNaN(lat) || isNaN(lng)) {
-		throw new Error('Invalid LatLng object: (' + lat + ', ' + lng + ')');
-	}
-
 	// @property lat: Number
 	// Latitude in degrees
-	this.lat = +lat;
+	this.lat = checkNumber(lat);
 
 	// @property lng: Number
 	// Longitude in degrees
-	this.lng = +lng;
+	this.lng = checkNumber(lng);
 
 	// @property alt: Number
 	// Altitude in meters (optional)
-	if (alt !== undefined) {
-		this.alt = +alt;
+	if (arguments.length === 3) {
+		this.alt = checkNumber(alt);
 	}
+}
+
+function checkNumber(a) {
+	if (typeof a === 'string') {
+		if (!isNaN(a)) {
+			a = parseFloat(a);
+		}
+		if (!isNaN(a)) {
+			a = +a;
+		}
+	}
+	if ((typeof a === 'number' || a instanceof Number) && isFinite(a)) {
+		return a;
+	}
+	throw new Error('Number expected');
 }
 
 LatLng.prototype = {
@@ -122,16 +133,17 @@ export function toLatLng(a, b, c) {
 		if (a.length === 2) {
 			return new LatLng(a[0], a[1]);
 		}
-		return null;
-	}
-	if (a === undefined || a === null) {
-		return a;
 	}
 	if (typeof a === 'object' && 'lat' in a) {
-		return new LatLng(a.lat, 'lng' in a ? a.lng : a.lon, a.alt);
+		var lat = a.lat,
+		    lng = 'lng' in a ? a.lng : a.lon;
+		if ('alt' in a) {
+			return new LatLng(lat, lng, a.alt);
+		}
+		return new LatLng(a.lat, 'lng' in a ? a.lng : a.lon);
 	}
-	if (b === undefined) {
-		return null;
+	if (arguments.length === 3) {
+		return new LatLng(a, b, c);
 	}
-	return new LatLng(a, b, c);
+	return new LatLng(a, b);
 }

--- a/src/geo/LatLngBounds.js
+++ b/src/geo/LatLngBounds.js
@@ -64,7 +64,13 @@ LatLngBounds.prototype = {
 			if (!sw2 || !ne2) { return this; }
 
 		} else {
-			return obj ? this.extend(toLatLng(obj) || toLatLngBounds(obj)) : this;
+			if (!obj) { return this; }
+			try {
+				obj = toLatLng(obj);
+			} catch (err) {
+				obj = toLatLngBounds(obj);
+			}
+			return this.extend(obj);
 		}
 
 		if (!sw && !ne) {

--- a/src/geo/crs/CRS.js
+++ b/src/geo/crs/CRS.js
@@ -109,10 +109,12 @@ export var CRS = {
 	// CRS's `wrapLat` and `wrapLng` properties, if they are outside the CRS's bounds.
 	wrapLatLng: function (latlng) {
 		var lng = this.wrapLng ? Util.wrapNum(latlng.lng, this.wrapLng, true) : latlng.lng,
-		    lat = this.wrapLat ? Util.wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat,
-		    alt = latlng.alt;
+		    lat = this.wrapLat ? Util.wrapNum(latlng.lat, this.wrapLat, true) : latlng.lat;
 
-		return new LatLng(lat, lng, alt);
+		if ('alt' in latlng) {
+			return new LatLng(lat, lng, latlng.alt);
+		}
+		return new LatLng(lat, lng);
 	},
 
 	// @method wrapLatLngBounds(bounds: LatLngBounds): LatLngBounds

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -232,7 +232,11 @@ function _pointToLayer(pointToLayerFn, geojson, latlng, options) {
 // Creates a `LatLng` object from an array of 2 numbers (longitude, latitude)
 // or 3 numbers (longitude, latitude, altitude) used in GeoJSON for points.
 export function coordsToLatLng(coords) {
-	return new LatLng(coords[1], coords[0], coords[2]);
+	if (coords.length === 3) {
+		return new LatLng(coords[1], coords[0], coords[2]);
+	} else {
+		return new LatLng(coords[1], coords[0]);
+	}
 }
 
 // @function coordsToLatLngs(coords: Array, levelsDeep?: Number, coordsToLatLng?: Function): Array


### PR DESCRIPTION
Throw on any invalid value of lat/lng/alt
(alt is validated if is explicitly specified)

Ref: #7128

---
Question:
- [x] Should we throw instead of returning `null`?
- [ ] Should we be same strict with `alt`, or better allow `undefined` value for compatibility purposes?