### PR TITLE
Use different cache keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,22 +18,14 @@ jobs:
           check-latest: true
           cache: npm
 
-      - name: Cache dependencies
-        id: cache-dependencies
-        uses: actions/cache@v3
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Cache setup
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-setup
+          key: ${{ github.ref }}-${{ github.sha }}-setup
 
   build:
     needs: setup
@@ -43,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-setup
+          key: ${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -59,7 +51,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build
+          key: ${{ github.ref }}-${{ github.sha }}-build
 
   build-release:
     needs: setup
@@ -69,7 +61,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-setup
+          key: ${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -85,7 +77,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build-release
+          key: ${{ github.ref }}-${{ github.sha }}-build-release
 
   lint:
     needs: setup
@@ -95,7 +87,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-setup
+          key: ${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -114,7 +106,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build-release
+          key: ${{ github.ref }}-${{ github.sha }}-build-release
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -142,7 +134,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build
+          key: ${{ github.ref }}-${{ github.sha }}-build
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -161,7 +153,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build
+          key: ${{ github.ref }}-${{ github.sha }}-build
 
       - name: Compress artifacts
         working-directory: dist
@@ -187,7 +179,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ runner.os }}-${{ github.sha }}-build
+          key: ${{ github.ref }}-${{ github.sha }}-build
 
       - name: Set up Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Use cache keys based on the `ref` to ensure no caches are shared between regular builds and release builds.

Closes #8460.