### PR TITLE
Fix Events.listens for nested propagations

### DIFF
--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -706,6 +706,17 @@ describe('Events', function () {
 			expect(marker.listens('test', true)).to.be(true);
 		});
 
+		it('is true if there is an event handler on parent parent', function () {
+			var fgP = L.featureGroup(),
+			fg = L.featureGroup().addTo(fgP),
+			marker = L.marker([0, 0]).addTo(fg),
+			spy = sinon.spy();
+
+			fgP.on('test', spy);
+			expect(marker.listens('test', false)).to.be(false);
+			expect(marker.listens('test', true)).to.be(true);
+		});
+
 		it('is true if there is an event handler with specific function on parent', function () {
 			var fg = L.featureGroup(),
 			marker = L.marker([0, 0]).addTo(fg),

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -216,15 +216,17 @@ export var Events = {
 			console.warn('"string" type argument expected');
 		}
 
+		// we don't overwrite the input `fn` value, because we need to use it for propagation
+		var _fn = fn;
 		if (typeof fn !== 'function') {
 			propagate = !!fn;
-			fn = undefined;
+			_fn = undefined;
 			context = undefined;
 		}
 
 		var listeners = this._events && this._events[type];
 		if (listeners && listeners.length) {
-			if (this._listens(type, fn, context) !== false) {
+			if (this._listens(type, _fn, context) !== false) {
 				return true;
 			}
 		}


### PR DESCRIPTION
The problem was that the value of `fn` was overwritten and then passed again to `listens` in the propagation.

closes #8450