### PR TITLE
Parse dist-tag from version for publishing on NPM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,6 +211,8 @@ jobs:
 
       - name: test dist-tag parse
         run: echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?'
+        env:
+          VERSION: v1.8.0-alpha.1
 
       - name: Publish to NPM
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
 
   publish-npm:
     needs: build
-    # if: github.repository_owner == 'Leaflet' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository_owner == 'Leaflet' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Restore build
@@ -209,15 +209,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
 
-      - name: test dist-tag parse
-        run: echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?'
-        env:
-          VERSION: v1.8.0-alpha.1
-
       - name: Publish to NPM
         run: |
-          TAG=$(echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
-          npm publish --tag ${TAG:-latest} --dry-run
+          TAG=$(echo $GITHUB_REF_NAME | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
+          npm publish --tag ${TAG:-latest}
         env:
-          VERSION: v1.8.0-alpha.1
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,7 +194,7 @@ jobs:
 
   publish-npm:
     needs: build
-    if: github.repository_owner == 'Leaflet' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.repository_owner == 'Leaflet' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Restore build
@@ -210,6 +210,9 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Publish to NPM
-        run: npm publish
+        run: |
+          TAG=$(echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')
+          npm publish --tag ${TAG:-latest} --dry-run
         env:
+          VERSION: v1.8.0-alpha.1
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -209,6 +209,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
 
+      - name: test dist-tag parse
+        run: echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?'
+
       - name: Publish to NPM
         run: |
           TAG=$(echo $VERSION | grep -oP '^v\d+\.\d+\.\d+-?\K(\w+)?')


### PR DESCRIPTION
Makes it so that we do `npm publish --tag latest` for stable releases and e.g. `npm publish --tag beta` for versions like `v1.8.0-beta.1`. Closes #8038.