### PR TITLE
Avoid ignoring dragstart events during zoom in/out (#8201)

### DIFF
--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -78,8 +78,6 @@ export var Draggable = Evented.extend({
 
 		this._moved = false;
 
-		if (DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
-
 		if (e.touches && e.touches.length !== 1) {
 			// Finish dragging to avoid conflict with touchZoom
 			if (Draggable._dragging === this) {


### PR DESCRIPTION
This line of code will cancel a drag that starts during the zoom in/out animation. Said line looks extremely specific so there may well be a good reason it's there, but neither comments nor commit messages indicate a particular reason for its existence, and after removing it the tests continue to pass.

Please let me know if I've done something silly in this process. It's my first time doing a pull request ;)