### PR TITLE
Fix "listener not found" warning when setting `maxBounds`

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -307,6 +307,15 @@ describe("Map", function () {
 			});
 			map.setView(center, 18, {animate: false});
 		});
+
+		it("does not try to remove listeners if it wasn't set before", function () {
+			L.tileLayer("", {minZoom: 0, maxZoom: 20}).addTo(map);
+			container.style.width = container.style.height = "500px";
+			var bounds = L.latLngBounds([51.5, -0.05], [51.55, 0.05]);
+			map.off = sinon.spy();
+			map.setMaxBounds(bounds, {animate: false});
+			expect(map.off.called).not.to.be.ok();
+		});
 	});
 
 	describe("#getMinZoom and #getMaxZoom", function () {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -449,11 +449,11 @@ export var Map = Evented.extend({
 		if (this._maxBoundsSet) {
 			this._maxBoundsSet = false;
 			this.off('moveend', this._panInsideMaxBounds);
+		}
 
-			if (!bounds.isValid()) {
-				this.options.maxBounds = null;
-				return this;
-			}
+		if (!bounds.isValid()) {
+			this.options.maxBounds = null;
+			return this;
 		}
 
 		this.options.maxBounds = bounds;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -446,11 +446,14 @@ export var Map = Evented.extend({
 	setMaxBounds: function (bounds) {
 		bounds = toLatLngBounds(bounds);
 
-		if (!bounds.isValid()) {
-			this.options.maxBounds = null;
-			return this.off('moveend', this._panInsideMaxBounds);
-		} else if (this.options.maxBounds) {
+		if (this._maxBoundsSet) {
+			this._maxBoundsSet = false;
 			this.off('moveend', this._panInsideMaxBounds);
+
+			if (!bounds.isValid()) {
+				this.options.maxBounds = null;
+				return this;
+			}
 		}
 
 		this.options.maxBounds = bounds;
@@ -459,6 +462,7 @@ export var Map = Evented.extend({
 			this._panInsideMaxBounds();
 		}
 
+		this._maxBoundsSet = true;
 		return this.on('moveend', this._panInsideMaxBounds);
 	},
 


### PR DESCRIPTION
Fixes #7951. A simpler alternative to #8161.