### PR TITLE
Fix position:sticky which causes wrong document positioning

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -504,6 +504,9 @@ table.plugins td:first-child a {
 .api-page h2:first-child {
 	border: none;
 }
+.api-page .ghost-pointer {
+	height: 0;
+}
 
 #toc h4 {
 	margin-top: 0;

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -924,8 +924,8 @@ are respected, and that the renderers do exist on the map.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-layers-and-controls'>Methods for Layers and Controls</h4>
-
+<h4>Methods for Layers and Controls</h4>
+<div class="ghost-pointer" id='map-methods-for-layers-and-controls'></div>
 
 <table><thead>
 	<tr>
@@ -1014,8 +1014,8 @@ are respected, and that the renderers do exist on the map.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-modifying-map-state'>Methods for modifying map state</h4>
-
+<h4>Methods for modifying map state</h4>
+<div class="ghost-pointer" id='map-methods-for-modifying-map-state'></div>
 
 <table><thead>
 	<tr>
@@ -1199,8 +1199,8 @@ and aborts resetting the map view if map.locate was called with
 
 </section><section class='collapsable'>
 
-<h4 id='map-other-methods'>Other Methods</h4>
-
+<h4>Other Methods</h4>
+<div class="ghost-pointer" id='map-other-methods'></div>
 
 <table><thead>
 	<tr>
@@ -1260,8 +1260,8 @@ if it's already initialized, optionally passing a function context.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-getting-map-state'>Methods for Getting Map State</h4>
-
+<h4>Methods for Getting Map State</h4>
+<div class="ghost-pointer" id='map-methods-for-getting-map-state'></div>
 
 <table><thead>
 	<tr>
@@ -1340,8 +1340,8 @@ If <code>zoom</code> is omitted, the map's current zoom level is used.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-conversion-methods'>Conversion Methods</h4>
-
+<h4>Conversion Methods</h4>
+<div class="ghost-pointer" id='map-conversion-methods'></div>
 
 <table><thead>
 	<tr>
@@ -2100,7 +2100,7 @@ panning inertia).</td>
 	</div>
 </div>
 
-</section><h2 id='marker'>Marker</h2><p>L.Marker is used to display clickable/draggable icons on the map. Extends <a href="#layer"><code>Layer</code></a>.</p>
+</section><h2>Marker</h2><div class="ghost-pointer" id='marker'></div><p>L.Marker is used to display clickable/draggable icons on the map. Extends <a href="#layer"><code>Layer</code></a>.</p>
 
 <section>
 <h3 id='marker-example'>Usage example</h3>
@@ -2969,7 +2969,7 @@ properties. The event can optionally be propagated to event parents.</p>
 </section>
 
 
-</section><h2 id='popup'>Popup</h2><p>Used to open popups in certain places of the map. Use <a href="#map-openpopup">Map.openPopup</a> to
+</section><h2>Popup</h2><div class="ghost-pointer" id='popup'></div><p>Used to open popups in certain places of the map. Use <a href="#map-openpopup">Map.openPopup</a> to
 open popups while making sure that only one popup is open at one time
 (recommended for usability), or use <a href="#map-addlayer">Map.addLayer</a> to open as many as you want.</p>
 
@@ -3688,7 +3688,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='tooltip'>Tooltip</h2><p>Used to display small texts on top of map layers.</p>
+</section><h2>Tooltip</h2><div class="ghost-pointer" id='tooltip'></div><p>Used to display small texts on top of map layers.</p>
 
 <section>
 <h3 id='tooltip-example'>Usage example</h3>
@@ -4284,7 +4284,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='tilelayer'>TileLayer</h2><p>Used to load and display tile layers on the map. Note that most tile servers require attribution, which you can set under <a href="#layer"><code>Layer</code></a>. Extends <a href="#gridlayer"><code>GridLayer</code></a>.</p>
+</section><h2>TileLayer</h2><div class="ghost-pointer" id='tilelayer'></div><p>Used to load and display tile layers on the map. Note that most tile servers require attribution, which you can set under <a href="#layer"><code>Layer</code></a>. Extends <a href="#gridlayer"><code>GridLayer</code></a>.</p>
 
 <section>
 <h3 id='tilelayer-example'>Usage example</h3>
