### PR TITLE
zoom event was not fired anymore while pinch zoom

### DIFF
--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -61,4 +61,38 @@ describe("Map.TouchZoom", function () {
 		f2.wait(100).moveTo(525, 300, 0)
 			.down().moveBy(-200, 0, 500).up(100);
 	});
+
+	it.skipIfNotTouch("fires zoom event while pinch zoom", function (done) {
+		map.setView([0, 0], 4);
+
+		var spy = sinon.spy();
+		map.on('zoom', spy);
+
+		var pinchZoomEvent = false;
+		map.on('zoom', function (e) {
+			pinchZoomEvent = e.pinch || pinchZoomEvent;
+		});
+		map.once('zoomend', function () {
+			expect(spy.callCount > 5).to.be.ok();
+			expect(pinchZoomEvent).to.be.ok();
+
+			expect(map.getCenter()).to.eql({lat:0, lng:0});
+			// Initial zoom 4, initial distance 450px, final distance 50px
+			expect(map.getZoom()).to.be(1);
+
+			done();
+		});
+
+		L.rectangle(map.getBounds().pad(-0.2)).addTo(map);
+
+		var hand = new Hand({timing: 'fastframe'});
+		var f1 = hand.growFinger(touchEventType);
+		var f2 = hand.growFinger(touchEventType);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(75, 300, 0)
+			.down().moveBy(200, 0, 500).up(100);
+		f2.wait(100).moveTo(525, 300, 0)
+			.down().moveBy(-200, 0, 500).up(100);
+	});
 });

--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -73,7 +73,7 @@ describe("Map.TouchZoom", function () {
 			pinchZoomEvent = e.pinch || pinchZoomEvent;
 		});
 		map.once('zoomend', function () {
-			expect(spy.callCount > 5).to.be.ok();
+			expect(spy.callCount > 1).to.be.ok();
 			expect(pinchZoomEvent).to.be.ok();
 
 			expect(map.getCenter()).to.eql({lat:0, lng:0});

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1233,6 +1233,8 @@ export var Map = Evented.extend({
 			// Fired repeatedly during any movement of the map,
 			// including pan and fly animations.
 			this.fire('move', data);
+		} else if (data && data.pinch) {	// Always fire 'zoom' if pinching because #3530
+			this.fire('zoom', data);
 		}
 		return this;
 	},


### PR DESCRIPTION
With #7967 I supressed the `zoom` event from firing but it is needed while pinch zoom.

I added a test that this can't be removed anymore without knowing it.