### PR TITLE
Fix undefined iconAnchor

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -204,6 +204,20 @@ describe("Marker", function () {
 			var icon = marker._icon;
 			expect(icon.hasAttribute('alt')).to.be(false);
 		});
+
+		it("pan map to focus marker", function (done) {
+			var marker = L.marker([70, 0], {icon: L.divIcon()});
+			map.addLayer(marker);
+
+			setTimeout(function () {
+				expect(function () {
+					marker._icon.focus();
+				}).to.not.throwException();
+
+				done();
+			}, 100);
+
+		});
 	});
 
 	describe("#setLatLng", function () {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -390,7 +390,7 @@ export var Marker = Layer.extend({
 
 		var iconOpts = this.options.icon.options;
 		var size = point(iconOpts.iconSize);
-		var anchor = point(iconOpts.iconAnchor);
+		var anchor = iconOpts.iconAnchor ? point(iconOpts.iconAnchor) : point(0, 0);
 
 		map.panInside(this._latlng, {
 			paddingTopLeft: anchor,


### PR DESCRIPTION
With the implementation of #8042 a error occurs (mostly on DivIcons) if `iconAnchor` is not defined.

Fixes issues in #8044.