### PR TITLE
Fix vector drift when dragging and immediately zooming

### DIFF
--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -90,4 +90,71 @@ describe("Map.TouchZoom", function () {
 		f2.wait(100).moveTo(525, 300, 0)
 			.down().moveBy(-200, 0, 500).up(100);
 	});
+
+	it.skipIfNotTouch("Dragging is possible after pinch zoom", function (done) {
+		map.setView([0, 0], 8);
+
+		L.polygon([
+			[0, 0],
+			[0, 1],
+			[1, 1],
+			[1, 0]
+		]).addTo(map);
+
+		var hand = new Hand({
+			timing: 'fastframe',
+			onStop: function () {
+				expect(map.getCenter().lat).to.be(0);
+				expect(map.getCenter().lng > 5).to.be(true);
+				done();
+			}
+		});
+
+		var f1 = hand.growFinger(touchEventType);
+		var f2 = hand.growFinger(touchEventType);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(75, 300, 0).down()
+			.moveBy(200, 0, 500).up();
+
+		f2.wait(100).moveTo(525, 300, 0)
+			.down().moveBy(-200, 0, 500).up(100);
+
+		f1.wait(100).moveTo(200, 300, 0).down()
+			.moveBy(5, 0, 20) // We move 5 pixels first to overcome the 3-pixel threshold of L.Draggable (fastframe)
+			.moveBy(-150, 0, 200) // Dragging
+			.up();
+
+	});
+
+	it.skipIfNotTouch("TouchZoom works with disabled map dragging", function (done) {
+		map.remove();
+
+		map = new L.Map(container, {
+			touchZoom: true,
+			inertia: false,
+			zoomAnimation: false,	// If true, the test has to wait extra 250msec,
+			dragging: false
+		});
+
+		map.setView([0, 0], 4);
+		map.once('zoomend', function () {
+			expect(map.getCenter()).to.eql({lat:0, lng:0});
+			// Initial zoom 4, initial distance 450px, final distance 50px
+			expect(map.getZoom()).to.be(1);
+
+			done();
+		});
+
+		var hand = new Hand({timing: 'fastframe'});
+		var f1 = hand.growFinger(touchEventType);
+		var f2 = hand.growFinger(touchEventType);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(75, 300, 0)
+			.down().moveBy(200, 0, 500).up(100);
+		f2.wait(100).moveTo(525, 300, 0)
+			.down().moveBy(-200, 0, 500).up(100);
+	});
+
 });

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -80,6 +80,14 @@ export var Draggable = Evented.extend({
 
 		if (DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
 
+		if (e.touches && e.touches.length !== 1) {
+			// Finish dragging to avoid conflict with touchZoom
+			if (Draggable._dragging === this) {
+				this.finishDrag();
+			}
+			return;
+		}
+
 		if (Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
 		Draggable._dragging = this;  // Prevent dragging multiple objects at once.
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -62,7 +62,7 @@ export var Draggable = Evented.extend({
 		// If we're currently dragging this draggable,
 		// disabling it counts as first ending the drag.
 		if (Draggable._dragging === this) {
-			this.finishDrag();
+			this.finishDrag(true);
 		}
 
 		DomEvent.off(this._dragStartTarget, START, this._onDown, this);
@@ -188,7 +188,7 @@ export var Draggable = Evented.extend({
 		this.finishDrag();
 	},
 
-	finishDrag: function () {
+	finishDrag: function (noInertia) {
 		DomUtil.removeClass(document.body, 'leaflet-dragging');
 
 		if (this._lastTarget) {
@@ -207,6 +207,7 @@ export var Draggable = Evented.extend({
 			// @event dragend: DragEndEvent
 			// Fired when the drag ends.
 			this.fire('dragend', {
+				noInertia: noInertia,
 				distance: this._newPos.distanceTo(this._startPos)
 			});
 		}

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -85,13 +85,11 @@ export var Renderer = Layer.extend({
 
 	_updateTransform: function (center, zoom) {
 		var scale = this._map.getZoomScale(zoom, this._zoom),
-		    position = DomUtil.getPosition(this._container),
 		    viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding),
 		    currentCenterPoint = this._map.project(this._center, zoom),
-		    destCenterPoint = this._map.project(center, zoom),
-		    centerOffset = destCenterPoint.subtract(currentCenterPoint),
 
-		    topLeftOffset = viewHalf.multiplyBy(-scale).add(position).add(viewHalf).subtract(centerOffset);
+		    topLeftOffset = viewHalf.multiplyBy(-scale).add(currentCenterPoint)
+				  .subtract(this._map._getNewPixelOrigin(center, zoom));
 
 		if (Browser.any3d) {
 			DomUtil.setTransform(this._container, topLeftOffset, scale);

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -47,12 +47,6 @@ export var create = Browser.vml ? vmlCreate : svgCreate;
 
 export var SVG = Renderer.extend({
 
-	getEvents: function () {
-		var events = Renderer.prototype.getEvents.call(this);
-		events.zoomstart = this._onZoomStart;
-		return events;
-	},
-
 	_initContainer: function () {
 		this._container = create('svg');
 
@@ -69,13 +63,6 @@ export var SVG = Renderer.extend({
 		delete this._container;
 		delete this._rootGroup;
 		delete this._svgSize;
-	},
-
-	_onZoomStart: function () {
-		// Drag-then-pinch interactions might mess up the center and zoom.
-		// In this case, the easiest way to prevent this is re-do the renderer
-		//   bounds and padding when the zooming starts.
-		this._update();
 	},
 
 	_update: function () {

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -187,7 +187,7 @@ export var Drag = Handler.extend({
 		var map = this._map,
 		    options = map.options,
 
-		    noInertia = !options.inertia || this._times.length < 2;
+		    noInertia = !options.inertia || e.noInertia || this._times.length < 2;
 
 		map.fire('dragend', e);
 


### PR DESCRIPTION
This PR fixes the pinch zoom vector drifting issue with 3 things combined:

- #6126 by @[manubb](https://github.com/manubb) that fixes animation math in `Renderer` to take panning offset into account
- #7073 by @johnd0e that stops dragging as soon as the second finger is placed to avoid conflicting handlers.
- Disable inertia when dragging is stopped through the case above rather than panning, fixing edge cases when pinch-zooming quickly.

This should address the issue without any performance overhead. I haven't added any tests though — @Falke-Design wondering if those you wrote in #7965 could be applicable and moved here.

Tested both on iOS (put one finger, drag, then put another finger and pinch) and desktop (drag with the mouse, then push + to zoom without releasing the mouse).

- Includes and closes #7073
- Includes and closes #6126
- Closes #7965
- Fixes #7401
- Fixes #7072
- Fixes #6395
- Fixes #7466
- Fixes #6099
