### PR TITLE
chore: replaced `substr` with `substring`

### DIFF
--- a/docs/docs/js/reference.js
+++ b/docs/docs/js/reference.js
@@ -71,7 +71,7 @@ if (document.body.className.indexOf('api-page') !== -1) {
 					return el.parentNode && (' ' + el.parentNode.className + ' ').indexOf(' accordion ') > -1 ? el.parentNode : null;
 				};
 
-				var elm = document.getElementById(urlAnchor.substr(1));
+				var elm = document.getElementById(urlAnchor.substring(1));
 				if (elm) {
 					var parent = getParentAccordion(elm);
 					if (parent) {

--- a/docs/edit.html
+++ b/docs/edit.html
@@ -18,7 +18,7 @@
                 js: "var map = L.map('map', {\n\tlayers: [\n\t\tL.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t\t\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n\t\t})\n\t],\n\tcenter: [0, 0],\n\tzoom: 0\n});"
             };
 
-            var hash = location.hash.substr(1);
+            var hash = location.hash.substring(1);
 
             if (hash) {
                 hash.split(';').forEach(function (str) {


### PR DESCRIPTION
 `substr` method is deprecated, it should be avoided using.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr