### PR TITLE
Add command to serve docs per npm script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,22 +142,19 @@ and is automatically generated from a set of HTML and Markdown files by [Jekyll]
 The easiest way to make little improvements such as fixing typos without even leaving the browser
 is by editing one of the files with the online GitHub editor:
 browse the [`docs/ directory`](https://github.com/Leaflet/Leaflet/tree/main/docs),
-choose a certain file for editing (e.g. `plugins.md` for the list of Leaflet plugins),
-click the Edit button, make changes and follow instructions from there.
+choose a certain file for editing, click the Edit button, make changes and follow instructions from there.
 Once it gets merged, the changes will immediately appear on the website.
 
 If you need to make edits in a local repository to see how it looks in the process, do the following:
 
- 1. [Install Ruby](http://www.ruby-lang.org/en/) if you don't have it yet.
+ 1. [Install Ruby](https://www.ruby-lang.org/en/downloads/) if you don't have it yet.
  2. Run `gem install jekyll`.
  3. Enter the directory where you cloned the Leaflet repository
  4. Make sure you are in the `main` branch by running `git checkout main`
- 5. Enter the documentation subdirectory by running `cd docs`
- 6. Run `bundle install`
- 7. Run `jekyll serve --watch` (if you have a Gem::LoadError error run `bundle exec jekyll serve --watch` instead)
- 8. Open `localhost:4000` in your web browser.
+ 5. Run `npm run serve`
+ 6. Open `localhost:4000` in your web browser.
 
-Now any file changes will be updated when you reload pages automatically.
+Now any file changes in `docs/` will be applied when you reload pages.
 After committing the changes, just send a pull request.
 
 ### API documentation

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+
+gem "webrick", "~> 1.7"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "watch": "rollup -w -c build/rollup-config.js",
     "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --source-map content=dist/leaflet-src.js.map --source-map url=leaflet.js.map --comments",
     "integrity": "node ./build/integrity.js",
-    "bundlemon": "bundlemon --subProject no-compression --defaultCompression none && bundlemon --subProject gzip-compression --defaultCompression gzip"
+    "bundlemon": "bundlemon --subProject no-compression --defaultCompression none && bundlemon --subProject gzip-compression --defaultCompression gzip",
+    "serve": "cd docs && bundle exec jekyll serve"
   },
   "eslintConfig": {
     "ignorePatterns": [


### PR DESCRIPTION
Make it possible to serve docs over `npm run serve`.

And added webrick to the Gemfile -> I always needed to install it with Windows 

@IvanSanchez I have in mind that you are using Linux, can you please test `npm run serve`?

@Malvoz, @jonkoops feel free to test it too and check if there are some problems with the `webrick` installation