### PR TITLE
Support dashOffset on canvas layer

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -340,7 +340,8 @@ export const Canvas = Renderer.extend({
 
 		if (options.stroke && options.weight !== 0) {
 			if (ctx.setLineDash) {
-				ctx.setLineDash(layer.options && layer.options._dashArray || []);
+				ctx.lineDashOffset = Number(options.dashOffset || 0);
+				ctx.setLineDash(options._dashArray || []);
 			}
 			ctx.globalAlpha = options.opacity;
 			ctx.lineWidth = options.weight;


### PR DESCRIPTION
the PathOption `dashOffset` is currently ignored on canvas layers.

