### PR TITLE
Remove Internet Explorer from browser detection

### DIFF
--- a/debug/vector/geojson.html
+++ b/debug/vector/geojson.html
@@ -107,9 +107,7 @@
 				fillOpacity: 0.7
 			});
 
-			if (!L.Browser.ie) {
-				layer.bringToFront();
-			}
+			layer.bringToFront();
 
 			info.update(layer.feature.properties);
 		}

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -535,25 +535,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	overflow: auto;
 	}
 
-.leaflet-oldie .leaflet-popup-content-wrapper {
-	-ms-zoom: 1;
-	}
-.leaflet-oldie .leaflet-popup-tip {
-	width: 24px;
-	margin: 0 auto;
-
-	-ms-filter: "progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678)";
-	filter: progid:DXImageTransform.Microsoft.Matrix(M11=0.70710678, M12=0.70710678, M21=-0.70710678, M22=0.70710678);
-	}
-
-.leaflet-oldie .leaflet-control-zoom,
-.leaflet-oldie .leaflet-control-layers,
-.leaflet-oldie .leaflet-popup-content-wrapper,
-.leaflet-oldie .leaflet-popup-tip {
-	border: 1px solid #999;
-	}
-
-
 /* div icon */
 
 .leaflet-div-icon {

--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -92,7 +92,7 @@ css: "#map {
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
+		if (!L.Browser.opera && !L.Browser.edge) {
 			layer.bringToFront();
 		}
 

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -94,7 +94,7 @@ Now let's make the states highlighted visually in some way when they are hovered
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
+		if (!L.Browser.opera && !L.Browser.edge) {
 			layer.bringToFront();
 		}
 	}

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -60,7 +60,7 @@ describe('DomUtil', function () {
 			expect(L.DomUtil.getStyle(el, 'color')).to.eql('green');
 		});
 
