### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/debug/hacks/jitter.html
+++ b/debug/hacks/jitter.html
@@ -24,7 +24,7 @@
 </div>
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 		osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -26,7 +26,7 @@
 
 		var map = L.map('map').setView([50.5, 0], 5);
 
-		var OSM_Mapnik = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var OSM_Mapnik = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			maxZoom: 19,
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 		}).addTo(map);

--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -15,7 +15,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			osm2 = new L.TileLayer(osmUrl, {attribution: 'Hello world'});

--- a/debug/map/geolocation.html
+++ b/debug/map/geolocation.html
@@ -16,7 +16,7 @@
 
     <script>
 
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/image-overlay.html
+++ b/debug/map/image-overlay.html
@@ -18,7 +18,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 			latlng = new L.LatLng(50.5, 30.51);

--- a/debug/map/layer_remove_add.html
+++ b/debug/map/layer_remove_add.html
@@ -19,7 +19,7 @@
     <script>
         map = L.map('map', { center: [0, 0], zoom: 3, maxZoom: 4 });
 
-        var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     		}).addTo(map);
 

--- a/debug/map/map-mobile.html
+++ b/debug/map/map-mobile.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			latlng = new L.LatLng(50.5, 30.51);

--- a/debug/map/map-popup.html
+++ b/debug/map/map-popup.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/map-scaled.html
+++ b/debug/map/map-scaled.html
@@ -38,7 +38,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/map.html
+++ b/debug/map/map.html
@@ -18,7 +18,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/marker-autopan.html
+++ b/debug/map/marker-autopan.html
@@ -55,7 +55,7 @@
             console.log('poly click');
         });
 
-        var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     		}).addTo(map);
     </script>

--- a/debug/map/markers.html
+++ b/debug/map/markers.html
@@ -54,7 +54,7 @@
             console.log('poly click');
         });
 
-        var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     		}).addTo(map);
     </script>

--- a/debug/map/max-bounds-bouncy.html
+++ b/debug/map/max-bounds-bouncy.html
@@ -20,7 +20,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm1 = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			osm2 = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),

--- a/debug/map/max-bounds-infinite.html
+++ b/debug/map/max-bounds-infinite.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			bounds = new L.LatLngBounds(new L.LatLng(49.5, Number.NEGATIVE_INFINITY), new L.LatLng(61.2, Number.POSITIVE_INFINITY));

--- a/debug/map/max-bounds.html
+++ b/debug/map/max-bounds.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			bounds = new L.LatLngBounds(new L.LatLng(49.5, -11.3), new L.LatLng(61.2, 2.5));

--- a/debug/map/opacity.html
+++ b/debug/map/opacity.html
@@ -81,7 +81,7 @@
 		CASE 1: no opacity set on any layers
 		**********/
 		// OSM Basemap
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
 		var osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: ''}).addTo(map1);

--- a/debug/map/popup.html
+++ b/debug/map/popup.html
@@ -17,7 +17,7 @@
 
   <script>
 
-    var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
       osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/rollup.html
+++ b/debug/map/rollup.html
@@ -22,7 +22,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/map/scroll.html
+++ b/debug/map/scroll.html
@@ -21,7 +21,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			latlng = new L.LatLng(50.5, 30.51);

--- a/debug/map/svgoverlay.html
+++ b/debug/map/svgoverlay.html
@@ -23,7 +23,7 @@
 
 		var map = L.map('map');
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			maxZoom: 19,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 		}).addTo(map);

--- a/debug/map/tooltip.html
+++ b/debug/map/tooltip.html
@@ -29,7 +29,7 @@
 
 		var map = L.map('map').setView(center, 13);
 
-		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 		}).addTo(map);
 

--- a/debug/map/videooverlay.html
+++ b/debug/map/videooverlay.html
@@ -21,7 +21,7 @@
 
 		var map = L.map('map');
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			maxZoom: 19,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 		}).addTo(map);

