### PR TITLE
docs: Remove `table` semantics from tables used for layout purposes for iframe includes

### DIFF
--- a/docs/_includes/frame.html
+++ b/docs/_includes/frame.html
@@ -1,4 +1,4 @@
-<table>
+<table role="presentation">
 <tr><td style='text-align: center; border: none'>
 <iframe src='{{ include.url }}'
 	width='{% if include.width %}{{ include.width }}{% else %}616{% endif %}'


### PR DESCRIPTION
Removes the implicit `role="table"` from tables that are used for layout purposes for iframe includes.

This change improves the screen reader experience on the website, whether you're a screen reader user or just a developer testing things out.

