### PR TITLE
Speed up TileLayer.setUrl test (251ms to 13ms)

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -494,17 +494,21 @@ describe('TileLayer', function () {
 			};
 			map.setView([0, 0], 1);
 
+			var timer;
 			layer.on('tileload load', function (e) {
 				counts[e.type]++;
+
+				// Assets are in memory so all of these events should fire within <1ms of eachother
+				// Let's check assertions after a 10ms debounce
+				clearTimeout(timer);
+				timer = setTimeout(function () {
+					expect(counts.load).to.equal(1);
+					expect(counts.tileload).to.equal(8);
+					done();
+				}, 10);
 			});
 
 			layer.setUrl(placeKitten);
-
-			setTimeout(function () {
-				expect(counts.load).to.equal(1);
-				expect(counts.tileload).to.equal(8);
-				done();
-			}, 250);
 		});
 	});
 });


### PR DESCRIPTION
This test does depend on asynchronous behaviour as its loads 8 tiles onto the map, but those tiles are already in memory as a data URI and they load very quickly. With some brief `console.log` profiling, I observed all tiles loading within 2ms.

I thought about reducing the test's length by running assertions on the 8th `tileload` event, but that wouldn't guard against additional unnecessary tile load.

Instead, because the tiles load exceptionally quickly, I've wrapped the assertions in a 10ms debounce.

This speeds up the test from 251ms to 13ms