### PR TITLE
Upgrade ESLint config to latest version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,18 @@ module.exports = {
 		'no-unused-expressions': ['error', {allowShortCircuit: true}],
 		'spaced-comment': 'error',
 		'strict': 'off',
-		'wrap-iife': 'off'
+		'wrap-iife': 'off',
+		// TODO: Re-enable the rules below and fix the linting issues.
+		'arrow-spacing': 'off',
+		'func-name-matching': 'off',
+		'no-duplicate-imports': 'off',
+		'no-invalid-this': 'off',
+		'no-var': 'off',
+		'object-shorthand': 'off',
+		'prefer-arrow-callback': 'off',
+		'prefer-rest-params': 'off',
+		'prefer-spread': 'off',
+		'prefer-template': 'off'
 	},
 	overrides: [
 		{

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-    ignore:
-      - dependency-name: eslint-config-mourner
-        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: /
     open-pull-requests-limit: 999

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@rollup/plugin-json": "^5.0.0",
         "bundlemon": "^1.4.0",
         "eslint": "^8.23.1",
-        "eslint-config-mourner": "^2.0.3",
+        "eslint-config-mourner": "^3.0.0",
         "happen": "~0.3.2",
         "husky": "^8.0.1",
         "karma": "^6.4.1",
@@ -1383,9 +1383,9 @@
       }
     },
     "node_modules/eslint-config-mourner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-2.0.3.tgz",
-      "integrity": "sha512-ydFFzE/WkqvmozI3CM0lAtDZoYfmN03ycjlHzdPZW5x+o3Me1pI0lyfpsWoz9kOqykZk8qlvOVC5BN5UMwtXrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-3.0.0.tgz",
+      "integrity": "sha512-QWMt3Cbqkhg/73fZ2UrTNa/p27nF3JhI1Ej2Jg7qSBri88Y0bg4LFzz0/6I5IrvFR10c6UPwDS+DsV9Ec42aVQ==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -5712,9 +5712,9 @@
       }
     },
     "eslint-config-mourner": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-2.0.3.tgz",
-      "integrity": "sha512-ydFFzE/WkqvmozI3CM0lAtDZoYfmN03ycjlHzdPZW5x+o3Me1pI0lyfpsWoz9kOqykZk8qlvOVC5BN5UMwtXrg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-3.0.0.tgz",
+      "integrity": "sha512-QWMt3Cbqkhg/73fZ2UrTNa/p27nF3JhI1Ej2Jg7qSBri88Y0bg4LFzz0/6I5IrvFR10c6UPwDS+DsV9Ec42aVQ==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@rollup/plugin-json": "^5.0.0",
     "bundlemon": "^1.4.0",
     "eslint": "^8.23.1",
-    "eslint-config-mourner": "^2.0.3",
+    "eslint-config-mourner": "^3.0.0",
     "happen": "~0.3.2",
     "husky": "^8.0.1",
     "karma": "^6.4.1",


### PR DESCRIPTION
Upgrades the ESLint config (`eslint-config-mourner`) to the latest version. Rules that require migration have been disabled, subsequent PRs will migrate this code to keep review impact low.