### PR TITLE
Remove `role="presentation"` from image tiles (HTML validation error fix)

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -154,17 +154,11 @@ export var TileLayer = GridLayer.extend({
 			tile.referrerPolicy = this.options.referrerPolicy;
 		}
 
-		/*
-		 Alt tag is set to empty string to keep screen readers from reading URL and for compliance reasons
-		 https://www.w3.org/TR/WCAG20-TECHS/H67
-		*/
+		// The alt attribute is set to the empty string,
+		// allowing screen readers to ignore the decorative image tiles.
+		// https://www.w3.org/WAI/tutorials/images/decorative/
+		// https://www.w3.org/TR/html-aria/#el-img-empty-alt
 		tile.alt = '';
-
-		/*
-		 Set role="presentation" to force screen readers to ignore this
-		 https://www.w3.org/TR/wai-aria/roles#textalternativecomputation
-		*/
-		tile.setAttribute('role', 'presentation');
 
 		tile.src = this.getTileUrl(coords);
 


### PR DESCRIPTION
Fixes https://github.com/Leaflet/Leaflet/issues/7632.

[`img` with an empty `alt` is implicitly `role="presentation"`](https://www.w3.org/TR/html-aria/#el-img-empty-alt) and it's [not clear that `role="presentation"` was ever useful](https://github.com/Leaflet/Leaflet/issues/7632#issuecomment-1088659800).

---

Side note:

I can no longer reproduce [the TalkBack issue that would potentially justify setting `aria-hidden="true"`](https://github.com/Leaflet/Leaflet/issues/7632#issuecomment-1066980024), nor can I [Get image descriptions](https://support.google.com/chrome/answer/9311597?co=GENIE.Platform%3DAndroid&oco=1) to test if TalkBack would even respect `aria-hidden="true"`. Perhaps the feature was removed from Android, or it's very well hidden and now disabled by default. I'll revisit the TalkBack issue in the future, to see if `aria-hidden="true"` is desired.