### PR TITLE
Fix current error in the maser (SVG width: auto in IE)

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -48,8 +48,7 @@
 .leaflet-container .leaflet-overlay-pane svg{
 	max-width: none !important;
 	max-height: none !important;
-
-}
+  }
 .leaflet-container .leaflet-marker-pane img,
 .leaflet-container .leaflet-shadow-pane img,
 .leaflet-container .leaflet-tile-pane img,
@@ -59,7 +58,7 @@
 	max-height: none !important;
 	width: auto;
 	padding: 0;
-}
+  }
 
 .leaflet-container.leaflet-touch-zoom {
 	-ms-touch-action: pan-x pan-y;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -45,7 +45,7 @@
 	}
 /* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
 /* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container .leaflet-overlay-pane svg{
+.leaflet-container .leaflet-overlay-pane svg {
 	max-width: none !important;
 	max-height: none !important;
 	}

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -45,7 +45,11 @@
 	}
 /* .leaflet-container svg: reset svg max-width decleration shipped in Joomla! (joomla.org) 3.x */
 /* .leaflet-container img: map is broken in FF if you have max-width: 100% on tiles */
-.leaflet-container .leaflet-overlay-pane svg,
+.leaflet-container .leaflet-overlay-pane svg{
+	max-width: none !important;
+	max-height: none !important;
+
+}
 .leaflet-container .leaflet-marker-pane img,
 .leaflet-container .leaflet-shadow-pane img,
 .leaflet-container .leaflet-tile-pane img,
@@ -55,7 +59,7 @@
 	max-height: none !important;
 	width: auto;
 	padding: 0;
-	}
+}
 
 .leaflet-container.leaflet-touch-zoom {
 	-ms-touch-action: pan-x pan-y;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -48,7 +48,7 @@
 .leaflet-container .leaflet-overlay-pane svg{
 	max-width: none !important;
 	max-height: none !important;
-  }
+	}
 .leaflet-container .leaflet-marker-pane img,
 .leaflet-container .leaflet-shadow-pane img,
 .leaflet-container .leaflet-tile-pane img,
@@ -58,7 +58,7 @@
 	max-height: none !important;
 	width: auto;
 	padding: 0;
-  }
+	}
 
 .leaflet-container.leaflet-touch-zoom {
 	-ms-touch-action: pan-x pan-y;


### PR DESCRIPTION
If in IE `width: auto` is added to a svg layers, it overwrites the predefined `width` from the tag / element self. So I remove `width: auto` from svg layer. Or better I excluded the svg style `.leaflet-overlay-pane svg` from the styles they has `width: auto`.
![ie_svg_width](https://user-images.githubusercontent.com/19800037/142737521-5f02a95c-57e1-4593-84c5-c529c4e600b3.gif)

The error occurs because the svg layer (circle) is not anymore there, when the click at the expected position happens.

The error is caused from #6843
