### PR TITLE
Fix scrolling in docs

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -533,6 +533,7 @@ table.plugins td:first-child a {
 
 #toc-copy {
 	display: none;
+	z-index: 1;
 }
 
 #toc-copy div {
@@ -832,6 +833,18 @@ tr:target {
 .api-page h2[id]:before {
 	margin-left: -32px;
 	margin-top: 14px;
+}
+
+.api-page h2[id]:after {
+	content: '';
+	margin-left: -32px;
+	margin-top: 19px;
+	width: 23px;
+	height: 23px;
+	background-color: #fff;
+	position: absolute;
+	left: 0;
+	top: 0;
 }
 
 .api-page tr[id] td:first-child:before {

--- a/docs/docs/js/docs.js
+++ b/docs/docs/js/docs.js
@@ -71,46 +71,47 @@ if (toc) {
 		scrollPos();
 	});
 
-	window.addEventListener("load", function (e) {
+	window.addEventListener('load', function () {
 		var currentHash = window.location.hash;
 		var elem = document.querySelector(currentHash);
 
-		if(elem.tagName === 'H2' || elem.tagName === 'H4'){
+		if (elem.tagName === 'H2' || elem.tagName === 'H4') {
 			setTimeout(()=>{
-				scrollToHeader(elem, true)
-			},10);
+				scrollToHeader(elem, true);
+			}, 10);
 		}
 	}, false);
+}
 
-	function clickOnAnchor(e){
-		// if the parent element of <a> is clicked we ignore it
-		if(e.target.tagName !== 'A'){
-			return;
-		}
 
-		var anchor = '#'+ e.target.href.split('#')[1];
-		var elemHeader = document.querySelector(anchor);
-
-		scrollToHeader(elemHeader, '#'+elemHeader.id === currentAnchor);
-
-		// prevent default browser anchor scroll
-		e.preventDefault();
+function clickOnAnchor(e) {
+	// if the parent element of <a> is clicked we ignore it
+	if (e.target.tagName !== 'A') {
+		return;
 	}
 
-	function scrollToHeader(elemHeader, sameAnchor){
-		var scrollBy = elemHeader.nextSibling.offsetTop;
+	var anchor = '#' + e.target.href.split('#')[1];
+	var elemHeader = document.querySelector(anchor);
 
-		if(L.Browser.chrome && sameAnchor){
-			// chromium remove the anchor element from the scroll-position
-			// we check with sameAnchor if the User has clicked on the same anchor link again
-			scrollBy = scrollBy - elemHeader.offsetHeight;
-		}else{
-			// we scroll a little bit more down to get the element already sticky
-			scrollBy += 5;
-		}
-		// scroll to the anchor
-		window.scrollTo(0,scrollBy);
-		// apply the new anchor to the location url
-		currentAnchor = window.location.hash = '#'+elemHeader.id;
+	scrollToHeader(elemHeader, '#' + elemHeader.id === currentAnchor);
+
+	// prevent default browser anchor scroll
+	e.preventDefault();
+}
+
+function scrollToHeader(elemHeader, sameAnchor) {
+	var scrollBy = elemHeader.nextSibling.offsetTop;
+
+	if (L.Browser.chrome && sameAnchor) {
+		// chromium remove the anchor element from the scroll-position
+		// we check with sameAnchor if the User has clicked on the same anchor link again
+		scrollBy = scrollBy - elemHeader.offsetHeight;
+	} else {
+		// we scroll a little bit more down to get the element already sticky
+		scrollBy += 5;
 	}
+	// scroll to the anchor
+	window.scrollTo(0, scrollBy);
+	// apply the new anchor to the location url
+	currentAnchor = window.location.hash = '#' + elemHeader.id;
 }

--- a/docs/docs/js/docs.js
+++ b/docs/docs/js/docs.js
@@ -8,11 +8,24 @@ tocCopy.id = 'toc-copy';
 var toc = document.querySelector('#toc');
 
 if (toc) {
+	var currentAnchor = '';
+
+	// top menu
+	var menus = document.querySelectorAll('#toc a');
+	var i;
+
+	for (i = 0; i < menus.length; i++) {
+		menus[i].addEventListener('click', function (e) {
+			clickOnAnchor(e);
+		});
+	}
+
+	// sidebar menu
 	tocCopy.innerHTML = toc.innerHTML;
 	document.getElementsByClassName('container')[0].appendChild(tocCopy);
 
-	var menus = document.querySelectorAll('#toc-copy ul');
-	var i;
+	menus = document.querySelectorAll('#toc-copy ul');
+	i = 0;
 
 	for (i = 0; i < menus.length; i++) {
 		menus[i].addEventListener('mouseover', function () {
@@ -21,6 +34,10 @@ if (toc) {
 
 		menus[i].addEventListener('mouseout', function () {
 			this.previousElementSibling.classList.remove('hover');
+		});
+
+		menus[i].addEventListener('click', function (e) {
+			clickOnAnchor(e);
 		});
 	}
 
@@ -53,4 +70,47 @@ if (toc) {
 	window.addEventListener('scroll', function () {
 		scrollPos();
 	});
+
+	window.addEventListener("load", function (e) {
+		var currentHash = window.location.hash;
+		var elem = document.querySelector(currentHash);
+
+		if(elem.tagName === 'H2' || elem.tagName === 'H4'){
+			setTimeout(()=>{
+				scrollToHeader(elem, true)
+			},10);
+		}
+	}, false);
+
+	function clickOnAnchor(e){
+		// if the parent element of <a> is clicked we ignore it
+		if(e.target.tagName !== 'A'){
+			return;
+		}
+
+		var anchor = '#'+ e.target.href.split('#')[1];
+		var elemHeader = document.querySelector(anchor);
+
+		scrollToHeader(elemHeader, '#'+elemHeader.id === currentAnchor);
+
+		// prevent default browser anchor scroll
+		e.preventDefault();
+	}
+
+	function scrollToHeader(elemHeader, sameAnchor){
+		var scrollBy = elemHeader.nextSibling.offsetTop;
+
+		if(L.Browser.chrome && sameAnchor){
+			// chromium remove the anchor element from the scroll-position
+			// we check with sameAnchor if the User has clicked on the same anchor link again
+			scrollBy = scrollBy - elemHeader.offsetHeight;
+		}else{
+			// we scroll a little bit more down to get the element already sticky
+			scrollBy += 5;
+		}
+		// scroll to the anchor
+		window.scrollTo(0,scrollBy);
+		// apply the new anchor to the location url
+		currentAnchor = window.location.hash = '#'+elemHeader.id;
+	}
 }


### PR DESCRIPTION
Scrolling to the anchor is now be done manually instead of the browser internal function.

Fixes #7971
Closes #7972

Chromium browsers have a weird sideeffect. If we scroll to the same anchor in chromium browsers again, the scroll position has changed and the height of the sticky anchor was subtracted from the total scroll height / scroll position

@Malvoz, @NICEXAI, @avioli please check [Demo](https://florianbischof.net/leaflet/docs-scroll/reference.html#latlng)