### PR TITLE
Speed up tests relating to containerPoint / layerPoint methods

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1975,7 +1975,7 @@ describe("Map", function () {
 				done();
 			});
 
-			map.panBy([50, 50]);
+			map.panBy([50, 50], {animate: false});
 		});
 	});
 

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1958,7 +1958,7 @@ describe("Map", function () {
 				done();
 			});
 
-			map.panBy([50, 50]);
+			map.panBy([50, 50], {animate: false});
 		});
 	});
 


### PR DESCRIPTION
Animations don't seem necessary for these tests. Disabling them saves 525ms