### PR TITLE
Add a Ukrainian flag to default attribution 🇺🇦 

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -4,6 +4,7 @@ import {Map} from '../map/Map';
 import * as Util from '../core/Util';
 import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
+import Browser from '../core/Browser';
 
 /*
  * @class Control.Attribution
@@ -21,8 +22,8 @@ export var Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">Leaflet</a>'
-
+		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">' +
+				(Browser.emoji ? '&#127482;&#127462; ' : '') + 'Leaflet</a>'
 	},
 
 	initialize: function (options) {

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -6,7 +6,7 @@ import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
 import Browser from '../core/Browser';
 
-const ukrainianFlag = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
+var ukrainianFlag = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
 
 /*
  * @class Control.Attribution

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -6,6 +6,8 @@ import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
 import Browser from '../core/Browser';
 
+const ukrainianFlag = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
+
 /*
  * @class Control.Attribution
  * @aka L.Control.Attribution
@@ -22,8 +24,7 @@ export var Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">' +
-				(Browser.emoji ? '&#127482;&#127462; ' : '') + 'Leaflet</a>'
+		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">' + (Browser.svg ? ukrainianFlag + ' ' : '') + 'Leaflet</a>'
 	},
 
 	initialize: function (options) {

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -24,7 +24,7 @@ export var Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">' + (Browser.svg ? ukrainianFlag + ' ' : '') + 'Leaflet</a>'
+		prefix: '<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">' + (Browser.inlineSvg ? ukrainianFlag + ' ' : '') + 'Leaflet</a>'
 	},
 
 	initialize: function (options) {

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -6,7 +6,8 @@ import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
 import Browser from '../core/Browser';
 
-var ukrainianFlag = '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="8"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
+var ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="12" height="8"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
+
 
 /*
  * @class Control.Attribution

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -163,17 +163,6 @@ var vml = !svg && (function () {
 	}
 }());
 
-var emoji = !!canvas && (function () { // emoji detection logic by the Modernizr team, MIT-licensed
-	var ctx = document.createElement('canvas').getContext('2d');
-	var offset = 12 * (ctx.webkitBackingStorePixelRatio || ctx.mozBackingStorePixelRatio ||
-			ctx.msBackingStorePixelRatio || ctx.oBackingStorePixelRatio || ctx.backingStorePixelRatio || 1);
-	ctx.fillStyle = '#f00';
-	ctx.textBaseline = 'top';
-	ctx.font = '32px Arial';
-	ctx.fillText('\ud83d\udc28', 0, 0);
-	return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
-})();
-
 function userAgentContains(str) {
 	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
 }
@@ -211,6 +200,5 @@ export default {
 	passiveEvents: passiveEvents,
 	canvas: canvas,
 	svg: svg,
-	vml: vml,
-	emoji: emoji
+	vml: vml
 };

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -146,6 +146,12 @@ var canvas = (function () {
 // `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
 var svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
 
+var inlineSvg = !!svg && (function () {
+	var div = document.createElement('div');
+	div.innerHTML = '<svg/>';
+	return (div.firstChild && div.firstChild.namespaceURI) === 'http://www.w3.org/2000/svg';
+})();
+
 // @property vml: Boolean
 // `true` if the browser supports [VML](https://en.wikipedia.org/wiki/Vector_Markup_Language).
 var vml = !svg && (function () {
@@ -200,5 +206,6 @@ export default {
 	passiveEvents: passiveEvents,
 	canvas: canvas,
 	svg: svg,
-	vml: vml
+	vml: vml,
+	inlineSvg: inlineSvg
 };

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -163,6 +163,16 @@ var vml = !svg && (function () {
 	}
 }());
 
+var emoji = !!canvas && (function () { // emoji detection logic by the Modernizr team, MIT-licensed
+	var ctx = document.createElement('canvas').getContext('2d');
+	var offset = 12 * (ctx.webkitBackingStorePixelRatio || ctx.mozBackingStorePixelRatio ||
+			ctx.msBackingStorePixelRatio || ctx.oBackingStorePixelRatio || ctx.backingStorePixelRatio || 1);
+	ctx.fillStyle = '#f00';
+	ctx.textBaseline = 'top';
+	ctx.font = '32px Arial';
+	ctx.fillText('\ud83d\udc28', 0, 0);
+	return ctx.getImageData(offset, offset, 1, 1).data[0] !== 0;
+})();
 
 function userAgentContains(str) {
 	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
@@ -202,4 +212,5 @@ export default {
 	canvas: canvas,
 	svg: svg,
 	vml: vml,
+	emoji: emoji
 };


### PR DESCRIPTION
Add a 🇺🇦 flag to the default attribution prefix (where SVG is supported). Just a tiny, unobtrusive way to bring more attention to Leaflet's Ukrainian background across websites that use it.

<img width="402" alt="image" src="https://user-images.githubusercontent.com/25395/161427353-6f7c72b2-0e8d-4314-9d2c-bdcf844282b4.png">
