### PR TITLE
Remove old DOCS-TODO.md reference

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-exclude: [build, debug, node_modules, spec, src, CNAME, reference-tpl.html, CHANGELOG.md, README.md, LICENSE, DOCS-TODO.md]
+exclude: [build, debug, node_modules, spec, src, CNAME, reference-tpl.html, CHANGELOG.md, README.md, LICENSE]
 
 markdown: kramdown
 


### PR DESCRIPTION
There used to be a [DOCS-TODO.md](https://github.com/Leaflet/Leaflet/commit/4d776737ab7886f3f9e825c4083ddb54ab5d5003), not anymore.