### PR TITLE
Add an official Accessibility Statement

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,80 @@
+---
+layout: v2
+title: Accessibility
+bodyclass: a11y-statement-page
+---
+
+## Accessibility Statement for Leaflet
+
+This is an accessibility statement from Leaflet.
+
+<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="50px" viewBox="0 0 24 24" width="50px" style="fill:#199900;margin:-.75em 0 -1.5em 0;"><path d="M0 0h24v24H0z" fill="none"></path><path d="M20.5 6c-2.61.7-5.67 1-8.5 1s-5.89-.3-8.5-1L3 8c1.86.5 4 .83 6 1v13h2v-6h2v6h2V9c2-.17 4.14-.5 6-1l-.5-2zM12 6c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></svg>
+
+### Conformance status
+
+The
+[Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/)
+defines requirements for designers and developers to improve accessibility
+for people with disabilities.
+It defines three levels of conformance:
+Level A, Level AA, and Level AAA.
+
+Leaflet is partially conformant with WCAG 2.1
+[Level A](https://www.w3.org/TR/WCAG21/#cc1).
+Partially conformant means that some parts of the content do not fully conform
+to the accessibility standard.
+
+### Measures to support accessibility
+
+Leaflet strives to provide accessible maps.
+[Accessibility issues to be addressed](https://github.com/Leaflet/Leaflet/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility) are tracked and discussed
+on Github.
+
+### Feedback
+
+We welcome your feedback on the accessibility of Leaflet.
+If you encounter accessibility barriers, please check to see if there's a
+relevant bug or
+[file a new bug report](https://github.com/Leaflet/Leaflet/issues/new/choose).
+Or tweet
+[@LeafletJS](https://twitter.com/LeafletJS).
+
+
+### Compatibility with browsers and assistive technology
+
+Leaflet is designed to be compatible with the following assistive technologies:
+
+- Screen readers (partial compatibility)
+
+### Technical specifications
+
+Accessibility of Leaflet relies on the following technologies to work with
+the particular combination of web browser and any assistive technologies or
+plugins installed on your computer:
+
+- ARIA
+- CSS
+- HTML
+- JavaScript
+
+These technologies are relied upon for conformance with the accessibility
+standards used.
+
+### Limitations
+
+Despite our best efforts to ensure accessibility of Leaflet,
+there may be some limitations.
+
+Known limitations for Leaflet exist as
+[Github issues with the "accessibility" label](https://github.com/Leaflet/Leaflet/issues?q=is%3Aopen+is%3Aissue+label%3Aaccessibility).
+
+### Evaluation report
+
+An evaluation report for Leaflet JS is available at:
+
+- [Web map tools WCAG 2.1 evaluation](https://github.com/Malvoz/web-maps-wcag-evaluation/blob/master/README.md)
+
+---
+
+This statement was created on 10 January 2022 using the
+[W3C Accessibility Statement Generator Tool](https://www.w3.org/WAI/planning/statements/).

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -8,7 +8,7 @@ bodyclass: a11y-statement-page
 
 This is an accessibility statement from Leaflet.
 
-<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="50px" viewBox="0 0 24 24" width="50px" style="fill:#199900;margin:-.75em 0 -1.5em 0;"><path d="M0 0h24v24H0z" fill="none"></path><path d="M20.5 6c-2.61.7-5.67 1-8.5 1s-5.89-.3-8.5-1L3 8c1.86.5 4 .83 6 1v13h2v-6h2v6h2V9c2-.17 4.14-.5 6-1l-.5-2zM12 6c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></svg>
+<svg class="a11y-icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"></path><path d="M20.5 6c-2.61.7-5.67 1-8.5 1s-5.89-.3-8.5-1L3 8c1.86.5 4 .83 6 1v13h2v-6h2v6h2V9c2-.17 4.14-.5 6-1l-.5-2zM12 6c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2z"></path></svg>
 
 ### Conformance status
 

--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -1102,3 +1102,22 @@ iframe[src*='youtube.com'] {
 	padding: 5px 10px;
 	border-radius: 10px;
 }
+
+/* Accessibility statement */
+
+svg.a11y-icon {
+	fill: #199900;
+	position: absolute;
+	right: 0;
+	top: 21em;
+	width: 45vw;
+	height: auto;
+	z-index: -1;
+	opacity: .075;
+}
+
+@media screen and (max-width: 767px) {
+	svg.a11y-icon {
+		display: none;
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Leaflet/Leaflet/issues/7537.

The accessibility statement, including _all_ headings and most paragraphs, were [generated](https://www.w3.org/WAI/planning/statements/generator/#create) from input. Though many of the paragraphs were modified, mostly to fit appropriate links in (the template wanted a list of known limitations a.k.a. accessibility issues, I chose to link to Github instead).

Adding this proposed accessibility statement has the implications:
- [x] Leaflet is officially concluded to **partially** support WCAG 2.1 [Level A](https://www.w3.org/TR/WCAG21/#cc1) - this is because Leaflet fails at least one Level A Success Criterion (and probably more). Naturally, the immediate goal would be to fully support Level A and then reflect that in the statement.
- [x] Developers and users (coming from the attribution link in the maps, for example) can find official information on accessibility in Leaflet.
- [ ] There should probably be a link either in the header or footer to the accessibility statement.
- [ ] Should most likely scope the Accessibility Statement to Leaflet _maps_ (i.e. excluding the website, we don't want to block WCAG Level conformance on site issues, although site issues should also be reported by users). TBD how to express this.
- [ ] Probably rename this file `accessibility-statement` for ambiguity now that https://leafletjs.com/examples/accessibility/ exists.

I'm hoping this is all that is required to add a new document. <s>I don't have Ruby installed.</s> 😛

/cc @mourner, @IvanSanchez, @johnd0e, @jonkoops, @Falke-Design