### PR TITLE
Remove Microsoft-specific Pointer Events from browser detection

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -78,13 +78,9 @@ var mobileWebkit = mobile && webkit;
 // `true` for all webkit-based browsers in a mobile device supporting CSS transforms.
 var mobileWebkit3d = mobile && webkit3d;
 
-// @property msPointer: Boolean
-// `true` for browsers implementing the Microsoft touch events model (notably IE10).
-var msPointer = !window.PointerEvent && window.MSPointerEvent;
-
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
-var pointer = !!(window.PointerEvent || msPointer);
+var pointer = !!window.PointerEvent;
 
 // @property touchNative: Boolean
 // `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).
@@ -173,7 +169,6 @@ export default {
 	mobile,
 	mobileWebkit,
 	mobileWebkit3d,
-	msPointer,
 	pointer,
 	touch,
 	touchNative,

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -1,15 +1,9 @@
-import * as DomEvent from './DomEvent';
-import Browser from '../core/Browser';
 import {falseFn} from '../core/Util';
 
-/*
- * Extends L.DomEvent to provide touch support for Internet Explorer and Windows-based devices.
- */
-
-var POINTER_DOWN =   Browser.msPointer ? 'MSPointerDown'   : 'pointerdown';
-var POINTER_MOVE =   Browser.msPointer ? 'MSPointerMove'   : 'pointermove';
-var POINTER_UP =     Browser.msPointer ? 'MSPointerUp'     : 'pointerup';
-var POINTER_CANCEL = Browser.msPointer ? 'MSPointerCancel' : 'pointercancel';
+var POINTER_DOWN =   'pointerdown';
+var POINTER_MOVE =   'pointermove';
+var POINTER_UP =     'pointerup';
+var POINTER_CANCEL = 'pointercancel';
 var pEvent = {
 	touchstart  : POINTER_DOWN,
 	touchmove   : POINTER_MOVE,
@@ -25,8 +19,8 @@ var handle = {
 var _pointers = {};
 var _pointerDocListener = false;
 
-// Provides a touch events wrapper for (ms)pointer events.
-// ref https://www.w3.org/TR/pointerevents/ https://www.w3.org/Bugs/Public/show_bug.cgi?id=22890
+// Provides a touch events wrapper for pointer events.
+// ref https://www.w3.org/TR/pointerevents/
 
 export function addPointerListener(obj, type, handler) {
 	if (type === 'touchstart') {
@@ -77,7 +71,7 @@ function _addPointerDocListener() {
 }
 
 function _handlePointer(handler, e) {
-	if (e.pointerType === (e.MSPOINTER_TYPE_MOUSE || 'mouse')) { return; }
+	if (e.pointerType === 'mouse') { return; }
 
 	e.touches = [];
 	for (var i in _pointers) {
@@ -89,9 +83,5 @@ function _handlePointer(handler, e) {
 }
 
 function _onPointerStart(handler, e) {
-	// IE10 specific: MsTouch needs preventDefault. See #2000
-	if (e.MSPOINTER_TYPE_TOUCH && e.pointerType === e.MSPOINTER_TYPE_TOUCH) {
-		DomEvent.preventDefault(e);
-	}
 	_handlePointer(handler, e);
 }

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -1,14 +1,10 @@
 import {falseFn} from '../core/Util';
 
-var POINTER_DOWN =   'pointerdown';
-var POINTER_MOVE =   'pointermove';
-var POINTER_UP =     'pointerup';
-var POINTER_CANCEL = 'pointercancel';
 var pEvent = {
-	touchstart  : POINTER_DOWN,
-	touchmove   : POINTER_MOVE,
-	touchend    : POINTER_UP,
-	touchcancel : POINTER_CANCEL
+	touchstart  : 'pointerdown',
+	touchmove   : 'pointermove',
+	touchend    : 'pointerup',
+	touchcancel : 'pointercancel'
 };
 var handle = {
 	touchstart  : _onPointerStart,
@@ -61,10 +57,10 @@ function _addPointerDocListener() {
 	// need to keep track of what pointers and how many are active to provide e.touches emulation
 	if (!_pointerDocListener) {
 		// we listen document as any drags that end by moving the touch off the screen get fired there
-		document.addEventListener(POINTER_DOWN, _globalPointerDown, true);
-		document.addEventListener(POINTER_MOVE, _globalPointerMove, true);
-		document.addEventListener(POINTER_UP, _globalPointerUp, true);
-		document.addEventListener(POINTER_CANCEL, _globalPointerUp, true);
+		document.addEventListener('pointerdown', _globalPointerDown, true);
+		document.addEventListener('pointermove', _globalPointerMove, true);
+		document.addEventListener('pointerup', _globalPointerUp, true);
+		document.addEventListener('pointercancel', _globalPointerUp, true);
 
 		_pointerDocListener = true;
 	}


### PR DESCRIPTION
Removes Microsoft-specific Pointer Events from the browser detection code, and removes all related code based on this. This removes the `L.Browser.msPointer` API.
