### PR TITLE
Check if `getElement()` is undefined before adding focus listener (Canvas)

### DIFF
--- a/spec/suites/layer/vector/RectangleSpec.js
+++ b/spec/suites/layer/vector/RectangleSpec.js
@@ -110,4 +110,16 @@ describe('Rectangle', function () {
 			expect(rectangle.getLatLngs()).to.eql(rectangle._latlngs);
 		});
 	});
+
+	describe("#Canvas", function () {
+		it("doesn't apply `focus` listener if element is undefined", function () {
+			map.remove();
+
+			map = L.map(container, {renderer: L.canvas()});
+			map.setView([0, 0], 6);
+			expect(function () {
+				L.polygon([[[2, 3], [4, 5]]]).addTo(map).bindTooltip('test');
+			}).to.not.throwException();
+		});
+	});
 });

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -387,15 +387,19 @@ Layer.include({
 	},
 
 	_addFocusListenersOnLayer: function (layer) {
-		DomEvent.on(layer.getElement(), 'focus', function () {
-			this._tooltip._source = layer;
-			this.openTooltip();
-		}, this);
-		DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
+		if (layer.getElement()) {
+			DomEvent.on(layer.getElement(), 'focus', function () {
+				this._tooltip._source = layer;
+				this.openTooltip();
+			}, this);
+			DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
+		}
 	},
 
 	_setAriaDescribedByOnLayer: function (layer) {
-		layer.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
+		if (layer.getElement()) {
+			layer.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
+		}
 	},
 
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -387,18 +387,20 @@ Layer.include({
 	},
 
 	_addFocusListenersOnLayer: function (layer) {
-		if (layer.getElement()) {
-			DomEvent.on(layer.getElement(), 'focus', function () {
+		var el = layer.getElement();
+		if (el) {
+			DomEvent.on(el, 'focus', function () {
 				this._tooltip._source = layer;
 				this.openTooltip();
 			}, this);
-			DomEvent.on(layer.getElement(), 'blur', this.closeTooltip, this);
+			DomEvent.on(el, 'blur', this.closeTooltip, this);
 		}
 	},
 
 	_setAriaDescribedByOnLayer: function (layer) {
-		if (layer.getElement()) {
-			layer.getElement().setAttribute('aria-describedby', this._tooltip._container.id);
+		var el = layer.getElement();
+		if (el) {
+			el.setAttribute('aria-describedby', this._tooltip._container.id);
 		}
 	},
 


### PR DESCRIPTION
Fix #8442