### PR TITLE
Added `aria-expanded` state with toggle feature for `leaflet-control-layers-toggle`, regarding Issue #7526

### DIFF
--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -177,7 +177,6 @@ export var Layers = Control.extend({
 
 		// makes this work on IE touch devices by stopping it from firing a mouseout event when the touch is released
 		container.setAttribute('aria-haspopup', true);
-
 		DomEvent.disableClickPropagation(container);
 		DomEvent.disableScrollPropagation(container);
 
@@ -188,6 +187,7 @@ export var Layers = Control.extend({
 		link.href = '#';
 		link.title = 'Layers';
 		link.setAttribute('role', 'button');
+
 		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
 		DomEvent.on(link, 'focus',
 			() => {
@@ -199,8 +199,14 @@ export var Layers = Control.extend({
 				keyboardFocus = false;
 			}
 		);
-		DomEvent.on(link, 'keydown', () => {
+		DomEvent.on(container, 'click', () => {
 			if (keyboardFocus) {
+				this.expand();
+				link.setAttribute('aria-expanded', 'true');
+			}
+		});
+		DomEvent.on(link, 'keydown', (e) => {
+			if (keyboardFocus && e.key === 'Enter') {
 				this.expand();
 				link.setAttribute('aria-expanded', 'true');
 			}

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -184,15 +184,34 @@ export var Layers = Control.extend({
 		var section = this._section = DomUtil.create('section', className + '-list');
 
 		var link = this._layersLink = DomUtil.create('a', className + '-toggle', container);
+		var keyboardFocus = false;
 		link.href = '#';
 		link.title = 'Layers';
 		link.setAttribute('role', 'button');
 		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
-		DomEvent.on(link, 'focus', this.expand, this);
+		DomEvent.on(link, 'focus',
+			() => {
+				keyboardFocus = true;
+			}
+			, this);
+		DomEvent.on(link, 'focusout',
+			() => {
+				keyboardFocus = false;
+			}
+		);
+		DomEvent.on(link, 'keydown', () => {
+			if (keyboardFocus) {
+				this.expand();
+				link.setAttribute('aria-expanded', 'true');
+			}
+		});
 		link.setAttribute('aria-expanded', 'false');
 
 		if (collapsed) {
-			this._map.on('click', this.collapse, this);
+			this._map.on('click', () => {
+				this.collapse();
+				link.setAttribute('aria-expanded', 'false');
+			}, this);
 
 			DomEvent.on(container, {
 				mouseenter: function () {
@@ -207,14 +226,6 @@ export var Layers = Control.extend({
 					this.collapse();
 					link.setAttribute('aria-expanded', 'false');
 				},
-				focusin: function () {
-					link.setAttribute('aria-expanded', 'true');
-				},
-				focusout: function () {
-					this.collapse();
-					link.setAttribute('aria-expanded', 'false');
-				}
-
 			}, this);
 		}
 

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -183,6 +183,14 @@ export var Layers = Control.extend({
 
 		var section = this._section = DomUtil.create('section', className + '-list');
 
+		var link = this._layersLink = DomUtil.create('a', className + '-toggle', container);
+		link.href = '#';
+		link.title = 'Layers';
+		link.setAttribute('role', 'button');
+		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
+		DomEvent.on(link, 'focus', this.expand, this);
+		link.setAttribute('aria-expanded', 'false');
+
 		if (collapsed) {
 			this._map.on('click', this.collapse, this);
 
@@ -190,21 +198,19 @@ export var Layers = Control.extend({
 				mouseenter: function () {
 					DomEvent.on(section, 'click', DomEvent.preventDefault);
 					this.expand();
+					link.setAttribute('aria-expanded', 'true');
 					setTimeout(function () {
 						DomEvent.off(section, 'click', DomEvent.preventDefault);
 					});
 				},
-				mouseleave: this.collapse
+				mouseleave: function () {
+					this.collapse();
+					link.setAttribute('aria-expanded', 'false');
+				}
 			}, this);
 		}
 
-		var link = this._layersLink = DomUtil.create('a', className + '-toggle', container);
-		link.href = '#';
-		link.title = 'Layers';
-		link.setAttribute('role', 'button');
 
-		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
-		DomEvent.on(link, 'focus', this.expand, this);
 
 		if (!collapsed) {
 			this.expand();

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -206,7 +206,15 @@ export var Layers = Control.extend({
 				mouseleave: function () {
 					this.collapse();
 					link.setAttribute('aria-expanded', 'false');
+				},
+				focusin: function () {
+					link.setAttribute('aria-expanded', 'true');
+				},
+				focusout: function () {
+					this.collapse();
+					link.setAttribute('aria-expanded', 'false');
 				}
+
 			}, this);
 		}
 


### PR DESCRIPTION
# Description

This PR adds the `aria-expanded` state to the `leaflet-control-layers-toggle`  anchor element(`<a/`). This `aria-expanded` state is toggled to `true` on mouse enter event and to `false` on the mouse leave event. 

Here is a GIF demonstrating this change:
![GIF of the `aria-expanded` attribute toggling on mouse hover](https://i.imgur.com/g2DFdk6.gif)

Fixes #7526

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Accessibility feature 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Prior to committing the `npm run lint` command was run successfully with no issues

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
