### PR TITLE
Alternate fix for PopUp keepInView recursion and speed up associated test

### DIFF
--- a/debug/map/popup-keepinview.html
+++ b/debug/map/popup-keepinview.html
@@ -16,9 +16,11 @@
   <div id="map"></div>
 
   <div>
+    <label><input type="checkbox" id="keepInView" checked>Set keepInView</label>
     <button id="popupWithinBounds">Add popup within bounds</button>
     <button id="popupSlightlyBeyondBounds">Add popup slightly beyond bounds</button>
     <button id="popupBeyondBounds">Add popup far away</button>
+    <button id="movePopup">Move last popup</button>
   </div>
     
   <script>
@@ -31,6 +33,9 @@
     var map = L.map('map')
         .setView(center, 15)
         .addLayer(osm);
+
+    var lastPopup;
+    var keepInViewCheckbox = document.querySelector('#keepInView');
 
     function getRandomLatLng(llbounds, expandRange) {
       // How many degrees to expand the search range by
@@ -52,27 +57,35 @@
     });
     
     document.querySelector('#popupWithinBounds').addEventListener('click', function() {
-      var p = L.popup({keepInView: true})
+      lastPopup = L.popup({keepInView: keepInViewCheckbox.checked})
         .setContent('Popup')
         .setLatLng(getRandomLatLng(map.getBounds()));
 
-      map.openPopup(p);
+      map.openPopup(lastPopup);
     });
     
     document.querySelector('#popupSlightlyBeyondBounds').addEventListener('click', function() {
-      var p = L.popup({keepInView: true})
+      lastPopup = L.popup({keepInView: keepInViewCheckbox.checked})
         .setContent('Popup')
         .setLatLng(getRandomLatLng(map.getBounds(), .01));
 
-      map.openPopup(p);
+      map.openPopup(lastPopup);
     });
     
     document.querySelector('#popupBeyondBounds').addEventListener('click', function() {
-      var p = L.popup({keepInView: true})
+      lastPopup = L.popup({keepInView: keepInViewCheckbox.checked})
         .setContent('Popup')
         .setLatLng(getRandomLatLng(map.getBounds(), 1));
 
-      map.openPopup(p);
+      map.openPopup(lastPopup);
+    });
+
+    document.querySelector('#movePopup').addEventListener('click', function() {
+      if (!lastPopup) {
+        alert("No popup to move!");
+        return;
+      }
+      lastPopup.setLatLng(map.getBounds().getNorthEast());
     });
     
   </script>

--- a/debug/map/popup-keepinview.html
+++ b/debug/map/popup-keepinview.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Leaflet debug page</title>
+
+  <link rel="stylesheet" href="../../dist/leaflet.css" />
+
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <link rel="stylesheet" href="../css/screen.css" />
+
+  <script src="../../dist/leaflet-src.js"></script>
+</head>
+<body>
+
+  <div id="map"></div>
+
+  <div>
+    <button id="popupWithinBounds">Add popup within bounds</button>
+    <button id="popupSlightlyBeyondBounds">Add popup slightly beyond bounds</button>
+    <button id="popupBeyondBounds">Add popup far away</button>
+  </div>
+    
+  <script>
+
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+    var center = [50.5, 30.51];
+    var map = L.map('map')
+        .setView(center, 15)
+        .addLayer(osm);
+
+    function getRandomLatLng(llbounds, expandRange) {
+      // How many degrees to expand the search range by
+      var expandRange = expandRange || 0;
+
+      var s = llbounds.getSouth() - expandRange,
+          n = llbounds.getNorth() + expandRange,
+          w = llbounds.getWest() - expandRange,
+          e = llbounds.getEast() + expandRange;
+
+      return L.latLng(
+        s + (Math.random() * (n - s)),
+        w + (Math.random() * (e - w))
+      )
+    }
+
+    map.on('autopanstart move moveend', function(e) {
+      console.log(e);
+    });
+    
+    document.querySelector('#popupWithinBounds').addEventListener('click', function() {
+      var p = L.popup({keepInView: true})
+        .setContent('Popup')
+        .setLatLng(getRandomLatLng(map.getBounds()));
+
+      map.openPopup(p);
+    });
+    
+    document.querySelector('#popupSlightlyBeyondBounds').addEventListener('click', function() {
+      var p = L.popup({keepInView: true})
+        .setContent('Popup')
+        .setLatLng(getRandomLatLng(map.getBounds(), .01));
+
+      map.openPopup(p);
+    });
+    
+    document.querySelector('#popupBeyondBounds').addEventListener('click', function() {
+      var p = L.popup({keepInView: true})
+        .setContent('Popup')
+        .setLatLng(getRandomLatLng(map.getBounds(), 1));
+
+      map.openPopup(p);
+    });
+    
+  </script>
+</body>
+</html>

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -466,6 +466,21 @@ describe('Popup', function () {
 			});
 			map.openPopup(p);
 		});
