### PR TITLE
Add slow test stats and make some tests faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "karma-rollup-preprocessor": "^7.0.8",
         "karma-safari-launcher": "~1.0.0",
         "karma-sinon": "^1.0.5",
+        "karma-time-stats-reporter": "^0.1.0",
         "leafdoc": "^2.3.0",
         "lint-staged": "^13.0.3",
         "mocha": "^10.0.0",
@@ -884,6 +885,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clone-regexp": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -919,6 +929,19 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "node_modules/columnify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
+      "integrity": "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==",
+      "dev": true,
+      "dependencies": {
+        "strip-ansi": "^6.0.1",
+        "wcwidth": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -1101,6 +1124,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "node_modules/defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -2479,6 +2511,87 @@
       "peerDependencies": {
         "karma": ">=0.10",
         "sinon": "*"
+      }
+    },
+    "node_modules/karma-time-stats-reporter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-time-stats-reporter/-/karma-time-stats-reporter-0.1.0.tgz",
+      "integrity": "sha512-7oCfFIqFs8D3xcDBfP75taNlmiSe9KeWfi+VChy31EHG+JL7Hf9B58Opyb5uG0aeKdsXfLWptG3KTt0duwCzjQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "columnify": "^1.5.4"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/karma-time-stats-reporter/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/karma/node_modules/graceful-fs": {
@@ -4333,6 +4446,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5235,6 +5357,12 @@
         }
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true
+    },
     "clone-regexp": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -5264,6 +5392,16 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
+    },
+    "columnify": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
+      "integrity": "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==",
+      "dev": true,
+      "requires": {
+        "strip-ansi": "^6.0.1",
+        "wcwidth": "^1.0.0"
+      }
     },
     "commander": {
       "version": "8.3.0",
@@ -5405,6 +5543,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "dev": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
     },
     "depd": {
       "version": "2.0.0",
@@ -6470,6 +6617,74 @@
       "integrity": "sha512-wrkyAxJmJbn75Dqy17L/8aILJWFm7znd1CE8gkyxTBFnjMSOe2XTJ3P30T8SkxWZHmoHX0SCaUJTDBEoXs25Og==",
       "dev": true,
       "requires": {}
+    },
+    "karma-time-stats-reporter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/karma-time-stats-reporter/-/karma-time-stats-reporter-0.1.0.tgz",
+      "integrity": "sha512-7oCfFIqFs8D3xcDBfP75taNlmiSe9KeWfi+VChy31EHG+JL7Hf9B58Opyb5uG0aeKdsXfLWptG3KTt0duwCzjQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "columnify": "^1.5.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "leafdoc": {
       "version": "2.3.0",
@@ -7809,6 +8024,15 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
       "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "karma-rollup-preprocessor": "^7.0.8",
     "karma-safari-launcher": "~1.0.0",
     "karma-sinon": "^1.0.5",
+    "karma-time-stats-reporter": "^0.1.0",
     "leafdoc": "^2.3.0",
     "lint-staged": "^13.0.3",
     "mocha": "^10.0.0",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -33,7 +33,9 @@ module.exports = function (config) {
 			'karma-edge-launcher',
 			'karma-chrome-launcher',
 			'karma-safari-launcher',
-			'karma-firefox-launcher'],
+			'karma-firefox-launcher',
+			'karma-time-stats-reporter'
+		],
 
 		// frameworks to use
 		frameworks: ['mocha', 'sinon', 'expect'],
@@ -61,7 +63,12 @@ module.exports = function (config) {
 
 		// test results reporter to use
 		// possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-		// reporters: ['dots'],
+		reporters: ['progress', 'time-stats'],
+
+		timeStatsReporter: {
+			reportTimeStats: false,
+			longestTestsCount: 10
+		},
 
 		// web server port
 		port: 9876,

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1240,7 +1240,7 @@ describe("Map", function () {
 				done();
 			};
 			map.setView([0, 0], 0);
-			map.on("zoomend", callback).flyTo(newCenter, newZoom);
+			map.on("zoomend", callback).flyTo(newCenter, newZoom, {duration: 0.1});
 		});
 
 		it("flyTo start latlng == end latlng", function (done) {
@@ -1255,7 +1255,7 @@ describe("Map", function () {
 				done();
 			});
 
-			map.flyTo(dc, 4);
+			map.flyTo(dc, 4, {duration: 0.1});
 		});
 	});
 

--- a/spec/suites/map/handler/Map.KeyboardSpec.js
+++ b/spec/suites/map/handler/Map.KeyboardSpec.js
@@ -16,6 +16,9 @@ describe("Map.Keyboard", function () {
 			zoomAnimation: false	// If true, the test has to wait extra 250msec
 		});
 
+		// make keyboard-caused panning instant to cut down on test running time
+		map.panBy = function (offset) { return L.Map.prototype.panBy.call(this, offset, {animate: false}); };
+
 		map.setView([0, 0], 5);
 
 		// Keyboard functionality expects the map to be focused (clicked or cycle-tabbed)
