### PR TITLE
Add django-leaflet in frameworks-build-systems documentation.

### DIFF
--- a/docs/_plugins/frameworks-build-systems/django-leaflet.md
+++ b/docs/_plugins/frameworks-build-systems/django-leaflet.md
@@ -1,0 +1,12 @@
+---
+name: Django Leaflet
+category: frameworks-build-systems
+repo: https://github.com/makinacorpus/django-leaflet
+author: Makina Corpus
+author-url: https://makina-corpus.com/
+demo: 
+compatible-v0: true
+compatible-v1: true
+---
+
+Use Leaflet in your **Django** projects. Includes admin integration, form widget, template tags, and much more!


### PR DESCRIPTION
Hi,

I just added [django-leaflet](https://github.com/makinacorpus/django-leaflet) to the framework documentation.

Many thanks for the review :+1: .