+
+		it('moves on setLatLng after initial autopan', function (done) {
+			var p = L.popup().setContent('Popup').setLatLng(map.getBounds().getNorthEast());
+
+			map.once('moveend', function () {
+				map.once('moveend', function () {
+					expect(map.getBounds().contains(p.getLatLng())).to.be(true);
+					done();
+				});
+
+				p.setLatLng(map.getBounds().getNorthEast());
+			});
+
+			map.openPopup(p);
+		});
 	});
 
 	describe('L.Layer#_popup', function () {

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -423,7 +423,7 @@ describe('Popup', function () {
 				.down().moveBy(10, 10, 20).up();
 		});
 
-		it('moves the map over a long distance to the popup if it is not in the view (keepInView)', function () {
+		it('moves the map over a short distance to the popup if it is not in the view (keepInView)', function (done) {
 			container.style.position = 'absolute';
 			container.style.left = 0;
 			container.style.top = 0;
@@ -431,15 +431,40 @@ describe('Popup', function () {
 
 			// to prevent waiting until the animation is finished
 			map.options.inertia = false;
-			map.options.animate = false;
 
 			var spy = sinon.spy();
 			map.on('autopanstart', spy);
-			var p = L.popup({keepInView: true}).setContent('Popup').setLatLng([center[0], center[1] + 50]);
-			map.openPopup(p);
 
-			expect(spy.called).to.be(true);
-			expect(map.getBounds().contains(p.getLatLng())).to.be(true);
+			// Short hop to the edge of the map (at time of writing, will trigger an animated pan)
+			var p = L.popup({keepInView: true}).setContent('Popup').setLatLng(map.getBounds()._northEast);
+			map.once('moveend', function () {
+				expect(spy.callCount).to.be(1);
+				expect(map.getBounds().contains(p.getLatLng())).to.be(true);
+				done();
+			});
+			map.openPopup(p);
+		});
+
+		it('moves the map over a long distance to the popup if it is not in the view (keepInView)', function (done) {
+			container.style.position = 'absolute';
+			container.style.left = 0;
+			container.style.top = 0;
+			container.style.zIndex = 10000;
+
+			// to prevent waiting until the animation is finished
+			map.options.inertia = false;
+
+			var spy = sinon.spy();
+			map.on('autopanstart', spy);
+
+			// Long hop (at time of writing, will trigger a view reset)
+			var p = L.popup({keepInView: true}).setContent('Popup').setLatLng([center[0], center[1] + 50]);
+			map.once('moveend', function () {
+				expect(spy.callCount).to.be(1);
+				expect(map.getBounds().contains(p.getLatLng())).to.be(true);
+				done();
+			});
+			map.openPopup(p);
 		});
 	});
 

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -423,7 +423,7 @@ describe('Popup', function () {
 				.down().moveBy(10, 10, 20).up();
 		});
 
-		it('moves the map over a long distance to the popup if it is not in the view (keepInView)', function (done) {
+		it('moves the map over a long distance to the popup if it is not in the view (keepInView)', function () {
 			container.style.position = 'absolute';
 			container.style.left = 0;
 			container.style.top = 0;
@@ -431,17 +431,15 @@ describe('Popup', function () {
 
 			// to prevent waiting until the animation is finished
 			map.options.inertia = false;
+			map.options.animate = false;
 
 			var spy = sinon.spy();
 			map.on('autopanstart', spy);
 			var p = L.popup({keepInView: true}).setContent('Popup').setLatLng([center[0], center[1] + 50]);
 			map.openPopup(p);
 
-			setTimeout(function () {
-				expect(spy.called).to.be(true);
-				expect(map.getBounds().contains(p.getLatLng())).to.be(true);
-				done();
-			}, 800);
+			expect(spy.called).to.be(true);
+			expect(map.getBounds().contains(p.getLatLng())).to.be(true);
 		});
 	});
 

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -258,9 +258,10 @@ export var Popup = DivOverlay.extend({
 		if (!this.options.autoPan) { return; }
 		if (this._map._panAnim) { this._map._panAnim.stop(); }
 
-		// We can endlessly recursive if keepInView is set with animations disabled. Let's guard against that by exiting
-		// early if we're in the middle of an earlier pan.
-		if (this._autopanning) {
+		// We can endlessly recurse if keepInView is set and the view resets.
+		// Let's guard against that by exiting early if we're responding to our
+		// own autopan.
+		if (this._autopanning && this.options.keepInView) {
 			this._autopanning = false;
 			return;
 		}
@@ -299,7 +300,12 @@ export var Popup = DivOverlay.extend({
 		// @event autopanstart: Event
 		// Fired when the map starts autopanning when opening a popup.
 		if (dx || dy) {
-			this._autopanning = true;
+			// Track that we're autopanning, as this function will be re-ran
+			// on moveend
+			if (this.options.keepInView) {
+				this._autopanning = true;
+			}
+
 			map
 			    .fire('autopanstart')
 			    .panBy([dx, dy]);

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -259,9 +259,8 @@ export var Popup = DivOverlay.extend({
 		if (this._map._panAnim) { this._map._panAnim.stop(); }
 
 		// We can endlessly recurse if keepInView is set and the view resets.
-		// Let's guard against that by exiting early if we're responding to our
-		// own autopan.
-		if (this._autopanning && this.options.keepInView) {
+		// Let's guard against that by exiting early if we're responding to our own autopan.
+		if (this._autopanning) {
 			this._autopanning = false;
 			return;
 		}
@@ -300,8 +299,7 @@ export var Popup = DivOverlay.extend({
 		// @event autopanstart: Event
 		// Fired when the map starts autopanning when opening a popup.
 		if (dx || dy) {
-			// Track that we're autopanning, as this function will be re-ran
-			// on moveend
+			// Track that we're autopanning, as this function will be re-ran on moveend
 			if (this.options.keepInView) {
 				this._autopanning = true;
 			}

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -254,9 +254,17 @@ export var Popup = DivOverlay.extend({
 		DomUtil.setPosition(this._container, pos.add(anchor));
 	},
 
-	_adjustPan: function (e) {
+	_adjustPan: function () {
 		if (!this.options.autoPan) { return; }
 		if (this._map._panAnim) { this._map._panAnim.stop(); }
+
+		// We can endlessly recursive if keepInView is set with animations disabled. Let's guard against that by exiting
+		// early if we're in the middle of an earlier pan.
+		if (this._autopanning) {
+			this._autopanning = false;
+			return;
+		}
+
 
 		var map = this._map,
 		    marginBottom = parseInt(DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
@@ -292,9 +300,10 @@ export var Popup = DivOverlay.extend({
 		// @event autopanstart: Event
 		// Fired when the map starts autopanning when opening a popup.
 		if (dx || dy) {
+			this._autopanning = true;
 			map
 			    .fire('autopanstart')
-			    .panBy([dx, dy], {animate: e && e.type === 'moveend'});
+			    .panBy([dx, dy]);
 		}
 	},
 

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -265,7 +265,6 @@ export var Popup = DivOverlay.extend({
 			return;
 		}
 
-
 		var map = this._map,
 		    marginBottom = parseInt(DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
 		    containerHeight = this._container.offsetHeight + marginBottom,


### PR DESCRIPTION
Related to #8483

I was reviewing the PopUp keepInView test with the eye of speeding it up, however I found that the pan animation was forced on. This was introduced with #7792 to guard against infinite recursion from `(on moveend) -> _adjustPan -> panBy -> _resetView -> (fire moveend)`.

Reviewing the Popup code, we always expect `_adjustPan` to be triggered by its own `panBy` call but ordinarily the view will have updated and the `dx` and `dy` offsets will be 0, avoiding the recursive call. We only end up with the recursive call when `_resetView` is called, because the map doesn't have a chance to re-render itself (is that right?).

The fact that `_adjustPan` will always invoke itself allows an alternate solution: We can set a local variable when we start autopanning, and check it in the later invocation. If its present, we know the `moveend` currently being handled was invoked by the same function, and can thus return early – also avoiding the recursive invocation.

With this change, the associated test can be simplified and sped up from 812ms to 10ms (81x faster).

I'm raising this as a draft for now as I'm keen for thoughts on this as an alternate fix. I also want to do some manual testing varying pan distances and animations to further validate the change.