### PR TITLE
getZoom() after passing zoom options in panTo not working fix

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -305,6 +305,11 @@ export var Map = Evented.extend({
 	// @method panTo(latlng: LatLng, options?: Pan options): this
 	// Pans the map to a given center.
 	panTo: function (center, options) { // (LatLng)
+
+		if (options && options.zoom !== undefined) {
+			this._zoom = this._limitZoom(options.zoom);
+		}
+
 		return this.setView(center, this._zoom, {pan: options});
 	},
 


### PR DESCRIPTION
```
map.panTo([50, 30], {zoom: 15});
map.getZoom();

```
The output was NaN. 
It will result in 15 as of now.

Hope this PR helps.