### PR TITLE
Prevent major updates of Mocha through Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: sinon
         update-types: ["version-update:semver-major"]
+      - dependency-name: mocha
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 999


### PR DESCRIPTION
Newer versions of Mocha are using syntax that is not supported by Internet Explorer and thus breaks our tests. This change will prevent Dependabot from offering up major updates to this dependency.

More information can be found under https://github.com/Leaflet/Leaflet/pull/8204#issuecomment-1114878906 and https://github.com/mochajs/mocha/pull/4848