### PR TITLE
Publish package to NPM when pushing tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build project
         run: npm run build
+        env:
+          NODE_ENV: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
 
       - name: Cache setup
         uses: actions/cache@v2
@@ -89,7 +91,7 @@ jobs:
       - name: Run tests on ${{ matrix.browser }}
         run: npm test -- --browsers ${{ matrix.browser }}
 
-  deploy:
+  publish-artifacts:
     needs: setup
     if: github.repository_owner == 'Leaflet' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
@@ -106,9 +108,11 @@ jobs:
 
       - name: Determine directory for artifacts
         id: artifacts-directory
-        run: VERSION=$(git tag --points-at HEAD) echo "::set-output name=path::content/leaflet/${VERSION:-master}"
+        run: |
+          VERSION=$(git tag --points-at HEAD)
+          echo "::set-output name=path::content/leaflet/${VERSION:-master}"
 
-      - name: Deploy artifacts
+      - name: Publish artifacts
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
           args: --acl public-read --delete
@@ -118,3 +122,25 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: dist
           DEST_DIR: ${{ steps.artifacts-directory.outputs.path }}
+
+  publish-npm:
+    needs: setup
+    if: github.repository_owner == 'Leaflet' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Restore setup
+        uses: actions/cache@v2
+        with:
+          path: ./*
+          key: ${{ runner.os }}-${{ github.sha }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
 ## Releasing a new version of Leaflet
 
 - [ ] Update [the changelog](https://github.com/Leaflet/Leaflet/blob/master/CHANGELOG.md) since last release and commit.
-- [ ] Run `npm publish --dry-run` to run all the necessary checks without actually publishing, and make sure it runs successfully.
 - [ ] Run `npm version <patch | minor | major>` (this will bump the version in `package.json` and create a new tag).
-- [ ] Run `npm publish` to publish to NPM.
+- [ ] Run `git push --follow-tags` to push the commit created by NPM to Github (together with the tag).
+- [ ] Wait for the CI to complete and follow the logs to make sure it runs successfully.
 - [ ] Verify that the release was correctly published to NPM by checking:
   - [ ] [Leaflet NPM package page](https://www.npmjs.com/package/leaflet)
   - [ ] files on [Leaflet unpkg page](https://unpkg.com/leaflet@latest/)

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-watch-config.js",
     "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --source-map content=dist/leaflet-src.js.map --source-map url=leaflet.js.map --comments",
-    "integrity": "node ./build/integrity.js",
-    "prepublishOnly": "npm ci && npm run lint && npm run test && NODE_ENV=release npm run build"
+    "integrity": "node ./build/integrity.js"
   },
   "eslintConfig": {
     "ignorePatterns": [


### PR DESCRIPTION
Publishes a new version to NPM when a tag is pushed to the repo. This requires a secret called [`NPM_TOKEN`](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) containing a token to publish to NPM (see 'Automation' token in the [docs](https://docs.npmjs.com/creating-and-viewing-access-tokens)).

Also includes the following changes:
- `NODE_ENV` is now set to `release` if the build is ran for a tagged commit to ensure proper version info in build.
- Version detection for AWS deployment is fixed (was broken by [this](https://github.com/Leaflet/Leaflet/commit/38c330defb2baf76514b7d199c6b000a61cd9653#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R102) change).

This change works towards closing #7712 