### PR TITLE
Change OpenStreetMap links to HTTPS

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -13,7 +13,7 @@ This is a collection of answers to the most frequently asked questions about Lea
 #### The map is wrong in my neighborhood, could you fix it?
 
 Nope, but you can.
-The map you see on Leaflet examples is based on [OpenStreetMap](http://openstreetmap.org),
+The map you see on Leaflet examples is based on [OpenStreetMap](https://www.openstreetmap.org/),
 a free editable map of the world.
 Signing up and editing the map there is easy,
 and the changes will be reflected on the map in a few minutes.
@@ -22,7 +22,7 @@ and the changes will be reflected on the map in a few minutes.
 
 Leaflet is provider-agnostic, meaning you can use any map provider as long as you conform to its terms of use.
 You can roll your own tiles as well.
-[OpenStreetMap](http://openstreetmap.org) is the most popular data source among different tile providers,
+[OpenStreetMap](https://www.openstreetmap.org/) is the most popular data source among different tile providers,
 but there are providers that use other sources.
 
 Check out [this example](http://leaflet-extras.github.io/leaflet-providers/preview/)

--- a/debug/map/tile-debug.html
+++ b/debug/map/tile-debug.html
@@ -156,7 +156,7 @@
         resetCounter();
 
         var positron = L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
         });
 
         var grid = L.gridLayer({

--- a/docs/edit.html
+++ b/docs/edit.html
@@ -15,7 +15,7 @@
                 cssFile: 'https://unpkg.com/leaflet/dist/leaflet.css',
                 css: 'body {\n\tmargin: 0;\n}\nhtml, body, #leaflet {\n\theight: 100%\n}',
                 jsFile: 'https://unpkg.com/leaflet/dist/leaflet-src.js',
-                js: "var map = new L.Map('leaflet', {\n\tlayers: [\n\t\tnew L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t\t\t'attribution': 'Map data © <a href=\"http://openstreetmap.org\">OpenStreetMap</a> contributors'\n\t\t})\n\t],\n\tcenter: [0, 0],\n\tzoom: 0\n});"
+                js: "var map = new L.Map('leaflet', {\n\tlayers: [\n\t\tnew L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t\t\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n\t\t})\n\t],\n\tcenter: [0, 0],\n\tzoom: 0\n});"
             };
 
             var hash = location.hash.substr(1);


### PR DESCRIPTION
Follow-up on https://github.com/Leaflet/Leaflet/pull/6082

This should change all new or remaining OpenStreetMap links from HTTP to HTTPS.

Fixes #8010 