### PR TITLE
Shorter Bundlemon check names

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "watch": "rollup -w -c build/rollup-config.js",
     "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --source-map content=dist/leaflet-src.js.map --source-map url=leaflet.js.map --comments",
     "integrity": "NODE_ENV=release npm run build && node ./build/integrity.js",
-    "bundlemon": "bundlemon --subProject no-compression --defaultCompression none && bundlemon --subProject gzip-compression --defaultCompression gzip",
+    "bundlemon": "bundlemon --subProject js --defaultCompression none && bundlemon --subProject js-gzip --defaultCompression gzip",
     "serve": "cd docs && bundle exec jekyll serve"
   },
   "eslintConfig": {


### PR DESCRIPTION
Just making the Bundlemon check names shorter so there's more space for report text in the popup:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/25395/165530357-f5e01ffd-3825-4489-8a08-94137ef9dce0.png">

Will be beneficial after landing https://github.com/LironEr/bundlemon/pull/99.