### PR TITLE
Remove will-change

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -171,9 +171,6 @@
 
 /* zoom and fade animations */
 
-.leaflet-fade-anim .leaflet-tile {
-	will-change: opacity;
-	}
 .leaflet-fade-anim .leaflet-popup {
 	opacity: 0;
 	-webkit-transition: opacity 0.2s linear;
@@ -188,9 +185,7 @@
 	    -ms-transform-origin: 0 0;
 	        transform-origin: 0 0;
 	}
-.leaflet-zoom-anim .leaflet-zoom-animated {
-	will-change: transform;
-	}
+
 .leaflet-zoom-anim .leaflet-zoom-animated {
 	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);
 	   -moz-transition:    -moz-transform 0.25s cubic-bezier(0,0,0.25,1);


### PR DESCRIPTION
Prevent browser (mostly Firefox) resource depletion by premature optimization usage of `will-change`. At the municipality of Amsterdam, we're heavily relying on Leaflet and having map instances open regularly leads to degraded performance in Firefox, because of the use of `will-change`.

See https://developer.mozilla.org/en-US/docs/Web/CSS/will-change for reference.