### PR TITLE
Add drustack/Leaflet.ResetView to plugins

### DIFF
--- a/docs/_plugins/bookmarked-pan-zoom/drustack--leaflet.resetview.md
+++ b/docs/_plugins/bookmarked-pan-zoom/drustack--leaflet.resetview.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.ResetView
+category: bookmarked-pan-zoom
+repo: https://github.com/drustack/Leaflet.ResetView
+author: Wong Hoi Sing Edison
+author-url: https://github.com/hswong3i
+demo: https://drustack.github.io/Leaflet.ResetView/
+compatible-v0: false
+compatible-v1: true
+---
+
+A reset view control for Leaflet. Design for [Drupal Leaflet Module](https://www.drupal.org/project/leaflet) integration.


### PR DESCRIPTION
A reset view control for Leaflet.

Design for [Drupal Leaflet Module](https://www.drupal.org/project/leaflet) integration.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>