### PR TITLE
Remove Karma launcher for Microsoft Edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "husky": "^8.0.1",
         "karma": "^6.4.1",
         "karma-chrome-launcher": "^3.1.1",
-        "karma-edge-launcher": "^0.4.2",
         "karma-expect": "^1.1.3",
         "karma-firefox-launcher": "^2.1.2",
         "karma-mocha": "^2.0.1",
@@ -1222,12 +1221,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
-    "node_modules/edge-launcher": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/edge-launcher/-/edge-launcher-1.2.2.tgz",
-      "integrity": "sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==",
-      "dev": true
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2388,21 +2381,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/karma-edge-launcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
-      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
-      "dev": true,
-      "dependencies": {
-        "edge-launcher": "1.2.2"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "karma": ">=0.9"
       }
     },
     "node_modules/karma-expect": {
@@ -5578,12 +5556,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
-    "edge-launcher": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/edge-launcher/-/edge-launcher-1.2.2.tgz",
-      "integrity": "sha512-JcD5WBi3BHZXXVSSeEhl6sYO8g5cuynk/hifBzds2Bp4JdzCGLNMHgMCKu5DvrO1yatMgF0goFsxXRGus0yh1g==",
-      "dev": true
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6463,15 +6435,6 @@
             "isexe": "^2.0.0"
           }
         }
-      }
-    },
-    "karma-edge-launcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/karma-edge-launcher/-/karma-edge-launcher-0.4.2.tgz",
-      "integrity": "sha512-YAJZb1fmRcxNhMIWYsjLuxwODBjh2cSHgTW/jkVmdpGguJjLbs9ZgIK/tEJsMQcBLUkO+yO4LBbqYxqgGW2HIw==",
-      "dev": true,
-      "requires": {
-        "edge-launcher": "1.2.2"
       }
     },
     "karma-expect": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "husky": "^8.0.1",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
-    "karma-edge-launcher": "^0.4.2",
     "karma-expect": "^1.1.3",
     "karma-firefox-launcher": "^2.1.2",
     "karma-mocha": "^2.0.1",

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -30,7 +30,6 @@ module.exports = function (config) {
 			'karma-mocha',
 			'karma-sinon',
 			'karma-expect',
-			'karma-edge-launcher',
 			'karma-chrome-launcher',
 			'karma-safarinative-launcher',
 			'karma-firefox-launcher',


### PR DESCRIPTION
We no longer support 'old' Edge, so let's remove it from the test suite.