### PR TITLE
Fix 2 step mouse wheel scrolling

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -169,6 +169,13 @@ var vml = !svg && (function () {
 	}
 }());
 
+
+// @property mac: Boolean; `true` when the browser is running in a Mac platform
+var mac = navigator.platform.indexOf('Mac') === 0;
+
+// @property mac: Boolean; `true` when the browser is running in a Linux platform
+var linux = navigator.platform.indexOf('Linux') === 0;
+
 function userAgentContains(str) {
 	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
 }
@@ -207,5 +214,7 @@ export default {
 	canvas: canvas,
 	svg: svg,
 	vml: vml,
-	inlineSvg: inlineSvg
+	inlineSvg: inlineSvg,
+	mac: mac,
+	linux: linux
 };

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -263,8 +263,9 @@ export function getMousePosition(e, container) {
 	);
 }
 
-// OSX (Mac), Safari and Chrome on Linux scrolls double the pixels as in other platforms (see #7403 and #4538),
-// for all other Browsers we need double the scroll pixels by our self
+
+// For all Browsers except OSX (Mac), Safari and Chrome on Linux
+// we need double the scroll pixels (see #7403 and #4538)
 var wheelPxFactor =
 	(Browser.mac || Browser.safari || (Browser.linux && Browser.chrome)) ? window.devicePixelRatio :
 	window.devicePixelRatio > 0 ? 2 * window.devicePixelRatio : 1;

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -264,12 +264,14 @@ export function getMousePosition(e, container) {
 }
 
 
-// For all Browsers except OSX (Mac), Safari and Chrome on Linux
-// we need double the scroll pixels (see #7403 and #4538)
-var wheelPxFactor =
-	(Browser.mac || Browser.safari || (Browser.linux && Browser.chrome)) ? window.devicePixelRatio :
-	window.devicePixelRatio > 0 ? 2 * window.devicePixelRatio : 1;
+//  except , Safari and
+// We need double the scroll pixels (see #7403 and #4538) for all Browsers
+// except OSX (Mac) -> 3x, Chrome running on Linux 1x
 
+var wheelPxFactor =
+	(Browser.linux && Browser.chrome) ? window.devicePixelRatio :
+	Browser.mac ? window.devicePixelRatio * 3 :
+	window.devicePixelRatio > 0 ? 2 * window.devicePixelRatio : 1;
 // @function getWheelDelta(ev: DOMEvent): Number
 // Gets normalized wheel delta from a wheel DOM event, in vertical
 // pixels scrolled (negative if scrolling down).

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -263,11 +263,11 @@ export function getMousePosition(e, container) {
 	);
 }
 
-// Chrome on Win scrolls double the pixels as in other platforms (see #4538),
-// and Firefox scrolls device pixels, not CSS pixels
+// OSX (Mac), Safari and Chrome on Linux scrolls double the pixels as in other platforms (see #7403 and #4538),
+// for all other Browsers we need double the scroll pixels by our self
 var wheelPxFactor =
-	(Browser.win && Browser.chrome) ? 2 * window.devicePixelRatio :
-	Browser.gecko ? window.devicePixelRatio : 1;
+	(Browser.mac || Browser.safari || (Browser.linux && Browser.chrome)) ? window.devicePixelRatio :
+	window.devicePixelRatio > 0 ? 2 * window.devicePixelRatio : 1;
 
 // @function getWheelDelta(ev: DOMEvent): Number
 // Gets normalized wheel delta from a wheel DOM event, in vertical


### PR DESCRIPTION
We compared different Browsers (https://github.com/Leaflet/Leaflet/issues/7403#issuecomment-1101669097) and it shows us that all other Browsers than OSX(Mac), Safari, and Chrome on Linux have a double deltaX value. So we need for this Browsers `2 * devicePixelRatio`.

Fix: #7403, Close #7477.

We need to check if every Browser works fine:

- [x] **Win 10**
  - [x] Firefox (@Falke-Design, @KommX, @jinchun-wang)
  - [x] Chrome (@Falke-Design, @jinchun-wang)
  - [x] Edge (@Falke-Design, @jinchun-wang)
- [x] **Win 11**
  - [x] Firefox (@jinchun-wang)
  - [x] Chrome (@jinchun-wang)
  - [x] Edge (@jinchun-wang)
- [x] **Linux**
  - [x] Firefox (@zdila, @paulatthehug)
  - [x] Chrome (@paulatthehug)
  - [x] Edge (@IvanSanchez)
- [x] **OSX**
  - [x] Firefox (@jeffreykog)
  - [x] Chrome (@jeffreykog)
  - [x] Edge (@jeffreykog)
  - [x] Safari (@paulatthehug, @jeffreykog)

Demo: 
v1: https://plnkr.co/edit/gqQUNU9mf6RiqxD4
v2 (incl. macOS): https://plnkr.co/edit/vtEzxb7P0EFCkHoq