### PR TITLE
Fix intermittent wobble when setMaxBounds(map.getBounds())

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -458,6 +458,20 @@ describe("Map", function () {
 			map.setMaxBounds(bounds, {animate: false});
 			expect(map.off.called).not.to.be.ok();
 		});
+
+		it("avoid subpixel / floating point related wobble (#8532)", function (done) {
+			map.setView([50.450036, 30.5241361], 13);
+
+			var spy = sinon.spy();
+			map.on('moveend', spy);
+			map.setMaxBounds(map.getBounds());
+
+			// Unfortunately this is one of those tests where we need to allow at least one animation tick
+			setTimeout(function () {
+				expect(spy.called).to.be(false);
+				done();
+			}, 300);
+		});
 	});
 
 	describe("#setMinZoom and #setMaxZoom", function () {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1543,7 +1543,7 @@ export var Map = Evented.extend({
 		// If offset is less than a pixel, ignore.
 		// This prevents unstable projections from getting into
 		// an infinite loop of tiny offsets.
-		if (offset.round().equals([0, 0])) {
+		if (Math.abs(offset.x) <= 1 && Math.abs(offset.y) <= 1) {
 			return center;
 		}
 


### PR DESCRIPTION
Fixes #8532

At certain coordinate and/or screen size combinations, `Map.setMaxBounds` ended up triggering an infinite `_panInsideMaxBounds` loop due to slight discrepancies in reprojected center points across loops.

We are supposed to break out of this loop if our recalculated centers are identical:

https://github.com/Leaflet/Leaflet/blob/4372a9fcadce23d23a21370439179c09d1118ab3/src/map/Map.js#L503-L514

And our `_limitCenter` code was already set up to catch subpixel offsets, ignore them, and returning the identical center to break the loop.

Unfortunately it seems the projection instability can cause up to 1px offsets, which this code was not catching.

This PR adds a failing test for the problem as reported, using the `setView` values from the bug report. This test does appear to consistently fail.

The PR also updates `_limitCenter` to ignore up to 1 pixel offsets, which fixes the issue.