### PR TITLE
Replace `Util.bind()` with `Function.bind()`

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -33,32 +33,6 @@ describe('Util', function () {
 		});
 	});
 
-	describe('#bind', function () {
-		it('returns the given function with the given context', function () {
-			var fn = function () {
-				return this;
-			};
-
-			var fn2 = L.Util.bind(fn, {foo: 'bar'});
-
-			expect(fn2()).to.eql({foo: 'bar'});
-		});
-
-		it('passes additional arguments to the bound function', function () {
-			var fn = sinon.spy(),
-			    foo = {},
-			    a = {},
-			    b = {},
-			    c = {};
-
-			var fn2 = L.Util.bind(fn, foo, a, b);
-
-			fn2(c);
-
-			expect(fn.calledWith(a, b, c)).to.be.ok();
-		});
-	});
-
 	describe('#stamp', function () {
 		it('sets a unique id on the given object and returns it', function () {
 			var a = {},

--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -2,7 +2,7 @@
 	describe("#hasLayer", function () {
 		it("throws when called without proper argument", function () {
 			var lg = L.layerGroup();
-			var hasLayer = L.Util.bind(lg.hasLayer, lg);
+			var hasLayer = lg.hasLayer.bind(lg);
 			expect(hasLayer).withArgs(new L.Layer()).to.not.throwException(); // control case
 
 			expect(hasLayer).withArgs(undefined).to.throwException();

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -825,7 +825,7 @@ describe("Map", function () {
 
 	describe("#hasLayer", function () {
 		it("throws when called without proper argument", function () {
-			var hasLayer = L.Util.bind(map.hasLayer, map);
+			var hasLayer = map.hasLayer.bind(map);
 			expect(hasLayer).withArgs(new L.Layer()).to.not.throwException(); // control case
 
 			expect(hasLayer).withArgs(undefined).to.throwException();
@@ -1798,7 +1798,7 @@ describe("Map", function () {
 
 	describe("#Geolocation", function () {
 		it("doesn't throw error if location is found and map is not existing", function () {
-			var fn = L.Util.bind(map._handleGeolocationResponse, map);
+			var fn = map._handleGeolocationResponse.bind(map);
 			map.remove();
 			map = null;
 			expect(function () {
@@ -1807,7 +1807,7 @@ describe("Map", function () {
 		});
 		it("doesn't throw error if location is not found and map is not existing", function () {
 			map._locateOptions = {setView: true};
-			var fn = L.Util.bind(map._handleGeolocationError, map);
+			var fn = map._handleGeolocationError.bind(map);
 			map.remove();
 			map = null;
 			expect(function () {

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -238,9 +238,9 @@ export var Layers = Control.extend({
 		});
 
 		if (this.options.sortLayers) {
-			this._layers.sort(Util.bind(function (a, b) {
+			this._layers.sort((function (a, b) {
 				return this.options.sortFunction(a.layer, b.layer, a.name, b.name);
-			}, this));
+			}).bind(this));
 		}
 
 		if (this.options.autoZIndex && layer.setZIndex) {

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -28,23 +28,6 @@ export var create = Object.create || (function () {
 	};
 })();
 
-// @function bind(fn: Function, …): Function
-// Returns a new function bound to the arguments passed, like [Function.prototype.bind](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
-// Has a `L.bind()` shortcut.
-export function bind(fn, obj) {
-	var slice = Array.prototype.slice;
-
-	if (fn.bind) {
-		return fn.bind.apply(fn, slice.call(arguments, 1));
-	}
-
-	var args = slice.call(arguments, 2);
-
-	return function () {
-		return fn.apply(obj, args.length ? args.concat(slice.call(arguments)) : arguments);
-	};
-}
-
 // @property lastId: Number
 // Last unique ID used by [`stamp()`](#util-stamp)
 export var lastId = 0;
@@ -228,7 +211,7 @@ export function requestAnimFrame(fn, context, immediate) {
 	if (immediate && requestFn === timeoutDefer) {
 		fn.call(context);
 	} else {
-		return requestFn.call(window, bind(fn, context));
+		return requestFn.call(window, fn.bind(context));
 	}
 }
 

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -12,4 +12,4 @@ export {Handler} from './Handler';
 
 import * as Util from './Util';
 export {Util};
-export {extend, bind, stamp, setOptions} from './Util';
+export {extend, stamp, setOptions} from './Util';

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -127,7 +127,7 @@ export var DivOverlay = Layer.extend({
 	onRemove: function (map) {
 		if (map._fadeAnimated) {
 			DomUtil.setOpacity(this._container, 0);
-			this._removeTimeout = setTimeout(Util.bind(DomUtil.remove, undefined, this._container), 200);
+			this._removeTimeout = setTimeout(DomUtil.remove.bind(null, this._container), 200);
 		} else {
 			DomUtil.remove(this._container);
 		}

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -193,8 +193,8 @@ export var ImageOverlay = Layer.extend({
 
 		// @event load: Event
 		// Fired when the ImageOverlay layer has loaded its image
-		img.onload = Util.bind(this.fire, this, 'load');
-		img.onerror = Util.bind(this._overlayOnError, this, 'error');
+		img.onload = this.fire.bind(this, 'load');
+		img.onerror = this._overlayOnError.bind(this);
 
 		if (this.options.crossOrigin || this.options.crossOrigin === '') {
 			img.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -62,7 +62,7 @@ export var VideoOverlay = ImageOverlay.extend({
 
 		// @event load: Event
 		// Fired when the video has finished loading the first frame
-		vid.onloadeddata = Util.bind(this.fire, this, 'load');
+		vid.onloadeddata = this.fire.bind(this, 'load');
 
 		if (wasElementSupplied) {
 			var sourceElements = vid.getElementsByTagName('source');

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -807,7 +807,7 @@ export var GridLayer = Layer.extend({
 		var tilePos = this._getTilePos(coords),
 		    key = this._tileCoordsToKey(coords);
 
-		var tile = this.createTile(this._wrapCoords(coords), Util.bind(this._tileReady, this, coords));
+		var tile = this.createTile(this._wrapCoords(coords), this._tileReady.bind(this, coords));
 
 		this._initTile(tile);
 
@@ -815,7 +815,7 @@ export var GridLayer = Layer.extend({
 		// we know that tile is async and will be ready later; otherwise
 		if (this.createTile.length < 2) {
 			// mark tile as ready, but delay one frame for opacity animation to happen
-			Util.requestAnimFrame(Util.bind(this._tileReady, this, coords, null, tile));
+			Util.requestAnimFrame(this._tileReady.bind(this, coords, null, tile));
 		}
 
 		DomUtil.setPosition(tile, tilePos);
@@ -884,7 +884,7 @@ export var GridLayer = Layer.extend({
 			} else {
 				// Wait a bit more than 0.2 secs (the duration of the tile fade-in)
 				// to trigger a pruning.
-				setTimeout(Util.bind(this._pruneTiles, this), 250);
+				setTimeout(this._pruneTiles.bind(this), 250);
 			}
 		}
 	},

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -147,8 +147,8 @@ export var TileLayer = GridLayer.extend({
 	createTile: function (coords, done) {
 		var tile = document.createElement('img');
 
-		DomEvent.on(tile, 'load', Util.bind(this._tileOnLoad, this, done, tile));
-		DomEvent.on(tile, 'error', Util.bind(this._tileOnError, this, done, tile));
+		DomEvent.on(tile, 'load', this._tileOnLoad.bind(this, done, tile));
+		DomEvent.on(tile, 'error', this._tileOnError.bind(this, done, tile));
 
 		if (this.options.crossOrigin || this.options.crossOrigin === '') {
 			tile.crossOrigin = this.options.crossOrigin === true ? '' : this.options.crossOrigin;
@@ -197,12 +197,7 @@ export var TileLayer = GridLayer.extend({
 	},
 
 	_tileOnLoad: function (done, tile) {
-		// For https://github.com/Leaflet/Leaflet/issues/3332
-		if (Browser.ielt9) {
-			setTimeout(Util.bind(done, this, null, tile), 0);
-		} else {
-			done(null, tile);
-		}
+		done(null, tile);
 	},
 
 	_tileOnError: function (done, tile, e) {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -413,9 +413,9 @@ export var Canvas = Renderer.extend({
 		this._fireEvent(this._hoveredLayer ? [this._hoveredLayer] : false, e);
 
 		this._mouseHoverThrottled = true;
-		setTimeout(Util.bind(function () {
+		setTimeout((function () {
 			this._mouseHoverThrottled = false;
-		}, this), 32);
+		}).bind(this), 32);
 	},
 
 	_fireEvent: function (layers, e, type) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -137,7 +137,7 @@ export var Map = Evented.extend({
 		this._initLayout();
 
 		// hack for https://github.com/Leaflet/Leaflet/issues/1980
-		this._onResize = Util.bind(this._onResize, this);
+		this._onResize = this._onResize.bind(this);
 
 		this._initEvents();
 
@@ -585,7 +585,7 @@ export var Map = Evented.extend({
 
 			if (options.debounceMoveend) {
 				clearTimeout(this._sizeTimer);
-				this._sizeTimer = setTimeout(Util.bind(this.fire, this, 'moveend'), 200);
+				this._sizeTimer = setTimeout(this.fire.bind(this, 'moveend'), 200);
 			} else {
 				this.fire('moveend');
 			}
@@ -639,8 +639,8 @@ export var Map = Evented.extend({
 			return this;
 		}
 
-		var onResponse = Util.bind(this._handleGeolocationResponse, this),
-		    onError = Util.bind(this._handleGeolocationError, this);
+		var onResponse = this._handleGeolocationResponse.bind(this),
+		    onError = this._handleGeolocationError.bind(this);
 
 		if (options.watch) {
 			this._locationWatchId =
@@ -1711,7 +1711,7 @@ export var Map = Evented.extend({
 		this._move(this._animateToCenter, this._animateToZoom, undefined, true);
 
 		// Work around webkit not firing 'transitionend', see https://github.com/Leaflet/Leaflet/issues/3689, 2693
-		setTimeout(Util.bind(this._onZoomTransitionEnd, this), 250);
+		setTimeout(this._onZoomTransitionEnd.bind(this), 250);
 	},
 
 	_onZoomTransitionEnd: function () {

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -1,6 +1,5 @@
 import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
-import * as Util from '../../core/Util';
 import * as DomUtil from '../../dom/DomUtil';
 import * as DomEvent from '../../dom/DomEvent';
 import {LatLngBounds} from '../../geo/LatLngBounds';
@@ -126,7 +125,7 @@ export var BoxZoom = Handler.extend({
 		// Postpone to next JS tick so internal click event handling
 		// still see it as "moved".
 		this._clearDeferredResetState();
-		this._resetStateTimeout = setTimeout(Util.bind(this._resetState, this), 0);
+		this._resetStateTimeout = setTimeout(this._resetState.bind(this), 0);
 
 		var bounds = new LatLngBounds(
 		        this._map.containerPointToLatLng(this._startPoint),

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -1,7 +1,6 @@
 import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
 import * as DomEvent from '../../dom/DomEvent';
-import * as Util from '../../core/Util';
 
 /*
  * L.Handler.ScrollWheelZoom is used by L.Map to enable mouse scroll wheel zoom on the map.
@@ -54,7 +53,7 @@ export var ScrollWheelZoom = Handler.extend({
 		var left = Math.max(debounce - (+new Date() - this._startTime), 0);
 
 		clearTimeout(this._timer);
-		this._timer = setTimeout(Util.bind(this._performZoom, this), left);
+		this._timer = setTimeout(this._performZoom.bind(this), left);
 
 		DomEvent.stop(e);
 	},

--- a/src/map/handler/Map.TapHold.js
+++ b/src/map/handler/Map.TapHold.js
@@ -2,7 +2,6 @@ import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
 import * as DomEvent from '../../dom/DomEvent';
 import {Point} from '../../geometry/Point';
-import * as Util from '../../core/Util';
 import Browser from '../../core/Browser';
 
 /*
@@ -42,7 +41,7 @@ export var TapHold = Handler.extend({
 		var first = e.touches[0];
 		this._startPos = this._newPos = new Point(first.clientX, first.clientY);
 
-		this._holdTimeout = setTimeout(Util.bind(function () {
+		this._holdTimeout = setTimeout((function () {
 			this._cancel();
 			if (!this._isTapValid()) { return; }
 
@@ -50,7 +49,7 @@ export var TapHold = Handler.extend({
 			DomEvent.on(document, 'touchend', DomEvent.preventDefault);
 			DomEvent.on(document, 'touchend touchcancel', this._cancelClickPrevent);
 			this._simulateEvent('contextmenu', first);
-		}, this), tapHoldDelay);
+		}).bind(this), tapHoldDelay);
 
 		DomEvent.on(document, 'touchend touchcancel contextmenu', this._cancel, this);
 		DomEvent.on(document, 'touchmove', this._onMove, this);

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -97,7 +97,7 @@ export var TouchZoom = Handler.extend({
 
 		Util.cancelAnimFrame(this._animRequest);
 
-		var moveFn = Util.bind(map._move, map, this._center, this._zoom, {pinch: true, round: false}, undefined);
+		var moveFn = map._move.bind(map, this._center, this._zoom, {pinch: true, round: false}, undefined);
 		this._animRequest = Util.requestAnimFrame(moveFn, this, true);
 
 		DomEvent.preventDefault(e);


### PR DESCRIPTION
Removes the `Util.bind()` function and replaces it with the standard [`Function.bind()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) method. `Util.bind()` included backwards compatibility with older browsers, which is no longer required now that we have raised our target browsers.

This change is also needed to update the linter configuration as it introspects `.bind()` calls for certain rules (such as [`no-invalid-this`](https://eslint.org/docs/latest/rules/no-invalid-this)).