### PR TITLE
Upload files to AWS even if the file-size is the same

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Deploy artifacts
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
-          args: --acl public-read --delete
+          args: --acl public-read --delete --exact-timestamps
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Should resolve an issue where not all files are synced to AWS even through they have been updated (as reported [here](https://github.com/Leaflet/Leaflet/issues/5999#issuecomment-990740003)). Adding the [`--exact-timestamps`](https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html) flag will ensure that even if the size of a given file is the same it will still be synced to AWS if it was created at a different moment.

Related issue for AWS can be found under https://github.com/aws/aws-cli/issues/3273