### PR TITLE
New private function Util._checkNumber instead of checking over isNaN

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -239,3 +239,19 @@ export function cancelAnimFrame(id) {
 		cancelFn.call(window, id);
 	}
 }
+
+function isNumeric(str) { // https://stackoverflow.com/a/175787/2520247
+	return !isNaN(str) && !isNaN(parseFloat(str));
+}
+
+// keep it private intentionally, because such function implementation
+// heavily depends on it's particular application and unable to suit all the cases
+export function _checkNumber(a) {
+	if (typeof a === 'string' && isNumeric(a)) {
+		a = +a;
+	}
+	if ((typeof a === 'number' || a instanceof Number) && isFinite(a)) {
+		return a;
+	}
+	throw new Error('Number expected');
+}

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -31,8 +31,7 @@ export var Circle = CircleMarker.extend({
 		}
 		Util.setOptions(this, options);
 		this._latlng = toLatLng(latlng);
-
-		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
+		this.options.radius = Util._checkNumber(this.options.radius);
 
 		// @section
 		// @aka Circle options


### PR DESCRIPTION
1. `isNaN` itself is not reliable way to check if value can be converted to number. There a lot of discussions, and I just point to these unit tests: https://run.plnkr.co/plunks/93FPpacuIcXqqKMecLdk/

2. Just making sure that the value is convertible to number is not enough. Instead we should actually convert the value to number as early as possible (otherwise `'5'+5 = '55'`).
There are some places in code vulnerable to this sort of bugs, and a number of open issues (too lazy to link them right now).

Ref: #7761, #7128.

---
Questions:
- [x] Should we have common method instead of copy-paste (#7765, #7767, this, and potentially a lot of other cases)?
- [ ] Better name (`validateNumber`)?
- [ ] Should it be exposed as public method?
- [x] Should it be applied widely (e.g. in all constructors taking number options)?