### PR TITLE
Fix HTML error in Layer Control, Fix #6434

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -339,7 +339,7 @@ export var Layers = Control.extend({
 
 		// Helps from preventing layer control flicker when checkboxes are disabled
 		// https://github.com/Leaflet/Leaflet/issues/2771
-		var holder = document.createElement('div');
+		var holder = document.createElement('span');
 
 		label.appendChild(holder);
 		holder.appendChild(input);


### PR DESCRIPTION
Fix https://github.com/Leaflet/Leaflet/issues/6434: "Error: Element div not allowed as child of element label" message from HTML validator