### PR TITLE
Fix Marker position while zooming

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1211,7 +1211,7 @@ export var Map = Evented.extend({
 		return this;
 	},
 
-	_move: function (center, zoom, data) {
+	_move: function (center, zoom, data, supressEvent) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -1221,17 +1221,20 @@ export var Map = Evented.extend({
 		this._lastCenter = center;
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
-		// @event zoom: Event
-		// Fired repeatedly during any change in zoom level,
-		// including zoom and fly animations.
-		if (zoomChanged || (data && data.pinch)) {	// Always fire 'zoom' if pinching because #3530
-			this.fire('zoom', data);
-		}
+		if(!supressEvent) {
+			// @event zoom: Event
+			// Fired repeatedly during any change in zoom level,
+			// including zoom and fly animations.
+			if (zoomChanged || (data && data.pinch)) {	// Always fire 'zoom' if pinching because #3530
+				this.fire('zoom', data);
+			}
 
-		// @event move: Event
-		// Fired repeatedly during any movement of the map,
-		// including pan and fly animations.
-		return this.fire('move', data);
+			// @event move: Event
+			// Fired repeatedly during any movement of the map,
+			// including pan and fly animations.
+			this.fire('move', data);
+		}
+		return this;
 	},
 
 	_moveEnd: function (zoomChanged) {
@@ -1697,6 +1700,12 @@ export var Map = Evented.extend({
 			noUpdate: noUpdate
 		});
 
+		if(!this._tempFireZoomEvent){
+			this._tempFireZoomEvent = this._zoom !== this._animateToZoom;
+		}
+
+		this._move(this._animateToCenter, this._animateToZoom, undefined, true);
+
 		// Work around webkit not firing 'transitionend', see https://github.com/Leaflet/Leaflet/issues/3689, 2693
 		setTimeout(Util.bind(this._onZoomTransitionEnd, this), 250);
 	},
@@ -1710,7 +1719,14 @@ export var Map = Evented.extend({
 
 		this._animatingZoom = false;
 
-		this._move(this._animateToCenter, this._animateToZoom);
+		this._move(this._animateToCenter, this._animateToZoom, undefined, true);
+
+		if(this._tempFireZoomEvent){
+			this.fire('zoom');
+		}
+		delete this._tempFireZoomEvent;
+
+		this.fire('move');
 
 		// This anim frame should prevent an obscure iOS webkit tile loading race condition.
 		Util.requestAnimFrame(function () {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1221,7 +1221,7 @@ export var Map = Evented.extend({
 		this._lastCenter = center;
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
-		if(!supressEvent) {
+		if (!supressEvent) {
 			// @event zoom: Event
 			// Fired repeatedly during any change in zoom level,
 			// including zoom and fly animations.
@@ -1700,7 +1700,7 @@ export var Map = Evented.extend({
 			noUpdate: noUpdate
 		});
 
-		if(!this._tempFireZoomEvent){
+		if (!this._tempFireZoomEvent) {
 			this._tempFireZoomEvent = this._zoom !== this._animateToZoom;
 		}
 
@@ -1721,7 +1721,7 @@ export var Map = Evented.extend({
 
 		this._move(this._animateToCenter, this._animateToZoom, undefined, true);
 
-		if(this._tempFireZoomEvent){
+		if (this._tempFireZoomEvent) {
 			this.fire('zoom');
 		}
 		delete this._tempFireZoomEvent;


### PR DESCRIPTION
If a marker is set to a new latlng while zooming the marker jumps around. The problem is that the `this._pixelOrigin` (which is used for the calculation of the marker position) is only set after the zoom (`_onZoomTransitionEnd`), so while zooming the old pixelOrigin is used and the marker jumps. 

I tried to create a test but it was not possible.

- Fixes #7017
- Fixes #5181
- Fixes #5505
- Fixes #5994 (It describes exactly that issue but I'm not abel to reproduce it with the demo)

New src: [link](https://florianbischof.net/leaflet/marker-zoom/leaflet-src.js)

![marker_jumping_wrong](https://user-images.githubusercontent.com/19800037/152519142-9b144c6b-e873-4144-b588-cc2ac92bc1fb.gif)

Fixed:
![marker_jumping_fix](https://user-images.githubusercontent.com/19800037/152519208-4b606a61-90ee-4c25-9aeb-0902efc43df3.gif)
