### PR TITLE
Circle: radius must be specified

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -11,9 +11,10 @@ describe('Circle', function () {
 	});
 
 	describe('#init', function () {
-		it('uses default radius if not given', function () {
-			var circle = L.circle([0, 0]);
-			expect(circle.getRadius()).to.eql(10);
+		it('throws error if radius is not given', function () {
+			expect(function () {
+				L.circle([0, 0]);
+			}).to.throwException('Circle radius cannot be NaN');
 		});
 
 		it('throws error if radius is NaN', function () {

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -29,10 +29,12 @@ export var Circle = CircleMarker.extend({
 			// Backwards compatibility with 0.7.x factory (latlng, radius, options?)
 			options = Util.extend({}, legacyOptions, {radius: options});
 		}
+		if (!this.options || isNaN(options.radius)) {
+			throw new Error('Circle radius cannot be NaN');
+		}
+
 		Util.setOptions(this, options);
 		this._latlng = toLatLng(latlng);
-
-		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 
 		// @section
 		// @aka Circle options


### PR DESCRIPTION
Currently circle default radius (10) is inherited from CircleMarker.
I do not think that it's good.