### PR TITLE
Better support for RTL text (tooltips)

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -106,6 +106,9 @@
 .leaflet-map-pane canvas { z-index: 100; }
 .leaflet-map-pane svg    { z-index: 200; }
 
+
+.leaflet-rtl .leaflet-tooltip-pane   {direction: ltr;}
+
 .leaflet-vml-shape {
 	width: 1px;
 	height: 1px;
@@ -268,6 +271,10 @@ svg.leaflet-image-layer.leaflet-interactive path {
 /* general typography */
 .leaflet-container {
 	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+	}
+
+.leaflet-rtl{
+	direction: rtl;
 	}
 
 
@@ -638,4 +645,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	left: 0;
 	margin-left: -12px;
 	border-right-color: #fff;
+	}
+
+.leaflet-rtl .leaflet-tooltip-pane > * {
+	direction: rtl;
 	}

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1318,4 +1318,22 @@ describe("Map", function () {
 			expect(map.getZoom()).to.be(undefined);
 		});
 	});
+
+	describe("RTL", function () {
+		beforeEach(function () {
+			if (container._leaflet_id) {
+				map.remove();
+			}
+			document.body.removeChild(container);
+
+			container = document.createElement("div");
+			container.style.direction = 'rtl';
+			document.body.appendChild(container);
+			map = L.map(container);
+		});
+
+		it("adds CSS class leaflet-rtl to the map container", function () {
+			expect(L.DomUtil.hasClass(map.getContainer(), 'leaflet-rtl')).to.be(true);
+		});
+	});
 });

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -943,6 +943,17 @@ export var Map = Evented.extend({
 		return this._container;
 	},
 
+	// @method setRTLDirection(rtl: Boolean): this
+	// Support for right-to-left text direction. Adds to the map container the CSS-Class `leaflet-rtl`.
+	// During initialization the style `direction: rtl` is searched on the map container and accordingly `leaflet-rtl` is set
+	setRTLDirection: function (rtl) {
+		if (rtl) {
+			DomUtil.addClass(this._container, 'leaflet-rtl');
+		} else {
+			DomUtil.removeClass(this._container, 'leaflet-rtl');
+		}
+		return this;
+	},
 
 	// @section Conversion Methods
 
@@ -1104,6 +1115,8 @@ export var Map = Evented.extend({
 			(Browser.ielt9 ? ' leaflet-oldie' : '') +
 			(Browser.safari ? ' leaflet-safari' : '') +
 			(this._fadeAnimated ? ' leaflet-fade-anim' : ''));
+
+		this.setRTLDirection(DomUtil.getStyle(container, 'direction') === 'rtl');
 
 		var position = DomUtil.getStyle(container, 'position');
 


### PR DESCRIPTION
New function `map.setRTLDirection(boolean)`. It adds the CSS-Class `.leaflet-rtl` to the map container. 
During initialization the style `direction: rtl` is searched on the map container and if is found `setRTLDirection(true)` is called. 
Fix: #7201

RTL was not supported for Tooltips:
![grafik](https://user-images.githubusercontent.com/19800037/141683806-64ec5a14-f66c-47c6-a45f-94f9f4c0d225.png)
![grafik](https://user-images.githubusercontent.com/19800037/141683818-b931eb49-fa1f-4cc0-84e9-91f7d1e83049.png)
