### PR TITLE
Use the topmost browsing context for links in tutorial frames

### DIFF
--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+	<base target="_top">
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	{% capture title %}{% if page.title %}{{ page.title }} - {% elsif post.title %}{{ post.title }} - {% endif %}{% endcapture %}


### PR DESCRIPTION
Fix https://github.com/Leaflet/Leaflet/issues/8465.

Links in the tutorials' iframes now open link targets in the browser window, and not in the iframes (currently if you click e.g. attribution links in https://leafletjs.com/examples/quick-start/ it opens the page in the iframe).