### PR TITLE
Add touchevents to Canvas

### DIFF
--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -1,3 +1,4 @@
+/* global pointerToTouch */
 describe('DomEvent.Pointer', function () {
 	var el,
 	    listeners = {};
@@ -22,7 +23,6 @@ describe('DomEvent.Pointer', function () {
 
 	var skip = describe.skip;
 
-	var pointerToTouch = L.Browser.pointer && !L.Browser.touchNative;
 	(pointerToTouch ? describe : skip)('#Simulates touch based on pointer events', function () {
 		it('adds a listener and calls it on pointer event', function () {
 			pointerEvents.forEach(function (type) {

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -1,3 +1,4 @@
+/* global touchPointerMap */
 describe("Marker", function () {
 	var map,
 	    div,
@@ -6,7 +7,10 @@ describe("Marker", function () {
 
 	beforeEach(function () {
 		div = document.createElement('div');
-		div.style.height = '100px';
+		div.style.height = '400px';
+		div.style.width = '400px';
+		div.style.position = 'absolute';
+		div.style.top = '0';
 		document.body.appendChild(div);
 
 		map = L.map(div).setView([0, 0], 0);
@@ -327,5 +331,27 @@ describe("Marker", function () {
 			});
 			happen.mousemove(marker._icon);
 		});
+
+
+		it.skipIfNotTouch("DOM touch events fired on marker", function () {
+			var spyStart = sinon.spy();
+			var spyMove = sinon.spy();
+			var spyEnd = sinon.spy();
+			var spyCancel = sinon.spy();
+			var layer = new L.Marker([1, 2]).addTo(map);
+			layer.on("touchstart", spyStart);
+			layer.on("touchmove", spyMove);
+			layer.on("touchend", spyEnd);
+			layer.on("touchcancel", spyCancel);
+			happen.at(touchPointerMap['touchstart'], 200, 190);
+			happen.at(touchPointerMap['touchmove'], 200, 190);
+			happen.at(touchPointerMap['touchend'], 200, 190);
+			happen.at(touchPointerMap['touchcancel'], 200, 190);
+			expect(spyStart.calledOnce).to.be.ok();
+			expect(spyMove.calledOnce).to.be.ok();
+			expect(spyEnd.calledOnce).to.be.ok();
+			expect(spyCancel.calledOnce).to.be.ok();
+		});
+
 	});
 });

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -1,3 +1,4 @@
+/* global touchPointerMap */
 describe('Canvas', function () {
 	document.body.appendChild(document.createElement('div'));
 	var c, map, latLngs;
@@ -47,6 +48,18 @@ describe('Canvas', function () {
 			map.on("click", spy);
 			happen.at('click', 50, 50);
 			expect(spy.callCount).to.eql(1);
+		});
+
+		it.skipIfNotTouch("DOM touch events propagate from canvas polygon to map", function () {
+			map.setView([0, 0], 0);
+			var spy = sinon.spy();
+			var spyLayer = sinon.spy();
+			map.on("touchmove", spy);
+			var layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			layer.on("touchmove", spyLayer);
+			happen.at(touchPointerMap['touchmove'], 200, 200);
+			expect(spy.calledOnce).to.be.ok();
+			expect(spyLayer.calledOnce).to.be.ok();
 		});
 
 		it("DOM events fired on canvas polygon can be cancelled before being caught by the map", function () {
@@ -104,7 +117,7 @@ describe('Canvas', function () {
 		it.skipIfNotTouch("should not block touchmove event going to non-canvas features", function () {
 			var spyMap = sinon.spy();
 			map.on("touchmove", spyMap);
-			happen.at('touchmove', 151, 151); // empty space
+			happen.at(touchPointerMap['touchmove'], 151, 151); // empty space
 			expect(spyMap.calledOnce).to.be.ok();
 		});
 
@@ -171,7 +184,8 @@ describe('Canvas', function () {
 					done();
 				}
 			});
-			var mouse = hand.growFinger('touch');
+
+			var mouse = hand.growFinger(touchEventType);
 
 			// We move 5 pixels first to overcome the 3-pixel threshold of
 			// L.Draggable.
@@ -208,7 +222,7 @@ describe('Canvas', function () {
 					done();
 				}
 			});
-			var mouse = hand.growFinger('touch');
+			var mouse = hand.growFinger(touchEventType);
 
 			// We move 5 pixels first to overcome the 3-pixel threshold of
 			// L.Draggable.
@@ -248,7 +262,7 @@ describe('Canvas', function () {
 					done();
 				}
 			});
-			var mouse = hand.growFinger('touch');
+			var mouse = hand.growFinger(touchEventType);
 
 			mouse.wait(100)
 				.moveTo(300, 300, 0).down().moveBy(5, 0, 20).up()

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1,3 +1,5 @@
+/* global touchPointerMap */
+
 describe("Map", function () {
 	var container,
 	    map;
@@ -1287,6 +1289,97 @@ describe("Map", function () {
 			expect(spy.callCount).to.be(2);
 			expect(spy.firstCall.lastArg).to.be.ok();
 			expect(spy.secondCall.lastArg).to.be.ok();
+		});
+	});
+
+	describe.skipIfNotTouch("#DOM touch events", function () {
+
+		beforeEach(function () {
+			container.style.width = "400px";
+			container.style.height = "400px";
+			container.style.position = "absolute";
+			container.style.top = "0";
+			map.setView([0, 0], 0);
+		});
+
+		it("DOM touch events fired on map", function () {
+			var spyStart = sinon.spy();
+			var spyMove = sinon.spy();
+			var spyEnd = sinon.spy();
+			var spyCancel = sinon.spy();
+			map.on("touchstart", spyStart);
+			map.on("touchmove", spyMove);
+			map.on("touchend", spyEnd);
+			map.on("touchcancel", spyCancel);
+			happen.at(touchPointerMap['touchstart'], 235, 135);
+			happen.at(touchPointerMap['touchmove'], 235, 135);
+			happen.at(touchPointerMap['touchend'], 235, 135);
+			happen.at(touchPointerMap['touchcancel'], 235, 135);
+			expect(spyStart.calledOnce).to.be.ok();
+			expect(spyMove.calledOnce).to.be.ok();
+			expect(spyEnd.calledOnce).to.be.ok();
+			expect(spyCancel.calledOnce).to.be.ok();
+		});
+
+		it.skipIfNotTouch("DOM touch events fired on polygon", function () {
+			var spyStart = sinon.spy();
+			var spyMove = sinon.spy();
+			var spyEnd = sinon.spy();
+			var spyCancel = sinon.spy();
+			var layer = L.polygon([[100, 0], [100, 100], [0, 100], [0, 0]]).addTo(map);
+			layer.on("touchstart", spyStart);
+			layer.on("touchmove", spyMove);
+			layer.on("touchend", spyEnd);
+			layer.on("touchcancel", spyCancel);
+			happen.at(touchPointerMap['touchstart'], 235, 135);
+			happen.at(touchPointerMap['touchmove'], 235, 135);
+			happen.at(touchPointerMap['touchend'], 235, 135);
+			happen.at(touchPointerMap['touchcancel'], 235, 135);
+			expect(spyStart.calledOnce).to.be.ok();
+			expect(spyMove.calledOnce).to.be.ok();
+			expect(spyEnd.calledOnce).to.be.ok();
+			expect(spyCancel.calledOnce).to.be.ok();
+		});
+
+		it("DOM events propagate from polygon to map", function () {
+			var spy = sinon.spy();
+			var spyLayer = sinon.spy();
+			map.on("touchmove", spy);
+			var layer = new L.Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			layer.on("touchmove", spyLayer);
+			happen.at(touchPointerMap['touchmove'], 200, 200);
+			expect(spy.calledOnce).to.be.ok();
+			expect(spyLayer.calledOnce).to.be.ok();
+		});
+
+		it("DOM events propagate from marker to map", function () {
+			var spy = sinon.spy();
+			map.on("touchmove", spy);
+			new L.Marker([1, 2]).addTo(map);
+			happen.at(touchPointerMap['touchmove'], 200, 190);
+			expect(spy.calledOnce).to.be.ok();
+		});
+
+		it("DOM events fired on marker can be cancelled before being caught by the map", function () {
+			var mapSpy = sinon.spy();
+			var layerSpy = sinon.spy();
+			map.on("touchmove", mapSpy);
+			var layer = new L.Marker([1, 2]).addTo(map);
+			layer.on("touchmove", L.DomEvent.stopPropagation).on("touchmove", layerSpy);
+			happen.at(touchPointerMap['touchmove'], 200, 190);
+			expect(layerSpy.calledOnce).to.be.ok();
+			expect(mapSpy.called).not.to.be.ok();
+		});
+
+		it("DOM events fired on polygon can be cancelled before being caught by the map", function () {
+			var mapSpy = sinon.spy();
+			var layerSpy = sinon.spy();
+			map.on("touchmove", mapSpy);
+			var layer = new L.Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			layer.on("touchmove", L.DomEvent.stopPropagation).on("touchmove", layerSpy);
+			happen.at(touchPointerMap['touchmove'], 200, 200);
+			expect(layerSpy.calledOnce).to.be.ok();
+			expect(mapSpy.called).not.to.be.ok();
 		});
 	});
 

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1321,7 +1321,7 @@ describe("Map", function () {
 			expect(spyCancel.calledOnce).to.be.ok();
 		});
 
-		it.skipIfNotTouch("DOM touch events fired on polygon", function () {
+		it("DOM touch events fired on polygon", function () {
 			var spyStart = sinon.spy();
 			var spyMove = sinon.spy();
 			var spyEnd = sinon.spy();
@@ -1345,9 +1345,9 @@ describe("Map", function () {
 			var spy = sinon.spy();
 			var spyLayer = sinon.spy();
 			map.on("touchmove", spy);
-			var layer = new L.Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			var layer = L.polygon([[100, 0], [100, 100], [0, 100], [0, 0]]).addTo(map);
 			layer.on("touchmove", spyLayer);
-			happen.at(touchPointerMap['touchmove'], 200, 200);
+			happen.at(touchPointerMap['touchmove'], 235, 135);
 			expect(spy.calledOnce).to.be.ok();
 			expect(spyLayer.calledOnce).to.be.ok();
 		});
@@ -1375,9 +1375,9 @@ describe("Map", function () {
 			var mapSpy = sinon.spy();
 			var layerSpy = sinon.spy();
 			map.on("touchmove", mapSpy);
-			var layer = new L.Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			var layer = L.polygon([[100, 0], [100, 100], [0, 100], [0, 0]]).addTo(map);
 			layer.on("touchmove", L.DomEvent.stopPropagation).on("touchmove", layerSpy);
-			happen.at(touchPointerMap['touchmove'], 200, 200);
+			happen.at(touchPointerMap['touchmove'], 235, 135);
 			expect(layerSpy.calledOnce).to.be.ok();
 			expect(mapSpy.called).not.to.be.ok();
 		});

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -26,7 +26,7 @@ describe('Map.TapHoldSpec.js', function () {
 	});
 
 	afterEach(function () {
-		happen.once(el, {type: 'touchend'});
+		happen.once(el, {type: 'touchend', touches: [posStart], changedTouches: [posStart]});
 		for (var id = 0; id <= 2; id++) { // reset pointers (for prosphetic-hand)
 			happen.once(el, {type: 'pointercancel', pointerId:id});
 		}
@@ -70,7 +70,7 @@ describe('Map.TapHoldSpec.js', function () {
 		happen.once(el, {type: 'touchstart', touches: [posStart, posNear]});
 		happen.once(el, L.extend({type: 'pointerdown', pointerId:1}, posNear));
 		clock.tick(100);
-		happen.once(el, {type: 'touchend', touches: [posStart]});
+		happen.once(el, {type: 'touchend', touches: [posStart], changedTouches: [posStart]});
 		happen.once(el, L.extend({type: 'pointerup', pointerId:0}, posNear));
 		clock.tick(450);
 
@@ -110,7 +110,7 @@ describe('Map.TapHoldSpec.js', function () {
 		happen.once(el, {type: 'touchstart', touches: [posStart]});
 		happen.once(el, L.extend({type: 'pointerdown', pointerId:0}, posStart));
 		clock.tick(650);
-		happen.once(el, {type: 'touchend', touches: [posStart]});
+		happen.once(el, {type: 'touchend', touches: [posStart], changedTouches: [posStart]});
 		happen.once(el, L.extend({type: 'pointerup', pointerId:0}, posNear));
 
 		expect(clickSpy.notCalled).to.be.ok();

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -82,6 +82,11 @@ function _handlePointer(handler, e) {
 	for (var i in _pointers) {
 		e.touches.push(_pointers[i]);
 	}
+
+	if (e.touches.length === 0 && e.type !== 'pointercancel' && e.type !== 'pointerup') {
+		e.touches = [e];
+	}
+
 	e.changedTouches = [e];
 
 	handler(e);

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -228,6 +228,7 @@ export function stop(e) {
 // Gets normalized mouse position from a DOM event relative to the
 // `container` (border excluded) or to the whole page if not specified.
 export function getMousePosition(e, container) {
+	// TODO: Add here the touchevent logic
 	if (!container) {
 		return new Point(e.clientX, e.clientY);
 	}

--- a/src/layer/Layer.Interactive.leafdoc
+++ b/src/layer/Layer.Interactive.leafdoc
@@ -37,3 +37,15 @@ Fired when the user right-clicks on the layer, prevents
 default browser context menu from showing if there are listeners on
 this event. Also fired on mobile when the user holds a single touch
 for a second (also called long press).
+
+@event touchstart: MouseEvent
+Fired when the user places a touch point on the layer.
+
+@event touchend: MouseEvent
+Fired when the user removes a touch point of the layer.
+
+@event touchmove: MouseEvent
+Fired when the user moves a touch point on the layer.
+
+@event touchcancel: MouseEvent
+Fired when the touch point has been disrupted in an implementation-specific manner.

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -69,8 +69,10 @@ export var Canvas = Renderer.extend({
 	_initContainer: function () {
 		var container = this._container = document.createElement('canvas');
 
-		DomEvent.on(container, 'mousemove', this._onMouseMove, this);
-		DomEvent.on(container, 'click dblclick mousedown mouseup contextmenu', this._onClick, this);
+		var touchMove = Browser.touch ? 'touchmove' : '';
+		var touchClick = Browser.touch ? 'touchstart touchend touchcancel' : '';
+		DomEvent.on(container, 'mousemove ' + touchMove, this._onMouseMove, this);
+		DomEvent.on(container, 'click dblclick contextmenu mousedown mouseup ' + touchClick, this._onClick, this);
 		DomEvent.on(container, 'mouseout', this._handleMouseOut, this);
 		container['_leaflet_disable_events'] = true;
 
@@ -354,7 +356,11 @@ export var Canvas = Renderer.extend({
 	// so we emulate that by calculating what's under the mouse on mousemove/click manually
 
 	_onClick: function (e) {
-		var point = this._map.mouseEventToLayerPoint(e), layer, clickedLayer;
+		var first = e.touches ? e.touches[0] : e;
+		if (e.type === 'touchend') {
+			first = e.changedTouches[0];
+		}
+		var point = this._map.mouseEventToLayerPoint(first), layer, clickedLayer;
 
 		for (var order = this._drawFirst; order; order = order.next) {
 			layer = order.layer;
@@ -370,7 +376,8 @@ export var Canvas = Renderer.extend({
 	_onMouseMove: function (e) {
 		if (!this._map || this._map.dragging.moving() || this._map._animatingZoom) { return; }
 
-		var point = this._map.mouseEventToLayerPoint(e);
+		var first = e.touches ? e.touches[0] : e;
+		var point = this._map.mouseEventToLayerPoint(first);
 		this._handleMouseHover(e, point);
 	},
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -69,10 +69,10 @@ export var Canvas = Renderer.extend({
 	_initContainer: function () {
 		var container = this._container = document.createElement('canvas');
 
-		var touchMove = Browser.touch ? 'touchmove' : '';
-		var touchClick = Browser.touch ? 'touchstart touchend touchcancel' : '';
-		DomEvent.on(container, 'mousemove ' + touchMove, this._onMouseMove, this);
-		DomEvent.on(container, 'click dblclick contextmenu mousedown mouseup ' + touchClick, this._onClick, this);
+		var touchMove = Browser.touch ? 'touchmove ' : '';
+		var touchClick = Browser.touch ? 'touchstart touchend touchcancel ' : '';
+		DomEvent.on(container, touchMove + 'mousemove', this._onMouseMove, this);
+		DomEvent.on(container, touchClick + 'click dblclick contextmenu mousedown mouseup', this._onClick, this);
 		DomEvent.on(container, 'mouseout', this._handleMouseOut, this);
 		container['_leaflet_disable_events'] = true;
 
@@ -357,7 +357,7 @@ export var Canvas = Renderer.extend({
 
 	_onClick: function (e) {
 		var first = e.touches ? e.touches[0] : e;
-		if (e.type === 'touchend') {
+		if (['touchend', 'touchcancel', 'pointerup', 'pointercancel'].indexOf(e.type) > -1) {
 			first = e.changedTouches[0];
 		}
 		var point = this._map.mouseEventToLayerPoint(first), layer, clickedLayer;
@@ -426,7 +426,19 @@ export var Canvas = Renderer.extend({
 	},
 
 	_fireEvent: function (layers, e, type) {
-		this._map._fireDOMEvent(e, type || e.type, layers);
+
+		// this is not needed if #7064 is merged
+		var _type = type || e.type;
+		if (_type === 'pointerdown') {
+			_type = 'touchstart';
+		} else if (_type === 'pointermove') {
+			_type = 'touchmove';
+		} else if (_type === 'pointerup') {
+			_type = 'touchend';
+		} else if (_type === 'pointercancel') {
+			_type = 'touchcancel';
+		}
+		this._map._fireDOMEvent(e, _type, layers);
 	},
 
 	_bringToFront: function (layer) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1431,8 +1431,12 @@ export var Map = Evented.extend({
 
 		if (e.type !== 'keypress' && e.type !== 'keydown' && e.type !== 'keyup') {
 			var isMarker = target.getLatLng && (!target._radius || target._radius <= 10);
+			var first = e.touches ? e.touches[0] : e;
+			if (e.type === 'touchend') {
+				first = e.changedTouches[0];
+			}
 			data.containerPoint = isMarker ?
-				this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(e);
+				this.latLngToContainerPoint(target.getLatLng()) : this.mouseEventToContainerPoint(first);
 			data.layerPoint = this.containerPointToLayerPoint(data.containerPoint);
 			data.latlng = isMarker ? target.getLatLng() : this.layerPointToLatLng(data.layerPoint);
 		}


### PR DESCRIPTION
Touchevents are now passed to the layer through Canvas.

It was not possible to listen on mouse or touch events on a layer if `preferCanvas` is enabled on the map.


"No" events fired:
![canvas_touch_wrong](https://user-images.githubusercontent.com/19800037/144719923-79de7cac-65dc-44a5-ab48-7d9791257eff.gif)

Fixed: Touchevents fired
![canvas_touch_working](https://user-images.githubusercontent.com/19800037/144719927-6317ab9d-f0bc-473c-88fc-87e363c90d17.gif)


I created a demo code for this, which catches all mouse and touch events on the layer. You will see in the "current demo" nothing is fired / a few times (very randomly) mousemove fired. 

```
circle.on('mousedown touchstart mousemove touchmove mouseup touchend', (e)=>{
			var obj = events[e.type];
			events[e.type] = obj ? obj + 1 : 1;

			var elm = document.getElementById('debug');

			var text = "";
			for(var type in events) {
				text += type+": "+events[type]+"<br>";
			}
			elm.innerHTML = text;
		});
```

[Here](https://plnkr.co/edit/EjJh2WRwiXIEZ10d) is a Plunkr, but touch simulation is not working there, so I added the demo on my server too:
- [Current](https://florianbischof.net/leaflet/canvas_touch/old.html)
- [New / fixed](https://florianbischof.net/leaflet/canvas_touch/)

