### PR TITLE
Potentially fix path for tagged artifacts upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,10 +175,6 @@ jobs:
         working-directory: dist
         run: zip -r leaflet.zip .
 
-      - name: Determine directory for artifacts
-        id: artifacts-directory
-        run: echo "::set-output name=path::content/leaflet/${GITHUB_REF_NAME:-main}"
-
       - name: Publish artifacts
         uses: jakejarvis/s3-sync-action@v0.5.1
         with:
@@ -188,7 +184,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           SOURCE_DIR: dist
-          DEST_DIR: ${{ steps.artifacts-directory.outputs.path }}
+          DEST_DIR: content/leaflet/${{ env.GITHUB_REF_NAME }}
 
   publish-npm:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,9 +177,7 @@ jobs:
 
       - name: Determine directory for artifacts
         id: artifacts-directory
-        run: |
-          VERSION=$(git tag --points-at HEAD)
-          echo "::set-output name=path::content/leaflet/${VERSION:-main}"
+        run: echo "::set-output name=path::content/leaflet/${GITHUB_REF_NAME:-main}"
 
       - name: Publish artifacts
         uses: jakejarvis/s3-sync-action@v0.5.1


### PR DESCRIPTION
A blind attempt at fixing #8045. I have no idea why `git tag --points-at HEAD` didn't work here, but maybe let's try with the built in environment var?