@@ -29,83 +32,59 @@ describe("Map.Keyboard", function () {
 	});
 
 	describe("arrow keys", function () {
-		it("move the map north", function (done) {
-
+		it("move the map north", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_ARROW_UP});
 			happen.keypress(document, {keyCode: KEYCODE_ARROW_UP});
 			happen.keyup(document,    {keyCode: KEYCODE_ARROW_UP});
 
-			setTimeout(function () {
-				expect(map.getCenter().lat).to.be.greaterThan(0);
-				done();
-			}, 300);
+			expect(map.getCenter().lat).to.be.greaterThan(0);
 		});
 
-		it("move the map south", function (done) {
-
+		it("move the map south", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_ARROW_DOWN});
 			happen.keypress(document, {keyCode: KEYCODE_ARROW_DOWN});
 			happen.keyup(document,    {keyCode: KEYCODE_ARROW_DOWN});
 
-			setTimeout(function () {
-				expect(map.getCenter().lat).to.be.lessThan(0);
-				done();
-			}, 300);
+			expect(map.getCenter().lat).to.be.lessThan(0);
 		});
 
-		it("move the map west", function (done) {
-
+		it("move the map west", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_ARROW_LEFT});
 			happen.keypress(document, {keyCode: KEYCODE_ARROW_LEFT});
 			happen.keyup(document,    {keyCode: KEYCODE_ARROW_LEFT});
 
-			setTimeout(function () {
-				expect(map.getCenter().lng).to.be.lessThan(0);
-				done();
-			}, 300);
+			expect(map.getCenter().lng).to.be.lessThan(0);
 		});
 
-		it("move the map east", function (done) {
-
+		it("move the map east", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_ARROW_RIGHT});
 			happen.keypress(document, {keyCode: KEYCODE_ARROW_RIGHT});
 			happen.keyup(document,    {keyCode: KEYCODE_ARROW_RIGHT});
 
-			setTimeout(function () {
-				expect(map.getCenter().lng).to.be.greaterThan(0);
-				done();
-			}, 300);
+			expect(map.getCenter().lng).to.be.greaterThan(0);
 		});
 	});
 
 	describe("plus/minus keys", function () {
-		it("zoom in", function (done) {
-
+		it("zoom in", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_PLUS});
 			happen.keypress(document, {keyCode: KEYCODE_PLUS});
 			happen.keyup(document,    {keyCode: KEYCODE_PLUS});
 
-			setTimeout(function () {
-				expect(map.getZoom()).to.be.greaterThan(5);
-				done();
-			}, 300);
+			expect(map.getZoom()).to.be.greaterThan(5);
 		});
 
-		it("zoom out", function (done) {
-
+		it("zoom out", function () {
 			happen.keydown(document,  {keyCode: KEYCODE_MINUS});
 			happen.keypress(document, {keyCode: KEYCODE_MINUS});
 			happen.keyup(document,    {keyCode: KEYCODE_MINUS});
 
-			setTimeout(function () {
-				expect(map.getZoom()).to.be.lessThan(5);
-				done();
-			}, 300);
+			expect(map.getZoom()).to.be.lessThan(5);
 		});
 	});
 
 	describe("does not move the map if disabled", function () {
-		it("no zoom in", function (done) {
+		it("no zoom in", function () {
 
 			map.keyboard.disable();
 
@@ -113,13 +92,10 @@ describe("Map.Keyboard", function () {
 			happen.keypress(document, {keyCode: KEYCODE_PLUS});
 			happen.keyup(document,    {keyCode: KEYCODE_PLUS});
 
-			setTimeout(function () {
-				expect(map.getZoom()).to.eql(5);
-				done();
-			}, 300);
+			expect(map.getZoom()).to.eql(5);
 		});
 
-		it("no move north", function (done) {
+		it("no move north", function () {
 
 			map.keyboard.disable();
 
@@ -127,10 +103,7 @@ describe("Map.Keyboard", function () {
 			happen.keypress(document, {keyCode: KEYCODE_ARROW_UP});
 			happen.keyup(document,    {keyCode: KEYCODE_ARROW_UP});
 
-			setTimeout(function () {
-				expect(map.getCenter().lat).to.eql(0);
-				done();
-			}, 300);
+			expect(map.getCenter().lat).to.eql(0);
 		});
 	});
 


### PR DESCRIPTION
Ref #8483. Adds a Karma plugin that displays 10 slowest tests after running the test suite:

```
2833ms GridLayer number of 256px tiles loaded in synchronous animated grid @800x600px Loads 290, unloads 275 tiles on MAD-TRD flyTo()
2813ms TileLayer number of kittens loaded Loads 290, unloads 275 kittens on MAD-TRD flyTo()                                          
809ms  Popup L.Map#openPopup moves the map over a long distance to the popup if it is not in the view (keepInView)                   
665ms  Map.ScrollWheelZoom changes the option 'wheelPxPerZoomLevel'                                                                  
606ms  Path #events can add a layer while being inside a moveend handler                                                             
365ms  Map.ScrollWheelZoom changes the option 'wheelDebounceTime'                                                                    
321ms  LineUtil #polylineCenter computes center of a small line and test it on every zoom                                            
310ms  Map.ScrollWheelZoom scrollWheelZoom: 'center'                                                                                 
306ms  Map.ScrollWheelZoom zooms out while firing 'wheel' event                                                                      
300ms  Map.ScrollWheelZoom zooms in while firing 'wheel' event     
```

Also makes a few of the unit tests faster, cutting down overall time by ~10 seconds.