### PR TITLE
bugFix: moving scroll-padding-top prop to reference.css

### DIFF
--- a/docs/SlavaUkraini/docs/css/main.css
+++ b/docs/SlavaUkraini/docs/css/main.css
@@ -9,11 +9,6 @@ html, body, input, select, button, textarea, table {
 	text-rendering: optimizeLegibility;
 }
 
-html {
-	scroll-padding-top: 5em;
-	overflow: auto;
-}
-
 body {
 	line-height: 1.5;
 	color: black;

--- a/docs/SlavaUkraini/docs/css/reference.css
+++ b/docs/SlavaUkraini/docs/css/reference.css
@@ -1,3 +1,8 @@
+html {
+	scroll-padding-top: 5em;
+	overflow: auto;
+}
+
 h2 {
     margin-top: 2em;
 }

--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -10,7 +10,6 @@ html, body, input, select, button, textarea, table {
 }
 
 html {
-	scroll-padding-top: 5em;
 	overflow: auto;
 }
 

--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -9,10 +9,6 @@ html, body, input, select, button, textarea, table {
 	text-rendering: optimizeLegibility;
 }
 
-html {
-	overflow: auto;
-}
-
 body {
 	line-height: 1.5;
 	color: black;

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -1,5 +1,5 @@
 html {
-	scroll-padding-top: 5em;
+    scroll-padding-top: 5em;
     overflow: auto;
 }
 

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -1,5 +1,6 @@
 html {
 	scroll-padding-top: 5em;
+    overflow: auto;
 }
 
 h2 {

--- a/docs/docs/css/reference.css
+++ b/docs/docs/css/reference.css
@@ -1,3 +1,7 @@
+html {
+	scroll-padding-top: 5em;
+}
+
 h2 {
     margin-top: 2em;
 }


### PR DESCRIPTION
This is a fix for issue #8080 

As mentioned on the issue:
 - Removed `scroll-padding-top` property from [main.css](https://github.com/Leaflet/Leaflet/blob/main/docs/docs/css/main.css)
 - Added it to [reference.css](https://github.com/Leaflet/Leaflet/blob/main/docs/docs/css/reference.css) file under `html` tag.