### PR TITLE
Added support for {-y}tiled maps into infinite

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -185,12 +185,20 @@ export var TileLayer = GridLayer.extend({
 			y: coords.y,
 			z: this._getZoomForUrl()
 		};
-		if (this._map && !this._map.options.crs.infinite) {
-			var invertedY = this._globalTileRange.max.y - coords.y;
-			if (this.options.tms) {
-				data['y'] = invertedY;
+		if (this._map) {
+			// treat all !crs.infinite as before -- inverting by subtract from globalTileRange
+			if (!this._map.options.crs.infinite) {
+				var invertedY = this._globalTileRange.max.y - coords.y;
+				if (this.options.tms) {
+					data['y'] = invertedY;
+				}
+				data['-y'] = invertedY;
 			}
-			data['-y'] = invertedY;
+			// Infinite? Yes.  But if we have also inverted (typically by CRS.Simple) the Y axis
+			// then we can supply -y by just inverting (and offset by 1, to get origin bottom left)
+			else if (this._map.options.crs.transformation._c == -1) {
+				data['-y'] = (-1 * coords.y) - 1;  // invert y, offset origin to bottom/left corner
+			}
 		}
 
 		return Util.template(this._url, Util.extend(data, this.options));


### PR DESCRIPTION
Fixes #8395.

@Falke-Design Please review. 
Please note - There was a explicit test for {-y} to be not set on infinite crs. This test *will fail*.

The test was added due to the issue https://github.com/Leaflet/Leaflet/issues/4338 - the problem was that TMS "needs an upper bound for the CRS's Y coordinate, to be able to flip the tile row". In the case of infinite crs, we don't have an upper bound, that's probably why they added the check on {-y}.
**In my PR, we don't use the upper bound, we simply set {-y} = (-1 * coords.y) - 1.** 
So, I think the test should be modified. 
Any suggestions ? @jonkoops @mourner  @IvanSanchez 