### PR TITLE
Changelog update (1.8.0-beta.0): document the change to fonts as breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Leaflet Changelog
 * Fix `Class.extend` to not modify source props object ([#6766](https://github.com/Leaflet/Leaflet/pull/6766) by [@johnd0e](https://github.com/johnd0e))
 * Improve `Browser.touch` touch devices detection ([#7029](https://github.com/Leaflet/Leaflet/pull/7029) by [@johnd0e](https://github.com/johnd0e))
 * Get rid of legacy Android hacks ([#7022](https://github.com/Leaflet/Leaflet/pull/7022) by [@johnd0e](https://github.com/johnd0e))
+* Allow fonts to respect users' browser settings by making the `font-size` _relative_ to the map container. (You can change the font size on `leaflet-container` to adjust it if needed.) ([#7800](https://github.com/Leaflet/Leaflet/pull/7800) by [@Chandu-4444](https://github.com/Chandu-4444))
 
 ### ❇️ API changes
 


### PR DESCRIPTION
Close https://github.com/Leaflet/Leaflet/issues/7952 by documenting the font size change as a breaking change, and also by noting where people can make changes if they need to adjust the fonts, as requested in https://github.com/Leaflet/Leaflet/issues/7952#issuecomment-1067427953.