### PR TITLE
Tooltip accessibility improvements: focus and voice over

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -286,8 +286,7 @@ describe('Tooltip', function () {
 		expect(group._tooltip._container.innerHTML).to.be("I'm marker 1.");
 
 		// toggle popup on marker2
-		// happen.mouseover(marker2._icon, {relatedTarget: map._container});
-		happen.once(marker2._icon, {type: 'focus'});
+		happen.mouseover(marker2._icon, {relatedTarget: map._container});
 		expect(map.hasLayer(group._tooltip)).to.be(true);
 		expect(group._tooltip._container.innerHTML).to.be("I'm marker 2.");
 	});

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -25,6 +25,89 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(layer._tooltip)).to.be(false);
 	});
 
+	it("opens on marker focus and closes on blur", function () {
+		var layer = L.marker(center).addTo(map);
+
+		layer.bindTooltip('Tooltip');
+
+		var element = layer.getElement();
+
+		happen.once(element, {type:'focus'});
+
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+
+		happen.once(element, {type:'blur'});
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+	});
+
+	it("opens on marker focus and closes on blur when first bound, then added to map", function () {
+		var layer = L.marker(center);
+
+		layer.bindTooltip('Tooltip').addTo(map);
+
+		var element = layer.getElement();
+
+		happen.once(element, {type:'focus'});
+
+		expect(map.hasLayer(layer._tooltip)).to.be(true);
+
+		happen.once(element, {type:'blur'});
+		expect(map.hasLayer(layer._tooltip)).to.be(false);
+	});
+
+	it("opens on marker focus and closes on blur in layer group", function () {
+		var marker1 = L.marker([41.18, 9.45], {description: 'Marker 1'});
+		var marker2 = L.marker([41.18, 9.46], {description: 'Marker 2'});
+		var group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+		group.bindTooltip(function (layer) {
+			return 'Group tooltip: ' + layer.options.description;
+		});
+
+		var element1 = marker1.getElement();
+		var element2 = marker2.getElement();
+
+		happen.once(element1, {type:'focus'});
+
+		expect(map.hasLayer(group._tooltip)).to.be(true);
+		expect(group._tooltip._container.innerHTML).to.be("Group tooltip: Marker 1");
+
+		happen.once(element1, {type:'blur'});
+		expect(map.hasLayer(group._tooltip)).to.be(false);
+
+		happen.once(element2, {type:'focus'});
+
+		expect(map.hasLayer(group._tooltip)).to.be(true);
+		expect(group._tooltip._container.innerHTML).to.be("Group tooltip: Marker 2");
+
+		happen.once(element2, {type:'blur'});
+		expect(map.hasLayer(group._tooltip)).to.be(false);
+	});
+
+	it("points in aria-describedby to bound element", function () {
+		var layer = L.marker(center).addTo(map);
+
+		layer.bindTooltip('Tooltip');
+		var element = layer.getElement();
+
+		happen.once(element, {type:'focus'});
+
+		var tooltip = layer.getTooltip();
+		expect(element.getAttribute('aria-describedby')).to.equal(tooltip._container.id);
+	});
+
+	it("points in aria-describedby to bound elements in layer group", function () {
+		var layer = L.marker(center).addTo(map);
+
+		layer.bindTooltip('Tooltip');
+		var element = layer.getElement();
+
+		happen.once(element, {type:'focus'});
+
+		var tooltip = layer.getTooltip();
+		expect(element.getAttribute('aria-describedby')).to.equal(tooltip._container.id);
+
+	});
+
 	it("stays open on marker when permanent", function () {
 		var layer = L.marker(center).addTo(map);
 
@@ -203,7 +286,8 @@ describe('Tooltip', function () {
 		expect(group._tooltip._container.innerHTML).to.be("I'm marker 1.");
 
 		// toggle popup on marker2
-		happen.mouseover(marker2._icon, {relatedTarget: map._container});
+		// happen.mouseover(marker2._icon, {relatedTarget: map._container});
+		happen.once(marker2._icon, {type: 'focus'});
 		expect(map.hasLayer(group._tooltip)).to.be(true);
 		expect(group._tooltip._container.innerHTML).to.be("I'm marker 2.");
 	});

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -83,7 +83,7 @@ describe('Tooltip', function () {
 		expect(map.hasLayer(group._tooltip)).to.be(false);
 	});
 
-	it("points in aria-describedby to bound element", function () {
+	it("is mentioned in aria-describedby of a bound layer", function () {
 		var layer = L.marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
@@ -95,15 +95,19 @@ describe('Tooltip', function () {
 		expect(element.getAttribute('aria-describedby')).to.equal(tooltip._container.id);
 	});
 
-	it("points in aria-describedby to bound elements in layer group", function () {
-		var layer = L.marker(center).addTo(map);
+	it("is mentioned in aria-describedby of a bound layer group", function () {
+		var marker1 = L.marker([41.18, 9.45], {description: 'Marker 1'});
+		var marker2 = L.marker([41.18, 9.46], {description: 'Marker 2'});
+		var group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+		group.bindTooltip(function (layer) {
+			return 'Group tooltip: ' + layer.options.description;
+		});
 
-		layer.bindTooltip('Tooltip');
-		var element = layer.getElement();
+		var element = marker2.getElement();
 
 		happen.once(element, {type:'focus'});
 
-		var tooltip = layer.getTooltip();
+		var tooltip = group.getTooltip();
 		expect(element.getAttribute('aria-describedby')).to.equal(tooltip._container.id);
 
 	});

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -305,21 +305,18 @@ Layer.include({
 
 	_addFocusHooks: function () {
 		if (this.getElement) {
-			this._addListenersOnLayer(this);
+			this._addFocusListenersOnLayer(this);
 		} else if (this.eachLayer) {
-			this.eachLayer(this._addListenersOnLayer.bind(this));
+			this.eachLayer(this._addFocusListenersOnLayer.bind(this));
 		}
 	},
 
-	_addListenersOnLayer: function (layer) {
-		DomEvent.on(layer.getElement(), 'focus', () => this._openTooltipWithExplicitSource(layer));
+	_addFocusListenersOnLayer: function (layer) {
+		DomEvent.on(layer.getElement(), 'focus', () => {
+			this._tooltip._source = layer;
+			this.openTooltip();
+		});
 		DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
-	},
-
-	// since the focus event comes from an HTML Element and does not have .layer or .map downstream, we have to explicitly set _source to the leaflet class here.
-	_openTooltipWithExplicitSource: function (layer) {
-		this._tooltip._source = layer;
-		this.openTooltip();
 	},
 
 	// @method openTooltip(latlng?: LatLng): this

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -289,9 +289,9 @@ Layer.include({
 			events.mouseout = this.closeTooltip;
 			events.click = this._openTooltip;
 			if (this._map) {
-				this._addFocusHooks();
+				this._addFocusListeners();
 			} else {
-				events.add = this._addFocusHooks;
+				events.add = this._addFocusListeners;
 			}
 		} else {
 			events.add = this._openTooltip;
@@ -357,7 +357,7 @@ Layer.include({
 		return this._tooltip;
 	},
 
-	_addFocusHooks: function () {
+	_addFocusListeners: function () {
 		if (this.getElement) {
 			this._addFocusListenersOnLayer(this);
 		} else if (this.eachLayer) {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -118,8 +118,8 @@ export var Tooltip = DivOverlay.extend({
 
 		this._contentNode = this._container = DomUtil.create('div', className);
 
-		this._container.role = 'tooltip';
-		this._container.setAttribute('id', 'tooltip-' + Util.stamp(this));
+		this._container.setAttribute('role', 'tooltip');
+		this._container.setAttribute('id', 'leaflet-tooltip-' + Util.stamp(this));
 	},
 
 	_updateLayout: function () {},
@@ -366,10 +366,10 @@ Layer.include({
 	},
 
 	_addFocusListenersOnLayer: function (layer) {
-		DomEvent.on(layer.getElement(), 'focus', () => {
+		DomEvent.on(layer.getElement(), 'focus', function () {
 			this._tooltip._source = layer;
 			this.openTooltip();
-		});
+		}, this);
 		DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
 	},
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -303,22 +303,6 @@ Layer.include({
 		this._tooltipHandlersAdded = !remove;
 	},
 
-	_addFocusHooks: function () {
-		if (this.getElement) {
-			this._addFocusListenersOnLayer(this);
-		} else if (this.eachLayer) {
-			this.eachLayer(this._addFocusListenersOnLayer.bind(this));
-		}
-	},
-
-	_addFocusListenersOnLayer: function (layer) {
-		DomEvent.on(layer.getElement(), 'focus', () => {
-			this._tooltip._source = layer;
-			this.openTooltip();
-		});
-		DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
-	},
-
 	// @method openTooltip(latlng?: LatLng): this
 	// Opens the bound tooltip at the specified `latlng` or at the default tooltip anchor if no `latlng` is passed.
 	openTooltip: function (latlng) {
@@ -327,11 +311,9 @@ Layer.include({
 			this._tooltip.openOn(this._map);
 
 			if (this.getElement) {
-				this.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
+				this._setAriaDescribedByOnLayer(this);
 			} else if (this.eachLayer) {
-				this.eachLayer(function (layer) {
-					layer.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
-				}, this);
+				this.eachLayer(this._setAriaDescribedByOnLayer, this);
 			}
 		}
 		return this;
@@ -374,6 +356,27 @@ Layer.include({
 	getTooltip: function () {
 		return this._tooltip;
 	},
+
+	_addFocusHooks: function () {
+		if (this.getElement) {
+			this._addFocusListenersOnLayer(this);
+		} else if (this.eachLayer) {
+			this.eachLayer(this._addFocusListenersOnLayer, this);
+		}
+	},
+
+	_addFocusListenersOnLayer: function (layer) {
+		DomEvent.on(layer.getElement(), 'focus', () => {
+			this._tooltip._source = layer;
+			this.openTooltip();
+		});
+		DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
+	},
+
+	_setAriaDescribedByOnLayer: function (layer) {
+		layer.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
+	},
+
 
 	_openTooltip: function (e) {
 		if (!this._tooltip || !this._map || (this._map.dragging && this._map.dragging.moving())) {


### PR DESCRIPTION
This PR addresses #8111 & #8112.

I've used the approach described in mentioned issues. I had to add logic for checking if the layer we're working with is a single `Layer` (one Marker, Polygon, etc.) or a `LayerGroup` (e.g., a group of Markers).

Changes include:
1. The layer a tooltip is bound to now has an `aria-describedby` attribute
2. Every tooltip has an id to accommodate the change above
3. Tooltips are open when acquiring focus and close on blur

Here is a before/after demo on a `debug/map/tooltip.html` with Voice Over narration visible:
<details><summary>Before</summary>
<img src="https://user-images.githubusercontent.com/982323/168687065-3a47a282-0398-4dbb-9788-0bb1013970e4.gif" />
</details>

<details><summary>After</summary>
<img src="https://user-images.githubusercontent.com/982323/168687070-81ca383f-ae25-4ed0-a6cd-6da3ec2ab85e.gif" />
</details>