@@ -5153,7 +5153,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='tilelayer-wms'>TileLayer.WMS</h2><p>Used to display <a href="https://en.wikipedia.org/wiki/Web_Map_Service">WMS</a> services as tile layers on the map. Extends <a href="#tilelayer"><code>TileLayer</code></a>.</p>
+</section><h2>TileLayer.WMS</h2><div class="ghost-pointer" id='tilelayer-wms'></div><p>Used to display <a href="https://en.wikipedia.org/wiki/Web_Map_Service">WMS</a> services as tile layers on the map. Extends <a href="#tilelayer"><code>TileLayer</code></a>.</p>
 
 <section>
 <h3 id='tilelayer-wms-example'>Usage example</h3>
@@ -6084,7 +6084,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='imageoverlay'>ImageOverlay</h2><p>Used to load and display a single image over specific bounds of the map. Extends <a href="#layer"><code>Layer</code></a>.</p>
+</section><h2>ImageOverlay</h2><div class="ghost-pointer" id='imageoverlay'></div><p>Used to load and display a single image over specific bounds of the map. Extends <a href="#layer"><code>Layer</code></a>.</p>
 
 <section>
 <h3 id='imageoverlay-example'>Usage example</h3>
@@ -6826,7 +6826,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='videooverlay'>VideoOverlay</h2><p>Used to load and display a video player over specific bounds of the map. Extends <a href="#imageoverlay"><code>ImageOverlay</code></a>.</p>
+</section><h2>VideoOverlay</h2><div class="ghost-pointer" id='videooverlay'></div><p>Used to load and display a video player over specific bounds of the map. Extends <a href="#imageoverlay"><code>ImageOverlay</code></a>.</p>
 <p>A video overlay uses the <a href="https://developer.mozilla.org/docs/Web/HTML/Element/video"><code>&lt;video&gt;</code></a>
 HTML5 element.</p>
 
@@ -7659,7 +7659,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='svgoverlay'>SVGOverlay</h2><p>Used to load, display and provide DOM access to an SVG file over specific bounds of the map. Extends <a href="#imageoverlay"><code>ImageOverlay</code></a>.</p>
+</section><h2>SVGOverlay</h2><div class="ghost-pointer" id='svgoverlay'></div><p>Used to load, display and provide DOM access to an SVG file over specific bounds of the map. Extends <a href="#imageoverlay"><code>ImageOverlay</code></a>.</p>
 <p>An SVG overlay uses the <a href="https://developer.mozilla.org/docs/Web/SVG/Element/svg"><code>&lt;svg&gt;</code></a> element.</p>
 
 <section>
@@ -8440,7 +8440,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='path'>Path</h2><p>An abstract class that contains options and constants shared between vector
+</section><h2>Path</h2><div class="ghost-pointer" id='path'></div><p>An abstract class that contains options and constants shared between vector
 overlays (Polygon, Polyline, Circle). Do not use it directly. Extends <a href="#layer"><code>Layer</code></a>.</p>
 
 <section>
@@ -9138,7 +9138,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='polyline'>Polyline</h2><p>A class for drawing polyline overlays on a map. Extends <a href="#path"><code>Path</code></a>.</p>
+</section><h2>Polyline</h2><div class="ghost-pointer" id='polyline'></div><p>A class for drawing polyline overlays on a map. Extends <a href="#path"><code>Path</code></a>.</p>
 
 <section>
 <h3 id='polyline-example'>Usage example</h3>
@@ -10007,7 +10007,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='polygon'>Polygon</h2><p>A class for drawing polygon overlays on a map. Extends <a href="#polyline"><code>Polyline</code></a>.</p>
+</section><h2>Polygon</h2><div class="ghost-pointer" id='polygon'></div><p>A class for drawing polygon overlays on a map. Extends <a href="#polyline"><code>Polyline</code></a>.</p>
 <p>Note that points you pass when creating a polygon shouldn't have an additional last point equal to the first one — it's better to filter out such points.</p>
 
 <section>
@@ -10904,7 +10904,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='rectangle'>Rectangle</h2><p>A class for drawing rectangle overlays on a map. Extends <a href="#polygon"><code>Polygon</code></a>.</p>
+</section><h2>Rectangle</h2><div class="ghost-pointer" id='rectangle'></div><p>A class for drawing rectangle overlays on a map. Extends <a href="#polygon"><code>Polygon</code></a>.</p>
 
 <section>
 <h3 id='rectangle-example'>Usage example</h3>
