### PR TITLE
website: ensure no borders on dialog iframe

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -1119,7 +1119,7 @@ iframe[src*='youtube.com'] {
 	border-radius: 10px;
 }
 
-/** Begin Slava Ukraini Dialog **/
+/** Begin site dialog **/
 #dialog {
 	position: fixed;
 	width: 100%;
@@ -1151,6 +1151,7 @@ https://css-tricks.com/a-css-approach-to-trap-focus-inside-of-an-element/
 #dialog iframe {
 	width: 100%;
 	height: 100%;
+	border: 0;
 }
 
 .overflowHidden {
@@ -1182,4 +1183,4 @@ blockquote {
 	font-style: italic;
 }
 
-/** End Slava Ukraini Dialog **/
+/** End site dialog **/


### PR DESCRIPTION
[`wms.html`](https://leafletjs.com/examples/wms/wms.html) for example, uses the generic `iframe` CSS selector, which applies a border to the dialog's iframe:

![iframe-border](https://user-images.githubusercontent.com/26493779/174446066-6415131a-9ede-425c-abf1-d0cd70f812c0.png)

Explicitly setting `border: 0` to the dialog's iframe to override this.
