### PR TITLE
Add drustack/Leaflet.SyncView to plugins

### DIFF
--- a/docs/_plugins/interactive-pan-zoom/drustack--leaflet.syncview.md
+++ b/docs/_plugins/interactive-pan-zoom/drustack--leaflet.syncview.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.SyncView
+category: interactive-pan-zoom
+repo: https://github.com/drustack/Leaflet.SyncView
+author: Wong Hoi Sing Edison
+author-url: https://github.com/hswong3i
+demo: https://drustack.github.io/Leaflet.SyncView/
+compatible-v0: false
+compatible-v1: true
+---
+
+A sync view control for Leaflet. Design for [Drupal Leaflet Module](https://www.drupal.org/project/leaflet) integration.


### PR DESCRIPTION
A sync view control for Leaflet.

Design for [Drupal Leaflet Module](https://www.drupal.org/project/leaflet) integration.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>