### PR TITLE
Increase captureTimeout and browserSocketTimeout

### DIFF
--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -123,7 +123,10 @@ module.exports = function (config) {
 		concurrency: 1,
 
 		// If browser does not capture in given timeout [ms], kill it
-		captureTimeout: 10000,
+		captureTimeout: 60000,
+
+		// Timeout for the client socket connection [ms].
+		browserSocketTimeout: 30000,
 
 		// Continuous Integration mode
 		// if true, it capture browsers, run tests and exit


### PR DESCRIPTION
Maybe fix: #7824 

Changed the `captureTimeout` to the karma default: [doc](https://github.com/karma-runner/karma/blob/master/docs/config/01-configuration-file.md#capturetimeout)
Increased `browserSocketTimeout` from 20sec to 30sec, like suggested in the karma [doc](https://github.com/karma-runner/karma/blob/master/docs/config/01-configuration-file.md#browsersockettimeout)