### PR TITLE
Add Leaflet.Draw.Svg to plugins

### DIFF
--- a/docs/_plugins/edit-geometries/leaflet-draw-svg.md
+++ b/docs/_plugins/edit-geometries/leaflet-draw-svg.md
@@ -5,7 +5,7 @@ repo: https://github.com/robidev/Leaflet.Draw.Svg
 author: Robin Massink
 author-url: https://github.com/robidev
 demo: https://robidev.github.io/Leaflet.Draw.Svg/local_svg/index.html
-compatible-v0:
+compatible-v0: true
 compatible-v1: true
 ---
 

--- a/docs/_plugins/edit-geometries/leaflet-draw-svg.md
+++ b/docs/_plugins/edit-geometries/leaflet-draw-svg.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.draw.svg
+category: edit-geometries
+repo: https://github.com/robidev/Leaflet.Draw.Svg
+author: Robin Massink
+author-url: https://github.com/robidev
+demo: https://robidev.github.io/Leaflet.Draw.Svg/local_svg/index.html
+compatible-v0:
+compatible-v1: true
+---
+
+Plugin to Leaflet.Draw to allow adding/moving/removing custom SVG files on a leaflet map. It allows to define a SVG as XML text, and converts it into an SVG object that can be displayed by leaflet as an editable feature.


### PR DESCRIPTION
Leaflet.Draw.Svg is a plugin to Leaflet and Leaflet.Draw to allow adding/moving/removing custom SVG files on a leaflet map. It allows to define a SVG as XML text, and converts it into an SVG object that can be displayed by leaflet as an editable feature.

Would you be interested to add it to the list of plugins?