@@ -11811,7 +11811,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='circle'>Circle</h2><p>A class for drawing circle overlays on a map. Extends <a href="#circlemarker"><code>CircleMarker</code></a>.</p>
+</section><h2>Circle</h2><div class="ghost-pointer" id='circle'></div><p>A class for drawing circle overlays on a map. Extends <a href="#circlemarker"><code>CircleMarker</code></a>.</p>
 <p>It's an approximation and starts to diverge from a real circle closer to poles (due to projection distortion).</p>
 
 <section>
@@ -12689,7 +12689,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='circlemarker'>CircleMarker</h2><p>A circle of a fixed size with radius specified in pixels. Extends <a href="#path"><code>Path</code></a>.</p>
+</section><h2>CircleMarker</h2><div class="ghost-pointer" id='circlemarker'></div><p>A circle of a fixed size with radius specified in pixels. Extends <a href="#path"><code>Path</code></a>.</p>
 
 <section>
 <h3 id='circlemarker-factory'>Creation</h3>
@@ -13509,7 +13509,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='svg'>SVG</h2><p>VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
+</section><h2>SVG</h2><div class="ghost-pointer" id='svg'></div><p>VML was deprecated in 2012, which means VML functionality exists only for backwards compatibility
 with old versions of Internet Explorer.</p>
 <p>Allows vector layers to be displayed with <a href="https://developer.mozilla.org/docs/Web/SVG">SVG</a>.
 Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
@@ -14128,7 +14128,7 @@ into &quot;M..L..L..&quot; instructions</td>
 </section>
 
 
-</section><h2 id='canvas'>Canvas</h2><p>Allows vector layers to be displayed with <a href="https://developer.mozilla.org/docs/Web/API/Canvas_API"><code>&lt;canvas&gt;</code></a>.
+</section><h2>Canvas</h2><div class="ghost-pointer" id='canvas'></div><p>Allows vector layers to be displayed with <a href="https://developer.mozilla.org/docs/Web/API/Canvas_API"><code>&lt;canvas&gt;</code></a>.
 Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 <p>Due to <a href="http://caniuse.com/#search=canvas">technical limitations</a>, Canvas is not
 available in all web browsers, notably IE8, and overlapping geometries might
@@ -14708,7 +14708,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='layergroup'>LayerGroup</h2><p>Used to group several layers and handle them as one. If you add it to the map,
+</section><h2>LayerGroup</h2><div class="ghost-pointer" id='layergroup'></div><p>Used to group several layers and handle them as one. If you add it to the map,
 any layers added or removed from the group will be added/removed on the map as
 well. Extends <a href="#layer"><code>Layer</code></a>.</p>
 
@@ -15317,7 +15317,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='featuregroup'>FeatureGroup</h2><p>Extended <a href="#layergroup"><code>LayerGroup</code></a> that makes it easier to do the same thing to all its member layers:</p>
+</section><h2>FeatureGroup</h2><div class="ghost-pointer" id='featuregroup'></div><p>Extended <a href="#layergroup"><code>LayerGroup</code></a> that makes it easier to do the same thing to all its member layers:</p>
 <ul>
 <li><a href="#layer-bindpopup"><code>bindPopup</code></a> binds a popup to all of the layers at once (likewise with <a href="#layer-bindtooltip"><code>bindTooltip</code></a>)</li>
 <li>Events are propagated to the <a href="#featuregroup"><code>FeatureGroup</code></a>, so if the group has an event
@@ -16001,7 +16001,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='geojson'>GeoJSON</h2><p>Represents a GeoJSON object or an array of GeoJSON objects. Allows you to parse
+</section><h2>GeoJSON</h2><div class="ghost-pointer" id='geojson'></div><p>Represents a GeoJSON object or an array of GeoJSON objects. Allows you to parse
 GeoJSON data and display it on the map. Extends <a href="#featuregroup"><code>FeatureGroup</code></a>.</p>
 
 <section>
@@ -16858,7 +16858,7 @@ Can use a custom <a href="#geojson-coordstolatlng"><code>coordsToLatLng</code></
 </section>
 
 
-</section><h2 id='gridlayer'>GridLayer</h2><p>Generic class for handling a tiled grid of HTML elements. This is the base class for all tile layers and replaces <code>TileLayer.Canvas</code>.
+</section><h2>GridLayer</h2><div class="ghost-pointer" id='gridlayer'></div><p>Generic class for handling a tiled grid of HTML elements. This is the base class for all tile layers and replaces <code>TileLayer.Canvas</code>.
 GridLayer can be extended to create a tiled grid of HTML elements like <code>&lt;canvas&gt;</code>, <code>&lt;img&gt;</code> or <code>&lt;div&gt;</code>. GridLayer will handle creating and animating these DOM elements for you.</p>
 
 <section>
