### PR TITLE
add demo link & update description for Maps Marker Pro 3rd party plugin

### DIFF
--- a/docs/_plugins/3rd-party-integration/maps-marker-pro.md
+++ b/docs/_plugins/3rd-party-integration/maps-marker-pro.md
@@ -4,9 +4,10 @@ category: 3rd-party-integration
 repo: https://www.mapsmarker.com/
 author: Robert Harm
 author-url: https://www.harm.co.at/
-demo: 
+demo: https://demo.mapsmarker.com
 compatible-v0:
 compatible-v1: true
 ---
 
-A WordPress plugin that enables users to pin, organize and share their favorite places and tracks through their WordPress powered site.
+A WordPress plugin / comprehensive geo-content management system that allows users to pin, organize and share their favorite places and tracks as well as elevation charts. 
+Also integrates several leaflet plugins like leaflet-bing-layer, leaflet-edgebuffer, leaflet-fullscreen, leaflet-gesture-handling, leaflet-minimap, leaflet.gridlayer.googlemutant, leaflet.locatecontrol, leaflet.markercluster and leaflet-geoman-free.


### PR DESCRIPTION
added demo link & updated the description, also including leaflet plugins used for our WordPress plugin