### PR TITLE
Ensure map centre is maintained for zoom operations

### DIFF
--- a/debug/map/zoom-remain-centered-after-pan.html
+++ b/debug/map/zoom-remain-centered-after-pan.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<link rel="stylesheet" href="../css/screen.css" />
+
+	<script src="../leaflet-include.js"></script>
+</head>
+<body>
+
+
+	<div id="map"></div>
+
+	<script>
+		// Check the 'center' setting of the scroll-wheel, double-click and touch-zoom
+		// handlers after a pan operation. The map centre should be stable.
+
+		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = L.tileLayer(osmUrl, {minZoom: 2, attribution: osmAttrib}),
+			latlng = new L.LatLng(51.1788409,-1.82618),
+			newLatLng = new L.LatLng(51.05, -1.78);
+
+		var map = new L.Map('map', {
+			center: newLatLng,
+			maxZoom: 18,
+			zoom: 10,
+			layers: [osm],
+			scrollWheelZoom: 'center', // zoom to center regardless where mouse is
+			doubleClickZoom: 'center',
+			touchZoom:       'center'
+		});
+
+		L.marker(newLatLng).addTo(map);
+		L.marker(latlng).addTo(map);
+
+		L.control.scale().addTo(map);
+
+		// Initial pan
+		map.setView(latlng);
+
+	</script>
+</body>
+</html>

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -132,6 +132,8 @@ export var Drag = Handler.extend({
 			this._prunePositions(time);
 		}
 
+		this._map._movedAfterCentered = true;
+
 		this._map
 		    .fire('move', e)
 		    .fire('drag', e);
@@ -187,7 +189,6 @@ export var Drag = Handler.extend({
 	_onDragEnd: function (e) {
 		var map = this._map,
 		    options = map.options,
-
 		    noInertia = !options.inertia || this._times.length < 2;
 
 		map.fire('dragend', e);


### PR DESCRIPTION
The main PR was closed because we renamed the `master` branch to `main`. 
For more infos look into: #6066

----
# #6066:

An issue exists where the rounding operations necessary to produce pixel-aligned map views can result in 'drifting' of the map centre when zooming in and out. For example, if you pan to a specific landmark, zoom all the way out, then zoom in again, the centre will have shifted. (Note that you should use keyboard + and - or the on-screen buttons to zoom into/out of the centre, not your mousewheel or pinch-to-zoom.)

This fix regards the center parameter passed to setView as the 'last known good' map centroid, storing it in _lastCenter, which already exists for a similar purpose. Subsequent drag, move, zoom and setView operations set or reset _lastCenter and an associated _movedAfterCentered field. The getCenter function has been changed to return the _lastCenter latlng if _movedAfterCentered is not set, similar to the existing _moved() check (which does the same for if the map hasn't been moved from its origin). This means that layerPointToLatLng is not called with the pixel-based centre coords when the geographical centre is available and still accurate, removing the round operation and the accumulated error as you zoom in and out.

A test file is included - debug\map\zoom-remain-centered-after-pan.html - which does an initial animated pan when initially loaded. Zooming in and out on the new version should be stable, whereas the same operations should show the drift on Leaflet version 1.3.

I haven't been able to produce an automated test. If one's required, I'd appreciate assistance setting one up.

The issues addressed by the fix are: #3737 and #5994.