### PR TITLE
Accessibility popup close button

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -520,13 +520,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	width: 18px;
 	height: 14px;
 	font: 16px/14px Tahoma, Verdana, sans-serif;
-	color: #c3c3c3;
+	color: #757575;
 	text-decoration: none;
 	font-weight: bold;
 	background: transparent;
 	}
 .leaflet-container a.leaflet-popup-close-button:hover {
-	color: #999;
+	color: #585858;
 	}
 .leaflet-popup-scrolled {
 	overflow: auto;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -525,7 +525,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	font: 16px/14px Tahoma, Verdana, sans-serif;
 	color: #757575;
 	text-decoration: none;
-	font-weight: bold;
 	background: transparent;
 	}
 .leaflet-container a.leaflet-popup-close-button:hover {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -193,7 +193,7 @@ export var Popup = DivOverlay.extend({
 			closeButton.setAttribute('role', 'button'); // overrides the implicit role=link of <a> elements #7399
 			closeButton.setAttribute('aria-label', 'Close popup');
 			closeButton.href = '#close';
-			closeButton.innerHTML = '&#215;';
+			closeButton.innerHTML = '<span aria-hidden="true">&#215;</span>';
 
 			DomEvent.on(closeButton, 'click', this._close, this);
 		}

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -190,6 +190,8 @@ export var Popup = DivOverlay.extend({
 
 		if (this.options.closeButton) {
 			var closeButton = this._closeButton = DomUtil.create('a', prefix + '-close-button', container);
+			closeButton.setAttribute('role', 'button'); // overrides the implicit role=link of <a> elements #7399
+			closeButton.setAttribute('aria-label', 'Close popup');
 			closeButton.href = '#close';
 			closeButton.innerHTML = '&#215;';
 


### PR DESCRIPTION
- Change the color of the close button for a better contrast #7539 
- Add `role=button` and the `aria-label='Close popup'` to the `<a>` element #7399
- Add `aria-hidden` to the `times` / `x` character to prevent the reading of screen readers #7472

Close Button old:
![grafik](https://user-images.githubusercontent.com/19800037/142755448-75e28123-ab65-4ff1-89d3-d2a1470aee4f.png)
New:
![grafik](https://user-images.githubusercontent.com/19800037/142755418-a01e9e42-7729-4de4-8c80-cf9b6e60b663.png)


Fixes: #7539, #7399, #7472

Related PR: #7079
@Malvoz fyi