### PR TITLE
CSS improvements (responsive map embedding in examples/tutorials)

### DIFF
--- a/docs/_includes/frame.html
+++ b/docs/_includes/frame.html
@@ -1,7 +1,7 @@
 <table>
-<tr><td style='text-align: center; border: none'>
+<tr><td style='text-align: center; border: none; padding: 0'>
 <iframe src='{{ include.url }}'
-	width='{% if include.width %}{{ include.width }}{% else %}616{% endif %}'
+	width='{% if include.width %}{{ include.width }}{% else %}100%{% endif %}'
 	height='{% if include.height %}{{ include.height }}{% else %}416{% endif %}'></iframe>
 </td></tr>
 <tr><td style='text-align: center; border: none'>

--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -19,8 +19,9 @@
 			margin: 0;
 		}
 		#map {
-			width: 600px;
-			height: 400px;
+			width: 100%;
+			height: 100%;
+			position: absolute;
 		}
 	</style>
 {% endunless %}


### PR DESCRIPTION
Fix #7342 
Fix #7420 

I described here my changes: https://github.com/Leaflet/Leaflet/issues/7342#issuecomment-976381354