### PR TITLE
Enable outlines on `leaflet-container` for keyboard users

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -251,6 +251,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .leaflet-container {
 	background: #ddd;
+	outline-offset: 1px;
 	}
 .leaflet-container a {
 	color: #0078A8;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -251,7 +251,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .leaflet-container {
 	background: #ddd;
-	outline: 0;
 	}
 .leaflet-container a {
 	color: #0078A8;


### PR DESCRIPTION
To pass [SC 2.4.7 Focus Visible](https://www.w3.org/TR/WCAG21/#focus-visible), the `outline` on `leaflet-container` must be visible on keyboard focus:

> Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible.

Passing the SC can be accomplished (together with https://github.com/Leaflet/Leaflet/pull/7259) by removing `outline: 0` on `leaflet-container`.

## Preview

1. https://github.com/Leaflet/Leaflet/commit/f2ffb3bec57b71caaa56acc691089d52196a5be8:

   <img width="600" src="https://user-images.githubusercontent.com/26493779/153723490-85c4aaa3-3e8a-4f1b-afe0-afaea970d83c.png" alt="keyboard outline restored">
   
    (note how the outline is clipped and seems to be thicker at the bottom, for some reason, I haven't investigated much but seems to be affected both by stacking contexts and `overflow: hidden` on the container)

2. https://github.com/Leaflet/Leaflet/commit/87ef061c2fadb1907d399d911a8ed2b5ac1b5dc6:

   <img width="600" src="https://user-images.githubusercontent.com/26493779/153723521-874d01e5-c111-4dfb-949c-23bbf87591af.png" alt="keyboard outline adjusted for better visibility">

   (opinionated change: default outline adjusted slightly)


