### PR TITLE
Fix `map.getCenter()` returning a mutable object

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -119,6 +119,13 @@ describe("Map", function () {
 			map.invalidateSize();
 			expect(map.getCenter()).not.to.eql(center);
 		});
+
+		it("returns a new object that can be mutated without affecting the map", function () {
+			map.setView([10, 10], 1);
+			var center = map.getCenter();
+			center.lat += 10;
+			expect(map.getCenter()).to.eql(L.latLng(10, 10));
+		});
 	});
 
 	describe("#whenReady", function () {
@@ -1027,14 +1034,14 @@ describe("Map", function () {
 		beforeEach(function () {
 			container.style.height = container.style.width = "500px";
 			map.setView(L.latLng([53.0, 0.15]), 12, {animate: false});
-			center = map.getCenter();
+			center = map.getCenter().clone();
 			tl = map.getBounds().getNorthWest();
 			tlPix = map.getPixelBounds().min;
 		});
 
 		it("does not pan the map when the target is within bounds", function () {
 			map.panInside(tl, {animate:false});
-			expect(center).to.equal(map.getCenter());
+			expect(center).to.eql(map.getCenter());
 		});
 
 		it("pans the map when padding is provided and the target is within the border area", function () {
@@ -1066,13 +1073,13 @@ describe("Map", function () {
 
 		it("supports different padding values for each border", function () {
 			var p = tlPix.add([40, 0]),	// Top-Left
-			    opts = {paddingTL: [60, 20], paddingBR: [10, 10]};
+			    opts = {paddingTL: [60, 20], paddingBR: [10, 10], animate: false};
 			map.panInside(map.unproject(p), opts);
-			expect(center).to.equal(map.getCenter());
+			expect(center).to.eql(map.getCenter());
 
 			var br = map.getPixelBounds().max;	// Bottom-Right
-			map.panInside(map.unproject(L.point(br.x - 20, br.y)), opts);
-			expect(center).to.not.equal(map.getCenter);
+			map.panInside(map.unproject(L.point(br.x + 20, br.y)), opts);
+			expect(center).to.not.eql(map.getCenter());
 		});
 
 		it("pans on both X and Y axes when the target is outside of the view area and both the point's coords are outside the bounds", function () {

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -132,7 +132,7 @@ describe("Map.Drag", function () {
 			});
 
 			var originalCenter = L.latLng(0, 0);
-			map.setView(originalCenter, 1);
+			map.setView(originalCenter.clone(), 1);
 
 			var spy = sinon.spy();
 			map.on('drag', spy);
@@ -142,7 +142,7 @@ describe("Map.Drag", function () {
 				onStop: function () {
 					expect(map.getZoom()).to.be(1);
 					// Expect center point to be the same as before the click
-					expect(map.getCenter()).to.be(originalCenter);
+					expect(map.getCenter()).to.eql(originalCenter);
 					expect(spy.callCount).to.eql(0); // No drag event should have been fired.
 
 					done();
@@ -273,7 +273,7 @@ describe("Map.Drag", function () {
 				inertia: false
 			});
 			var originalCenter = L.latLng(0, 0);
-			map.setView(originalCenter, 1);
+			map.setView(originalCenter.clone(), 1);
 
 			map.on('mousedown', function () {
 				map.dragging.disable();
@@ -286,7 +286,7 @@ describe("Map.Drag", function () {
 				onStop: function () {
 					expect(map.getZoom()).to.be(1);
 					// Expect center point to be the same as before the click
-					expect(map.getCenter()).to.be(originalCenter);
+					expect(map.getCenter()).to.eql(originalCenter);
 					expect(spy.callCount).to.eql(0); // No drag event should have been fired.
 
 					done();

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -820,7 +820,7 @@ export var Map = Evented.extend({
 		this._checkIfLoaded();
 
 		if (this._lastCenter && !this._moved()) {
-			return this._lastCenter;
+			return this._lastCenter.clone();
 		}
 		return this.layerPointToLatLng(this._getCenterLayerPoint());
 	},


### PR DESCRIPTION
Closes #8164 by cloning the `LatLng` object returned by `map.getCenter()` so that mutating it afterwards doesn't lead to unexpected bugs. Also fixes a `panInside` test that didn't work properly before. cc @Sillson