### PR TITLE
Refactor font sizes for text content

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -264,8 +264,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 /* general typography */
 .leaflet-container {
-	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
-	font: 0.75rem/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+	font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+	line-height: 1.5;
 	}
 
 
@@ -417,8 +417,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-container .leaflet-control-attribution,
 .leaflet-container .leaflet-control-scale {
-	font-size: 11px;
-	font-size: 0.69rem;
+	font-size: smaller;
 	}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
@@ -431,8 +430,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-top: none;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
-	font-size: 11px;
-	font-size: 0.69rem;
+	font-size: smaller;
 	white-space: nowrap;
 	overflow: hidden;
 	-moz-box-sizing: border-box;


### PR DESCRIPTION
## Comparison

<table>
  <tr>
    <th></th>
    <th>Default</th>
    <th>Custom <code>font-size</code><sup> <a href="#note">[NOTE]</a></sup></th>
    <th>Browser setting: <q>Very large</q></th>
  </tr>
  <tr>
    <th>1.7.1</th>
    <td><img src="https://user-images.githubusercontent.com/26493779/157889544-b050c91f-89a9-46d6-8532-7b8d4efed510.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157889544-b050c91f-89a9-46d6-8532-7b8d4efed510.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157889544-b050c91f-89a9-46d6-8532-7b8d4efed510.png"></td>
  </tr>
  <tr>
    <th>1.8.0-beta.0</th>
    <td><img src="https://user-images.githubusercontent.com/26493779/157890770-9592cb24-1655-4518-87b3-96edba66a649.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157911958-13f0e385-6eba-4d9f-b5c1-3ba2a1fb778b.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157890845-db1a2e68-d270-43e0-a21b-730f1038e643.png"></td>
  </tr>
  <tr>
    <th>PR preview</th>
    <td><img src="https://user-images.githubusercontent.com/26493779/157891039-591e2250-b981-41be-bf8e-fe286f646f25.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157912035-8d225588-28cb-4392-a410-217bf0764ab7.png"></td>
    <td><img src="https://user-images.githubusercontent.com/26493779/157890910-51340eff-5fcc-4c90-a8a8-19dec4456389.png"></td>
  </tr>
</table>

<details id="note">

<summary>[NOTE]: The custom font sizes used</summary><br>

```css
html {
  font-size: 200%; /* changes root font-size */
}

body {
  font-size: 0.3em; /* changes parent element font-size */
}
```

With these particular custom styles, the computed font-size _SHOULD_ be smaller than the _default_ font-size in the screenshots.

<hr>

</details>

<table>
  <tr>
    <th></th>
    <th>1.7.1</th>
    <th>1.8.0-beta.0</th>
    <th>PR preview</th>
  </tr>
  <tr>
    <th>Scales relatively to the root (<code>&lt;html&gt;</code>) font size?</th>
    <td>❌</td>
    <td>✔️</td>
    <td>✔️</td>
  </tr>
  <tr>
    <th>Scales relatively to custom font sizes on (non-root) ascendant elements?</th>
    <td>❌</td>
    <td>❌</td>
    <td>✔️</td>
  </tr>
  <tr>
    <th>Respects the user's browser settings?</th>
    <td>❌</td>
    <td>✔️</td>
    <td>✔️</td>
  </tr>
</table>

---

- Resolves https://github.com/Leaflet/Leaflet/issues/7952
  (by accepting that the new relative font sizes may cause illegible fonts depending on the application's CSS (i.e. responsibility is on the developer to not use too small font sizes), this is simply the nature of relative font sizes. In other words things like https://github.com/Leaflet/Leaflet/discussions/8044#discussioncomment-2331708 is expected and some developers may have to make CSS changes, the alternative is to close this PR, revert changes in https://github.com/Leaflet/Leaflet/pull/7800, and go back to the 1.7.1 scenario)
- Fixes https://github.com/Leaflet/Leaflet/pull/7346
  (because the attribution and scale control now has the same font size as the `<small>` element due to `font-size: smaller`, which is larger than 12px)
- Fixes https://github.com/Leaflet/Leaflet/issues/8051
  (because the default font size in Leaflet is now equal to that of body text, except for attribution and scale control which remain smaller)