### PR TITLE
Add print styles to prevent printers from removing background-images in controls

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -650,6 +650,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	/* Prevent printers from removing background-images of controls. */
 	.leaflet-control {
 		-webkit-print-color-adjust: exact;
-		              color-adjust: exact;
+		color-adjust: exact;
 		}
 	}

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -643,3 +643,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	margin-left: -12px;
 	border-right-color: #fff;
 	}
+
+/* Printing */
+	
+@media print {
+	/* Prevent printers from removing background-images of controls. */
+	.leaflet-control {
+		-webkit-print-color-adjust: exact;
+		              color-adjust: exact;
+		}
+	}


### PR DESCRIPTION
Fix https://github.com/Leaflet/Leaflet/issues/7490.

## Comparison (see the layer control icon)

### Before
<img width="600" src="https://user-images.githubusercontent.com/26493779/145372890-58dd589b-f277-40cc-a46d-69fb1b795a0d.png">

### After
<img width="600" src="https://user-images.githubusercontent.com/26493779/145372940-4f9d5eac-1c48-4dc5-9632-ac71588eaf3b.png">

See CSS [`color-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/color-adjust) for more info.