### PR TITLE
Expose ESM entrypoint with Leaflet global

### DIFF
--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -12,24 +12,15 @@ const watch = process.argv.indexOf('-w') > -1 || process.argv.indexOf('--watch')
 const version = release ? pkg.version : `${pkg.version}+${gitRev.branch()}.${gitRev.short()}`;
 const banner = createBanner(version);
 
-const outro = `var oldL = window.L;
-exports.noConflict = function() {
-	window.L = oldL;
-	return this;
-}
-// Always export us to window global (see #2364)
-window.L = exports;`;
-
 /** @type {import('rollup').RollupOptions} */
 const config = {
-	input: 'src/Leaflet.js',
+	input: 'src/LeafletWithGlobals.js',
 	output: [
 		{
 			file: pkg.main,
 			format: 'umd',
 			name: 'leaflet',
 			banner: banner,
-			outro: outro,
 			sourcemap: true,
 			freeze: false,
 			esModule: false
@@ -43,7 +34,7 @@ const config = {
 if (!watch) {
 	config.output.push(
 		{
-			file: 'dist/leaflet-src.esm.js',
+			file: pkg.module,
 			format: 'es',
 			banner: banner,
 			sourcemap: true,

--- a/debug/tests/esm.html
+++ b/debug/tests/esm.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <link rel="stylesheet" href="../../dist/leaflet.css" />
+    <link rel="stylesheet" href="../css/screen.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+    <script type="module">
+      import L from '../../dist/leaflet-src.esm.js';
+
+      var map = L.map('map', {
+        center: [39.84, -96.591],
+        zoom: 4,
+      });
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "uglify-js": "^3.15.4"
   },
   "main": "dist/leaflet-src.js",
+  "module": "dist/leaflet-src.esm.js",
   "style": "dist/leaflet.css",
   "files": [
     "dist",
@@ -69,7 +70,8 @@
     ],
     "root": true,
     "globals": {
-      "L": true
+      "L": true,
+      "globalThis": true
     },
     "env": {
       "commonjs": true,

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -1,14 +1,5 @@
 var json = require('@rollup/plugin-json');
 
-const outro = `var oldL = window.L;
-exports.noConflict = function() {
-	window.L = oldL;
-	return this;
-}
-
-// Always export us to window global (see #2364)
-window.L = exports;`;
-
 // Karma configuration
 module.exports = function (config) {
 
@@ -16,7 +7,7 @@ module.exports = function (config) {
 
 	var files = [
 		"spec/before.js",
-		"src/Leaflet.js",
+		"src/LeafletWithGlobals.js",
 		"spec/after.js",
 		"node_modules/happen/happen.js",
 		"node_modules/prosthetic-hand/dist/prosthetic-hand.js",
@@ -28,7 +19,7 @@ module.exports = function (config) {
 
 	var preprocessors = {};
 
-	preprocessors['src/Leaflet.js'] = ['rollup'];
+	preprocessors['src/LeafletWithGlobals.js'] = ['rollup'];
 
 	config.set({
 		// base path, that will be used to resolve files and exclude
@@ -64,7 +55,6 @@ module.exports = function (config) {
 			output: {
 				format: 'umd',
 				name: 'leaflet',
-				outro: outro,
 				freeze: false,
 			},
 		},

--- a/src/LeafletWithGlobals.js
+++ b/src/LeafletWithGlobals.js
@@ -1,0 +1,24 @@
+import * as L from './Leaflet';
+export * from './Leaflet';
+
+var globalL = L.extend(L, {noConflict: noConflict});
+export default globalL;
+
+var globalObject = getGlobalObject();
+var oldL = globalObject.L;
+
+globalObject.L = globalL;
+
+export function noConflict() {
+	globalObject.L = oldL;
+	return globalL;
+}
+
+function getGlobalObject() {
+	if (typeof globalThis !== 'undefined') { return globalThis; }
+	if (typeof self !== 'undefined') { return self; }
+	if (typeof window !== 'undefined') { return window; }
+	if (typeof global !== 'undefined') { return global; }
+
+	throw new Error('Unable to locate global object.');
+}


### PR DESCRIPTION
Introduces a `module` entrypoint to the package to allow some tooling to load the ECMAScript module variant of Leaflet. The goal of this PR is to introduce this as a non-breaking change, preserving the Leaflet global `L` to avoid breaking existing code.

This PR is limited in scope an purposefully and does not try to implement the following:

**[Tree-shaking](https://webpack.js.org/guides/tree-shaking/)**
This requires us to further decouple internals of Leaflet, ensuring that objects are not grouped together (e.g. `Control.Zoom`). Fully supporting this will also mean that we have to mark the [side effects](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free) of the package.

**[Conditional exports](https://nodejs.org/api/packages.html#conditional-exports)**
This is a new feature in Node.js that allows us to specify specific ESM and CommonJS entrypoints. It also prevents internals of the package from being exposed unintentionally since the exported API surface is defined explicitly.

This feature is not widely supported by tooling at this time, but will be preferred in the future as Node.js has never officialy supported the `module` field (unlike many bundlers). Since we currently do not offer running Leaflet under Node.js this is not a priority. 

As more tooling (such as bundlers) move to this standard we will likely end up implementing this.

Closes #7055