### PR TITLE
Remove an old iOS hack to fix glitches on rapid zoom

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1730,10 +1730,7 @@ export var Map = Evented.extend({
 
 		this.fire('move');
 
-		// This anim frame should prevent an obscure iOS webkit tile loading race condition.
-		Util.requestAnimFrame(function () {
-			this._moveEnd(true);
-		}, this);
+		this._moveEnd(true);
 	}
 });
 


### PR DESCRIPTION
Partially addresses #8101. @IvanSanchez can you double-check if this fixes it?