### PR TITLE
Video overlay tutorial: Accessible custom video controls

### DIFF
--- a/docs/examples/video-overlay/example.md
+++ b/docs/examples/video-overlay/example.md
@@ -33,7 +33,8 @@ title: Video Overlay Tutorial
 		var MyPlayControl = L.Control.extend({
 			onAdd: function () {
 				var button = L.DomUtil.create('button');
-				button.innerHTML = '▶️';
+				button.title = 'Play';
+				button.innerHTML = '<span aria-hidden="true">▶️</span>';
 				L.DomEvent.on(button, 'click', function () {
 					overlay.getElement().play();
 				});
@@ -43,7 +44,8 @@ title: Video Overlay Tutorial
 		var MyPauseControl = L.Control.extend({
 			onAdd: function () {
 				var button = L.DomUtil.create('button');
-				button.innerHTML = '⏸';
+				button.title = 'Pause';
+				button.innerHTML = '<span aria-hidden="true">⏸</span>';
 				L.DomEvent.on(button, 'click', function () {
 					overlay.getElement().pause();
 				});

--- a/docs/examples/video-overlay/example.md
+++ b/docs/examples/video-overlay/example.md
@@ -30,16 +30,6 @@ title: Video Overlay Tutorial
 	map.addLayer(overlay);
 
 	overlay.on('load', function () {
-		var MyPauseControl = L.Control.extend({
-			onAdd: function () {
-				var button = L.DomUtil.create('button');
-				button.innerHTML = '⏸';
-				L.DomEvent.on(button, 'click', function () {
-					overlay.getElement().pause();
-				});
-				return button;
-			}
-		});
 		var MyPlayControl = L.Control.extend({
 			onAdd: function () {
 				var button = L.DomUtil.create('button');
@@ -50,9 +40,19 @@ title: Video Overlay Tutorial
 				return button;
 			}
 		});
+		var MyPauseControl = L.Control.extend({
+			onAdd: function () {
+				var button = L.DomUtil.create('button');
+				button.innerHTML = '⏸';
+				L.DomEvent.on(button, 'click', function () {
+					overlay.getElement().pause();
+				});
+				return button;
+			}
+		});
 
-		var pauseControl = (new MyPauseControl()).addTo(map);
 		var playControl = (new MyPlayControl()).addTo(map);
+		var pauseControl = (new MyPauseControl()).addTo(map);
 	});
 
 </script>

--- a/docs/examples/video-overlay/index.md
+++ b/docs/examples/video-overlay/index.md
@@ -98,7 +98,8 @@ This allows us to build custom interfaces. For example, we can build a small sub
 		var MyPlayControl = L.Control.extend({
 			onAdd: function() {
 				var button = L.DomUtil.create('button');
-				button.innerHTML = '▶️';
+				button.title = 'Play';
+				button.innerHTML = '<span aria-hidden="true">▶️</span>';
 				L.DomEvent.on(button, 'click', function () {
 					videoOverlay.getElement().play();
 				});
@@ -108,7 +109,8 @@ This allows us to build custom interfaces. For example, we can build a small sub
 		var MyPauseControl = L.Control.extend({
 			onAdd: function() {
 				var button = L.DomUtil.create('button');
-				button.innerHTML = '⏸';
+				button.title = 'Pause';
+				button.innerHTML = '<span aria-hidden="true">⏸</span>';
 				L.DomEvent.on(button, 'click', function () {
 					videoOverlay.getElement().pause();
 				});

--- a/docs/examples/video-overlay/index.md
+++ b/docs/examples/video-overlay/index.md
@@ -95,16 +95,6 @@ This allows us to build custom interfaces. For example, we can build a small sub
 
 ```
 	videoOverlay.on('load', function () {
-		var MyPauseControl = L.Control.extend({
-			onAdd: function() {
-				var button = L.DomUtil.create('button');
-				button.innerHTML = '⏸';
-				L.DomEvent.on(button, 'click', function () {
-					videoOverlay.getElement().pause();
-				});
-				return button;
-			}
-		});
 		var MyPlayControl = L.Control.extend({
 			onAdd: function() {
 				var button = L.DomUtil.create('button');
@@ -115,9 +105,19 @@ This allows us to build custom interfaces. For example, we can build a small sub
 				return button;
 			}
 		});
+		var MyPauseControl = L.Control.extend({
+			onAdd: function() {
+				var button = L.DomUtil.create('button');
+				button.innerHTML = '⏸';
+				L.DomEvent.on(button, 'click', function () {
+					videoOverlay.getElement().pause();
+				});
+				return button;
+			}
+		});
 
-		var pauseControl = (new MyPauseControl()).addTo(map);
 		var playControl = (new MyPlayControl()).addTo(map);
+		var pauseControl = (new MyPauseControl()).addTo(map);
 	});
 ```
 


### PR DESCRIPTION
(This is just 1 item in a larger effort to try to improve a11y in docs per https://github.com/Leaflet/Leaflet/discussions/8006.)

This PR resolves an accessibility issue in the video overlay tutorial (the "Showing video files" item in https://github.com/Leaflet/Leaflet/discussions/8006#discussioncomment-2190730).

- [x] https://github.com/Leaflet/Leaflet/commit/c1ba8dd8f8cafffe65180015f7bbde124210e314 is just to reorder the controls, I thought it made more sense to have play button before pause button.
- [x] https://github.com/Leaflet/Leaflet/commit/e701a4f743b758f3751ee807053d195d2479f8d1 fixes the issue described below.

Currently on `main` (tested using the Narrator screen reader):

- The Play button is announced as <q>Right pointing triangle, button</q>
- The Pause button is announced as <q>Button</q>

With these changes:

- The Play button is announced as <q>Play, button</q>
- The Pause button is announced as <q>Pause, button</q>