### PR TITLE
Add DivOverlay to menu

### DIFF
--- a/build/docs-index.leafdoc
+++ b/build/docs-index.leafdoc
@@ -6,6 +6,7 @@ This file just defines the order of the classes in the docs.
 @class Map
 
 @class Marker
+@class DivOverlay
 @class Popup
 @class Tooltip
 

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -35,7 +35,7 @@ bodyclass: api-page
 		<h4>UI Layers</h4>
 		<ul>
 			<li><a href="#marker">Marker</a></li>
-            <li><a href="#divoverlay">DivOverlay</a></li>
+			<li><a href="#divoverlay">DivOverlay</a></li>
 			<li><a href="#popup">Popup</a></li>
 			<li><a href="#tooltip">Tooltip</a></li>
 		</ul>

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -35,6 +35,7 @@ bodyclass: api-page
 		<h4>UI Layers</h4>
 		<ul>
 			<li><a href="#marker">Marker</a></li>
+            <li><a href="#divoverlay">DivOverlay</a></li>
 			<li><a href="#popup">Popup</a></li>
 			<li><a href="#tooltip">Tooltip</a></li>
 		</ul>


### PR DESCRIPTION
DivOverlay is missing in the menu and was placed at the bottom of the docs (below Event objects): https://leafletjs.com/reference.html#divoverlay