### PR TITLE
Correct heading level in GeoJSON tutorial

### DIFF
--- a/docs/examples/geojson/index.md
+++ b/docs/examples/geojson/index.md
@@ -3,7 +3,7 @@ layout: tutorial_v2
 title: Using GeoJSON with Leaflet
 ---
 
-<h3>Using GeoJSON with Leaflet</h3>
+<h2>Using GeoJSON with Leaflet</h2>
 
 <p>GeoJSON is a very popular data format among many GIS technologies and services — it's simple, lightweight, straightforward, and Leaflet is quite good at handling it. In this example, you'll learn how to create and interact with map vectors created from <a href="https://tools.ietf.org/html/rfc7946">GeoJSON</a> objects.</p>
 


### PR DESCRIPTION
Before:

![h3](https://user-images.githubusercontent.com/26493779/167801467-5a709f94-cac5-4417-9cf2-e17d333580e1.png)

After:

![h2](https://user-images.githubusercontent.com/26493779/167801480-540f922f-b942-4450-8a96-ace9ec338c37.png)

