### PR TITLE
Remove Dependabot specific labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     rebase-strategy: disabled
     schedule:
       interval: weekly
+    labels:
+      - dependencies
     ignore:
       - dependency-name: eslint-config-mourner
         update-types: ["version-update:semver-major"]
@@ -17,3 +19,5 @@ updates:
     rebase-strategy: disabled
     schedule:
       interval: weekly
+    labels:
+      - dependencies


### PR DESCRIPTION
Remove the Dependabot specific `github_actions` and `javascript` labels. See https://github.com/Leaflet/Leaflet/discussions/8018#discussioncomment-2599692