### PR TITLE
fix inconsistency when pressing escape to close popup (#6551)

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -369,6 +369,7 @@ Layer.include({
 			this.on({
 				click: this._openPopup,
 				keypress: this._onKeyPress,
+				keydown: this._onKeyDown,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -385,6 +386,7 @@ Layer.include({
 			this.off({
 				click: this._openPopup,
 				keypress: this._onKeyPress,
+				keydown: this._onKeyDown,
 				remove: this.closePopup,
 				move: this._movePopup
 			});
@@ -472,6 +474,12 @@ Layer.include({
 	_onKeyPress: function (e) {
 		if (e.originalEvent.keyCode === 13) {
 			this._openPopup(e);
+		}
+	},
+
+	_onKeyDown: function (e) {
+		if (e.originalEvent.keyCode === 27) {
+			this.closePopup(e);
 		}
 	}
 });


### PR DESCRIPTION
Modified the Popup class's Layer to include a keydown eventListener to close the popup upon esc keydown

fix for issue #6551