### PR TITLE
Fix 2 links without URLs in docs

### DIFF
--- a/docs/examples/extending/extending-2-layers.md
+++ b/docs/examples/extending/extending-2-layers.md
@@ -15,7 +15,7 @@ A few of the Leaflet classes have so-called "extension methods": entry points fo
 
 One of them is `L.TileLayer.getTileUrl()`. This method is called internally by `L.TileLayer` whenever a new tile needs to know which image to load. By making a subclass of `L.TileLayer` and rewriting its `getTileUrl()` function, we can create custom behaviour.
 
-Let's illustrate with a custom `L.TileLayer` that will display random kitten images from [PlaceKitten]():
+Let's illustrate with a custom `L.TileLayer` that will display random kitten images from [PlaceKitten](https://placekitten.com):
 
     L.TileLayer.Kitten = L.TileLayer.extend({
         getTileUrl: function(coords) {

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -316,7 +316,7 @@ export function preventOutline(element) {
 }
 
 // @function restoreOutline()
-// Cancels the effects of a previous [`L.DomUtil.preventOutline`]().
+// Cancels the effects of a previous [`L.DomUtil.preventOutline`](#domutil-preventoutline).
 export function restoreOutline() {
 	if (!_outlineElement) { return; }
 	_outlineElement.style.outline = _outlineStyle;


### PR DESCRIPTION
Was updating the list in https://github.com/Leaflet/Leaflet/issues/8477 when I found 2 empty links.

(I only searched for empty links in markdown (`]()`), there may be other empty `<a>` links elsewhere.)