### PR TITLE
Add cache-version to tile url

### DIFF
--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -25,6 +25,13 @@ if (!Array.prototype.map) {
 	};
 }
 
+if (!String.prototype.startsWith) {
+	String.prototype.startsWith = function (searchString, position) {
+		position = position || 0;
+		return this.indexOf(searchString, position) === position;
+	};
+}
+
 expect.Assertion.prototype.near = function (expected, delta) {
 	expected = L.point(expected);
 	delta = delta || 1;

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -43,6 +43,10 @@ expect.Assertion.prototype.nearLatLng = function (expected, delta) {
 		.be.within(expected.lng - delta, expected.lng + delta);
 };
 
+expect.Assertion.prototype.startsWith = function (expected) {
+	expect(this.obj.startsWith(expected)).to.be.ok();
+};
+
 happen.at = function (what, x, y, props) {
 	this.once(document.elementFromPoint(x, y), L.Util.extend({
 		type: what,

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -307,7 +307,7 @@ describe('TileLayer', function () {
 
 			var i = 0;
 			eachImg(layer, function (img) {
-				expect(img.src).to.eql(urls[i]);
+				expect(img.src).to.startsWith(urls[i]);
 				i++;
 			});
 		});
@@ -322,7 +322,7 @@ describe('TileLayer', function () {
 			];
 			var i = 0;
 			eachImg(layer, function (img) {
-				expect(img.src).to.eql(urls[i]);
+				expect(img.src).to.startsWith(urls[i]);
 				i++;
 			});
 		});
@@ -380,7 +380,7 @@ describe('TileLayer', function () {
 
 			var i = 0;
 			eachImg(layer, function (img) {
-				expect(img.src).to.eql(urls[i]);
+				expect(img.src).to.startsWith(urls[i]);
 				i++;
 			});
 		});
@@ -400,7 +400,7 @@ describe('TileLayer', function () {
 
 			var i = 0;
 			eachImg(layer, function (img) {
-				expect(img.src).to.eql(urls[i]);
+				expect(img.src).to.startsWith(urls[i]);
 				i++;
 			});
 		});
@@ -453,6 +453,42 @@ describe('TileLayer', function () {
 				expect(counts.tileload).to.equal(8);
 				done();
 			}, 250);
+		});
+	});
+
+	describe('#redraw', function () {
+		it('reload tiles / images instead of using the browser cached ones', function (done) {
+			this.timeout(4000);
+
+			map.setView([0, 0], 0);
+
+			var layer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+			var counts = {
+				load: 0,
+				tileload: 0
+			};
+
+			var tileSrcs = [];
+
+			layer.on('tileload', function (e) {
+				counts.tileload++;
+				// >= 7 after redraw
+				if(counts.tileload === 1 || counts.tileload === 7){
+					tileSrcs.push(e.tile.src);
+				}
+			});
+
+			layer.on('load', function (e) {
+				counts.load++;
+				if (counts.load === 1){
+					layer.redraw();
+				} else {
+					expect(counts.load).to.equal(2);
+					expect(counts.tileload).to.equal(10);
+					expect(tileSrcs[0]).to.not.equal(tileSrcs[1]);
+					done();
+				}
+			});
 		});
 	});
 });

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -473,14 +473,14 @@ describe('TileLayer', function () {
 			layer.on('tileload', function (e) {
 				counts.tileload++;
 				// >= 7 after redraw
-				if(counts.tileload === 1 || counts.tileload === 7){
+				if (counts.tileload === 1 || counts.tileload === 7) {
 					tileSrcs.push(e.tile.src);
 				}
 			});
 
-			layer.on('load', function (e) {
+			layer.on('load', function () {
 				counts.load++;
-				if (counts.load === 1){
+				if (counts.load === 1) {
 					layer.redraw();
 				} else {
 					expect(counts.load).to.equal(2);

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -202,7 +202,7 @@ export var TileLayer = GridLayer.extend({
 		}
 
 		var url = Util.template(this._url, Util.extend(data, this.options));
-		if(!url.startsWith('data:')) {
+		if (!url.startsWith('data:')) {
 			url += (url.indexOf('?') === -1 ? '?' : '&') + 'v=' + this._reqCacheVersion;
 		}
 		return url;

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -33,6 +33,12 @@ import * as DomUtil from '../../dom/DomUtil';
  * ```
  * L.tileLayer('https://{s}.somedomain.com/{foo}/{z}/{x}/{y}.png', {foo: 'bar'});
  * ```
+ *
+ * It's also possible to use base64 encoded images:
+ *
+ * ```
+ * L.tileLayer('data:image/gif;base64,R0lGODlhAQ....ABAAACADs=');
+ * ```
  */
 
 
@@ -114,6 +120,8 @@ export var TileLayer = GridLayer.extend({
 			options.subdomains = options.subdomains.split('');
 		}
 
+		this._reqCacheVersion = new Date().getTime();
+
 		this.on('tileunload', this._onTileRemove);
 	},
 
@@ -193,7 +201,11 @@ export var TileLayer = GridLayer.extend({
 			data['-y'] = invertedY;
 		}
 
-		return Util.template(this._url, Util.extend(data, this.options));
+		var url = Util.template(this._url, Util.extend(data, this.options));
+		if(!url.startsWith('data:')) {
+			url += (url.indexOf('?') === -1 ? '?' : '&') + 'v=' + this._reqCacheVersion;
+		}
+		return url;
 	},
 
 	_tileOnLoad: function (done, tile) {
@@ -277,6 +289,11 @@ export var TileLayer = GridLayer.extend({
 		}
 
 		return GridLayer.prototype._tileReady.call(this, coords, err, tile);
+	},
+
+	redraw: function () {
+		this._reqCacheVersion = new Date().getTime();
+		return GridLayer.prototype.redraw.call(this);
 	}
 });
 


### PR DESCRIPTION
Fixes #6422

Now a cache-version is added to the tile / image url (https://b.tile.openstreetmap.org/15/19160/11042.png?v=1644357627558).
This means if `redraw()` is called, it changes the cache-version and the tiles are reloaded instead of loaded from the browser cache.