### PR TITLE
Speed up tests relating to focusing on Marker

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -203,17 +203,13 @@ describe("Marker", function () {
 			expect(icon.hasAttribute('alt')).to.be(false);
 		});
 
-		it("pan map to focus marker", function (done) {
+		it("pan map to focus marker", function () {
 			var marker = L.marker([70, 0], {icon: L.divIcon()});
 			map.addLayer(marker);
 
-			setTimeout(function () {
-				expect(function () {
-					marker._icon.focus();
-				}).to.not.throwException();
-
-				done();
-			}, 100);
+			expect(function () {
+				marker._icon.focus();
+			}).to.not.throwException();
 		});
 
 		it("pan map to focus marker with no iconSize", function (done) {

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -212,17 +212,13 @@ describe("Marker", function () {
 			}).to.not.throwException();
 		});
 
-		it("pan map to focus marker with no iconSize", function (done) {
+		it("pan map to focus marker with no iconSize", function () {
 			var marker = L.marker([70, 0], {icon: L.divIcon({iconSize: null})});
 			map.addLayer(marker);
 
-			setTimeout(function () {
-				expect(function () {
-					marker._panOnFocus();
-				}).to.not.throwException();
-
-				done();
-			}, 100);
+			expect(function () {
+				marker._panOnFocus();
+			}).to.not.throwException();
 		});
 	});
 


### PR DESCRIPTION
The setTimeouts do not seem to be doing anything on these tests.

I can see these tests were introduced alongside #8084 and #8091. Undoing the bug fixes from those PRs, the tests do fail as we expected without the setTimeouts.

Removing these timers saves 203ms on the tests.