### PR TITLE
Add first the `control-container` to the DOM and then the  `map-pane` (for tabbing) #7479

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1111,11 +1111,11 @@ export var Map = Evented.extend({
 			container.style.position = 'relative';
 		}
 
-		this._initPanes();
-
 		if (this._initControlPos) {
 			this._initControlPos();
 		}
+
+		this._initPanes();
 	},
 
 	_initPanes: function () {


### PR DESCRIPTION
Add first the `control-container` to the DOM and then the  `map-pane`, to change the order while tabbing. Now first the controls are focused and then all the layers.

@stevevance raised a similar concern in #3210 (quoting the relevant parts):

> I was testing my website with a person who is completely blind and uses the VoiceOver (VO) function on an iPad. I was observing her as she browsed the entire webpage (through a tapping function in VO that mimics tabbing between elements*) and came across the Leaflet map.
> ### Expectations
> The next tab should land on the zoom controls, layer controls, and any other controls, so the user can understand what functions are available to control the map


Fix: #7479

@Malvoz fyi