### PR TITLE
Update LICENSE to 2022 and automate on website

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2010-2021, Vladimir Agafonkin
+Copyright (c) 2010-2022, Vladimir Agafonkin
 Copyright (c) 2010-2011, CloudMade
 All rights reserved.
 

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -120,9 +120,9 @@
 
 <footer>
 	<div class="footer">
-		<p>&copy; 2010–2021 <a href="http://agafonkin.com/en">Vladimir Agafonkin</a>. Maps &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors.</p>
+		<p>&copy; 2010–{{ 'now' | date: "%Y" }} <a href="http://agafonkin.com/en">Vladimir Agafonkin</a>. Maps &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors.</p>
 	</div>
-	
+
 	<nav class="ext-links">
 	  <a class="ext-link twitter" href="https://twitter.com/LeafletJS" title="Follow LeafletJS on Twitter"><img alt="Follow LeafletJS on Twitter" src="{{root}}docs/images/twitter-round.png" width="46" /></a>
 	  <a class="ext-link github" href="http://github.com/Leaflet/Leaflet" title="View Source on GitHub"><img alt="View Source on GitHub" src="{{root}}docs/images/github-round.png" width="46" /></a>


### PR DESCRIPTION
Fixes #7891

I added a `jekyll` command to the website footer, which displays always the current year