### PR TITLE
Align the scale control's alpha transparency with the attribution control

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -441,7 +441,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	     box-sizing: border-box;
 
 	background: #fff;
-	background: rgba(255, 255, 255, 0.5);
+	background: rgba(255, 255, 255, 0.8);
 	}
 .leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;


### PR DESCRIPTION
See first https://github.com/Leaflet/Leaflet/pull/8548.

Suggestion to change the scale control to the [same transparency as the attribution](https://github.com/Leaflet/Leaflet/blob/3cb07e4577b9527a3453db1ee619fc7d5e730907/dist/leaflet.css#L401-L405) (see https://github.com/Leaflet/Leaflet/issues/7538#issuecomment-1067103552) for a higher contrast by default, and for consistency.

### Before

![old-scale-styles](https://user-images.githubusercontent.com/26493779/194748326-2b5ecc4e-3a6a-4dc5-b1bf-b5022ea24875.png)

### After

![new-scale-styles](https://user-images.githubusercontent.com/26493779/194748331-7d0b814c-4b96-40a5-9f26-6976ca9a64dc.png)