### PR TITLE
Remove the release check to manually modify the version number in `reference.html`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,6 @@
 of the version of docs prior to this release to the Internet Archive's Wayback Machine
 (and optionally, add a link to the snapshot in `docs/reference-versions.html`).
 - [ ] Run `npm run docs` to generate the new `docs/reference.html` and update integrity hashes in `docs/_config.yml`
-- [ ] Add the version number to the first paragraph in `docs/reference.html`
 - [ ] Update link to latest release in `docs/download.md`
 - [ ] Update the announcement section in `docs/index.html`
 - [ ] Commit all the changes and submit a PR for someone to review


### PR DESCRIPTION
Looks like the check was added in https://github.com/Leaflet/Leaflet/pull/8453/, but AFAICT it is not needed since https://github.com/Leaflet/Leaflet/pull/7730.