--- a/debug/map/wms.html
+++ b/debug/map/wms.html
@@ -16,7 +16,7 @@
 	<script>
 		var map = new L.Map('map');
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {attribution: osmAttrib}),
 			osm2 = L.tileLayer(osmUrl, {attribution: osmAttrib});

--- a/debug/map/zoom-delta.html
+++ b/debug/map/zoom-delta.html
@@ -59,7 +59,7 @@
 		var sf = [37.77, -122.42],
 			trd = [63.41, 10.41];
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm1 = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			osm2 = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),

--- a/debug/map/zoom-remain-centered.html
+++ b/debug/map/zoom-remain-centered.html
@@ -18,7 +18,7 @@
 		// Check the 'center' setting of the scroll-wheel, double-click and touch-zoom
 		// handlers
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {minZoom: 14, attribution: osmAttrib}),
 			latlng = new L.LatLng(51.1788409,-1.82618);

--- a/debug/map/zoomlevels.html
+++ b/debug/map/zoomlevels.html
@@ -20,8 +20,8 @@
 		var map = L.map('map').setView(L.latLng(50.5, 30.51), 0);
 
 		var osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-			osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {attribution: osmAttrib, minZoom: 0, maxZoom: 10}).addTo(map),
-			osm2 = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {attribution: 'Hello world', minZoom: 5, maxZoom: 18});
+			osm = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {attribution: osmAttrib, minZoom: 0, maxZoom: 10}).addTo(map),
+			osm2 = L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {attribution: 'Hello world', minZoom: 5, maxZoom: 18});
 
 		L.control.layers({
 			'OSM (5-18)': osm2,

--- a/debug/tests/add_remove_layers.html
+++ b/debug/tests/add_remove_layers.html
@@ -25,7 +25,7 @@
         map = new L.Map('map', {preferCanvas: true});
 
         // create the tile layer with correct attribution
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
         var osmAttrib = 'Map data © OpenStreetMap contributors';
         var osm = new L.TileLayer(osmUrl, { minZoom: 1, maxZoom: 17, attribution: osmAttrib, detectRetina: true });
         map.addLayer(osm);

--- a/debug/tests/canvasloop.html
+++ b/debug/tests/canvasloop.html
@@ -19,7 +19,7 @@
                 preferCanvas: true
             }).locate();
 
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
             }).addTo(map);
 

--- a/debug/tests/click_on_canvas.html
+++ b/debug/tests/click_on_canvas.html
@@ -15,7 +15,7 @@
     <div id="map"></div>
 
     <script>
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/tests/custom-panes.html
+++ b/debug/tests/custom-panes.html
@@ -33,7 +33,7 @@
 	<script>
 
 		function makeMap(container, options) {
-			var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 				osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 				osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/tests/detached-dom-memory-leak.html
+++ b/debug/tests/detached-dom-memory-leak.html
@@ -9,7 +9,7 @@
 	<script>
 	var map,
 		mapDiv,
-		osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+		osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
 
 
 	var recreateMap = function(){

--- a/debug/tests/doubleclick-events-slowdown.html
+++ b/debug/tests/doubleclick-events-slowdown.html
@@ -20,7 +20,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/tests/dragging_and_copyworldjump.html
+++ b/debug/tests/dragging_and_copyworldjump.html
@@ -26,7 +26,7 @@
 
 		<script>
 			function addLayerAndMarker(map) {
-				var layer = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				var layer = new L.TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 					maxZoom : 18
 				}).addTo(map);
 

--- a/debug/tests/dragging_cursors.html
+++ b/debug/tests/dragging_cursors.html
@@ -26,7 +26,7 @@
 
 		<script>
 			function addLayerAndMarkers(map) {
-				var layer = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				var layer = new L.TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 					maxZoom : 18
 				}).addTo(map);
 

--- a/debug/tests/esm.html
+++ b/debug/tests/esm.html
@@ -13,7 +13,7 @@
         zoom: 4,
       });
 
-      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+      L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
     </script>
   </body>
 </html>

