### PR TITLE
add 'top-center', 'bottom-center' control positions

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -143,6 +143,13 @@
 .leaflet-left {
 	left: 0;
 	}
+.leaflet-center {
+	width: 100%;
+	}
+.leaflet-center.leaflet-top,
+.leaflet-center.leaflet-bottom {
+	text-align: center;
+	}
 .leaflet-control {
 	float: left;
 	clear: both;
@@ -162,7 +169,12 @@
 .leaflet-right .leaflet-control {
 	margin-right: 10px;
 	}
-
+.leaflet-center .leaflet-control {
+	display: inline-block;
+	margin: inherit auto;
+	text-align: initial;
+	float: none;
+	}
 
 /* zoom and fade animations */
 

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -18,8 +18,8 @@ export var Control = Class.extend({
 	// @aka Control options
 	options: {
 		// @option position: String = 'topright'
-		// The position of the control (one of the map corners). Possible values are `'topleft'`,
-		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		// The position of the control. Possible values are `'topleft'`, `'topright'`,
+		// `'topcenter'`, `'bottomleft'`, `'bottomright'`, `'bottomcenter'`
 		position: 'topright'
 	},
 
@@ -159,8 +159,10 @@ Map.include({
 
 		createCorner('top', 'left');
 		createCorner('top', 'right');
+		createCorner('top', 'center');
 		createCorner('bottom', 'left');
 		createCorner('bottom', 'right');
+		createCorner('bottom', 'center');
 	},
 
 	_clearControlPos: function () {


### PR DESCRIPTION
The main PR was closed because we renamed the `master` branch to `main`. 
For more infos look into: #6935

-----
# #6935:
Similar functionality has already been written / discussed in possibly stale PRs such as #4518, #5554, and #5264.

An existing plugin (https://github.com/FCOO/leaflet-control-topcenter) implements near-identical functionality but uses flexbox (reducing IE compatibility).

Example code:
```html
<link rel='stylesheet' href='./Leaflet/dist/leaflet.css' />
<script src='./Leaflet/dist/leaflet-src.js'></script>
<div id='Map' style="height: 50vh"></div>
<script>
	const map = L.map('Map', { zoom: 4, center: [0, 0] });

	const baseLayer = L.tileLayer();

	L.control.layers({a: baseLayer, b: baseLayer, c: baseLayer}, null, {
		collapsed: false,
		position: 'bottomcenter'
	}).addTo(map);

	L.control.layers({a: baseLayer, b: baseLayer, c: baseLayer}, null, {
		collapsed: false,
		position: 'topcenter'
	}).addTo(map);
</script>
```