### PR TITLE
DomEvent.DoubleTap ignores clicks on <label>s

### DIFF
--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -1,3 +1,5 @@
+import * as DomEvent from './DomEvent';
+
 /*
  * Extends the event handling code with double tap support for mobile browsers.
  *
@@ -49,20 +51,18 @@ export function addDoubleTapListener(obj, handler) {
 		// This ignores clicks on elements which are a label with a 'for'
 		// attribute (or children of such a label), but not children of
 		// a <input>.
-		if (e.composedPath) {
-			var path = e.composedPath();
-			if (path.some(function (el) {
-				return el instanceof HTMLLabelElement && el.attributes.for;
-			}) &&
-				!path.some(function (el) {
-					return (
-						el instanceof HTMLInputElement ||
-						el instanceof HTMLSelectElement
-					);
-				})
-			) {
-				return;
-			}
+		var path = DomEvent.getPropagationPath(e);
+		if (path.some(function (el) {
+			return el instanceof HTMLLabelElement && el.attributes.for;
+		}) &&
+			!path.some(function (el) {
+				return (
+					el instanceof HTMLInputElement ||
+					el instanceof HTMLSelectElement
+				);
+			})
+		) {
+			return;
 		}
 
 		var now = Date.now();

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -44,6 +44,27 @@ export function addDoubleTapListener(obj, handler) {
 			return;
 		}
 
+		// When clicking on an <input>, the browser generates a click on its
+		// <label> (and vice versa) triggering two clicks in quick succession.
+		// This ignores clicks on elements which are a label with a 'ref'
+		// attribute (or children of such a label), but not children of
+		// a <input>.
+		if (e.composedPath) {
+			var path = e.composedPath();
+			if (path.some(function (el) {
+				return el instanceof HTMLLabelElement && el.attributes.ref;
+			}) &&
+				!path.some(function (el) {
+					return (
+						el instanceof HTMLInputElement ||
+						el instanceof HTMLSelectElement
+					);
+				})
+			) {
+				return;
+			}
+		}
+
 		var now = Date.now();
 		if (now - last <= delay) {
 			detail++;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -46,13 +46,13 @@ export function addDoubleTapListener(obj, handler) {
 
 		// When clicking on an <input>, the browser generates a click on its
 		// <label> (and vice versa) triggering two clicks in quick succession.
-		// This ignores clicks on elements which are a label with a 'ref'
+		// This ignores clicks on elements which are a label with a 'for'
 		// attribute (or children of such a label), but not children of
 		// a <input>.
 		if (e.composedPath) {
 			var path = e.composedPath();
 			if (path.some(function (el) {
-				return el instanceof HTMLLabelElement && el.attributes.ref;
+				return el instanceof HTMLLabelElement && el.attributes.for;
 			}) &&
 				!path.some(function (el) {
 					return (

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -224,6 +224,26 @@ export function stop(e) {
 	return this;
 }
 
+// @function getPropagationPath(ev: DOMEvent): Array
+// Compatibility polyfill for [`Event.composedPath()`](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath).
+// Returns an array containing the `HTMLElement`s that the given DOM event
+// should propagate to (if not stopped).
+export function getPropagationPath(ev) {
+	if (ev.composedPath) {
+		return ev.composedPath();
+	}
+
+	var path = [];
+	var el = ev.target;
+
+	while (el) {
+		path.push(el);
+		el = el.parentNode;
+	}
+	return path;
+}
+
+
 // @function getMousePosition(ev: DOMEvent, container?: HTMLElement): Point
 // Gets normalized mouse position from a DOM event relative to the
 // `container` (border excluded) or to the whole page if not specified.


### PR DESCRIPTION
Fixes #8225.

When clicking on a `<label>` linked to an `<input>` (or vice versa), browsers trigger an extra click on the related element, as per https://html.spec.whatwg.org/multipage/forms.html#the-label-element . This causes the `DomEvent.DoubleTap.js` logic to activate, and fire a ghost `dblclick` event.

So after sleeping on the problem, I found what should be a reliable approach: if the problem is the extra clicks that browsers introduce on `<label>`s... ignore those! Get the propagation path of the event, and check if:
- The event happened on a `<label>`, or on a child of a `<label>`
- The `<label>` has a `for` attribute (thus ignoring standalone labels and nested labels)
- The event is not happening on an `<input>` or child of an `<input>` (which means a nested label)

I think this approach is sound, but I haven't tested it extensively (or, to be honest, at all). I'm assuming that browsers do *not* trigger an extra click when the `<input>` is nested within a `<label>`, but I might be wrong about that.

Do note that `composedPath` is not implemented by all browsers (hence the `if (e.composedPath)` branch), so... (*checks notes*)... IE, Edge<74 and Safari<=9 would still display the buggy behaviour of #8225.

cc @pgrondelaers