@@ -17651,7 +17651,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='latlng'>LatLng</h2><p>Represents a geographical point with a certain latitude and longitude.</p>
+</section><h2>LatLng</h2><div class="ghost-pointer" id='latlng'></div><p>Represents a geographical point with a certain latitude and longitude.</p>
 
 <section>
 <h3 id='latlng-example'>Usage example</h3>
@@ -17795,7 +17795,7 @@ can't be added to it with the <code>include</code> function.</p>
 </section>
 
 
-</section><h2 id='latlngbounds'>LatLngBounds</h2><p>Represents a rectangular geographical area on a map.</p>
+</section><h2>LatLngBounds</h2><div class="ghost-pointer" id='latlngbounds'></div><p>Represents a rectangular geographical area on a map.</p>
 
 <section>
 <h3 id='latlngbounds-example'>Usage example</h3>
@@ -17989,7 +17989,7 @@ Negative values will retract the bounds.</p>
 </section>
 
 
-</section><h2 id='point'>Point</h2><p>Represents a point with <code>x</code> and <code>y</code> coordinates in pixels.</p>
+</section><h2>Point</h2><div class="ghost-pointer" id='point'></div><p>Represents a point with <code>x</code> and <code>y</code> coordinates in pixels.</p>
 
 <section>
 <h3 id='point-example'>Usage example</h3>
@@ -18190,7 +18190,7 @@ each coordinate of <code>scale</code>.</p>
 </section>
 
 
-</section><h2 id='bounds'>Bounds</h2><p>Represents a rectangular area in pixel coordinates.</p>
+</section><h2>Bounds</h2><div class="ghost-pointer" id='bounds'></div><p>Represents a rectangular area in pixel coordinates.</p>
 
 <section>
 <h3 id='bounds-example'>Usage example</h3>
@@ -18362,7 +18362,7 @@ overlap if their intersection is an area.</p>
 </section>
 
 
-</section><h2 id='icon'>Icon</h2><p>Represents an icon to provide when creating a marker.</p>
+</section><h2>Icon</h2><div class="ghost-pointer" id='icon'></div><p>Represents an icon to provide when creating a marker.</p>
 
 <section>
 <h3 id='icon-example'>Usage example</h3>
@@ -18578,7 +18578,7 @@ way, set this option to point to the right path.</td>
 </section>
 
 
-</section><h2 id='divicon'>DivIcon</h2><p>Represents a lightweight icon for markers that uses a simple <code>&lt;div&gt;</code>
+</section><h2>DivIcon</h2><div class="ghost-pointer" id='divicon'></div><p>Represents a lightweight icon for markers that uses a simple <code>&lt;div&gt;</code>
 element instead of an image. Inherits from <a href="#icon"><code>Icon</code></a> but ignores the <code>iconUrl</code> and shadow options.</p>
 
 <section>
@@ -18791,7 +18791,7 @@ styled according to the options.</p>
 	</div>
 </div>
 
-</section><h2 id='control-zoom'>Control.Zoom</h2><p>A basic zoom control with two buttons (zoom in and zoom out). It is put on the map by default unless you set its <a href="#map-zoomcontrol"><code>zoomControl</code> option</a> to <code>false</code>. Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2>Control.Zoom</h2><div class="ghost-pointer" id='control-zoom'></div><p>A basic zoom control with two buttons (zoom in and zoom out). It is put on the map by default unless you set its <a href="#map-zoomcontrol"><code>zoomControl</code> option</a> to <code>false</code>. Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
 <h3 id='control-zoom-factory'>Creation</h3>
@@ -18948,7 +18948,7 @@ The text set on the 'zoom out' button.</td>
 	</div>
 </div>
 
-</section><h2 id='control-attribution'>Control.Attribution</h2><p>The attribution control allows you to display attribution data in a small text box on a map. It is put on the map by default unless you set its <a href="#map-attributioncontrol"><code>attributionControl</code> option</a> to <code>false</code>, and it fetches attribution texts from layers with the <a href="#layer-getattribution"><code>getAttribution</code> method</a> automatically. Extends Control.</p>
+</section><h2>Control.Attribution</h2><div class="ghost-pointer" id='control-attribution'></div><p>The attribution control allows you to display attribution data in a small text box on a map. It is put on the map by default unless you set its <a href="#map-attributioncontrol"><code>attributionControl</code> option</a> to <code>false</code>, and it fetches attribution texts from layers with the <a href="#layer-getattribution"><code>getAttribution</code> method</a> automatically. Extends Control.</p>
 
 <section>
 <h3 id='control-attribution-factory'>Creation</h3>
