### PR TITLE
Change default font size of scale bar

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -433,6 +433,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-control-scale-line {
 	border: 2px solid #777;
 	border-top: none;
+	font-size: 10px;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
 	white-space: nowrap;


### PR DESCRIPTION
Hello 👋🏼 

I had a user notice that when the map initally loads at a zoom level of `3`, the metric scale bar slightly cuts off the unit value of `km`. Please see screenshot below. 

![image](https://user-images.githubusercontent.com/85003930/194720547-6be93446-38bf-4a2c-bcbc-97326ed9b753.png)

Since this is a scale bar and the width of it cannot be changed, I think the only solution must be to reduce the font size of the text slightly so that this doesn't occur. 

It is an edge-case but noticeable enough that a user reported it. I have tested font size `10px` on many different zoom levels and it seems to fix this issue. 

I also searched for related issues to this and did not find any discussion on this previously. (Maybe it was decided not to be a big enough deal to fix?). Please let me know if I missed any background discussion on this issue.

Here is how it looks with the adjusted font size at the same zoom level:

![image](https://user-images.githubusercontent.com/85003930/194720605-ec638e92-132a-4ec1-9580-91e84881f3ba.png)

Thanks