### PR TITLE
Fix SVG perf regression by partially bringing back will-change

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -185,6 +185,9 @@
 	    -ms-transform-origin: 0 0;
 	        transform-origin: 0 0;
 	}
+svg.leaflet-zoom-animated {
+	will-change: transform;
+}
 
 .leaflet-zoom-anim .leaflet-zoom-animated {
 	-webkit-transition: -webkit-transform 0.25s cubic-bezier(0,0,0.25,1);


### PR DESCRIPTION
I noticed that on my machine, the `debug/vector/geojson.html` example (a relatively complex SVG vectors example) was noticeably janky when zooming in. Looks like the browsers attempts to rasterize the vectors during the zoom animation, not only at the start, which is very expensive. 

It seems to be a regression after #7872, but we can bring the performance back by reverting the change only partially — restoring `will-change: transform` specifically on the animated `svg` element (which is expensive to rasterize every frame) and nowhere else. After the change, zooming in is smooth again both in Chrome & FF. cc @janjaap 