### PR TITLE
Locate - locationfound: Add check if map container has leaflet_id / is existing

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1327,7 +1327,7 @@ describe("Map", function () {
 				fn({coords: {latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752}});
 			}).to.not.throwException();
 		});
-		it("don't throw error if location is found and map is not existing", function () {
+		it("don't throw error if location is not found and map is not existing", function () {
 			map._locateOptions = {setView: true};
 			var fn = L.Util.bind(map._handleGeolocationError, map);
 			map.remove();

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1318,4 +1318,14 @@ describe("Map", function () {
 			expect(map.getZoom()).to.be(undefined);
 		});
 	});
+
+	describe("#Geolocation", function () {
+		it("don't throw error if location is found and map is not existing", function () {
+			var fn = L.Util.bind(map._handleGeolocationResponse, map);
+			map.remove();
+			expect(function (){
+				fn({ coords: { latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752} })
+			}).to.not.throwException();
+		});
+	});
 });

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1323,8 +1323,8 @@ describe("Map", function () {
 		it("don't throw error if location is found and map is not existing", function () {
 			var fn = L.Util.bind(map._handleGeolocationResponse, map);
 			map.remove();
-			expect(function (){
-				fn({ coords: { latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752} })
+			expect(function () {
+				fn({coords: {latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752}});
 			}).to.not.throwException();
 		});
 	});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1327,5 +1327,13 @@ describe("Map", function () {
 				fn({coords: {latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752}});
 			}).to.not.throwException();
 		});
+		it("don't throw error if location is found and map is not existing", function () {
+			map._locateOptions = {setView: true};
+			var fn = L.Util.bind(map._handleGeolocationError, map);
+			map.remove();
+			expect(function () {
+				fn({coords: {latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752}});
+			}).to.not.throwException();
+		});
 	});
 });

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1320,14 +1320,14 @@ describe("Map", function () {
 	});
 
 	describe("#Geolocation", function () {
-		it("don't throw error if location is found and map is not existing", function () {
+		it("doesn't throw error if location is found and map is not existing", function () {
 			var fn = L.Util.bind(map._handleGeolocationResponse, map);
 			map.remove();
 			expect(function () {
 				fn({coords: {latitude: 40.415296, longitude: 10.7419264, accuracy: 1129.5646101470752}});
 			}).to.not.throwException();
 		});
-		it("don't throw error if location is not found and map is not existing", function () {
+		it("doesn't throw error if location is not found and map is not existing", function () {
 			map._locateOptions = {setView: true};
 			var fn = L.Util.bind(map._handleGeolocationError, map);
 			map.remove();

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -665,6 +665,8 @@ export var Map = Evented.extend({
 	},
 
 	_handleGeolocationError: function (error) {
+		if (!this.getContainer()._leaflet_id) { return; }
+
 		var c = error.code,
 		    message = error.message ||
 		            (c === 1 ? 'permission denied' :
@@ -684,6 +686,8 @@ export var Map = Evented.extend({
 	},
 
 	_handleGeolocationResponse: function (pos) {
+		if (!this.getContainer()._leaflet_id) { return; }
+
 		var lat = pos.coords.latitude,
 		    lng = pos.coords.longitude,
 		    latlng = new LatLng(lat, lng),

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -665,7 +665,7 @@ export var Map = Evented.extend({
 	},
 
 	_handleGeolocationError: function (error) {
-		if (!this.getContainer()._leaflet_id) { return; }
+		if (!this._container._leaflet_id) { return; }
 
 		var c = error.code,
 		    message = error.message ||
@@ -686,7 +686,7 @@ export var Map = Evented.extend({
 	},
 
 	_handleGeolocationResponse: function (pos) {
-		if (!this.getContainer()._leaflet_id) { return; }
+		if (!this._container._leaflet_id) { return; }
 
 		var lat = pos.coords.latitude,
 		    lng = pos.coords.longitude,


### PR DESCRIPTION
If the map is removed before the location is found, it throwed an error. Now it checks if the map container has the leaflet_id else it returns.

Fix #7508