### PR TITLE
give the anchor attribute a data prefix in docs

### DIFF
--- a/docs/SlavaUkraini/docs/js/reference.js
+++ b/docs/SlavaUkraini/docs/js/reference.js
@@ -7,7 +7,7 @@ if (document.body.className.indexOf('api-page') !== -1) {
 
 		if (el.id) {
 			var anchor = document.createElement('a');
-			anchor.setAttribute('anchor', el.id);
+			anchor.setAttribute('data-anchor', el.id);
 			if (!el.children.length) {
 				// For headers, insert the anchor before.
 				el.parentNode.insertBefore(anchor, el);


### PR DESCRIPTION
Attempting to close #8137 
Changed only reference.js to include a data prefix for the attribute 'anchor' to conform with OpenUI's standardisation. No changes have been made reference.html or other files.