### PR TITLE
Fix opening / closing tooltip while dragging map

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -354,14 +354,14 @@ describe('Tooltip', function () {
 		map.dragging.moving = function () {
 			return true;
 		};
-		happen.at('mouseover',210, 195);
+		happen.at('mouseover', 210, 195);
 		expect(tooltip.isOpen()).to.be(false);
 
 		// simulate map not dragging anymore
 		map.dragging.moving = function () {
 			return false;
 		};
-		happen.at('mouseover',210, 195);
+		happen.at('mouseover', 210, 195);
 		expect(tooltip.isOpen()).to.be.ok();
 	});
 
@@ -372,7 +372,7 @@ describe('Tooltip', function () {
 		var tooltip = layer.getTooltip();
 
 		// open tooltip before "dragging map"
-		happen.at('mouseover',210, 195);
+		happen.at('mouseover', 210, 195);
 		expect(tooltip.isOpen()).to.be.ok();
 
 		// simulate map dragging
@@ -383,7 +383,7 @@ describe('Tooltip', function () {
 		expect(tooltip.isOpen()).to.be(false);
 
 		// tooltip should not open again while dragging
-		happen.at('mouseover',210, 195);
+		happen.at('mouseover', 210, 195);
 		expect(tooltip.isOpen()).to.be(false);
 	});
 });

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -343,4 +343,47 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(tooltip1)).to.not.be.ok();
 		expect(eventSpy.calledOnce).to.be.ok();
 	});
+
+	it("don't opens the tooltip on marker mouseover while dragging map", function () {
+		// Sometimes the mouse is moving faster then the map while dragging and then the marker can be hover and
+		// the tooltip opened / closed.
+		var layer = L.marker(center).addTo(map).bindTooltip('Tooltip');
+		var tooltip = layer.getTooltip();
+
+		// simulate map dragging
+		map.dragging.moving = function () {
+			return true;
+		};
+		happen.at('mouseover',210, 195);
+		expect(tooltip.isOpen()).to.be(false);
+
+		// simulate map not dragging anymore
+		map.dragging.moving = function () {
+			return false;
+		};
+		happen.at('mouseover',210, 195);
+		expect(tooltip.isOpen()).to.be.ok();
+	});
+
+	it("closes the tooltip on marker mouseout while dragging map and don't open it again", function () {
+		// Sometimes the mouse is moving faster then the map while dragging and then the marker can be hover and
+		// the tooltip opened / closed.
+		var layer = L.marker(center).addTo(map).bindTooltip('Tooltip');
+		var tooltip = layer.getTooltip();
+
+		// open tooltip before "dragging map"
+		happen.at('mouseover',210, 195);
+		expect(tooltip.isOpen()).to.be.ok();
+
+		// simulate map dragging
+		map.dragging.moving = function () {
+			return true;
+		};
+		happen.mouseout(layer._icon, {relatedTarget: map._container});
+		expect(tooltip.isOpen()).to.be(false);
+
+		// tooltip should not open again while dragging
+		happen.at('mouseover',210, 195);
+		expect(tooltip.isOpen()).to.be(false);
+	});
 });

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -388,7 +388,7 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		if (!this._tooltip || !this._map) {
+		if (!this._tooltip || !this._map || this._map.dragging.moving()) {
 			return;
 		}
 		this._tooltip._source = e.layer || e.target;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -388,7 +388,7 @@ Layer.include({
 	},
 
 	_openTooltip: function (e) {
-		if (!this._tooltip || !this._map || this._map.dragging.moving()) {
+		if (!this._tooltip || !this._map || (this._map.dragging && this._map.dragging.moving())) {
 			return;
 		}
 		this._tooltip._source = e.layer || e.target;


### PR DESCRIPTION
While dragging the map it can happen that the mouse is moved faster then the map and then on the marker is `mouseover` and `mouseout` fired. Then this flickering happens (opening / closing):

![tooltip_flakering](https://user-images.githubusercontent.com/19800037/145726438-cda3c118-7bcc-4d8b-81f4-bf010b2947d8.gif)

To prevent this I added a check in `openTooltip` if the map is currently moving.

This means:
- If the tooltip is open and while dragging `mouseout` is fired, it closes and don't opening again if `mouseover` is fired later.
- If the tooltip is closed and `mouseover` is fired, it don't opens.

Fixed:
![tooltip_flakering_fix](https://user-images.githubusercontent.com/19800037/145726654-e017c5a9-6b35-4596-98fc-36a5f5126dd4.gif)
While the mouse is on the marker the tooltip keeps open, but if it goes away from the marker, `mouseout` is fired and the tooltip closes and is not opened again.
