### PR TITLE
Fix #7439 for mousemove

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -94,6 +94,13 @@ describe('Canvas', function () {
 			expect(spyCircle.callCount).to.eql(1);
 		});
 
+		it("should not block mousemove event going to non-canvas features", function () {
+			var spyMap = sinon.spy();
+			map.on("mousemove", spyMap);
+			happen.at('mousemove', 151, 151); // empty space
+			expect(spyMap.calledOnce).to.be.ok();
+		});
+
 		it("should fire preclick before click", function () {
 			var clickSpy = sinon.spy();
 			var preclickSpy = sinon.spy();

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -401,9 +401,7 @@ export var Canvas = Renderer.extend({
 			}
 		}
 
-		if (this._hoveredLayer) {
-			this._fireEvent([this._hoveredLayer], e);
-		}
+		this._fireEvent(this._hoveredLayer ? [this._hoveredLayer] : false, e);
 
 		this._mouseHoverThrottled = true;
 		setTimeout(Util.bind(function () {


### PR DESCRIPTION
We need pass event to map when canvas does not have targets

(continuation of #7720-#7721)

- [x] unit test