### PR TITLE
Add check for blocker issues/PRs in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,6 @@
 ## Releasing a new version of Leaflet
 
+- [ ] Ensure no [blocker](https://github.com/Leaflet/Leaflet/labels/blocker) issues and pull requests are unresolved.
 - [ ] Update [the changelog](https://github.com/Leaflet/Leaflet/blob/main/CHANGELOG.md) since last release and commit.
 - [ ] Run `npm version <patch | minor | major>` (this will bump the version in `package.json` and create a new tag).
 - [ ] Run `git push --follow-tags` to push the commit created by NPM to Github (together with the tag).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 ## Releasing a new version of Leaflet
 
-- [ ] Ensure no [blocker](https://github.com/Leaflet/Leaflet/labels/blocker) issues and pull requests are unresolved.
+- [ ] Ensure all https://github.com/Leaflet/Leaflet/labels/blocker issues and pull requests are resolved.
 - [ ] Update [the changelog](https://github.com/Leaflet/Leaflet/blob/main/CHANGELOG.md) since last release and commit.
 - [ ] Run `npm version <patch | minor | major>` (this will bump the version in `package.json` and create a new tag).
 - [ ] Run `git push --follow-tags` to push the commit created by NPM to Github (together with the tag).


### PR DESCRIPTION
Per https://github.com/Leaflet/Leaflet/discussions/8018#discussioncomment-2229603:

> With the assumption that issues/PRs with this label must be checked manually - I suggest that we add a check in [RELEASE.md](https://github.com/Leaflet/Leaflet/blob/main/RELEASE.md) to ensure these issues/PRs are never skipped on releases.