### PR TITLE
Responsive map examples

### DIFF
--- a/docs/_includes/frame.html
+++ b/docs/_includes/frame.html
@@ -1,8 +1,9 @@
 <table role="presentation">
-<tr><td style='text-align: center; border: none'>
+<tr><td style='text-align: center; border: none; padding: 0;'>
 <iframe src='{{ include.url }}'
-	width='{% if include.width %}{{ include.width }}{% else %}616{% endif %}'
-	height='{% if include.height %}{{ include.height }}{% else %}416{% endif %}'></iframe>
+	width='{% if include.width %}{{ include.width }}{% else %}600{% endif %}'
+	height='{% if include.height %}{{ include.height }}{% else %}400{% endif %}'
+	style="max-width: 100%; max-height: 90vh; box-sizing: border-box;"></iframe>
 </td></tr>
 <tr><td style='text-align: center; border: none'>
 <small><a href='{{ include.url }}'>See this example stand-alone.</a></small>

--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	{% capture title %}{% if page.title %}{{ page.title }} - {% elsif post.title %}{{ post.title }} - {% endif %}{% endcapture %}
 	<title>{{ title }}Leaflet</title>
@@ -12,18 +12,19 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin=""/>
     <script src="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js" integrity="{{site.integrity_hash_uglified}}" crossorigin=""></script>
 
-{% unless page.customMapContainer == "true" %}
 	<style>
 		html, body {
 			height: 100%;
 			margin: 0;
 		}
-		#map {
-			width: 600px;
+		.leaflet-container {
 			height: 400px;
+			width: 600px;
+			max-width: 100%;
+			max-height: 100%;
 		}
 	</style>
-{% endunless %}
+
 	{% if page.css %}<style>{{ page.css }}</style>{% endif %}
 </head>
 <body{% if page.bodyclass %} class="{{ page.bodyclass }}"{% endif %}>


### PR DESCRIPTION
I don't know if this should fix/supersede:
- https://github.com/Leaflet/Leaflet/issues/7420
  - https://github.com/Leaflet/Leaflet/pull/7482
  - https://github.com/Leaflet/Leaflet/pull/7803

because this PR doesn't fix unresponsive media elements, so depends on how you interpret the initial issue and the PRs to fix it.

Anyhow, this PR makes the map examples responsive. Here are screenshots of a few examples:

<table>
  <tr>
    <th>Example</th>
    <th>Live Site</th>
    <th>PR Preview</th>
  </tr>
  <tr>
    <th>
<a href="https://leafletjs.com/examples/wms/wms.html">WMS and TMS</a>
</th>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222516-258d7756-7a32-4d3d-a3ab-8c4e28424c73.png"></img></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222531-efd9c117-3d22-4c08-bc1e-852cd0e5e17e.png"></img></td>
  </tr>
 <tr>
    <th><a href="https://leafletjs.com/examples/choropleth/">Interactive choropleth</a></th>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222522-08cbe8fb-fdef-4768-8573-42abac841953.png"></img></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222525-13433437-a3eb-4955-8fe1-6d7afc5df66e.png"></img></td>
  </tr>
<tr>
    <th><a href="https://leafletjs.com/examples/layers-control/example.html">Layer control</a></th>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222526-b0545ab4-1426-4112-bc33-d0330899d060.png"></img></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/151222529-c9280d62-a953-4285-86d2-3fb8f7832ab3.png"></img></td>
  </tr>
</table>






