### PR TITLE
Speed up PathSpec's "Add layer inside move handler" test: 611ms to 5ms (122x faster)

### DIFF
--- a/spec/suites/layer/vector/PathSpec.js
+++ b/spec/suites/layer/vector/PathSpec.js
@@ -68,7 +68,7 @@ describe('Path', function () {
 			expect(mapSpy.called).to.be.ok();
 		});
 
-		it('can add a layer while being inside a moveend handler', function (done) {
+		it('can add a layer while being inside a moveend handler', function () {
 			var zoneLayer = L.layerGroup();
 			var polygon;
 			map.addLayer(zoneLayer);
@@ -82,15 +82,11 @@ describe('Path', function () {
 			map.invalidateSize();
 			map.setView([1, 2], 12, {animate: false});
 
-			map.panBy([-260, 0]);
-			setTimeout(function () {
-				expect(polygon._parts.length).to.be(0);
-				map.panBy([260, 0]);
-				setTimeout(function () {
-					expect(polygon._parts.length).to.be(1);
-					done();
-				}, 300);
-			}, 300);
+			map.panBy([-260, 0], {animate: false});
+			expect(polygon._parts.length).to.be(0);
+
+			map.panBy([260, 0], {animate: false});
+			expect(polygon._parts.length).to.be(1);
 		});
 
 		it('it should return tolerance with stroke', function () {


### PR DESCRIPTION
Related to #8483

The `panBy` calls within this test would invoke pan animations, adding 250ms per pan to the test's execution time. I assume these setTimeout calls were set at 300ms to wait for that animation to finish.

I don't believe this test needs to invoke animations. Disabling them and dropping the setTimeouts saves us half a second on the tests.