@@ -19118,7 +19118,7 @@ The text set on the 'zoom out' button.</td>
 	</div>
 </div>
 
-</section><h2 id='control-layers'>Control.Layers</h2><p>The layers control gives users the ability to switch between different base layers and switch overlays on/off (check out the <a href="http://leafletjs.com/examples/layers-control/">detailed example</a>). Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2>Control.Layers</h2><div class="ghost-pointer" id='control-layers'></div><p>The layers control gives users the ability to switch between different base layers and switch overlays on/off (check out the <a href="http://leafletjs.com/examples/layers-control/">detailed example</a>). Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
 <h3 id='control-layers-example'>Usage example</h3>
@@ -19365,7 +19365,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	</div>
 </div>
 
-</section><h2 id='control-scale'>Control.Scale</h2><p>A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems. Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2>Control.Scale</h2><div class="ghost-pointer" id='control-scale'></div><p>A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems. Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
 <h3 id='control-scale-example'>Usage example</h3>
@@ -19538,7 +19538,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	</div>
 </div>
 
-</section><h2 id='browser'>Browser</h2><p>A namespace with static properties for browser/feature detection used by Leaflet internally.</p>
+</section><h2>Browser</h2><div class="ghost-pointer" id='browser'></div><p>A namespace with static properties for browser/feature detection used by Leaflet internally.</p>
 
 <section>
 <h3 id='browser-example'>Usage example</h3>
@@ -19732,7 +19732,7 @@ touch events.</td>
 </section>
 
 
-</section><h2 id='util'>Util</h2><p>Various utility functions, used by Leaflet internally.</p>
+</section><h2>Util</h2><div class="ghost-pointer" id='util'></div><p>Various utility functions, used by Leaflet internally.</p>
 
 <section>
 <h3 id='util-function'>Functions</h3>
@@ -19889,7 +19889,7 @@ mobile devices (by setting image <code>src</code> to this string).</td>
 </section>
 
 
-</section><h2 id='transformation'>Transformation</h2><p>Represents an affine transformation: a set of coefficients <code>a</code>, <code>b</code>, <code>c</code>, <code>d</code>
+</section><h2>Transformation</h2><div class="ghost-pointer" id='transformation'></div><p>Represents an affine transformation: a set of coefficients <code>a</code>, <code>b</code>, <code>c</code>, <code>d</code>
 for transforming a point of a form <code>(x, y)</code> into <code>(a*x + b, c*y + d)</code> and doing
 the reverse. Used by Leaflet in its projections code.</p>
 
@@ -19975,7 +19975,7 @@ by the given scale. Only accepts actual <a href="#point"><code>L.Point</code></a
 </section>
 
 
-</section><h2 id='lineutil'>LineUtil</h2><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
+</section><h2>LineUtil</h2><div class="ghost-pointer" id='lineutil'></div><p>Various utility functions for polyline points processing, used by Leaflet internally to make polylines lightning-fast.</p>
 
 <section>
 <h3 id='lineutil-function'>Functions</h3>
@@ -20031,7 +20031,7 @@ points that are on the screen or near, increasing performance.</td>
 </section>
 
 
-</section><h2 id='polyutil'>PolyUtil</h2><p>Various utility functions for polygon geometries.</p>
+</section><h2>PolyUtil</h2><div class="ghost-pointer" id='polyutil'></div><p>Various utility functions for polygon geometries.</p>
 
 <section>
 <h3 id='polyutil-function'>Functions</h3>
@@ -20061,7 +20061,7 @@ than polyline, so there's a separate method for it.</td>
 </section>
 
 
-</section><h2 id='domevent'>DomEvent</h2><p>Utility functions to work with the <a href="https://developer.mozilla.org/docs/Web/API/Event">DOM events</a>, used by Leaflet internally.</p>
+</section><h2>DomEvent</h2><div class="ghost-pointer" id='domevent'></div><p>Utility functions to work with the <a href="https://developer.mozilla.org/docs/Web/API/Event">DOM events</a>, used by Leaflet internally.</p>
 
 <section>
 <h3 id='domevent-function'>Functions</h3>
@@ -20165,7 +20165,7 @@ a best guess of 60 pixels.</td>
 </section>
 
 
-</section><h2 id='domutil'>DomUtil</h2><p>Utility functions to work with the <a href="https://developer.mozilla.org/docs/Web/API/Document_Object_Model">DOM</a>
+</section><h2>DomUtil</h2><div class="ghost-pointer" id='domutil'></div><p>Utility functions to work with the <a href="https://developer.mozilla.org/docs/Web/API/Document_Object_Model">DOM</a>
 tree, used by Leaflet internally.</p>
 <p>Most functions expecting or returning a <code>HTMLElement</code> also work for
 SVG elements. The only difference is that classes refer to CSS classes
@@ -20369,7 +20369,7 @@ and <code>boundingClientRect</code> as the result of <a href="https://developer.
 </section>
 
 
-</section><h2 id='posanimation'>PosAnimation</h2><p>Used internally for panning animations, utilizing CSS3 Transitions for modern browsers and a timer fallback for IE6-9.</p>
+</section><h2>PosAnimation</h2><div class="ghost-pointer" id='posanimation'></div><p>Used internally for panning animations, utilizing CSS3 Transitions for modern browsers and a timer fallback for IE6-9.</p>
 
 <section>
 <h3 id='posanimation-example'>Usage example</h3>
@@ -20602,7 +20602,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='draggable'>Draggable</h2><p>A class for making DOM elements draggable (including touch support).
+</section><h2>Draggable</h2><div class="ghost-pointer" id='draggable'></div><p>A class for making DOM elements draggable (including touch support).
 Used internally for map and marker dragging. Only works for elements
 that were positioned with <a href="#domutil-setposition"><code>L.DomUtil.setPosition</code></a>.</p>
 
@@ -20873,7 +20873,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='class'>Class</h2><p>L.Class powers the OOP facilities of Leaflet and is used to create almost all of the Leaflet classes documented here.</p>
+</section><h2>Class</h2><div class="ghost-pointer" id='class'></div><p>L.Class powers the OOP facilities of Leaflet and is used to create almost all of the Leaflet classes documented here.</p>
 <p>In addition to implementing a simple classical inheritance model, it introduces several special properties for convenient code organization — options, includes and statics.</p>
 
 <section>
@@ -21110,7 +21110,7 @@ Returns a Javascript function that is a class constructor (to be called with <co
 </section>
 
 
-</section><h2 id='evented'>Evented</h2><p>A set of methods shared between event-powered classes (like <a href="#map"><code>Map</code></a> and <a href="#marker"><code>Marker</code></a>). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map to fire <code>'click'</code> event).</p>
+</section><h2>Evented</h2><div class="ghost-pointer" id='evented'></div><p>A set of methods shared between event-powered classes (like <a href="#map"><code>Map</code></a> and <a href="#marker"><code>Marker</code></a>). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map to fire <code>'click'</code> event).</p>
 
 <section>
 <h3 id='evented-example'>Usage example</h3>
@@ -21255,7 +21255,7 @@ properties. The event can optionally be propagated to event parents.</p>
 </section>
 
 
-</section><h2 id='layer'>Layer</h2><p>A set of methods from the Layer base class that all Leaflet layers use.
+</section><h2>Layer</h2><div class="ghost-pointer" id='layer'></div><p>A set of methods from the Layer base class that all Leaflet layers use.
 Inherits all methods, options and events from <a href="#evented"><code>L.Evented</code></a>.</p>
 
 <section>
@@ -21748,7 +21748,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='interactive-layer'>Interactive layer</h2><p>Some <a href="#layer"><code>Layer</code></a>s can be made interactive - when the user interacts
+</section><h2>Interactive layer</h2><div class="ghost-pointer" id='interactive-layer'></div><p>Some <a href="#layer"><code>Layer</code></a>s can be made interactive - when the user interacts
 with such a layer, mouse events like <code>click</code> and <code>mouseover</code> can be handled.
 Use the <a href="#evented-method">event handling methods</a> to handle these events.</p>
 
@@ -22296,7 +22296,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='control'>Control</h2><p>L.Control is a base class for implementing map controls. Handles positioning.
+</section><h2>Control</h2><div class="ghost-pointer" id='control'></div><p>L.Control is a base class for implementing map controls. Handles positioning.
 All other controls extend from this class.</p>
 
 <section>
