### PR TITLE
Set `role=button` on the Layer control

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -201,6 +201,7 @@ export var Layers = Control.extend({
 		var link = this._layersLink = DomUtil.create('a', className + '-toggle', container);
 		link.href = '#';
 		link.title = 'Layers';
+		link.setAttribute('role', 'button');
 
 		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
 		DomEvent.on(link, 'focus', this.expand, this);


### PR DESCRIPTION
Closes #6821 - This PR closes that issue because the WCAG error reported is only applicable to elements with `role=link` (implicit from `<a>` in the case of the layer control) and not buttons (which this PR changes)!

Closes #6869 - Unlike that PR, this doesn't set `aria-label` (in addition to the existing `title`) as that's not only redundant but would also cause some screen readers to announce "Layers" twice - which is an obvious annoyance to screen reader users.

Fix #7498.