### PR TITLE
Expand layers control on Enter keydown

### DIFF
--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -188,11 +188,17 @@ describe("Control.Layers", function () {
 	});
 
 	describe("collapse when collapsed: true", function () {
-		it('expands on toggle focus', function () {
+		it('expands on "Enter" keydown when toggle is focused', function () {
 			var layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
 			var toggle = layersCtrl._container.querySelector('.leaflet-control-layers-toggle');
-			happen.once(toggle, {type:'focus'});
+			happen.once(toggle, {type:'keydown', keyCode:13});
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok();
+		});
+
+		it('does not expand on "Enter" keydown when toggle is not focused', function () {
+			L.control.layers(null, null, {collapsed: true}).addTo(map);
+			happen.once(document, {type:'keydown', keyCode:13});
+			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.not.be.ok();
 		});
 
 		it('expands when mouse is over', function () {

--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -195,6 +195,13 @@ describe("Control.Layers", function () {
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok();
 		});
 
+		it('expands on click', function () {
+			var layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			var toggle = layersCtrl._container.querySelector('.leaflet-control-layers-toggle');
+			happen.once(toggle, {type:'click'});
+			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok();
+		});
+
 		it('does not expand on "Enter" keydown when toggle is not focused', function () {
 			L.control.layers(null, null, {collapsed: true}).addTo(map);
 			happen.once(document, {type:'keydown', keyCode:13});

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -204,7 +204,15 @@ export var Layers = Control.extend({
 		link.setAttribute('role', 'button');
 
 		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
-		DomEvent.on(link, 'focus', this.expand, this);
+		DomEvent.on(link, 'keydown', function (e) {
+			if (e.keyCode === 13) {
+				DomEvent.on(section, 'click', DomEvent.preventDefault);
+				this.expand();
+				setTimeout(function () {
+					DomEvent.off(section, 'click', DomEvent.preventDefault);
+				});
+			}
+		}, this);
 
 		if (!collapsed) {
 			this.expand();

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -187,13 +187,7 @@ export var Layers = Control.extend({
 			this._map.on('click', this.collapse, this);
 
 			DomEvent.on(container, {
-				mouseenter: function () {
-					DomEvent.on(section, 'click', DomEvent.preventDefault);
-					this.expand();
-					setTimeout(function () {
-						DomEvent.off(section, 'click', DomEvent.preventDefault);
-					});
-				},
+				mouseenter: this._expandSafely,
 				mouseleave: this.collapse
 			}, this);
 		}
@@ -203,14 +197,16 @@ export var Layers = Control.extend({
 		link.title = 'Layers';
 		link.setAttribute('role', 'button');
 
-		DomEvent.on(link, 'click', DomEvent.preventDefault); // prevent link function
-		DomEvent.on(link, 'keydown', function (e) {
-			if (e.keyCode === 13) {
-				DomEvent.on(section, 'click', DomEvent.preventDefault);
-				this.expand();
-				setTimeout(function () {
-					DomEvent.off(section, 'click', DomEvent.preventDefault);
-				});
+		DomEvent.on(link, {
+			keydown: function (e) {
+				if (e.keyCode === 13) {
+					this._expandSafely();
+				}
+			},
+			// Certain screen readers intercept the key event and instead send a click event
+			click: function (e) {
+				DomEvent.preventDefault(e);
+				this._expandSafely();
 			}
 		}, this);
 
@@ -417,6 +413,15 @@ export var Layers = Control.extend({
 			this.expand();
 		}
 		return this;
+	},
+
+	_expandSafely: function () {
+		var section = this._section;
+		DomEvent.on(section, 'click', DomEvent.preventDefault);
+		this.expand();
+		setTimeout(function () {
+			DomEvent.off(section, 'click', DomEvent.preventDefault);
+		});
 	}
 
 });


### PR DESCRIPTION
When navigating a Leaflet map by keyboard, instead of expanding the Layers control immediately when the toggle is focused, instead only expand when the Enter key is also pressed.

Fix https://github.com/Leaflet/Leaflet/issues/7191