### PR TITLE
add/removePointerListener: tolerate wrong event names

### DIFF
--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -64,6 +64,11 @@ describe('DomEvent.Pointer', function () {
 			});
 		});
 
+		it('does not throw on invalid event names', function () {
+			L.DomEvent.on(el, 'touchleave', L.Util.falseFn);
+			L.DomEvent.off(el, 'touchleave', L.Util.falseFn);
+		});
+
 		it('simulates touch events with correct properties', function () {
 			function containIn(props, evt) {
 				if (Array.isArray(props)) {

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -31,12 +31,20 @@ export function addPointerListener(obj, type, handler) {
 	if (type === 'touchstart') {
 		_addPointerDocListener();
 	}
+	if (!handle[type]) {
+		console.warn('wrong event specified:', type);
+		return L.Util.falseFn;
+	}
 	handler = handle[type].bind(this, handler);
 	obj.addEventListener(pEvent[type], handler, false);
 	return handler;
 }
 
 export function removePointerListener(obj, type, handler) {
+	if (!pEvent[type]) {
+		console.warn('wrong event specified:', type);
+		return;
+	}
 	obj.removeEventListener(pEvent[type], handler, false);
 }
 


### PR DESCRIPTION
Seen in Leaflet.draw (`touchleave`)
