### PR TITLE
Remove Edge from browser detection

### DIFF
--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -92,7 +92,7 @@ css: "#map {
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.opera && !L.Browser.edge) {
+		if (!L.Browser.opera) {
 			layer.bringToFront();
 		}
 

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -94,12 +94,12 @@ Now let's make the states highlighted visually in some way when they are hovered
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.opera && !L.Browser.edge) {
+		if (!L.Browser.opera) {
 			layer.bringToFront();
 		}
 	}
 
-Here we get access to the layer that was hovered through `e.target`, set a thick grey border on the layer as our highlight effect, also bringing it to the front so that the border doesn't clash with nearby states (but not for IE, Opera or Edge, since they have problems doing `bringToFront` on `mouseover`).
+Here we get access to the layer that was hovered through `e.target`, set a thick grey border on the layer as our highlight effect, also bringing it to the front so that the border doesn't clash with nearby states.
 
 Next we'll define what happens on `mouseout`:
 

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -18,9 +18,6 @@ import {svgCreate} from '../layer/vector/SVG.Util';
 
 var style = document.documentElement.style;
 
-// @property edge: Boolean; `true` for the Edge web browser.
-var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
-
 // @property webkit: Boolean;
 // `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
 var webkit = userAgentContains('webkit');
@@ -29,7 +26,7 @@ var webkit = userAgentContains('webkit');
 var opera = !!window.opera;
 
 // @property chrome: Boolean; `true` for the Chrome browser.
-var chrome = !edge && userAgentContains('chrome');
+var chrome = userAgentContains('chrome');
 
 // @property gecko: Boolean; `true` for gecko-based browsers like Firefox.
 var gecko = userAgentContains('gecko') && !webkit && !opera;
@@ -139,7 +136,6 @@ function userAgentContains(str) {
 
 
 export default {
-	edge,
 	webkit,
 	opera,
 	chrome,

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -278,8 +278,7 @@ export function getWheelPxFactor() {
 // Events from pointing devices without precise scrolling are mapped to
 // a best guess of 60 pixels.
 export function getWheelDelta(e) {
-	return (Browser.edge) ? e.wheelDeltaY / 2 : // Don't trust window-geometry-based delta
-	       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / getWheelPxFactor() : // Pixels
+	return (e.deltaY && e.deltaMode === 0) ? -e.deltaY / getWheelPxFactor() : // Pixels
 	       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 20 : // Lines
 	       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 60 : // Pages
 	       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events


### PR DESCRIPTION
Removes Edge from the browser detection code, and removes all related code based on this. This removes the `L.Browser.edge` API.
