### PR TITLE
Accessibility: make vector focusable

### DIFF
--- a/debug/vector/simple-canvas-svg.html
+++ b/debug/vector/simple-canvas-svg.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<link rel="stylesheet" href="../css/mobile.css" />
+
+	<script src="../../dist/leaflet-src.js"></script>
+</head>
+<body>
+	<h1>SVG</h1>
+	<div id="svg-map" style="height: 40%"></div>
+	<h1>Canvas</h1>
+	<div id="canvas-map" style="height: 40%"></div>
+
+
+	<script>
+		var map1 = L.map('svg-map');
+		var map2 = L.map('canvas-map', {preferCanvas: true});
+
+		function populateMap(map) {
+			map.setView([51.505, -0.09], 13);
+
+			var marker = L.marker([51.5, -0.09])
+				.bindPopup("<b>Hello world!</b><br />I am a popup.")
+				.addTo(map);
+
+			var circle = L.circle([51.508, -0.11], 500, {color: '#f03', opacity: 0.7})
+				.bindPopup("I am a circle.")
+				.addTo(map);
+
+			var polygon = L.polygon([
+				[51.509, -0.08],
+				[51.503, -0.06],
+				[51.51,  -0.047]])
+				.bindPopup("I am a polygon.")
+				.addTo(map);
+
+			var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+				osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+				osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}).addTo(map);
+		}
+
+		populateMap(map1);
+		populateMap(map2);
+	</script>
+</body>
+</html>

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -138,6 +138,13 @@ export var Canvas = Renderer.extend({
 	_initPath: function (layer) {
 		this._updateDashArray(layer);
 		this._layers[Util.stamp(layer)] = layer;
+		if (layer.options.keyboard) {
+			layer._path = DomUtil.create('div', 'leaflet-canvas-shadow-path', this._container);
+			layer._path.tabIndex = '0';
+			layer._path.setAttribute('role', 'img');
+			DomEvent.on(layer._path, 'focus', this._redraw, this);
+			DomEvent.on(layer._path, 'blur', this._redraw, this);
+		}
 
 		var order = layer._order = {
 			layer: layer,
@@ -269,6 +276,7 @@ export var Canvas = Renderer.extend({
 			layer = order.layer;
 			if (!bounds || (layer._pxBounds && layer._pxBounds.intersects(bounds))) {
 				layer._updatePath();
+				this._ctx.drawFocusIfNeeded(layer._path);
 			}
 		}
 

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -71,7 +71,11 @@ export var Path = Layer.extend({
 		// @option bubblingMouseEvents: Boolean = true
 		// When `true`, a mouse event on this path will trigger the same event on the map
 		// (unless [`L.DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-		bubblingMouseEvents: true
+		bubblingMouseEvents: true,
+
+		// @option keyboard: Boolean = true
+		// Whether the marker can be tabbed to with a keyboard and clicked by pressing enter.
+		keyboard: true
 	},
 
 	beforeAdd: function (map) {

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -104,6 +104,11 @@ export var SVG = Renderer.extend({
 			DomUtil.addClass(path, 'leaflet-interactive');
 		}
 
+		if (layer.options.keyboard) {
+			path.tabIndex = '0';
+			path.setAttribute('role', 'img');
+		}
+
 		this._updateStyle(layer);
 		this._layers[stamp(layer)] = layer;
 	},


### PR DESCRIPTION
This PR addresses #7822
This is my initial attempt that is working. It should also play nice with #8250, but additional testing is needed. 

**Changes include**:
- Vectors rendered in SVG have `role` set to `img` and `tabIndex` to be focusable by keyboard
- Vectors rendered in Canvas have "shadow" elements for each. Shadow elements have a role set to `img` and `tabIndex,` making them focusable by a keyboard. When the shadow element is focused, `redraw` is called, and the tied canvas element is outlined.
- `Path` class has new option `keyboard` with default `true` similar to `Marker`
- New page in the debug that renders the same simple map with both SVG and Canvas (see on the demo)

**Areas of improvement**
- Popups do not open with keyboard in Canvas but work in SVG

**Demo**
<details><summary>Demo</summary>
<img src="https://user-images.githubusercontent.com/982323/169148139-8f287013-d2c2-4074-b265-fef096a6d692.gif" />
</details>

**Possible discussion**
I tied canvas shadow elements to `layer._path`. `layer._path` is already used in SVG to store the actual path element and is returned by Path's `getElement.` On one hand., using `_path` is confusing. Still, it allows us to utilize changes for popup interaction that rely on `getElement` in #8250. I'll be happy to hear different opinions on the matter.
