### PR TITLE
Increase default font sizes for improved legibility

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -264,8 +264,10 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 /* general typography */
 .leaflet-container {
-	font: 12px/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
-	font: 0.75rem/1.5 "Helvetica Neue", Arial, Helvetica, sans-serif;
+	font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
+	font-size: 12px;
+	font-size: 0.75rem;
+	line-height: 1.5;
 	}
 
 
@@ -383,6 +385,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-control-layers label {
 	display: block;
+	font-size: 13px;
+	font-size: 1.08333em;
 	}
 .leaflet-control-layers-separator {
 	height: 0;
@@ -407,6 +411,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-control-scale-line {
 	padding: 0 5px;
 	color: #333;
+	line-height: 1.4;
 	}
 .leaflet-control-attribution a {
 	text-decoration: none;
@@ -414,11 +419,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-control-attribution a:hover,
 .leaflet-control-attribution a:focus {
 	text-decoration: underline;
-	}
-.leaflet-container .leaflet-control-attribution,
-.leaflet-container .leaflet-control-scale {
-	font-size: 11px;
-	font-size: 0.69rem;
 	}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
@@ -431,8 +431,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	border-top: none;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
-	font-size: 11px;
-	font-size: 0.69rem;
 	white-space: nowrap;
 	overflow: hidden;
 	-moz-box-sizing: border-box;
@@ -476,10 +474,13 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-popup-content {
 	margin: 13px 19px;
-	line-height: 1.4;
+	line-height: 1.3;
+	font-size: 13px;
+	font-size: 1.08333em;
 	}
 .leaflet-popup-content p {
-	margin: 18px 0;
+	margin: 17px 0;
+	margin: 1.3em 0;
 	}
 .leaflet-popup-tip-container {
 	width: 40px;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -404,7 +404,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 
 .leaflet-container .leaflet-control-attribution {
 	background: #fff;
-	background: rgba(255, 255, 255, 0.7);
+	background: rgba(255, 255, 255, 0.8);
 	margin: 0;
 	}
 .leaflet-control-attribution,


### PR DESCRIPTION
I have spent some time tweaking the default Leaflet font sizes for improved legibility, while not compromising on the look and compactness too much — here are the changes.

I'm wary about addressing #7952 (like in #8052) because once we fix it, we're getting a bunch of potential problems from the other side (cc @natevw) — Leaflet maps are very often embedded in content contexts like blogs (with parent font sizes varying to a great extent), and this will have breaking consequences on a lot of maps (needing design adjustments), while we want to retain relatively consistent look of Leaflet maps regardless of context — so that's more of an independent component within a certain design. The old `html { font-size: 62.5% }` hack is an acceptable edge case to leave to the user to address manually IMO.

I also want to retain the current base font-size of `.leaflet-container` because many plugins depend on it for their design choices. Thus I'm increasing font sizes on children controls instead.

Closes #7346. I've come to like the 1px increase — sorry for doubting this earlier @Malvoz! Also adjusted margins and line height a little bit to compensate, and bumped the opacity of the attribution control.

Before:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/25395/158141991-d400959a-8c73-40c3-87d7-979b33b65d9f.png"> 
After:
<img width="544" alt="image" src="https://user-images.githubusercontent.com/25395/158144766-42283a71-78b0-4213-aae4-4a84c32dd625.png">