--- a/debug/tests/event-perf-2.html
+++ b/debug/tests/event-perf-2.html
@@ -24,7 +24,7 @@
             profiler and examine times for _on, _off and fire.
 
         */
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/tests/mousemove_on_polygons.html
+++ b/debug/tests/mousemove_on_polygons.html
@@ -47,7 +47,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			latlng = new L.LatLng(39.05, 8.40);

--- a/debug/tests/opacity.html
+++ b/debug/tests/opacity.html
@@ -22,7 +22,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			latlng = new L.LatLng(50.5, 30.51);

--- a/debug/tests/popup_offset.html
+++ b/debug/tests/popup_offset.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/tests/popupcontextmenuclicks.html
+++ b/debug/tests/popupcontextmenuclicks.html
@@ -22,7 +22,7 @@ var map = L.map('map').setView([36.9, -95.4], 5);
 map.on('contextmenu', function (e) {
     alert('The map has been right-clicked');
 });
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 }).addTo(map);
 

--- a/debug/tests/reuse_popups.html
+++ b/debug/tests/reuse_popups.html
@@ -24,7 +24,7 @@
 
 		map.setView([51.505, -0.09], 13);
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		}).addTo(map);
 

--- a/debug/tests/rtl.html
+++ b/debug/tests/rtl.html
@@ -23,7 +23,7 @@
 
 	<script>
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		});
 

--- a/debug/tests/rtl2.html
+++ b/debug/tests/rtl2.html
@@ -16,7 +16,7 @@
 <div id="map"></div>
 <script>
     var map = L.map('map').setView([51.505, -0.09], 13);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
     map.on('click', function(e) {
         L.popup().setLatLng(e.latlng).setContent('Hello').openOn(map);
     });

--- a/debug/tests/svg_clicks.html
+++ b/debug/tests/svg_clicks.html
@@ -27,7 +27,7 @@
 	 	map = new L.Map('map');
 
 		// create the tile layer with correct attribution
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 		var osm = new L.TileLayer(osmUrl, { minZoom: 1, maxZoom: 17 });
 		map.addLayer(osm);
 		map.fitBounds(new L.LatLngBounds([51,7],[51,7]));

--- a/debug/vector/bounds-extend.html
+++ b/debug/vector/bounds-extend.html
@@ -15,7 +15,7 @@
     <button onclick="boundsExtendLatLng()">Extend the bounds of the center rectangle with the lower left marker</button>
     <script src="route.js"></script>
     <script>
-        var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osm = new L.TileLayer(osmUrl, {maxZoom: 18});
 
         var latLng = new L.LatLng(54.18815548107151, -7.657470703124999);

--- a/debug/vector/feature-group-bounds.html
+++ b/debug/vector/feature-group-bounds.html
@@ -18,7 +18,7 @@
 	<script src="geojson-sample.js"></script>
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			rectangle,

--- a/debug/vector/geojson.html
+++ b/debug/vector/geojson.html
@@ -51,7 +51,7 @@
 
 		var map = L.map('map').setView([37.8, -96], 4);
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		}).addTo(map);
 

--- a/debug/vector/inherit-dashArray.html
+++ b/debug/vector/inherit-dashArray.html
@@ -18,7 +18,7 @@
 			zoom: 3,
 			preferCanvas: true
 		});
-		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			minZoom: 1,
 			maxZoom: 17,
 			label: 'open street map'

--- a/debug/vector/moving-canvas.html
+++ b/debug/vector/moving-canvas.html
@@ -17,7 +17,7 @@
 
 	<script>
 
-		var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			maxZoom: 19,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 		});

--- a/debug/vector/rectangle.html
+++ b/debug/vector/rectangle.html
@@ -16,7 +16,7 @@
 
 	<script>
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/vector/touchzoomemu.html
+++ b/debug/vector/touchzoomemu.html
@@ -23,7 +23,7 @@
 	//	buffer += text + "\r\n";
 	//}
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osm = new L.TileLayer(osmUrl, {maxZoom: 18}),
 			map = new L.Map('map', {layers: [osm], center: new L.LatLng(51.505, -0.04), zoom: 13});
 

