### PR TITLE
Update Center calculation to work for very small layers too

### DIFF
--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -141,6 +141,75 @@ describe('LineUtil', function () {
 			expect(center).to.be.nearLatLng([80, 45]);
 		});
 
+		it('computes center of a small line and test it on every zoom', function () {
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polyline(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small line and test it on every zoom - CRS.EPSG3395', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG3395});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polyline(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small line and test it on every zoom - CRS.EPSG4326', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG4326});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polyline(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small line and test it on every zoom - CRS.Simple', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.Simple});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polyline(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
 		it('throws error if latlngs not passed', function () {
 			expect(function () {
 				L.LineUtil.polylineCenter(null, crs, zoom);

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -66,6 +66,75 @@ describe('PolyUtil', function () {
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
 		});
 
+		it('computes center of a small polygon and test it on every zoom', function () {
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polygon(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small polygon and test it on every zoom - CRS.EPSG3395', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG3395});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polygon(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small polygon and test it on every zoom - CRS.EPSG4326', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG4326});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polygon(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
+		it('computes center of a small polygon and test it on every zoom - CRS.Simple', function () {
+			map.remove();
+			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.Simple});
+
+			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
+
+			var layer = L.polygon(latlngs).addTo(map);
+			var i = 0;
+			function check() {
+				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
+				i++;
+				if (i < 30) { map.setZoom(i); }
+			}
+
+			map.on('zoomend', check);
+			map.setView(layer.getCenter(), i);
+		});
+
 		it('throws error if latlngs not passed', function () {
 			expect(function () {
 				L.PolyUtil.polygonCenter(null,  crs, zoom);

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -242,10 +242,10 @@ export function _flat(latlngs) {
 	return isFlat(latlngs);
 }
 
-/* @function polylineCenter(latlngs: LatLng[], crs: CRS, zoom: Number): LatLng
+/* @function polylineCenter(latlngs: LatLng[], crs: CRS): LatLng
  * Returns the center ([centroid](http://en.wikipedia.org/wiki/Centroid)) of the passed LatLngs (first ring) from a polyline.
  */
-export function polylineCenter(latlngs, crs, zoom) {
+export function polylineCenter(latlngs, crs) {
 	var i, halfDist, segDist, dist, p1, p2, ratio, center;
 
 	if (!latlngs || latlngs.length === 0) {
@@ -259,7 +259,7 @@ export function polylineCenter(latlngs, crs, zoom) {
 
 	var points = [];
 	for (var j in latlngs) {
-		points.push(crs.latLngToPoint(toLatLng(latlngs[j]), zoom));
+		points.push(crs.project(toLatLng(latlngs[j])));
 	}
 
 	var len = points.length;
@@ -288,5 +288,5 @@ export function polylineCenter(latlngs, crs, zoom) {
 			}
 		}
 	}
-	return crs.pointToLatLng(toPoint(center), zoom);
+	return crs.unproject(toPoint(center));
 }

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -55,10 +55,10 @@ export function clipPolygon(points, bounds, round) {
 	return points;
 }
 
-/* @function polygonCenter(latlngs: LatLng[] crs: CRS, zoom: Number): LatLng
+/* @function polygonCenter(latlngs: LatLng[] crs: CRS): LatLng
  * Returns the center ([centroid](http://en.wikipedia.org/wiki/Centroid)) of the passed LatLngs (first ring) from a polygon.
  */
-export function polygonCenter(latlngs, crs, zoom) {
+export function polygonCenter(latlngs, crs) {
 	var i, j, p1, p2, f, area, x, y, center;
 
 	if (!latlngs || latlngs.length === 0) {
@@ -72,7 +72,7 @@ export function polygonCenter(latlngs, crs, zoom) {
 
 	var points = [];
 	for (var k in latlngs) {
-		points.push(crs.latLngToPoint(toLatLng(latlngs[k]), zoom));
+		points.push(crs.project(toLatLng(latlngs[k])));
 	}
 
 	var len = points.length;
@@ -95,5 +95,5 @@ export function polygonCenter(latlngs, crs, zoom) {
 	} else {
 		center = [x / area, y / area];
 	}
-	return crs.pointToLatLng(toPoint(center), zoom);
+	return crs.unproject(toPoint(center));
 }

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -68,9 +68,7 @@ export var Polygon = Polyline.extend({
 		if (!this._map) {
 			throw new Error('Must add layer to map before using getCenter()');
 		}
-		var maxZoom = this._map.getMaxZoom();
-		var zoom = maxZoom === Infinity ? this._map.getZoom() : maxZoom;
-		return PolyUtil.polygonCenter(this._defaultShape(), this._map.options.crs, zoom);
+		return PolyUtil.polygonCenter(this._defaultShape(), this._map.options.crs);
 	},
 
 	_convertLatLngs: function (latlngs) {

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -120,9 +120,7 @@ export var Polyline = Path.extend({
 		if (!this._map) {
 			throw new Error('Must add layer to map before using getCenter()');
 		}
-		var maxZoom = this._map.getMaxZoom();
-		var zoom = maxZoom === Infinity ? this._map.getZoom() : maxZoom;
-		return LineUtil.polylineCenter(this._defaultShape(), this._map.options.crs, zoom);
+		return LineUtil.polylineCenter(this._defaultShape(), this._map.options.crs);
 	},
 
 	// @method getBounds(): LatLngBounds


### PR DESCRIPTION
The new center calculation (#7603) caused on small layers that the center was outside of the layer. This is fixed now.

Old:
![grafik](https://user-images.githubusercontent.com/19800037/189190384-82c2504e-4917-44ff-b6a1-f713dacb70cf.png)

New:
![grafik](https://user-images.githubusercontent.com/19800037/189190255-4270f4e9-fa59-4fb6-9213-805a9c74942b.png)
