### PR TITLE
Remove Internet Explorer from test framework

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,7 @@ env:
   NODE_VERSION: 16
 jobs:
   setup:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-2019]
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -40,10 +37,7 @@ jobs:
 
   build:
     needs: setup
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-2019]
+    runs-on: ubuntu-latest
     steps:
       - name: Restore setup
         uses: actions/cache@v3
@@ -135,7 +129,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -143,10 +137,6 @@ jobs:
           - browser: Chrome1280x1024
           - browser: FirefoxTouch
           - browser: FirefoxNoTouch
-          - browser: IE
-            os: windows-2019
-          - browser: IE10
-            os: windows-2019
     steps:
       - name: Restore build
         uses: actions/cache@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "karma-edge-launcher": "^0.4.2",
         "karma-expect": "^1.1.3",
         "karma-firefox-launcher": "^2.1.2",
-        "karma-ie-launcher": "^1.0.0",
         "karma-mocha": "^2.0.1",
         "karma-rollup-preprocessor": "^7.0.8",
         "karma-safari-launcher": "~1.0.0",
@@ -2455,18 +2454,6 @@
       "dependencies": {
         "is-wsl": "^2.2.0",
         "which": "^2.0.1"
-      }
-    },
-    "node_modules/karma-ie-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz",
-      "integrity": "sha512-ts71ke8pHvw6qdRtq0+7VY3ANLoZuUNNkA8abRaWV13QRPNm7TtSOqyszjHUtuwOWKcsSz4tbUtrNICrQC+SXQ==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.6.1"
-      },
-      "peerDependencies": {
-        "karma": ">=0.9"
       }
     },
     "node_modules/karma-mocha": {
@@ -6543,15 +6530,6 @@
       "requires": {
         "is-wsl": "^2.2.0",
         "which": "^2.0.1"
-      }
-    },
-    "karma-ie-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-ie-launcher/-/karma-ie-launcher-1.0.0.tgz",
-      "integrity": "sha512-ts71ke8pHvw6qdRtq0+7VY3ANLoZuUNNkA8abRaWV13QRPNm7TtSOqyszjHUtuwOWKcsSz4tbUtrNICrQC+SXQ==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.6.1"
       }
     },
     "karma-mocha": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "karma-edge-launcher": "^0.4.2",
     "karma-expect": "^1.1.3",
     "karma-firefox-launcher": "^2.1.2",
-    "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^2.0.1",
     "karma-rollup-preprocessor": "^7.0.8",
     "karma-safari-launcher": "~1.0.0",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -31,7 +31,6 @@ module.exports = function (config) {
 			'karma-sinon',
 			'karma-expect',
 			'karma-edge-launcher',
-			'karma-ie-launcher',
 			'karma-chrome-launcher',
 			'karma-safari-launcher',
 			'karma-firefox-launcher'],
@@ -104,10 +103,6 @@ module.exports = function (config) {
 					'dom.w3c_touch_events.enabled': 0
 				}
 			},
-			IE10: {
-				base: 'IE',
-				'x-ua-compatible': 'IE=EmulateIE10'
-			}
 		},
 
 		concurrency: 1,


### PR DESCRIPTION
Since we've decided to drop support for Internet Explorer (#6136) in v2 it makes sense to remove it from our test framework.