### PR TITLE
docs: :memo: Adding documentation for the support of lon in the latLng function, resolves 8509

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -19248,7 +19248,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <p>All Leaflet methods that accept LatLng objects also accept them in a simple Array form and simple object form (unless noted otherwise), so these lines are equivalent:</p>
 <pre><code>map.panTo([50, 30]);
 map.panTo({lng: 30, lat: 50});
-map.panTo({lat: 50, lng: 30});
+map.panTo({lat: 50, lng: 30}); // Note: `lon` can be used interchangably with `lng` in objects.
 map.panTo(L.latLng(50, 30));
 </code></pre>
 <p>Note that <a href="#latlng"><code>LatLng</code></a> does not inherit from Leaflet's <a href="#class"><code>Class</code></a> object,
@@ -19284,7 +19284,7 @@ can't be added to it with the <code>include</code> function.</p>
 	</tr>
 	<tr id='latlng-l-latlng'>
 		<td><code><b>L.latLng</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>)</code></td>
-		<td>Expects an plain object of the form <code>{lat: Number, lng: Number}</code> or <code>{lat: Number, lng: Number, alt: Number}</code> instead.</td>
+		<td>Expects an plain object of the form <code>{lat: Number, lng: Number}</code> or <code>{lat: Number, lng: Number, alt: Number}</code> instead.  As noted previously, <code>lon</code> can be used in place of <code>lng</code> when passing in an object to this function.</td>
 	</tr>
 </tbody></table>
 

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -19248,7 +19248,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <p>All Leaflet methods that accept LatLng objects also accept them in a simple Array form and simple object form (unless noted otherwise), so these lines are equivalent:</p>
 <pre><code>map.panTo([50, 30]);
 map.panTo({lng: 30, lat: 50});
-map.panTo({lat: 50, lng: 30}); // Note: `lon` can be used interchangably with `lng` in objects.
+map.panTo({lat: 50, lng: 30});
 map.panTo(L.latLng(50, 30));
 </code></pre>
 <p>Note that <a href="#latlng"><code>LatLng</code></a> does not inherit from Leaflet's <a href="#class"><code>Class</code></a> object,
@@ -19284,7 +19284,7 @@ can't be added to it with the <code>include</code> function.</p>
 	</tr>
 	<tr id='latlng-l-latlng'>
 		<td><code><b>L.latLng</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>)</code></td>
-		<td>Expects an plain object of the form <code>{lat: Number, lng: Number}</code> or <code>{lat: Number, lng: Number, alt: Number}</code> instead.  As noted previously, <code>lon</code> can be used in place of <code>lng</code> when passing in an object to this function.</td>
+		<td>Expects an plain object of the form <code>{lat: Number, lng: Number}</code> or <code>{lat: Number, lng: Number, alt: Number}</code> instead.</td>
 	</tr>
 </tbody></table>
 

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -17,7 +17,7 @@ import {toLatLngBounds} from './LatLngBounds';
  *
  * ```
  * map.panTo([50, 30]);
- * map.panTo({lat: 50, lng: 30});
+ * map.panTo({lat: 50, lng: 30}); // Note: `lon` can be used interchangably with `lng` in objects.
  * map.panTo(L.latLng(50, 30));
  * ```
  *
@@ -109,6 +109,7 @@ LatLng.prototype = {
 // @alternative
 // @factory L.latLng(coords: Object): LatLng
 // Expects an plain object of the form `{lat: Number, lng: Number}` or `{lat: Number, lng: Number, alt: Number}` instead.
+// As noted previously, `lon` can be used in place of `lng` when passing in objects to this function.
 
 export function toLatLng(a, b, c) {
 	if (a instanceof LatLng) {

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -109,7 +109,7 @@ LatLng.prototype = {
 // @alternative
 // @factory L.latLng(coords: Object): LatLng
 // Expects an plain object of the form `{lat: Number, lng: Number}` or `{lat: Number, lng: Number, alt: Number}` instead.
-// As noted previously, `lon` can be used in place of `lng` when passing in objects to this function.
+// As noted previously, `lon` can be used in place of `lng` when passing in an object to this function.
 
 export function toLatLng(a, b, c) {
 	if (a instanceof LatLng) {

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -109,7 +109,7 @@ LatLng.prototype = {
 // @alternative
 // @factory L.latLng(coords: Object): LatLng
 // Expects an plain object of the form `{lat: Number, lng: Number}` or `{lat: Number, lng: Number, alt: Number}` instead.
-// As noted previously, `lon` can be used in place of `lng` when passing in an object to this function.
+//  You can also use `lon` in place of `lng` in the object form.
 
 export function toLatLng(a, b, c) {
 	if (a instanceof LatLng) {

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -17,7 +17,8 @@ import {toLatLngBounds} from './LatLngBounds';
  *
  * ```
  * map.panTo([50, 30]);
- * map.panTo({lat: 50, lng: 30}); // Note: `lon` can be used interchangably with `lng` in objects.
+ * map.panTo({lat: 50, lng: 30});
+ * map.panTo({lat: 50, lon: 30});
  * map.panTo(L.latLng(50, 30));
  * ```
  *


### PR DESCRIPTION
### Issue

#8509 

### What I Did

Updated the reference docs and the comments in the LatLng.js file to include notes outlining the ability to use `lon` instead of `lng` when passing in an object to a function that uses the LatLng object.  References to where this functionality came from can be found in the issue and are present for compatibility with other services such as D3.js.  

