### PR TITLE
Update marker: role=button, alt=marker

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -190,12 +190,12 @@ describe("Marker", function () {
 			expect(marker._shadow.parentNode).to.be(map._panes.shadowPane);
 		});
 
-		it("sets the alt attribute to an empty string when no alt text is passed", function () {
+		it("sets the alt attribute to a default value when no alt text is passed", function () {
 			var marker = L.marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 			var icon = marker._icon;
 			expect(icon.hasAttribute('alt')).to.be(true);
-			expect(icon.alt).to.be('');
+			expect(icon.alt).to.be('Marker');
 		});
 
 		it("doesn't set the alt attribute for DivIcons", function () {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -40,9 +40,9 @@ export var Marker = Layer.extend({
 		// Text for the browser tooltip that appear on marker hover (no tooltip by default).
 		title: '',
 
-		// @option alt: String = ''
+		// @option alt: String = 'Marker'
 		// Text for the `alt` attribute of the icon image (useful for accessibility).
-		alt: '',
+		alt: 'Marker',
 
 		// @option zIndexOffset: Number = 0
 		// By default, marker images zIndex is set automatically based on its latitude. Use this option if you want to put the marker on top of all others (or below), specifying a high value like `1000` (or high negative value, respectively).
@@ -225,6 +225,7 @@ export var Marker = Layer.extend({
 
 		if (options.keyboard) {
 			icon.tabIndex = '0';
+			icon.setAttribute('role', 'button');
 		}
 
 		this._icon = icon;


### PR DESCRIPTION
Marker is set to alt=marker and role=button to Fix https://github.com/Leaflet/Leaflet/issues/7428 and now it's possible to open the pop-ups with my screen reader, it's not possible here: https://leafletjs.com/examples/quick-start/