### PR TITLE
Fix fractional zoom flicker when out of zoom range

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -550,8 +550,8 @@ export var GridLayer = Layer.extend({
 
 	_setView: function (center, zoom, noPrune, noUpdate) {
 		var tileZoom = Math.round(zoom);
-		if ((this.options.maxZoom !== undefined && tileZoom > this.options.maxZoom) ||
-		    (this.options.minZoom !== undefined && tileZoom < this.options.minZoom)) {
+		if ((this.options.maxZoom !== undefined && zoom > this.options.maxZoom) ||
+		    (this.options.minZoom !== undefined && zoom < this.options.minZoom)) {
 			tileZoom = undefined;
 		} else {
 			tileZoom = this._clampZoom(tileZoom);


### PR DESCRIPTION
Fixes: #8300

Will add test and comments if maintainers support this direction. Another option is to change pruneTiles so that it uses this._tileZoom instead of pulling the zoom off the map directly. This would leave the layer rendering until Math.round(this._map.getZoom()) > maxZoom` or in the example in the attached issue 3.5.