--- a/debug/vector/vector-bounds.html
+++ b/debug/vector/vector-bounds.html
@@ -15,7 +15,7 @@
     <button onclick="map.fitBounds(poly.getBounds())">Zoom to polygon</button>
 	<script src="route.js"></script>
 	<script>
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/vector/vector-canvas.html
+++ b/debug/vector/vector-canvas.html
@@ -18,7 +18,7 @@
 
 	<script src="route.js"></script>
 	<script>
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/vector/vector-mobile.html
+++ b/debug/vector/vector-mobile.html
@@ -16,7 +16,7 @@
 
 	<script src="route.js"></script>
 	<script>
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/vector/vector-simple.html
+++ b/debug/vector/vector-simple.html
@@ -34,7 +34,7 @@
 			.bindPopup("I am a polygon.")
 			.addTo(map);
 
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}).addTo(map);
 

--- a/debug/vector/vector.html
+++ b/debug/vector/vector.html
@@ -13,7 +13,7 @@
 
 	<script src="route.js"></script>
 	<script>
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/debug/vector/vector2.html
+++ b/debug/vector/vector2.html
@@ -13,7 +13,7 @@
 
 	<script src="route.js"></script>
 	<script>
-		var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -52,7 +52,7 @@
 		MB_ATTR = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, ' +
 			'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>';
 		MB_URL = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=' + ACCESS_TOKEN;
-		OSM_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+		OSM_URL = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 		OSM_ATTRIB = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 	</script>
 </head>

--- a/docs/_posts/2013-02-20-guest-post-draw.md
+++ b/docs/_posts/2013-02-20-guest-post-draw.md
@@ -41,7 +41,7 @@ Leaflet.draw is very simple to drop into you Leaflet application. The following 
 	var map = L.map('map').setView([175.30867, -37.77914], 13);
 
 	// add an OpenStreetMap tile layer
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 
@@ -116,7 +116,7 @@ Jacob Toye
 	var map = L.map('map').setView([-37.77914, 175.30867], 16);
 
 	// add an OpenStreetMap tile layer
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 

--- a/docs/edit.html
+++ b/docs/edit.html
@@ -15,7 +15,7 @@
                 cssFile: 'https://unpkg.com/leaflet/dist/leaflet.css',
                 css: 'body {\n\tmargin: 0;\n}\nhtml, body, #leaflet {\n\theight: 100%\n}',
                 jsFile: 'https://unpkg.com/leaflet/dist/leaflet-src.js',
-                js: "var map = new L.Map('leaflet', {\n\tlayers: [\n\t\tnew L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t\t\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n\t\t})\n\t],\n\tcenter: [0, 0],\n\tzoom: 0\n});"
+                js: "var map = new L.Map('leaflet', {\n\tlayers: [\n\t\tnew L.TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t\t\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n\t\t})\n\t],\n\tcenter: [0, 0],\n\tzoom: 0\n});"
             };
 
             var hash = location.hash.substr(1);

--- a/docs/examples/accessibility/example.md
+++ b/docs/examples/accessibility/example.md
@@ -7,7 +7,7 @@ title: Accessible markers
 
 	var map = L.map('map').setView([50.4501, 30.5234], 4);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/choropleth/example-basic.md
+++ b/docs/examples/choropleth/example-basic.md
@@ -7,7 +7,7 @@ title: Choropleth Tutorial
 
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/choropleth/example-color.md
+++ b/docs/examples/choropleth/example-color.md
@@ -8,7 +8,7 @@ title: Choropleth Tutorial
 
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -38,7 +38,7 @@ css: "#map {
 
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -35,7 +35,7 @@ Let's display our states data on the map:
 
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/custom-icons/example-one-icon.md
+++ b/docs/examples/custom-icons/example-one-icon.md
@@ -5,7 +5,7 @@ title: Custom Icons Tutorial
 <script>
 	var map = L.map('map').setView([51.5, -0.09], 13);
 
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 

--- a/docs/examples/custom-icons/example.md
+++ b/docs/examples/custom-icons/example.md
@@ -5,7 +5,7 @@ title: Custom Icons Tutorial
 <script>
 	var map = L.map('map').setView([51.5, -0.09], 13);
 
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 

