### PR TITLE
Fix HTML error in Layer Control, Fix #6434

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -297,7 +297,7 @@ describe("Control.Layers", function () {
 				'Marker A': markerA
 			}).addTo(map);
 
-			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span');
+			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span span');
 			expect(elems[0].innerHTML.trim()).to.be.equal('Base One');
 			expect(elems[1].innerHTML.trim()).to.be.equal('Base Two');
 			expect(elems[2].innerHTML.trim()).to.be.equal('Marker C');
@@ -323,7 +323,7 @@ describe("Control.Layers", function () {
 				sortLayers: true
 			}).addTo(map);
 
-			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span');
+			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span span');
 			expect(elems[0].innerHTML.trim()).to.be.equal('Base One');
 			expect(elems[1].innerHTML.trim()).to.be.equal('Base Two');
 			expect(elems[2].innerHTML.trim()).to.be.equal('Marker A');
@@ -350,7 +350,7 @@ describe("Control.Layers", function () {
 				sortFunction: function (a, b) { return a.options.customOption - b.options.customOption; }
 			}).addTo(map);
 
-			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span');
+			var elems = map.getContainer().querySelectorAll('div.leaflet-control-layers label span span');
 			expect(elems[0].innerHTML.trim()).to.be.equal('Base Two');
 			expect(elems[1].innerHTML.trim()).to.be.equal('Base One');
 			expect(elems[2].innerHTML.trim()).to.be.equal('Marker B');

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -339,7 +339,7 @@ export var Layers = Control.extend({
 
 		// Helps from preventing layer control flicker when checkboxes are disabled
 		// https://github.com/Leaflet/Leaflet/issues/2771
-		var holder = document.createElement('div');
+		var holder = document.createElement('span');
 
 		label.appendChild(holder);
 		holder.appendChild(input);


### PR DESCRIPTION
Fix #6434: "Error: Element div not allowed as child of element label" message from HTML validator