### PR TITLE
Allow the scale control's text to overflow the container

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -439,7 +439,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	-moz-box-sizing: border-box;
 	     box-sizing: border-box;
 	background: rgba(255, 255, 255, 0.8);
-  text-shadow: 1px 1px #fff;
+	text-shadow: 1px 1px #fff;
 	}
 .leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -436,12 +436,10 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	line-height: 1.1;
 	padding: 2px 5px 1px;
 	white-space: nowrap;
-	overflow: hidden;
 	-moz-box-sizing: border-box;
 	     box-sizing: border-box;
-
-	background: #fff;
 	background: rgba(255, 255, 255, 0.5);
+	text-shadow: 1px 1px #fff;
 	}
 .leaflet-control-scale-line:not(:first-child) {
 	border-top: 2px solid #777;


### PR DESCRIPTION
Fixes the issue described by @secondl1ght in https://github.com/Leaflet/Leaflet/pull/8543:

![scale-overflow-hidden](https://user-images.githubusercontent.com/26493779/194750866-0ab28254-0c1f-4881-a92d-db6ab659ae70.png)

By allowing the scale control's text to overflow the container and giving it a slight `text-shadow`, as suggested in https://github.com/Leaflet/Leaflet/pull/8543#issuecomment-1272492170:

![scale-text-overflow-visible](https://user-images.githubusercontent.com/26493779/194750901-bb51fc72-a94e-41ec-9451-4ae57a9872a0.png)