### PR TITLE
Replace deprecated eslint-plugin-script-tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.8.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
+        "@mapbox/eslint-plugin-script-tags": "^1.0.0",
         "@rollup/plugin-json": "^4.1.0",
         "bundlemon": "^1.3.2",
         "eslint": "^8.13.0",
         "eslint-config-mourner": "^2.0.3",
-        "eslint-plugin-script-tags": "^0.5.0",
         "git-rev-sync": "^3.0.2",
         "happen": "~0.3.2",
         "husky": "^8.0.1",
@@ -217,6 +217,17 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@mapbox/eslint-plugin-script-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/eslint-plugin-script-tags/-/eslint-plugin-script-tags-1.0.0.tgz",
+      "integrity": "sha512-csn1ZCxRpOr3lx+9m8FqE14Bdww1tKKnluWFmO+Xb2WcCQIwS/xe5wlfim7CCoAVK2KQVOIqaMwlMg1SnXrECQ==",
+      "dev": true,
+      "dependencies": {
+        "execall": "^2.0.0",
+        "lodash": "^4.17.21",
+        "split-lines": "^2.1.0"
+      }
     },
     "node_modules/@rollup/plugin-json": {
       "version": "4.1.0",
@@ -839,16 +850,15 @@
       }
     },
     "node_modules/clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "dependencies": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1299,18 +1309,6 @@
       "integrity": "sha512-ydFFzE/WkqvmozI3CM0lAtDZoYfmN03ycjlHzdPZW5x+o3Me1pI0lyfpsWoz9kOqykZk8qlvOVC5BN5UMwtXrg==",
       "dev": true
     },
-    "node_modules/eslint-plugin-script-tags": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-script-tags/-/eslint-plugin-script-tags-0.5.0.tgz",
-      "integrity": "sha512-iomN8+MwDyhRGWKwRKfBg4EchXuOCJ4iPC8bE9q255xdneXdIhvJU0AaWEe9GPXQIrJ3JKNKZbU1dAlAPbyyAg==",
-      "deprecated": "Now published as @mapbox/eslint-plugin-script-tags",
-      "dev": true,
-      "dependencies": {
-        "execall": "^1.0.0",
-        "lodash": "^4.16.0",
-        "split-lines": "^1.1.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -1479,15 +1477,15 @@
       }
     },
     "node_modules/execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "dependencies": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
       }
     },
     "node_modules/expect.js": {
@@ -2149,12 +2147,12 @@
       }
     },
     "node_modules/is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
       }
     },
     "node_modules/is-stream": {
@@ -2167,15 +2165,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3802,12 +3791,15 @@
       }
     },
     "node_modules/split-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-lines/-/split-lines-1.1.0.tgz",
-      "integrity": "sha1-Oruo9ZhhQUL5240nq2q4dWYqHgk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/split-lines/-/split-lines-2.1.0.tgz",
+      "integrity": "sha512-8dv+1zKgTpfTkOy8XZLFyWrfxO0NV/bj/3EaQ+hBrBxGv2DwiroljPjU8NlCr+59nLnsVm9WYT7lXKwe4TC6bw==",
       "dev": true,
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sprintf-js": {
@@ -4464,6 +4456,17 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@mapbox/eslint-plugin-script-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/eslint-plugin-script-tags/-/eslint-plugin-script-tags-1.0.0.tgz",
+      "integrity": "sha512-csn1ZCxRpOr3lx+9m8FqE14Bdww1tKKnluWFmO+Xb2WcCQIwS/xe5wlfim7CCoAVK2KQVOIqaMwlMg1SnXrECQ==",
+      "dev": true,
+      "requires": {
+        "execall": "^2.0.0",
+        "lodash": "^4.17.21",
+        "split-lines": "^2.1.0"
+      }
+    },
     "@rollup/plugin-json": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -4946,13 +4949,12 @@
       }
     },
     "clone-regexp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
-      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
       "dev": true,
       "requires": {
-        "is-regexp": "^1.0.0",
-        "is-supported-regexp-flag": "^1.0.0"
+        "is-regexp": "^2.0.0"
       }
     },
     "color-convert": {
@@ -5319,17 +5321,6 @@
       "integrity": "sha512-ydFFzE/WkqvmozI3CM0lAtDZoYfmN03ycjlHzdPZW5x+o3Me1pI0lyfpsWoz9kOqykZk8qlvOVC5BN5UMwtXrg==",
       "dev": true
     },
-    "eslint-plugin-script-tags": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-script-tags/-/eslint-plugin-script-tags-0.5.0.tgz",
-      "integrity": "sha512-iomN8+MwDyhRGWKwRKfBg4EchXuOCJ4iPC8bE9q255xdneXdIhvJU0AaWEe9GPXQIrJ3JKNKZbU1dAlAPbyyAg==",
-      "dev": true,
-      "requires": {
-        "execall": "^1.0.0",
-        "lodash": "^4.16.0",
-        "split-lines": "^1.1.0"
-      }
-    },
     "eslint-scope": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
@@ -5451,12 +5442,12 @@
       }
     },
     "execall": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execall/-/execall-1.0.0.tgz",
-      "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
       "dev": true,
       "requires": {
-        "clone-regexp": "^1.0.0"
+        "clone-regexp": "^2.1.0"
       }
     },
     "expect.js": {
@@ -5946,21 +5937,15 @@
       "dev": true
     },
     "is-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
       "dev": true
     },
     "is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
       "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true
-    },
-    "is-supported-regexp-flag": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
-      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
       "dev": true
     },
     "is-unicode-supported": {
@@ -7200,9 +7185,9 @@
       "dev": true
     },
     "split-lines": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-lines/-/split-lines-1.1.0.tgz",
-      "integrity": "sha1-Oruo9ZhhQUL5240nq2q4dWYqHgk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/split-lines/-/split-lines-2.1.0.tgz",
+      "integrity": "sha512-8dv+1zKgTpfTkOy8XZLFyWrfxO0NV/bj/3EaQ+hBrBxGv2DwiroljPjU8NlCr+59nLnsVm9WYT7lXKwe4TC6bw==",
       "dev": true
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "homepage": "https://leafletjs.com/",
   "description": "JavaScript library for mobile-friendly interactive maps",
   "devDependencies": {
+    "@mapbox/eslint-plugin-script-tags": "^1.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "bundlemon": "^1.3.2",
     "eslint": "^8.13.0",
     "eslint-config-mourner": "^2.0.3",
-    "eslint-plugin-script-tags": "^0.5.0",
     "git-rev-sync": "^3.0.2",
     "happen": "~0.3.2",
     "husky": "^8.0.1",
@@ -78,7 +78,7 @@
     },
     "extends": "mourner",
     "plugins": [
-      "script-tags"
+      "@mapbox/eslint-plugin-script-tags"
     ],
     "parserOptions": {
       "ecmaVersion": 6,


### PR DESCRIPTION
Replaces the deprecated `eslint-plugin-script-tags` package with it's successor `@mapbox/eslint-plugin-script-tags`.