### PR TITLE
Fix web archive link to v1.8.0 reference

### DIFF
--- a/docs/reference-versions.html
+++ b/docs/reference-versions.html
@@ -18,6 +18,6 @@ bodyclass: api-page
 	<li><a href='https://web.archive.org/web/20201202155513/https://leafletjs.com/reference-1.5.1.html'>API reference for <strong>1.5.1</strong></a>
 	<li><a href='https://web.archive.org/web/20211123172545/https://leafletjs.com/reference-1.6.0.html'>API reference for <strong>1.6.0</strong></a>
 	<li><a href='https://web.archive.org/web/20220505205646/https://leafletjs.com/reference-1.7.1.html'>API reference for <strong>1.7.1</strong></a>
-	<li><a href='https://web.archive.org/web/20220923053459/https://leafletjs.com/reference-1.8.0.html'>API reference for <strong>1.8.0</strong></a>
+	<li><a href='https://web.archive.org/web/20220908180925/https://leafletjs.com/reference.html'>API reference for <strong>1.8.0</strong></a>
 	<li><a href='reference.html'>API reference for <strong>Latest stable version</strong></a>
 </ul>


### PR DESCRIPTION
I suppose `reference-1.8.0.html` wasn't live for long enough between its creation and deletion for the web archive to keep it in the archive? Some sort of abuse protection perhaps?

Let's use https://web.archive.org/web/20220908180925/https://leafletjs.com/reference.html instead.