@@ -22405,7 +22405,7 @@ All other controls extend from this class.</p>
 </section>
 
 
-</section><h2 id='handler'>Handler</h2><p>Abstract class for map interaction handlers</p>
+</section><h2>Handler</h2><div class="ghost-pointer" id='handler'></div><p>Abstract class for map interaction handlers</p>
 
 <section>
 <h3 id='handler-method'>Methods</h3>
@@ -22497,7 +22497,7 @@ All other controls extend from this class.</p>
 </section>
 
 
-</section><h2 id='projection'>Projection</h2><p>An object with methods for projecting geographical coordinates of the world onto
+</section><h2>Projection</h2><div class="ghost-pointer" id='projection'></div><p>An object with methods for projecting geographical coordinates of the world onto
 a flat surface (and back). See <a href="http://en.wikipedia.org/wiki/Map_projection">Map projection</a>.</p>
 
 <section>
@@ -22599,7 +22599,8 @@ a sphere. Used by the <code>EPSG:3857</code> CRS.</td>
 </section>
 
 
-</section><h2 id='crs'>CRS</h2>
+</section><h2>CRS</h2>
+<div class="ghost-pointer" id='crs'></div>
 <section>
 <h3 id='crs-method'>Methods</h3>
 
@@ -22796,7 +22797,7 @@ and methods can't be added to them with the <code>include</code> function.</p></
 </section>
 
 
-</section><h2 id='renderer'>Renderer</h2><p>Base class for vector renderer implementations (<a href="#svg"><code>SVG</code></a>, <a href="#canvas"><code>Canvas</code></a>). Handles the
+</section><h2>Renderer</h2><div class="ghost-pointer" id='renderer'></div><p>Base class for vector renderer implementations (<a href="#svg"><code>SVG</code></a>, <a href="#canvas"><code>Canvas</code></a>). Handles the
 DOM container of the renderer, its bounds, and its zoom animation.</p>
 <p>A <a href="#renderer"><code>Renderer</code></a> works as an implicit layer group for all <a href="#path"><code>Path</code></a>s - the renderer
 itself can be added or removed to the map. All paths use a renderer, which can
@@ -23315,7 +23316,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='event-objects'>Event objects</h2><p>Whenever a class inheriting from <a href="#evented"><code>Evented</code></a> fires an event, a listener function
+</section><h2>Event objects</h2><div class="ghost-pointer" id='event-objects'></div><p>Whenever a class inheriting from <a href="#evented"><code>Evented</code></a> fires an event, a listener function
 will be called with an event argument, which is a plain object containing
 information about the event. For example:</p>
 <pre><code class="language-js">map.on('click', function(ev) {
@@ -25022,7 +25023,7 @@ properties. The event can optionally be propagated to event parents.</p>
 	</div>
 </div>
 
-</section><h2 id='global-switches'>Global Switches</h2><p>Global switches are created for rare cases and generally make
+</section><h2>Global Switches</h2><div class="ghost-pointer" id='global-switches'></div><p>Global switches are created for rare cases and generally make
 Leaflet to not detect a particular browser feature even if it's
 there. You need to set the switch as a global variable to true
 before including Leaflet on the page, like this:</p>
@@ -25048,7 +25049,7 @@ before including Leaflet on the page, like this:</p>
 </tbody>
 </table>
 
-<h2 id='noconflict'>noConflict</h2><p>This method restores the <code>L</code> global variable to the original value
+<h2>noConflict</h2><div class="ghost-pointer" id='noconflict'></div><p>This method restores the <code>L</code> global variable to the original value
 it had before Leaflet inclusion, and returns the real Leaflet
 namespace so you can put it elsewhere, like this:</p>
 <pre><code class="language-html">&lt;script src='libs/l.js'&gt;
@@ -25063,6 +25064,6 @@ var Leaflet = L.noConflict();
 &lt;/script&gt;
 </code></pre>
 
-<h2 id='version'>version</h2><p>A constant that represents the Leaflet version in use.</p>
+<h2>version</h2><div class="ghost-pointer" id='version'></div><p>A constant that represents the Leaflet version in use.</p>
 <pre><code class="language-js">L.version; // contains &quot;1.0.0&quot; (or whatever version is currently in use)
 </code></pre>


### PR DESCRIPTION
position:sticky causes the page to fail to be positioned by the '#' symbol, so the problem is solved by adding a normal element with zero height.