### PR TITLE
Summing the offset of chained movements

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -340,10 +340,13 @@ export var Map = Evented.extend({
 
 		// animate pan unless animate: false specified
 		if (options.animate !== false) {
+			if (this._panAnim._inProgress) {
+				this._destinationPos = this._destinationPos.subtract(offset).round();
+			} else {
+				this._destinationPos = this._getMapPanePos().subtract(offset).round();
+			}
 			DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
-
-			var newPos = this._getMapPanePos().subtract(offset).round();
-			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
+			this._panAnim.run(this._mapPane, this._destinationPos, options.duration || 0.25, options.easeLinearity);
 		} else {
 			this._rawPanBy(offset);
 			this.fire('move').fire('moveend');


### PR DESCRIPTION
If multiple movements (`panBy`, `setView()`) are chained, the offset is summed.

```
map.setView([40.722036, -73.998599], map.zoom, {
						animate: true,
						duration: 8
					}).panBy([-150, 0], {animate: true, duration: 0.5}).panBy([0, 50], {animate: true, duration: 0.5});
```

With Timeout and "unchained"-chain call:

```
setTimeout(function () {
	map.setView([40.722036, -73.998599], map.zoom, {
		animate: true,
		duration: 8
	})
}, 1000);
setTimeout(function () {
	map.panBy([-150, 0], {animate: true, duration: 0.5}).panBy([0, 50], {animate: true, duration: 0.5});
}, 2000);
```

![anim_chain](https://user-images.githubusercontent.com/19800037/141191970-5946a150-c5f3-4f73-ab3c-d377eab56efa.gif)


Fix: #2609

-------------

@johnd0e I don't get it work with `clock` to sleep x seconds, can you please help me to get it work?
