### PR TITLE
Remove "listener not found" warning

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -165,9 +165,7 @@ export var Events = {
 				this._events[type] = listeners = listeners.slice();
 			}
 			listeners.splice(index, 1);
-			return;
 		}
-		console.warn('listener not found');
 	},
 
 	// @method fire(type: String, data?: Object, propagate?: Boolean): this


### PR DESCRIPTION
The warning has no benefit but causes a lot of reported issues in plugins where many of them are not supported anymore.

- Leaflet: #8216, #7951, #8166
- https://github.com/geoman-io/leaflet-geoman/issues/1160
- https://github.com/CliffCloud/Leaflet.Sleep/issues/34