### PR TITLE
Remove gap between `leaflet-popup-tip-container` and `leaflet-popup-content-wrapper`

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -485,6 +485,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	height: 20px;
 	position: absolute;
 	left: 50%;
+	margin-top: -1px;
 	margin-left: -20px;
 	overflow: hidden;
 	pointer-events: none;
@@ -540,9 +541,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
 	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
-	}
-.leaflet-oldie .leaflet-popup-tip-container {
-	margin-top: -1px;
 	}
 
 .leaflet-oldie .leaflet-control-zoom,


### PR DESCRIPTION
- [x] Removes the gap between the `leaflet-popup-tip-container` and `leaflet-popup-content-wrapper`

> on your screenshots, there's a 1pm gap between the popup and its tip — I wonder if that's a bug we should fix too? Is it easily reproducible?

_Originally posted by @mourner in https://github.com/Leaflet/Leaflet/issues/7908#issuecomment-1013529489_

The gap can be seen in the screenshot below. I was able to reproduce the gap consistently in Chrome 97.0.4692.71. In Firefox 95.0.2 it wasn't always visible, and sometimes only visible during zoom.

<img width="300" src="https://user-images.githubusercontent.com/26493779/149854439-131f8a8f-17f9-4fed-a7a2-c95eb427b61c.png">

## Preview

<img width="300" src="https://user-images.githubusercontent.com/26493779/149854451-b86f27ac-1d17-48ef-bdc0-a7ad550dfdf5.png">

