### PR TITLE
Update leafletgeopackage.md

### DIFF
--- a/docs/_plugins/overlay-data-formats/leafletgeopackage.md
+++ b/docs/_plugins/overlay-data-formats/leafletgeopackage.md
@@ -1,10 +1,10 @@
 ---
 name: Leaflet-GeoPackage
 category: overlay-data-formats
-repo: https://github.com/ngageoint/geopackage-js/tree/master/leaflet
+repo: https://github.com/ngageoint/leaflet-geopackage
 author: Daniel Barela
 author-url: https://github.com/danielbarela
-demo: 
+demo: https://ngageoint.github.io/leaflet-geopackage/examples/index.html
 compatible-v0:
 compatible-v1: true
 ---


### PR DESCRIPTION
Geopackage-js for Leaflet has moved to its own repo, as noted in https://github.com/ngageoint/geopackage-js/commit/4f76e1a4900249e89cf99995062ee0e98af7fa34