### PR TITLE
Marker accessibility: conditional `role="button"` and `aria-expanded`

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -69,7 +69,7 @@ describe('Popup', function () {
 		map.addLayer(marker);
 
 		marker.bindPopup('Popup1');
-		var element = marker.getElement()
+		var element = marker.getElement();
 		expect(element.getAttribute('aria-expanded')).to.be('false');
 
 		// toggle open popup
@@ -84,7 +84,7 @@ describe('Popup', function () {
 	it("changes the role of a marker to button", function () {
 		var marker = L.marker(center);
 		map.addLayer(marker);
-		var element = marker.getElement()
+		var element = marker.getElement();
 		expect(element.getAttribute('role')).to.be('img');
 
 		marker.bindPopup('Popup1');

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -64,6 +64,33 @@ describe('Popup', function () {
 		expect(map.hasLayer(marker._popup)).to.be(false);
 	});
 
+	it("reflects its visibility when marker is clicked in aria-expanded", function () {
+		var marker = L.marker(center);
+		map.addLayer(marker);
+
+		marker.bindPopup('Popup1');
+		var element = marker.getElement()
+		expect(element.getAttribute('aria-expanded')).to.be('false');
+
+		// toggle open popup
+		happen.click(marker._icon);
+		expect(element.getAttribute('aria-expanded')).to.be('true');
+
+		// toggle close popup
+		happen.click(marker._icon);
+		expect(element.getAttribute('aria-expanded')).to.be('false');
+	});
+
+	it("changes the role of a marker to button", function () {
+		var marker = L.marker(center);
+		map.addLayer(marker);
+		var element = marker.getElement()
+		expect(element.getAttribute('role')).to.be('img');
+
+		marker.bindPopup('Popup1');
+		expect(element.getAttribute('role')).to.be('button');
+	});
+
 	it("it should use a popup with a function as content with a FeatureGroup", function () {
 		var marker1 = L.marker(center);
 		var marker2 = L.marker([54.6, 38.2]);

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -1,6 +1,7 @@
 import {DivOverlay} from './DivOverlay';
 import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
+import * as Util from '../core/Util';
 import {Point, toPoint} from '../geometry/Point';
 import {Map} from '../map/Map';
 import {Layer} from './Layer';
@@ -370,8 +371,15 @@ Layer.include({
 				click: this._openPopup,
 				keypress: this._onKeyPress,
 				remove: this.closePopup,
-				move: this._movePopup
+				move: this._movePopup,
+				popupopen: Util.bind(this._setAriaExpanded, this, true),
+				popupclose: Util.bind(this._setAriaExpanded, this, false),
 			});
+			if (this._map) {
+				this._setAccessibilityDefaults();
+			} else {
+				this._popup.on('add', this._setAccessibilityDefaults, this);
+			}
 			this._popupHandlersAdded = true;
 		}
 
@@ -386,7 +394,9 @@ Layer.include({
 				click: this._openPopup,
 				keypress: this._onKeyPress,
 				remove: this.closePopup,
-				move: this._movePopup
+				move: this._movePopup,
+				popupopen: Util.bind(this._setAriaExpanded, this, true),
+				popupclose: Util.bind(this._setAriaExpanded, this, false),
 			});
 			this._popupHandlersAdded = false;
 			this._popup = null;
@@ -441,6 +451,18 @@ Layer.include({
 	// Returns the popup bound to this layer.
 	getPopup: function () {
 		return this._popup;
+	},
+
+	_setAccessibilityDefaults: function () {
+		if (this.getElement) {
+			var element = this.getElement();
+			element.setAttribute('role', 'button');
+			element.setAttribute('aria-expanded', false);
+		}
+	},
+
+	_setAriaExpanded: function (state) {
+		this.getElement && this.getElement() && this.getElement().setAttribute('aria-expanded', state);
 	},
 
 	_openPopup: function (e) {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -235,7 +235,7 @@ export var Marker = Layer.extend({
 
 		if (options.keyboard) {
 			icon.tabIndex = '0';
-			icon.setAttribute('role', 'button');
+			icon.setAttribute('role', 'img');
 		}
 
 		this._icon = icon;


### PR DESCRIPTION
- Fixes #8116
- Fixes #7527

**Changes include:**
- Marker has default `role` of `img` as a non-interactive element.
- When Popup is bound, it sets the `role` of the element to `button`
- When Popup is bound, it reflects its state (open/close) in the `aria-expanded` attribute of the bound element (as true/false)

**Demo**
<details><summary>Demo</summary>
<img src="https://user-images.githubusercontent.com/982323/169100590-8615b7ef-7b50-4020-9df0-8adc515fc40e.gif" />
</details>

**Discussion points**
Both issues mentioned discuss Marker/Popup interaction specifically, but changes made here are on the layer level. This part is controversial since I am not sure if this is the responsibility of a Popup or a Marker. I am open to discussion and feedback here. The main problem I see here is that the behavior will work for some Layers and not others.

**Alternative**
The alternative implementation I see is to move this code to Marker and add Popup events for bind/unbind marker can react to. This way, the behavior will work only for Marker/Popup interaction and be more explicit.

Please let me know what you think in the comments.

