### PR TITLE
Map is panned to show markers when they're focused

### DIFF
--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -2,7 +2,9 @@ import {Layer} from '../Layer';
 import {IconDefault} from './Icon.Default';
 import * as Util from '../../core/Util';
 import {toLatLng as latLng} from '../../geo/LatLng';
+import {toPoint as point} from '../../geometry/Point';
 import * as DomUtil from '../../dom/DomUtil';
+import * as DomEvent from '../../dom/DomEvent';
 import {MarkerDrag} from './Marker.Drag';
 
 /*
@@ -72,6 +74,12 @@ export var Marker = Layer.extend({
 		// When `true`, a mouse event on this marker will trigger the same event on the map
 		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
 		bubblingMouseEvents: false,
+
+		// @option autoPanOnFocus: Boolean = true
+		// When `true`, the map will pan whenever the marker is focused (via
+		// e.g. pressing `tab` on the keyboard) to ensure the marker is
+		// visible within the map's bounds
+		autoPanOnFocus: true,
 
 		// @section Draggable marker options
 		// @option draggable: Boolean = false
@@ -237,6 +245,10 @@ export var Marker = Layer.extend({
 			});
 		}
 
+		if (this.options.autoPanOnFocus) {
+			DomEvent.on(icon, 'focus', this._panOnFocus, this);
+		}
+
 		var newShadow = options.icon.createShadow(this._shadow),
 		    addShadow = false;
 
@@ -272,6 +284,10 @@ export var Marker = Layer.extend({
 				mouseover: this._bringToFront,
 				mouseout: this._resetZIndex
 			});
+		}
+
+		if (this.options.autoPanOnFocus) {
+			DomEvent.off(this._icon, 'focus', this._panOnFocus, this);
 		}
 
 		DomUtil.remove(this._icon);
@@ -366,6 +382,20 @@ export var Marker = Layer.extend({
 
 	_resetZIndex: function () {
 		this._updateZIndex(0);
+	},
+
+	_panOnFocus: function(ev) {
+		var map = this._map;
+		if (!map) { return }
+
+		var iconOpts = this.options.icon.options;
+		var size = point(iconOpts.iconSize);
+		var anchor = point(iconOpts.iconAnchor);
+
+		map.panInside(this._latlng, {
+			paddingTopLeft: anchor,
+			paddingBottomRight: size.subtract(anchor)
+		});
 	},
 
 	_getPopupAnchor: function () {


### PR DESCRIPTION
Should fix #8040.

@Malvoz This is a quick implementation that I haven't tested thoroughly. If you can, please test with `DivIcon`s and marker images of different sizes.