### PR TITLE
Add aria-hidden to the +/- characters of zoom controls

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -53,6 +53,8 @@
 .leaflet-container .leaflet-tile {
 	max-width: none !important;
 	max-height: none !important;
+	width: auto;
+	padding: 0;
 	}
 
 .leaflet-container.leaflet-touch-zoom {

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -81,7 +81,7 @@ export var Zoom = Control.extend({
 
 	_createButton: function (html, title, className, container, fn) {
 		var link = DomUtil.create('a', className, container);
-		link.innerHTML = html;
+		link.innerHTML = '<span aria-hidden="true">'+html+'</span>';
 		link.href = '#';
 		link.title = title;
 

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -20,7 +20,8 @@ export var Zoom = Control.extend({
 
 		// @option zoomInText: String = '+'
 		// The text set on the 'zoom in' button.
-		zoomInText: '+',
+		zoomInText: '<span aria-hidden="true">+</span>',
+
 
 		// @option zoomInTitle: String = 'Zoom in'
 		// The title set on the 'zoom in' button.
@@ -28,7 +29,7 @@ export var Zoom = Control.extend({
 
 		// @option zoomOutText: String = '&#x2212;'
 		// The text set on the 'zoom out' button.
-		zoomOutText: '&#x2212;',
+		zoomOutText: '<span aria-hidden="true">&#x2212;</span>',
 
 		// @option zoomOutTitle: String = 'Zoom out'
 		// The title set on the 'zoom out' button.
@@ -81,7 +82,7 @@ export var Zoom = Control.extend({
 
 	_createButton: function (html, title, className, container, fn) {
 		var link = DomUtil.create('a', className, container);
-		link.innerHTML = '<span aria-hidden="true">' + html + '</span>';
+		link.innerHTML = html;
 		link.href = '#';
 		link.title = title;
 

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -22,7 +22,6 @@ export var Zoom = Control.extend({
 		// The text set on the 'zoom in' button.
 		zoomInText: '<span aria-hidden="true">+</span>',
 
-
 		// @option zoomInTitle: String = 'Zoom in'
 		// The title set on the 'zoom in' button.
 		zoomInTitle: 'Zoom in',

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -81,7 +81,7 @@ export var Zoom = Control.extend({
 
 	_createButton: function (html, title, className, container, fn) {
 		var link = DomUtil.create('a', className, container);
-		link.innerHTML = '<span aria-hidden="true">'+html+'</span>';
+		link.innerHTML = '<span aria-hidden="true">' + html + '</span>';
 		link.href = '#';
 		link.title = title;
 


### PR DESCRIPTION
Add aria-hidden to zoom controls to revents screen readers from announcing the characters "plus" and "minus" on hover
Fix: #7433

@Malvoz fyi