-		(L.Browser.ie ? it.skip : it)("returns empty string if style isn't defined", function () {
+		it("returns empty string if style isn't defined", function () {
 			var e = document.createElement('div');
 			expect(L.DomUtil.getStyle(e, "position")).to.be('');
 		});
@@ -217,7 +217,7 @@ describe('DomUtil', function () {
 	});
 
 	describe('#testProp', function () {
-		(L.Browser.ie ? it.skip : it)('check array of style names return first valid style name for element', function () {
+		it('check array of style names return first valid style name for element', function () {
 			var hasProp;
 			hasProp = L.DomUtil.testProp(['-webkit-transform', '-webkit-transform', '-ms-tranform', '-o-transform']);
 			expect(hasProp).to.match(/(?:-webkit-transform|-webkit-transform|-ms-tranform|-o-transform)/);
@@ -244,26 +244,25 @@ describe('DomUtil', function () {
 			expect(L.DomUtil.getStyle(el, 'transform')).to.not.be.equal(transform);
 		});
 
-		(L.Browser.ie ? it.skip : it)("reset the 3d CSS transform when offset and scale aren't specified", function () {
+		it("reset the 3d CSS transform when offset and scale aren't specified", function () {
 			L.DomUtil.setTransform(el);
 			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(' + 0 + 'px, ' + 0 + 'px, 0px)');
 		});
 
-		(L.Browser.ie ? it.skip : it)("set the 3d CSS transform with just the specified point if scale isn't specified", function () {
+		it("set the 3d CSS transform with just the specified point if scale isn't specified", function () {
 			L.DomUtil.setTransform(el, new L.Point(1, 1));
 			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(' + 1 + 'px, ' + 1 + 'px, 0px)');
 		});
 
-		(L.Browser.ie ? it.skip : it)("set 3d CSS transform to translate3d(0px, 0px, 0) and add to it scale(${scalevalue}) if only scale is specified", function () {
+		it("set 3d CSS transform to translate3d(0px, 0px, 0) and add to it scale(${scalevalue}) if only scale is specified", function () {
 			L.DomUtil.setTransform(el, undefined, 5);
 			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(' + 0 + 'px, ' + 0 + 'px, 0px) scale(' + 5 + ')');
 		});
 
-		(L.Browser.ie ? it.skip : it)("set the 3d CSS transform with the specified point ant the corresponding scale", function () {
+		it("set the 3d CSS transform with the specified point ant the corresponding scale", function () {
 			L.DomUtil.setTransform(el, new L.Point(1, 1), 5);
 			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(' + 1 + 'px, ' + 1 + 'px, 0px) scale(' + 5 + ')');
 		});
-		// TODO: test with Browser.ie3d to true
 	});
 
 	describe('#setPosition, #getPosition', function () {
@@ -347,7 +346,7 @@ describe('DomUtil', function () {
 			expect(L.DomUtil.getScale(childEl).boundingClientRect.bottom).to.not.be.equal(scale.boundingClientRect.bottom);
 		});
 
-		(L.Browser.ie ? it.skip : it)("returns x and y to 1 with all boundingClientRect's values to 0 for empty element not added yet to the body", function () {
+		it("returns x and y to 1 with all boundingClientRect's values to 0 for empty element not added yet to the body", function () {
 			var newElement = document.createElement("div");
 			var scale = L.DomUtil.getScale(newElement);
 			expect(scale.x).to.eql(1);
@@ -413,7 +412,7 @@ describe('DomUtil', function () {
 	});
 
 	describe('#preventOutline, #restoreOutline', function () {
-		(L.Browser.ie ? it.skip : it)('prevent / restore outline for the element', function () {
+		it('prevent / restore outline for the element', function () {
 			var child = document.createElement('div');
 			el.appendChild(child);
 			child.tabIndex = 0;

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -560,7 +560,6 @@ describe('Popup', function () {
 		});
 
 		it("does not close popup when clicking on it's tip", function () {
-			if (L.Browser.ie) { this.skip(); } // fixme
 			container.style.position = "absolute";
 			container.style.top = "0";
 			container.style.left = "0";

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -58,7 +58,7 @@ describe("Marker.Drag", function () {
 				container.style.webkitTransform = 'scale(' + scale.x + ', ' + scale.y + ')';
 			});
 
-			(L.Browser.ie ? it.skip : it)("drags a marker with mouse, compensating for CSS scale", function (done) {
+			it("drags a marker with mouse, compensating for CSS scale", function (done) {
 				var marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 
 				var start = L.point(300, 280);

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -250,7 +250,6 @@ describe('TileLayer', function () {
 		// browsers due to CSS animations!
 		it.skipIfNo3d("Loads 290, unloads 275 kittens on MAD-TRD flyTo()", function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
-			if (L.Browser.ie) { this.retries(3); } // It also sometimes fails in IE10 on CI
 
 			var mad = [40.40, -3.7], trd = [63.41, 10.41];
 
@@ -485,8 +484,6 @@ describe('TileLayer', function () {
 
 	describe('#setUrl', function () {
 		it('fires only one load event', function (done) {
-			if (L.Browser.ie) { this.retries(3); }
-
 			var layer = L.tileLayer(placeKitten).addTo(map);
 			var counts = {
 				load: 0,

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -94,7 +94,7 @@ describe("Map.Drag", function () {
 				container.style.webkitTransform = 'scale(' + scale.x + ', ' + scale.y + ')';
 			});
 
-			(L.Browser.ie ? it.skip : it)("change the center of the map, compensating for CSS scale", function (done) {
+			it("change the center of the map, compensating for CSS scale", function (done) {
 				map = new MyMap(container, {
 				    dragging: true,
 				    inertia: false

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -10,19 +10,13 @@ import {svgCreate} from '../layer/vector/SVG.Util';
  * @example
  *
  * ```js
- * if (L.Browser.ielt9) {
+ * if (L.Browser.android23) {
  *   alert('Upgrade your browser, dude!');
  * }
  * ```
  */
 
 var style = document.documentElement.style;
-
-// @property ie: Boolean; `true` for all Internet Explorer versions (not Edge).
-var ie = 'ActiveXObject' in window;
-
-// @property ielt9: Boolean; `true` for Internet Explorer versions less than 9.
-var ielt9 = ie && !document.addEventListener;
 
 // @property edge: Boolean; `true` for the Edge web browser.
 var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
@@ -50,7 +44,7 @@ var opera = !!window.opera;
 var chrome = !edge && userAgentContains('chrome');
 
 // @property gecko: Boolean; `true` for gecko-based browsers like Firefox.
-var gecko = userAgentContains('gecko') && !webkit && !opera && !ie;
+var gecko = userAgentContains('gecko') && !webkit && !opera;
 
 // @property safari: Boolean; `true` for the Safari browser.
 var safari = !chrome && userAgentContains('safari');
@@ -64,9 +58,6 @@ var opera12 = 'OTransition' in style;
 // @property win: Boolean; `true` when the browser is running in a Windows platform
 var win = navigator.platform.indexOf('Win') === 0;
 
-// @property ie3d: Boolean; `true` for all Internet Explorer versions supporting CSS transforms.
-var ie3d = ie && ('transition' in style);
-
 // @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
 var webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23;
 
@@ -75,7 +66,7 @@ var gecko3d = 'MozPerspective' in style;
 
 // @property any3d: Boolean
 // `true` for all browsers supporting CSS transforms.
-var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
+var any3d = !window.L_DISABLE_3D && (webkit3d || gecko3d) && !opera12 && !phantom;
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 var mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
@@ -164,8 +155,6 @@ function userAgentContains(str) {
 
 
 export default {
-	ie: ie,
-	ielt9: ielt9,
 	edge: edge,
 	webkit: webkit,
 	android: android,
@@ -178,7 +167,6 @@ export default {
 	phantom: phantom,
 	opera12: opera12,
 	win: win,
-	ie3d: ie3d,
 	webkit3d: webkit3d,
 	gecko3d: gecko3d,
 	any3d: any3d,

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -214,9 +214,7 @@ export function setTransform(el, offset, scale) {
 	var pos = offset || new Point(0, 0);
 
 	el.style[TRANSFORM] =
-		(Browser.ie3d ?
-			'translate(' + pos.x + 'px,' + pos.y + 'px)' :
-			'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)') +
+		'translate3d(' + pos.x + 'px,' + pos.y + 'px,0)' +
 		(scale ? ' scale(' + scale + ')' : '');
 }
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -310,9 +310,6 @@ export var GridLayer = Layer.extend({
 	_updateOpacity: function () {
 		if (!this._map) { return; }
 
-		// IE doesn't inherit filter opacity properly, so we're forced to set it on tiles
-		if (Browser.ielt9) { return; }
-
 		DomUtil.setOpacity(this._container, this.options.opacity);
 
 		var now = +new Date(),
@@ -796,11 +793,6 @@ export var GridLayer = Layer.extend({
 
 		tile.onselectstart = Util.falseFn;
 		tile.onmousemove = Util.falseFn;
-
-		// update opacity on tiles in IE7-8 because of filter inheritance problems
-		if (Browser.ielt9 && this.options.opacity < 1) {
-			DomUtil.setOpacity(tile, this.options.opacity);
-		}
 	},
 
 	_addTile: function (coords, container) {
@@ -879,7 +871,7 @@ export var GridLayer = Layer.extend({
 			// Fired when the grid layer loaded all visible tiles.
 			this.fire('load');
 
-			if (Browser.ielt9 || !this._map._fadeAnimated) {
+			if (!this._map._fadeAnimated) {
 				Util.requestAnimFrame(this._pruneTiles, this);
 			} else {
 				// Wait a bit more than 0.2 secs (the duration of the tile fade-in)

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1106,7 +1106,6 @@ export var Map = Evented.extend({
 		DomUtil.addClass(container, 'leaflet-container' +
 			(Browser.touch ? ' leaflet-touch' : '') +
 			(Browser.retina ? ' leaflet-retina' : '') +
-			(Browser.ielt9 ? ' leaflet-oldie' : '') +
 			(Browser.safari ? ' leaflet-safari' : '') +
 			(this._fadeAnimated ? ' leaflet-fade-anim' : ''));
 


### PR DESCRIPTION
Removes Internet Explorer from the browser detection code and removes all related code based on these checks. This removes the following APIs:

- `L.Browser.ie`
- `L.Browser.ielt9`
- `L.Browser.ie3d`