### PR TITLE
 leaflet.zoomfs compatibility

### DIFF
--- a/docs/_plugins/fullscreen-controls/leaflet-zoomfs.md
+++ b/docs/_plugins/fullscreen-controls/leaflet-zoomfs.md
@@ -5,8 +5,8 @@ repo: https://github.com/elidupuis/leaflet.zoomfs
 author: Eli Dupuis
 author-url: https://github.com/elidupuis
 demo: 
-compatible-v0:
-compatible-v1: true
+compatible-v0: true
+compatible-v1: false
 ---
 
 A fullscreen button control.


### PR DESCRIPTION
I don't think this plugin is compatible with Leaflet v1 :\

- the demo use Leaflet 0.5.1 https://github.com/elidupuis/leaflet.zoomfs/blob/master/index.html#L12
- the last commit on the repo was made 9 years ago
- the online demo page https://elidupuis.github.com/leaflet.zoomfs returns a 404 error

I'm not sure this change is handled by the news plugins page, feel free to close if it's too early :)