### PR TITLE
WIP: Minimal jekyll setup for handling the plugins webpage in a data-driven manner

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,3 +13,8 @@ latest_leaflet_version: 1.7.1
 integrity_hash_css: "sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
 integrity_hash_source: "sha512-I5Hd7FcJ9rZkH7uD01G3AjsuzFy3gqz7HIJvzFZGFt2mrCS4Piw9bYZvCgUE0aiJuiZFYIJIwpbNnDIM6ohTrg=="
 integrity_hash_uglified: "sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+
+
+collections:
+  plugins:
+    output: false

--- a/docs/_includes/plugin_category_table.html
+++ b/docs/_includes/plugin_category_table.html
@@ -1,0 +1,19 @@
+{% assign filteredplugins = site.plugins | where: "category", include.category %}
+
+<table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
+{% for plugin in filteredplugins %}
+	<tr>
+		<td>
+			<a href="{{ plugin.repo }}">{{ plugin.name }}</a>
+		</td><td>
+			{{ plugin.content | markdownify }}
+		</td><td>
+		{% if plugin.category %}
+			<a href="{{ plugin.author-url }}">{{ plugin.author }}</a>
+		{% else %}
+			{{ plugin.author }}
+		{% endif %}
+		</td>
+	</tr>
+{% endfor %}
+</table>

--- a/docs/_includes/plugin_category_table.html
+++ b/docs/_includes/plugin_category_table.html
@@ -3,11 +3,9 @@
 <table class="plugins"><tr><th>Plugin</th><th>Description</th><th>Maintainer</th></tr>
 {% for plugin in filteredplugins %}
 	<tr>
+		<td><a href="{{ plugin.repo }}">{{ plugin.name }}</a></td>
+		<td>{{ plugin.content }}</td>
 		<td>
-			<a href="{{ plugin.repo }}">{{ plugin.name }}</a>
-		</td><td>
-			{{ plugin.content | markdownify }}
-		</td><td>
 		{% if plugin.category %}
 			<a href="{{ plugin.author-url }}">{{ plugin.author }}</a>
 		{% else %}

--- a/docs/_plugins/leaflet-providers.md
+++ b/docs/_plugins/leaflet-providers.md
@@ -1,0 +1,12 @@
+---
+name: leaflet-providers
+category: basemap-providers
+repo: https://github.com/leaflet-extras/leaflet-providers
+author: leaflet-extras members
+author-url: https://github.com/leaflet-extras
+demo:
+compatible-v0: false
+compatible-v1: true
+---
+
+Contains configurations for various free tile providers & OSM, OpenCycleMap, Stamen, Esri, etc.

--- a/docs/_plugins/leaflet-wmts.md
+++ b/docs/_plugins/leaflet-wmts.md
@@ -1,0 +1,12 @@
+---
+name: leaflet.TileLayer.WMTS
+category: basemap-formats
+repo: https://github.com/mylen/leaflet.TileLayer.WMTS
+author: Alexandre Melard
+author-url: https://github.com/mylen
+demo:
+compatible-v0: false
+compatible-v1: true
+---
+
+Add WMTS (IGN) layering for leaflet.

--- a/docs/plugins-database.md
+++ b/docs/plugins-database.md
@@ -1,0 +1,37 @@
+---
+layout: v2
+title: Plugins
+bodyclass: plugins-page
+---
+
+## Leaflet Plugins database
+
+While Leaflet is meant to be as lightweight as possible, and focuses on a core set of features, an easy way to extend its functionality is to use third-party plugins. Thanks to the awesome community behind Leaflet, there are literally hundreds of nice plugins to choose from.
+
+---
+
+## Tile & image layers
+
+The following plugins allow loading different maps and provide functionality to tile and image layers.
+
+* [Basemap providers](#basemap-providers)
+* [Basemap formats](#basemap-formats)
+* [Non-map base layers](#non-map-base-layers)
+* [Tile/image display](#tileimage-display)
+* [Tile load](#tile-load)
+* [Vector tiles](#vector-tiles)
+
+
+### Basemap providers
+
+Ready-to-go basemaps, with little or no configuration at all.
+
+{% include plugin_category_table.html category="basemap-providers" %}
+
+
+### Basemap formats
+
+Plugins for loading basemaps or GIS raster layers in common (albeit non-default) formats.
+
+{% include plugin_category_table.html category="basemap-formats" %}
+

--- a/docs/plugins-database.md
+++ b/docs/plugins-database.md
@@ -4,6 +4,13 @@ title: Plugins
 bodyclass: plugins-page
 ---
 
+<style>
+table.plugins td > p {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+</style>
+
 ## Leaflet Plugins database
 
 While Leaflet is meant to be as lightweight as possible, and focuses on a core set of features, an easy way to extend its functionality is to use third-party plugins. Thanks to the awesome community behind Leaflet, there are literally hundreds of nice plugins to choose from.


### PR DESCRIPTION
Prompted by #7801.

This PR includes a *minimal* amount of stuff to demo how a collections-based plugins page would look like.

This is WIP since:
* [ ] all entries in the current plugins table need to be converted into individual markdown files
* [ ] `plugins-database.md` needs to cover all categories (instead of just the two first ones)
* [ ] Documentation for how to add a plugin to the list needs to be updated

cc @Falke-Design @mourner @johnd0e 