### PR TITLE
Hide the attribution separator from screen readers

### DIFF
--- a/spec/suites/control/Control.AttributionSpec.js
+++ b/spec/suites/control/Control.AttributionSpec.js
@@ -24,19 +24,19 @@ describe("Control.Attribution", function () {
 	describe('#addAttribution', function () {
 		it('adds one attribution correctly', function () {
 			control.addAttribution('foo');
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 		});
 
 		it('adds no duplicate attributions', function () {
 			control.addAttribution('foo');
 			control.addAttribution('foo');
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 		});
 
 		it('adds several attributions listed with comma', function () {
 			control.addAttribution('foo');
 			control.addAttribution('bar');
-			expect(container.innerHTML).to.eql('prefix | foo, bar');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo, bar');
 		});
 	});
 
@@ -45,7 +45,7 @@ describe("Control.Attribution", function () {
 			control.addAttribution('foo');
 			control.addAttribution('bar');
 			control.removeAttribution('foo');
-			expect(container.innerHTML).to.eql('prefix | bar');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> bar');
 		});
 		it('does nothing if removing attribution that was not present', function () {
 			control.addAttribution('foo');
@@ -54,7 +54,7 @@ describe("Control.Attribution", function () {
 			control.removeAttribution('baz');
 			control.removeAttribution('baz');
 			control.removeAttribution('');
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 		});
 	});
 
@@ -83,16 +83,16 @@ describe("Control.Attribution", function () {
 
 			expect(container.innerHTML).to.eql('prefix');
 			map.addLayer(fooLayer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 			map.addLayer(barLayer);
-			expect(container.innerHTML).to.eql('prefix | foo, bar');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo, bar');
 			map.addLayer(bazLayer);
-			expect(container.innerHTML).to.eql('prefix | foo, bar, baz');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo, bar, baz');
 
 			map.removeLayer(fooLayer);
-			expect(container.innerHTML).to.eql('prefix | bar, baz');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> bar, baz');
 			map.removeLayer(barLayer);
-			expect(container.innerHTML).to.eql('prefix | baz');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> baz');
 			map.removeLayer(bazLayer);
 			expect(container.innerHTML).to.eql('prefix');
 		});
@@ -107,16 +107,16 @@ describe("Control.Attribution", function () {
 
 			expect(container.innerHTML).to.eql('prefix');
 			map.addLayer(fooLayer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 			map.addLayer(fo2Layer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 			map.addLayer(fo3Layer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 
 			map.removeLayer(fooLayer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 			map.removeLayer(fo2Layer);
-			expect(container.innerHTML).to.eql('prefix | foo');
+			expect(container.innerHTML).to.eql('prefix <span aria-hidden="true">|</span> foo');
 			map.removeLayer(fo3Layer);
 			expect(container.innerHTML).to.eql('prefix');
 		});

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -119,7 +119,7 @@ export var Attribution = Control.extend({
 			prefixAndAttribs.push(attribs.join(', '));
 		}
 
-		this._container.innerHTML = prefixAndAttribs.join(' | ');
+		this._container.innerHTML = prefixAndAttribs.join(' <span aria-hidden="true">|</span> ');
 	}
 });
 


### PR DESCRIPTION
Prevents screen readers from announcing <q>vertical line</q> (as can be seen in https://github.com/Leaflet/Leaflet/pull/7079#discussion_r784114002) by hiding the attribution separator with `aria-hidden="true"`.

## Preview

<table><td width="300"><video src="https://user-images.githubusercontent.com/26493779/152660464-9f832c2a-d444-4ed4-b0f4-382629aa312f.mp4"></video></td></table>