### PR TITLE
Update CSS `color-adjust` to `print-color-adjust`

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -655,6 +655,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	/* Prevent printers from removing background-images of controls. */
 	.leaflet-control {
 		-webkit-print-color-adjust: exact;
-		color-adjust: exact;
+		print-color-adjust: exact;
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/Leaflet/Leaflet/issues/8210.

Strange to see MDN simply redirect [`color-adjust`](https://developer.mozilla.org/en-US/docs/web/css/color-adjust) to [`print-color-adjust`](https://developer.mozilla.org/en-US/docs/web/css/print-color-adjust), no worries for backwards-compatibility I suppose. Anyway, even if there are differences in support between the two, for Leaflet this isn't any critical CSS, just an enhancement (https://github.com/Leaflet/Leaflet/pull/7851).