### PR TITLE
Added option for setting value of `aria-label` for popup close button

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -49,6 +49,23 @@ describe('Popup', () => {
 		expect(map.hasLayer(popup)).to.be(true);
 	});
 
+	it('sets the default \'closeButtonLabel\' on the close button', () => {
+		const popup = L.popup()
+			.setLatLng(center)
+			.openOn(map);
+
+		expect(popup.getElement().querySelector('[aria-label="Close popup"]')).not.to.be(null);
+	});
+
+	it('sets a custom \'closeButtonLabel\' on the close button', () => {
+		const closeButtonLabel = 'TestLabel';
+		const popup = L.popup({closeButtonLabel})
+			.setLatLng(center)
+			.openOn(map);
+
+		expect(popup.getElement().querySelector(`[aria-label="${closeButtonLabel}"]`)).not.to.be(null);
+	});
+
 	it('toggles its visibility when marker is clicked', () => {
 		const marker = L.marker(center);
 		map.addLayer(marker);

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -97,6 +97,10 @@ export const Popup = DivOverlay.extend({
 		// Controls the presence of a close button in the popup.
 		closeButton: true,
 
+		// @option closeButtonLabel: String = 'Close popup'
+		// Specifies the 'aria-label' attribute of the close button.
+		closeButtonLabel: 'Close popup',
+
 		// @option autoClose: Boolean = true
 		// Set it to `false` if you want to override the default behavior of
 		// the popup closing when another popup is opened.
@@ -206,7 +210,8 @@ export const Popup = DivOverlay.extend({
 		if (this.options.closeButton) {
 			const closeButton = this._closeButton = DomUtil.create('a', `${prefix}-close-button`, container);
 			closeButton.setAttribute('role', 'button'); // overrides the implicit role=link of <a> elements #7399
-			closeButton.setAttribute('aria-label', 'Close popup');
+			closeButton.setAttribute('aria-label', this.options.closeButtonLabel);
+
 			closeButton.href = '#close';
 			closeButton.innerHTML = '<span aria-hidden="true">&#215;</span>';
 


### PR DESCRIPTION
Added an option for setting value of aria-label for popup close button in Popup.js. The default aria-label is 'Close Popup'. 
Please accept cc @jonkoops 