### PR TITLE
Speed up tests Map.ScrollWheelZoomSpec and Map.DoubleClickZoomSpec

### DIFF
--- a/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
+++ b/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
@@ -5,7 +5,8 @@ describe("Map.DoubleClickZoom", function () {
 		container = createContainer();
 		map = L.map(container, {
 			center: [0, 0],
-			zoom: 3
+			zoom: 3,
+			zoomAnimation: false
 		});
 	});
 
@@ -15,31 +16,32 @@ describe("Map.DoubleClickZoom", function () {
 
 	it("zooms in while dblclick", function (done) {
 		var zoom = map.getZoom();
-		happen.dblclick(container);
 
 		map.on('zoomend', function () {
 			expect(map.getCenter()).to.be.nearLatLng([17.308687886770034, -17.578125000000004]);
 			expect(map.getZoom()).to.be.greaterThan(zoom);
 			done();
 		});
+
+		happen.dblclick(container);
 	});
 
 	it("zooms out while dblclick and holding shift", function (done) {
 		var zoom = map.getZoom();
-		happen.dblclick(container, {shiftKey: true});
 
 		map.on('zoomend', function () {
 			expect(map.getCenter()).to.be.nearLatLng([-33.137551192346145, 35.15625000000001]);
 			expect(map.getZoom()).to.be.lessThan(zoom);
 			done();
 		});
+
+		happen.dblclick(container, {shiftKey: true});
 	});
 
 	it("doubleClickZoom: 'center'", function (done) {
 		var doubleClickZoomBefore = map.options.doubleClickZoom;
 		map.options.doubleClickZoom = 'center';
 		var zoom = map.getZoom();
-		happen.dblclick(container);
 
 		map.on('zoomend', function () {
 			expect(map.getCenter()).to.be.nearLatLng([0, 0]);
@@ -47,6 +49,8 @@ describe("Map.DoubleClickZoom", function () {
 			map.options.doubleClickZoom = doubleClickZoomBefore;
 			done();
 		});
+
+		happen.dblclick(container);
 	});
 
 });

--- a/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
+++ b/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
@@ -16,7 +16,8 @@ describe("Map.ScrollWheelZoom", function () {
 		container = createContainer();
 		map = L.map(container, {
 			center: [0, 0],
-			zoom: 3
+			zoom: 3,
+			zoomAnimation: false
 		});
 	});
 


### PR DESCRIPTION
Related to #8483 

Zoom animations are enabled by default within Leaflet, which adds a significant overhead to these numerous zoom-related tests.

I can see that Map.TouchZoomSpec chooses to disable animations on its tests for this reason:

https://github.com/Leaflet/Leaflet/blob/579c90d27132c56ff2c6f7e2f6e4707c622e7676/spec/suites/map/handler/Map.TouchZoomSpec.js#L9

Applying that change here reduces the time to run these tests from 2693ms to 379ms, saving 2.3 seconds.

In making this change I have verified that `Map._tryAnimatedZoom` and `Map._onZoomTransitionEnd` is invoked by other tests. There doesn't appear to be an explicit test proving zoom-related animations however. I'm wondering if there's value expanding MapSpec's "#zoomIn and #zoomOut" tests to prove animations (a fixed 250ms cost, instead of 250 * N ms)?