--- a/docs/examples/extending/tilt.md
+++ b/docs/examples/extending/tilt.md
@@ -59,7 +59,7 @@ title: Tilt handler
 		tilt: true
 	});
 
-	var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/extending/watermark.md
+++ b/docs/examples/extending/watermark.md
@@ -8,7 +8,7 @@ title: Watermark control
 		zoom: 1
 	});
 
-	var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/geojson/example.md
+++ b/docs/examples/geojson/example.md
@@ -7,7 +7,7 @@ title: GeoJSON tutorial
 <script>
 	var map = L.map('map').setView([39.74739, -105], 13);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/geojson/geojson-example.html
+++ b/docs/examples/geojson/geojson-example.html
@@ -16,7 +16,7 @@
 	<script>
 		var map = L.map('map').setView([39.74739, -105], 13);
 
-		var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+		var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 			maxZoom: 19,
 			attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 		}).addTo(map);

--- a/docs/examples/geojson/geojson.html
+++ b/docs/examples/geojson/geojson.html
@@ -14,7 +14,7 @@ title: Using GeoJSON with Leaflet
 
 	var map = L.map('map').setView([39.74739, -105], 13);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/layers-control/example.md
+++ b/docs/examples/layers-control/example.md
@@ -15,7 +15,7 @@ title: Layers Control Tutorial
  
 	var streets = L.tileLayer(mbUrl, {id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mbAttr});
 
-	var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	});

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -32,7 +32,7 @@ There are two types of layers: (1) base layers that are mutually exclusive (only
 
 Now let's create those base layers and add the default ones to the map:
 
-<pre><code>var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+<pre><code>var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 });

--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -13,7 +13,7 @@ css: "body {
 <script>
 	var map = L.map('map').fitWorld();
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/mobile/index.md
+++ b/docs/examples/mobile/index.md
@@ -33,7 +33,7 @@ We'll now initialize the map in the JavaScript code like we did in the [quick st
 
 <pre><code class="javascript">var map = L.map('map').fitWorld();
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 }).addTo(map);</code></pre>

--- a/docs/examples/overlays/example-image.md
+++ b/docs/examples/overlays/example-image.md
@@ -5,7 +5,7 @@ title: Image Overlay Tutorial
 <script>
 	var map = L.map('map').setView([37.8, -96], 4);
 
-	var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/overlays/example-nocontrols.md
+++ b/docs/examples/overlays/example-nocontrols.md
@@ -5,7 +5,7 @@ title: Video Overlay Tutorial
 <script>
 	var map = L.map('map');
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/overlays/example-svg.md
+++ b/docs/examples/overlays/example-svg.md
@@ -5,7 +5,7 @@ title: SVG Overlay Tutorial
 <script>
 	var map = L.map('map');
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/overlays/example-video.md
+++ b/docs/examples/overlays/example-video.md
@@ -5,7 +5,7 @@ title: Video Overlay Tutorial (video with controls)
 <script>
 	var map = L.map('map');
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/overlays/index.md
+++ b/docs/examples/overlays/index.md
@@ -29,7 +29,7 @@ First of all, create a Leaflet map and add a background `L.TileLayer` in the usu
 ```
 var map = L.map('map').setView([37.8, -96], 4);
 
-var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 }).addTo(map);
@@ -99,7 +99,7 @@ First of all, create a Leaflet map and add a background `L.TileLayer` in the usu
 ```
 var map = L.map('map').setView([37.8, -96], 4);
 
-var osm = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+var osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 }).addTo(map);

--- a/docs/examples/quick-start/example-basic.md
+++ b/docs/examples/quick-start/example-basic.md
@@ -8,7 +8,7 @@ customMapContainer: "true"
 
 	var map = L.map('map').setView([51.505, -0.09], 13);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/quick-start/example-overlays.md
