### PR TITLE
Workaround for DashArray with starting 0 on canvas layers

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -339,7 +339,8 @@ export var Canvas = Renderer.extend({
 
 		if (options.stroke && options.weight !== 0) {
 			if (ctx.setLineDash) {
-				ctx.setLineDash(layer.options && layer.options._dashArray || []);
+				ctx.lineDashOffset = Number(options.dashOffset || 0);
+				ctx.setLineDash(options._dashArray || []);
 			}
 			ctx.globalAlpha = options.opacity;
 			ctx.lineWidth = options.weight;

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -340,7 +340,12 @@ export var Canvas = Renderer.extend({
 		if (options.stroke && options.weight !== 0) {
 			if (ctx.setLineDash) {
 				ctx.lineDashOffset = Number(options.dashOffset || 0);
-				ctx.setLineDash(options._dashArray || []);
+				var dash = options._dashArray || [];
+				if (dash.length > 1 && dash[0] === 0) {
+					ctx.lineDashOffset += dash[1];
+					dash = dash.slice(2);
+				}
+				ctx.setLineDash(dash);
 			}
 			ctx.globalAlpha = options.opacity;
 			ctx.lineWidth = options.weight;


### PR DESCRIPTION
On svg layers a `dashArray="0 8 16 8"` is fine.  
`(example result: "  ----    ----  ")`
On canvas layers the internal `setLineDash([0,8,16,8])` will create artefacts at the begining of the dash. 
`(example result: "-  ----  -  ----  ")`

So we got different results on svg and canvas layers.

This can be workaround by converting the first zero argument into the dashOffset.

( required PR #7867 to support dashOffset)