### PR TITLE
Improve integrity generation for releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,11 +15,8 @@
 - [ ] Make a new branch for the update
 - [ ] Write a blog post about the new release and put it in `/docs/_posts`
 - [ ] If necessary to preserve previous version's docs, rename `docs/reference.html` to `docs/reference-X.Y.Z.html` and add it to the list in `docs/reference-versions.html`
-- [ ] Run `npm install` to ensure all dependencies are up-to-date.
-- [ ] Run `npm run docs` to generate the new `docs/reference.html`
+- [ ] Run `npm run docs` to generate the new `docs/reference.html` and update integrity hashes in `docs/_config.yml`
 - [ ] Add the version number to the first paragraph in `docs/reference.html`
-- [ ] Run `npm run build` to generate the latest distribution.
-- [ ] Run `npm run integrity` and make sure `docs/_config.yml` is updated with new hashes
 - [ ] Update link to latest release in `docs/download.md`
 - [ ] Update the announcement section in `docs/index.html`
 - [ ] Commit all the changes and submit a PR for someone to review

--- a/build/integrity.js
+++ b/build/integrity.js
@@ -1,28 +1,34 @@
 // This script calculates the integrity hashes of the files in dist/ , and
 // **overwrites** the values in the documentation.
 
-var ssri = require('ssri');
-var fs   = require('fs');
-var version = require('../package.json').version;
+const ssri = require('ssri');
+const fs = require('fs');
+const https = require('https');
+const version = require('../package.json').version;
 
-const integritySrc = ssri.fromData(fs.readFileSync('dist/leaflet-src.js'));
-const integrityUglified = ssri.fromData(fs.readFileSync('dist/leaflet.js'));
-const integrityCss = ssri.fromData(fs.readFileSync('dist/leaflet.css'));
+const getIntegrity = async (path) => new Promise((resolve) => {
+	https.get(`https://unpkg.com/leaflet@${version}/dist/${path}`, (res) => {
+		ssri.fromStream(res, {algorithms: ['sha256']}).then(integrity => resolve(integrity.toString()));
+	});
+});
 
+(async () => {
+	const integrityUglified = await getIntegrity('leaflet.js');
+	const integritySrc = await getIntegrity('leaflet-src.js');
+	const integrityCss = await getIntegrity('leaflet.css');
 
-console.log('Integrity hashes for ', version, ':');
-console.log('dist/leaflet-src.js: ', integritySrc.toString());
-console.log('dist/leaflet.js:     ', integrityUglified.toString());
-console.log('dist/leaflet.css:    ', integrityCss.toString());
+	console.log(`Integrity hashes for ${version}:`);
+	console.log(`dist/leaflet.js:     ${integrityUglified}`);
+	console.log(`dist/leaflet-src.js: ${integritySrc}`);
+	console.log(`dist/leaflet.css:    ${integrityCss}`);
 
-var docConfig = fs.readFileSync('docs/_config.yml').toString();
+	let docConfig = fs.readFileSync('docs/_config.yml', 'utf8');
 
-docConfig = docConfig
-	.replace(/latest_leaflet_version:.*/,  'latest_leaflet_version: ' + version)
-	.replace(/integrity_hash_source:.*/,   'integrity_hash_source: "' +   integritySrc.toString() + '"')
-	.replace(/integrity_hash_uglified:.*/, 'integrity_hash_uglified: "' + integrityUglified.toString() + '"')
-	.replace(/integrity_hash_css:.*/,      'integrity_hash_css: "' +      integrityCss.toString() + '"');
+	docConfig = docConfig
+		.replace(/latest_leaflet_version:.*/,  'latest_leaflet_version: ' + version)
+		.replace(/integrity_hash_source:.*/,   'integrity_hash_source: "' +   integritySrc + '"')
+		.replace(/integrity_hash_uglified:.*/, 'integrity_hash_uglified: "' + integrityUglified + '"')
+		.replace(/integrity_hash_css:.*/,      'integrity_hash_css: "' +      integrityCss + '"');
 
-// console.log('New jekyll docs config: \n', docConfig);
-
-fs.writeFileSync('docs/_config.yml', docConfig);
+	fs.writeFileSync('docs/_config.yml', docConfig);
+})();

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,9 +10,9 @@ latest_leaflet_version: 1.9.0
 # Integrity hashes for both leaflet.js and leaflet-src.js
 # These will be shown in the downloads page
 # See https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
-integrity_hash_css: "sha384-kxXhFDZB0L84bBV/apPOb8zGC+fsQ1dBPpKXPUXc1zRymi4BaueVyC27iDDPdssp"
-integrity_hash_source: "sha384-OpEbGD+GgOvGzqHl/VuP+X8cGvdUoPCw+F31C8ddag7seV0wOtUIChX0wCAoyZVD"
-integrity_hash_uglified: "sha384-JZO8CJyT9g8yj13j0R/ssKw7jx+QYlck09EBe8l/UxI6bE8JDmTF/VbHAIQYXDTD"
+integrity_hash_css: "sha256-sA+zWATbFveLLNqWO2gtiw3HL/lh1giY/Inf1BJ0z14="
+integrity_hash_source: "sha256-i6wHIYawzYV3LoV0z/0LzL7YfqO5XFf2icMT+B+PiQ8="
+integrity_hash_uglified: "sha256-oH+m3EWgtpoAmoBO/v+u8H/AdwB/54Gc/SgqjUKbb4Y="
 
 
 collections:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "docs": "node ./build/docs.js",
+    "docs": "node ./build/docs.js && node ./build/integrity.js",
     "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
     "lint": "eslint .",
@@ -50,7 +50,6 @@
     "rollup": "rollup -c build/rollup-config.js",
     "watch": "rollup -w -c build/rollup-config.js",
     "uglify": "uglifyjs dist/leaflet-src.js -c -m -o dist/leaflet.js --source-map filename=dist/leaflet.js.map --source-map content=dist/leaflet-src.js.map --source-map url=leaflet.js.map --comments",
-    "integrity": "NODE_ENV=release npm run build && node ./build/integrity.js",
     "bundlemon": "bundlemon --subProject js --defaultCompression none && bundlemon --subProject js-gzip --defaultCompression gzip",
     "serve": "cd docs && bundle exec jekyll serve",
     "prepare": "husky install"
@@ -65,7 +64,8 @@
       "docs/examples/map-panes/eu-countries.js",
       "docs/examples/extending/extending-2-layers.md",
       "docs/_posts/2012*",
-      "docs/_site"
+      "docs/_site",
+      "build/integrity.js"
     ],
     "root": true,
     "globals": {


### PR DESCRIPTION
Closes #8458. Instead of relying on the local files being correct when generating integrity hashes, just fetch the published ones from `unpkg`. This makes this step way less fragile, and simplifies the process.

I also updated the algorithm to `sha256` (one of the options per the spec) because it's shorter and looks less intimidating in examples, and we don't care about super duper security here.