+++ b/docs/examples/quick-start/example-overlays.md
@@ -8,7 +8,7 @@ customMapContainer: "true"
 
 	var map = L.map('map').setView([51.505, -0.09], 13);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/quick-start/example.md
+++ b/docs/examples/quick-start/example.md
@@ -8,7 +8,7 @@ customMapContainer: "true"
 
 	var map = L.map('map').setView([51.505, -0.09], 13);
 
-	var tiles = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	var tiles = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -52,7 +52,7 @@ Note that the `setView` call also returns the map object --- most Leaflet method
 
 Next, we'll add a tile layer to add to our map, in this case it's a OpenStreetMap tile layer. Creating a tile layer usually involves setting the [URL template](/reference.html#tilelayer-url-template) for the tile images, the attribution text, and the maximum zoom level of the layer. OpenStreetMap tiles are fine for programming your Leaflet map, but read the [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/) of OpenStreetMap if you're going to use the tiles in production.
 
-<pre><code class="javascript">L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+<pre><code class="javascript">L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 }).addTo(map);</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@ and a simple, readable&nbsp;<a title="Leaflet source code repository on GitHub" 
 
 <pre class="basic-code javascript"><code>var map = L.map('map').setView([51.505, -0.09], 13);
 
-L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&amp;copy; &lt;a href="https://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors'
 }).addTo(map);
 
@@ -209,7 +209,7 @@ and spreading the word about Leaflet among your colleagues and friends.</p>
 </div>
 
 <script>
-	var osmUrl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+	var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 		osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 		osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 

--- a/docs/reference-0.7.7.html
+++ b/docs/reference-0.7.7.html
@@ -1788,7 +1788,7 @@ var map = L.map('map', {
 
 <h3>Usage example</h3>
 
-<pre><code class="javascript">L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar'}).addTo(map);</code></pre>
+<pre><code class="javascript">L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar'}).addTo(map);</code></pre>
 
 <h3>Creation</h3>
 

--- a/docs/reference-1.0.3.html
+++ b/docs/reference-1.0.3.html
@@ -4148,7 +4148,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.1.0.html
+++ b/docs/reference-1.1.0.html
@@ -4161,7 +4161,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.2.0.html
+++ b/docs/reference-1.2.0.html
@@ -4161,7 +4161,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.3.4.html
+++ b/docs/reference-1.3.4.html
@@ -4227,7 +4227,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.4.0.html
+++ b/docs/reference-1.4.0.html
@@ -4237,7 +4237,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.5.1.html
+++ b/docs/reference-1.5.1.html
@@ -4259,7 +4259,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.6.0.html
+++ b/docs/reference-1.6.0.html
@@ -4273,7 +4273,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="lang-js">L.tileLayer(&#39;https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
+<pre><code class="lang-js">L.tileLayer(&#39;https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}&#39;, {foo: &#39;bar&#39;, attribution: &#39;&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors&#39;}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference-1.7.1.html
+++ b/docs/reference-1.7.1.html
@@ -4295,7 +4295,7 @@ properties. The event can optionally be propagated to event parents.</p>
 
 
 
-<pre><code class="language-js">L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors'}).addTo(map);
+<pre><code class="language-js">L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors'}).addTo(map);
 </code></pre>
 
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -5437,7 +5437,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 
-<pre><code class="language-js">L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors'}).addTo(map);
+<pre><code class="language-js">L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&amp;copy; &lt;a href=&quot;https://www.openstreetmap.org/copyright&quot;&gt;OpenStreetMap&lt;/a&gt; contributors'}).addTo(map);
 </code></pre>
 
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -14,7 +14,7 @@ import * as DomUtil from '../../dom/DomUtil';
  * @example
  *
  * ```js
- * L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
+ * L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar', attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
  * ```
  *
  * @section URL template


### PR DESCRIPTION
Now that tile.openstreetmap.org supports HTTP/2 + HTTP/3 the old (a|b|c).tile.openstreetmap.org is no longer recommended.

Use tile.openstreetmap.org directly is faster and will likely result in a better cache hit ratio.

Signed-off-by: Grant Slater <git@firefishy.com>