### PR TITLE
Fix fire same event inside of `once()`

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -532,8 +532,8 @@ describe('Events', function () {
 
 		it("doesn't call once twice", function () {
 			var obj = new L.Evented(),
-				spy = sinon.spy();
-			obj.once('test', function(){
+			spy = sinon.spy();
+			obj.once('test', function () {
 				spy();
 				obj.fire('test');
 			}, obj);

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -530,6 +530,20 @@ describe('Events', function () {
 			expect(spy.called).to.be(false);
 		});
 
+		it("doesn't call once twice", function () {
+			var obj = new L.Evented(),
+				spy = sinon.spy();
+			obj.once('test', function(){
+				spy();
+				obj.fire('test');
+			}, obj);
+
+			obj.fire('test');
+
+			expect(spy.calledOnce).to.be(true);
+		});
+
+
 		it('works if called from a context that doesnt implement #Events', function () {
 			var obj = new L.Evented(),
 			    spy = sinon.spy(),

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -192,7 +192,7 @@ export var Events = {
 					// off overwrites l.fn, so we need to copy fn to a var
 					var fn = l.fn;
 					if (l.once) {
-						this.off(type, l.fn, l.ctx);
+						this.off(type, fn, l.ctx);
 					}
 					fn.call(l.ctx || this, event);
 				}

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -95,7 +95,7 @@ export var Events = {
 	},
 
 	// attach listener (without syntactic sugar now)
-	_on: function (type, fn, context) {
+	_on: function (type, fn, context, _once) {
 		if (typeof fn !== 'function') {
 			console.warn('wrong listener type: ' + typeof fn);
 			return;
@@ -112,6 +112,9 @@ export var Events = {
 		}
 
 		var newListener = {fn: fn, ctx: context};
+		if(_once){
+			newListener.once = true;
+		}
 
 		this._events = this._events || {};
 		this._events[type] = this._events[type] || [];
@@ -182,12 +185,16 @@ export var Events = {
 
 		if (this._events) {
 			var listeners = this._events[type];
-
 			if (listeners) {
 				this._firingCount = (this._firingCount + 1) || 1;
 				for (var i = 0, len = listeners.length; i < len; i++) {
 					var l = listeners[i];
-					l.fn.call(l.ctx || this, event);
+					// off overwrites l.fn, so we need to copy fn to a var
+					var fn = l.fn;
+					if(l.once){
+						this.off.call(this, type, l.fn, l.ctx);
+					}
+					fn.call(l.ctx || this, event);
 				}
 
 				this._firingCount--;
@@ -262,23 +269,24 @@ export var Events = {
 	// Behaves as [`on(…)`](#evented-on), except the listener will only get fired once and then removed.
 	once: function (types, fn, context) {
 
+		// types can be a map of types/handlers
 		if (typeof types === 'object') {
 			for (var type in types) {
-				this.once(type, types[type], fn);
+				// we don't process space-separated events here for performance;
+				// it's a hot path since Layer uses the on(obj) syntax
+				this._on(type, types[type], fn, true);
 			}
-			return this;
+
+		} else {
+			// types can be a string of space-separated words
+			types = Util.splitWords(types);
+
+			for (var i = 0, len = types.length; i < len; i++) {
+				this._on(types[i], fn, context, true);
+			}
 		}
 
-		var handler = Util.bind(function () {
-			this
-			    .off(types, fn, context)
-			    .off(types, handler, context);
-		}, this);
-
-		// add a listener that's executed once and removed after that
-		return this
-		    .on(types, fn, context)
-		    .on(types, handler, context);
+		return this;
 	},
 
 	// @method addEventParent(obj: Evented): this

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -112,7 +112,7 @@ export var Events = {
 		}
 
 		var newListener = {fn: fn, ctx: context};
-		if(_once){
+		if (_once) {
 			newListener.once = true;
 		}
 
@@ -191,8 +191,8 @@ export var Events = {
 					var l = listeners[i];
 					// off overwrites l.fn, so we need to copy fn to a var
 					var fn = l.fn;
-					if(l.once){
-						this.off.call(this, type, l.fn, l.ctx);
+					if (l.once) {
+						this.off(type, l.fn, l.ctx);
 					}
 					fn.call(l.ctx || this, event);
 				}


### PR DESCRIPTION
If the same event is called in `once()` it ends up in a endless loop.

Now `once()` has the same logic as `on()` so it would be possible to be merged them together but then we need a new function or a 4 boolean argument in `on()` if it is `once`.


```js
var obj = new L.Evented();

obj.once('test', function(){
	console.log('Called in once function');
	obj.fire('test');
}, obj);

obj.fire('test');
```


[1.8.0 Demo](https://plnkr.co/edit/JQT7ULLm8JfSPnAi)