### PR TITLE
Implement BlanketOverlay as Renderer superclass

### DIFF
--- a/build/docs-index.leafdoc
+++ b/build/docs-index.leafdoc
@@ -61,5 +61,6 @@ This file just defines the order of the classes in the docs.
 @class Handler
 @class Projection
 @class CRS
+@class BlanketOverlay
 @class Renderer
 @class Event objects

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -113,6 +113,7 @@ bodyclass: api-page
 			<!--<li><a class="nodocs" href="#">IFeature</a></li>-->
 			<li><a href="#projection">Projection</a></li>
 			<li><a href="#crs">CRS</a></li>
+			<li><a href="#blanketoverlay">BlanketOverlay</a></li>
 			<li><a href="#renderer">Renderer</a></li>
 		</ul>
 

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -13,7 +13,8 @@
 	<div id="map"></div>
 
 	<script type="module">
-		import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../src/Leaflet.js';
+		// import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../src/Leaflet.js';
+		import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../dist/leaflet-src.esm.js';
 
 		const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
@@ -31,8 +32,8 @@
 				container.style.border = '2px solid red';
 
 				container.style.display= "flex";
-  container.style.justifyContent = "center";
-  container.style.alignItems = "center";
+				container.style.justifyContent = "center";
+				container.style.alignItems = "center";
 			},
 
 			_onSettled(ev){

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -13,14 +13,13 @@
 	<div id="map"></div>
 
 	<script type="module">
-		// import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../src/Leaflet.js';
 		import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../dist/leaflet-src.esm.js';
 
 		const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-		const map = window.map = new Map('map', {
+		const map = new Map('map', {
 			center: new LatLng(0,0),
 			zoom: 1,
 			layers: [osm]

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+
+	<meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
+
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+
+	<link rel="stylesheet" href="../css/mobile.css" />
+</head>
+<body>
+	<div id="map"></div>
+
+	<script type="module">
+		import {tileLayer, Map, LatLng, BlanketOverlay, Browser, Canvas, SVG, CircleMarker} from '../../src/Leaflet.js';
+
+		const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+			osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+			osm = tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
+
+		const map = window.map = new Map('map', {
+			center: new LatLng(0,0),
+			zoom: 1,
+			layers: [osm]
+		});
+
+		const DebugBlanket = BlanketOverlay.extend({
+			_initContainer(){
+				const container = this._container = document.createElement('div');
+				container.style.border = '2px solid red';
+
+				container.style.display= "flex";
+  container.style.justifyContent = "center";
+  container.style.alignItems = "center";
+			},
+
+			_onSettled(ev){
+				this._container.innerHTML = `
+				lat: ${this._center.lat.toFixed(6)}<br>
+				lng: ${this._center.lng.toFixed(6)}<br>
+				lat: ${this._map.getCenter().lat.toFixed(6)}<br>
+				lng: ${this._map.getCenter().lng.toFixed(6)}<br>
+				zoom: ${this._map.getZoom()}<br>
+				map bounds: <br>${this._map.getBounds().toBBoxString().split(',').map(n=>Number(n).toFixed(6)).join('<br>')}<br>
+				px bounds: ${this._bounds.min}, ${this._bounds.max}`;
+			}
+		})
+
+		new DebugBlanket({padding: -0.1}).addTo(map);
+
+		const canvas = new Canvas({padding:-0.1}).addTo(map);
+		const redCircle = new CircleMarker([40.5, -3.6], {radius: 20, color: 'red', renderer: canvas}).addTo(map);
+
+		const svg = new SVG({padding:-0.1}).addTo(map);
+		const blueCircle = new CircleMarker([63.4, 10.4], {radius: 20, color: 'blue', renderer: svg}).addTo(map);
+
+
+	</script>
+</body>
+</html>

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -29,7 +29,7 @@
 		const DebugBlanket = BlanketOverlay.extend({
 			_initContainer(){
 				const container = this._container = document.createElement('div');
-				container.style.border = '2px solid red';
+				container.style.border = '2px solid black';
 
 				container.style.display= "flex";
 				container.style.justifyContent = "center";
@@ -40,20 +40,29 @@
 				this._container.innerHTML = `
 				lat: ${this._center.lat.toFixed(6)}<br>
 				lng: ${this._center.lng.toFixed(6)}<br>
-				lat: ${this._map.getCenter().lat.toFixed(6)}<br>
-				lng: ${this._map.getCenter().lng.toFixed(6)}<br>
-				zoom: ${this._map.getZoom()}<br>
+				zoom: ${this._zoom}<br>
 				map bounds: <br>${this._map.getBounds().toBBoxString().split(',').map(n=>Number(n).toFixed(6)).join('<br>')}<br>
 				px bounds: ${this._bounds.min}, ${this._bounds.max}`;
 			}
 		})
 
-		new DebugBlanket({padding: -0.1}).addTo(map);
+		new DebugBlanket({
+			padding: -0.1,
+			continuous: true
+		}).addTo(map);
 
-		const canvas = new Canvas({padding:-0.1}).addTo(map);
+		const canvas = new Canvas({
+			padding:-0.1,
+			//continuous: true
+		}).addTo(map);
+		canvas._container.style.border='2px solid red';
 		const redCircle = new CircleMarker([40.5, -3.6], {radius: 20, color: 'red', renderer: canvas}).addTo(map);
 
-		const svg = new SVG({padding:-0.1}).addTo(map);
+		const svg = new SVG({
+			padding:-0.1,
+			//continuous: true,
+		}).addTo(map);
+		svg._container.style.border='2px solid blue';
 		const blueCircle = new CircleMarker([63.4, 10.4], {radius: 20, color: 'blue', renderer: svg}).addTo(map);
 
 

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -18,7 +18,7 @@ import * as DomEvent from '../dom/DomEvent.js';
 
 export const BlanketOverlay = Layer.extend({
 	// @section
-	// @aka Blanket options
+	// @aka BlanketOverlay options
 	options: {
 		// @option padding: Number = 0.1
 		// How much to extend the clip area around the map view (relative to its size)

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -1,0 +1,108 @@
+import {Layer} from './Layer.js';
+import * as DomUtil from '../dom/DomUtil.js';
+import * as Util from '../core/Util.js';
+import Browser from '../core/Browser.js';
+import * as DomEvent from '../dom/DomEvent.js';
+
+/*
+ * @class BlanketOverlay
+ * @inherits Layer
+ * @aka L.BlanketOverlay
+ *
+ * Represents an HTML element that covers ("blankets") the entire surface
+ * of the map.
+ *
+ * Do not use this class directly. It's meant for `Renderer`, and for plugins
+ * that rely on one single HTML element
+ */
+
+export const BlanketOverlay = Layer.extend({
+	// @section
+	// @aka Blanket options
+	options: {
+		// @option padding: Number = 0.1
+		// How much to extend the clip area around the map view (relative to its size)
+		// e.g. 0.1 would be 10% of map view in each direction
+		padding: 0.1
+	},
+
+	getEvents() {
+		const events = {
+			viewreset: this._reset,
+			zoom: this._onZoom,
+			moveend: this._update,
+			zoomend: this._onZoomEnd
+		};
+		if (this._zoomAnimated) {
+			events.zoomanim = this._onAnimZoom;
+		}
+		return events;
+	},
+
+	_onAnimZoom(ev) {
+		this._updateTransform(ev.center, ev.zoom);
+	},
+
+	_onZoom() {
+		this._updateTransform(this._map.getCenter(), this._map.getZoom());
+	},
+
+	_updateTransform(center, zoom) {
+		const scale = this._map.getZoomScale(zoom, this._zoom),
+		    viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding),
+		    currentCenterPoint = this._map.project(this._center, zoom),
+
+		    topLeftOffset = viewHalf.multiplyBy(-scale).add(currentCenterPoint)
+				  .subtract(this._map._getNewPixelOrigin(center, zoom));
+
+		if (Browser.any3d) {
+			DomUtil.setTransform(this._container, topLeftOffset, scale);
+		} else {
+			DomUtil.setPosition(this._container, topLeftOffset);
+		}
+	},
+
+	_reset() {
+		this._update();
+		this._updateTransform(this._center, this._zoom);
+		this._onViewReset();
+	},
+
+	/*
+	 * @section Subclass interface
+	 * @uninheritable
+	 * Subclasses must define the following methods:
+	 *
+	 * @method _initContainer(): undefined
+	 * Must initialize the HTML element to use as blanket, and store it as
+	 * `this._container`. The base implementation creates a blank `<div>`
+	 *
+	 * @method _destroyContainer(): undefined
+	 * Must destroy the HTML element in `this._container` and free any other
+	 * resources. The base implementation destroys the element and removes
+	 * any event handlers attached to it.
+	 *
+	 * @method _onZoomEnd(): undefined
+	 * (Optional) Runs on the map's `zoomend` event.
+	 *
+	 * @method _onViewReset(): undefined
+	 * (Optional) Runs on the map's `viewreset` event.
+	 *
+	 * @method _update(): undefined
+	 * Runs whenever the map changes state (center/zoom). This should (re)set
+	 * the size of the HTML element (likely from the map's `getSize()`) and
+	 * trigger the bulk of any rendering implementation.
+	 */
+	_initContainer() {
+		this._container = DomUtil.create('div');
+	},
+	_destroyContainer() {
+		DomUtil.remove(this._container);
+		DomEvent.off(this._container);
+		delete this._container;
+	},
+	_onZoomEnd: Util.falseFn,
+	_onViewReset: Util.falseFn,
+	_update: Util.falseFn,
+
+});

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -30,16 +30,13 @@ export const BlanketOverlay = Layer.extend({
 		Util.setOptions(this, options);
 	},
 
-	onAdd(map) {
+	onAdd() {
 		if (!this._container) {
 			this._initContainer(); // defined by renderer implementations
 
 			// always keep transform-origin as 0 0, #8794
 			this._container.classList.add('leaflet-zoom-animated');
 		}
-
-		this._center = map.getCenter();
-		this._zoom = map.getZoom();
 
 		this.getPane().appendChild(this._container);
 		this._resizeContainer();

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -137,8 +137,8 @@ export const BlanketOverlay = Layer.extend({
 		this._container = DomUtil.create('div');
 	},
 	_destroyContainer() {
-		DomUtil.remove(this._container);
 		DomEvent.off(this._container);
+		this._container.remove();
 		delete this._container;
 	},
 	_resizeContainer() {

--- a/src/layer/index.js
+++ b/src/layer/index.js
@@ -11,6 +11,8 @@ GeoJSON.getFeature = getFeature;
 GeoJSON.asFeature = asFeature;
 export {GeoJSON, geoJSON, geoJson};
 
+export {BlanketOverlay} from './BlanketOverlay.js';
+
 export {ImageOverlay, imageOverlay} from './ImageOverlay.js';
 export {VideoOverlay, videoOverlay} from './VideoOverlay.js';
 export {SVGOverlay, svgOverlay} from './SVGOverlay.js';

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -80,9 +80,7 @@ export const Canvas = Renderer.extend({
 	_destroyContainer() {
 		Util.cancelAnimFrame(this._redrawRequest);
 		delete this._ctx;
-		this._container.remove();
-		DomEvent.off(this._container);
-		delete this._container;
+		Renderer.prototype._destroyContainer.call(this);
 	},
 
 	_updatePaths() {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -106,18 +106,17 @@ export const Canvas = Renderer.extend({
 	_update() {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
-		// Renderer.prototype._update.call(this);
-
 		const b = this._bounds,
+		    s = this._ctxScale,
 		    container = this._container;
 
 		DomUtil.setPosition(container, b.min);
 
 		// translate so we use the same path coordinates after canvas element moves
 		this._ctx.setTransform(
-			this._ctxScale, 0, 0, this._ctxScale,
-			-b.min.x,
-			-b.min.y);
+			s, 0, 0, s,
+			-b.min.x * s,
+			-b.min.y * s);
 
 		// Tell paths to redraw themselves
 		this.fire('update');

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -1,5 +1,4 @@
 import {Renderer} from './Renderer.js';
-import * as DomUtil from '../../dom/DomUtil.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -107,10 +106,7 @@ export const Canvas = Renderer.extend({
 		if (this._map._animatingZoom && this._bounds) { return; }
 
 		const b = this._bounds,
-		    s = this._ctxScale,
-		    container = this._container;
-
-		DomUtil.setPosition(container, b.min);
+		    s = this._ctxScale;
 
 		// translate so we use the same path coordinates after canvas element moves
 		this._ctx.setTransform(

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -1,7 +1,6 @@
 import {Renderer} from './Renderer.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import * as DomEvent from '../../dom/DomEvent.js';
-import Browser from '../../core/Browser.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
@@ -58,8 +57,8 @@ export const Canvas = Renderer.extend({
 		this._postponeUpdatePaths = true;
 	},
 
-	onAdd() {
-		Renderer.prototype.onAdd.call(this);
+	onAdd(map) {
+		Renderer.prototype.onAdd.call(this, map);
 
 		// Redraw vectors since canvas is cleared upon removal,
 		// in case of removing the renderer itself from the map.
@@ -85,7 +84,7 @@ export const Canvas = Renderer.extend({
 
 	_resizeContainer() {
 		const size = Renderer.prototype._resizeContainer.call(this);
-		const m = this._ctxScale = Browser.retina ? 2 : 1;
+		const m = this._ctxScale = window.devicePixelRatio;
 
 		// set canvas size (also clearing it); use double size on retina
 		this._container.width = m * size.x;
@@ -107,7 +106,7 @@ export const Canvas = Renderer.extend({
 	_update() {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
-		Renderer.prototype._update.call(this);
+		// Renderer.prototype._update.call(this);
 
 		const b = this._bounds,
 		    container = this._container;

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -83,6 +83,15 @@ export const Canvas = Renderer.extend({
 		Renderer.prototype._destroyContainer.call(this);
 	},
 
+	_resizeContainer() {
+		const size = Renderer.prototype._resizeContainer.call(this);
+		const m = this._ctxScale = Browser.retina ? 2 : 1;
+
+		// set canvas size (also clearing it); use double size on retina
+		this._container.width = m * size.x;
+		this._container.height = m * size.y;
+	},
+
 	_updatePaths() {
 		if (this._postponeUpdatePaths) { return; }
 
@@ -101,24 +110,15 @@ export const Canvas = Renderer.extend({
 		Renderer.prototype._update.call(this);
 
 		const b = this._bounds,
-		    container = this._container,
-		    size = b.getSize(),
-		    m = Browser.retina ? 2 : 1;
+		    container = this._container;
 
 		DomUtil.setPosition(container, b.min);
 
-		// set canvas size (also clearing it); use double size on retina
-		container.width = m * size.x;
-		container.height = m * size.y;
-		container.style.width = `${size.x}px`;
-		container.style.height = `${size.y}px`;
-
-		if (Browser.retina) {
-			this._ctx.scale(2, 2);
-		}
-
 		// translate so we use the same path coordinates after canvas element moves
-		this._ctx.translate(-b.min.x, -b.min.y);
+		this._ctx.setTransform(
+			this._ctxScale, 0, 0, this._ctxScale,
+			-b.min.x,
+			-b.min.y);
 
 		// Tell paths to redraw themselves
 		this.fire('update');

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -2,7 +2,6 @@ import {BlanketOverlay} from '../BlanketOverlay.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
-
 /*
  * @class Renderer
  * @inherits BlanketOverlay
@@ -32,21 +31,13 @@ export const Renderer = BlanketOverlay.extend({
 	},
 
 	onAdd() {
-		if (!this._container) {
-			this._initContainer(); // defined by renderer implementations
-
-			// always keep transform-origin as 0 0
-			this._container.classList.add('leaflet-zoom-animated');
-		}
-
-		this.getPane().appendChild(this._container);
-		this._update();
+		BlanketOverlay.prototype.onAdd.call(this);
 		this.on('update', this._updatePaths, this);
 	},
 
 	onRemove() {
+		BlanketOverlay.prototype.onRemove.call(this);
 		this.off('update', this._updatePaths, this);
-		this._destroyContainer();
 	},
 
 	_onZoomEnd() {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -61,7 +61,8 @@ export const Renderer = BlanketOverlay.extend({
 	},
 
 	_onSettled() {
-		// Subclasses are responsible of firing the 'update' event.
+		// Subclasses are responsible of implementing `_update()` and firing
+		// the 'update' event.
 		this._update();
 	},
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -1,6 +1,5 @@
 import {BlanketOverlay} from '../BlanketOverlay.js';
 import * as Util from '../../core/Util.js';
-import {Bounds} from '../../geometry/Bounds.js';
 
 /*
  * @class Renderer
@@ -30,8 +29,8 @@ export const Renderer = BlanketOverlay.extend({
 		this._layers = this._layers || {};
 	},
 
-	onAdd() {
-		BlanketOverlay.prototype.onAdd.call(this);
+	onAdd(map) {
+		BlanketOverlay.prototype.onAdd.call(this, map);
 		this.on('update', this._updatePaths, this);
 	},
 
@@ -41,6 +40,9 @@ export const Renderer = BlanketOverlay.extend({
 	},
 
 	_onZoomEnd() {
+		// When a zoom ends, the "origin pixel" changes. Internal coordinates
+		// of paths are relative to the origin pixel and therefore need to
+		// be recalculated.
 		for (const id in this._layers) {
 			this._layers[id]._project();
 		}
@@ -58,16 +60,9 @@ export const Renderer = BlanketOverlay.extend({
 		}
 	},
 
-	_update() {
-		// Update pixel bounds of renderer container (for positioning/sizing/clipping later)
+	_onSettled() {
 		// Subclasses are responsible of firing the 'update' event.
-		const p = this.options.padding,
-		    size = this._map.getSize(),
-		    min = this._map.containerPointToLayerPoint(size.multiplyBy(-p)).round();
+		this._update();
+	},
 
-		this._bounds = new Bounds(min, min.add(size.multiplyBy(1 + p * 2)).round());
-
-		this._center = this._map.getCenter();
-		this._zoom = this._map.getZoom();
-	}
 });

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -1,13 +1,11 @@
-import {Layer} from '../Layer.js';
-import * as DomUtil from '../../dom/DomUtil.js';
+import {BlanketOverlay} from '../BlanketOverlay.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
 
-
 /*
  * @class Renderer
- * @inherits Layer
+ * @inherits BlanketOverlay
  * @aka L.Renderer
  *
  * Base class for vector renderer implementations (`SVG`, `Canvas`). Handles the
@@ -25,16 +23,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * its map has moved
  */
 
-export const Renderer = Layer.extend({
-
-	// @section
-	// @aka Renderer options
-	options: {
-		// @option padding: Number = 0.1
-		// How much to extend the clip area around the map view (relative to its size)
-		// e.g. 0.1 would be 10% of map view in each direction
-		padding: 0.1
-	},
+export const Renderer = BlanketOverlay.extend({
 
 	initialize(options) {
 		Util.setOptions(this, options);
@@ -60,47 +49,6 @@ export const Renderer = Layer.extend({
 		this._destroyContainer();
 	},
 
-	getEvents() {
-		const events = {
-			viewreset: this._reset,
-			zoom: this._onZoom,
-			moveend: this._update,
-			zoomend: this._onZoomEnd
-		};
-		if (this._zoomAnimated) {
-			events.zoomanim = this._onAnimZoom;
-		}
-		return events;
-	},
-
-	_onAnimZoom(ev) {
-		this._updateTransform(ev.center, ev.zoom);
-	},
-
-	_onZoom() {
-		this._updateTransform(this._map.getCenter(), this._map.getZoom());
-	},
-
-	_updateTransform(center, zoom) {
-		const scale = this._map.getZoomScale(zoom, this._zoom),
-		    viewHalf = this._map.getSize().multiplyBy(0.5 + this.options.padding),
-		    currentCenterPoint = this._map.project(this._center, zoom),
-
-		    topLeftOffset = viewHalf.multiplyBy(-scale).add(currentCenterPoint)
-				  .subtract(this._map._getNewPixelOrigin(center, zoom));
-
-		DomUtil.setTransform(this._container, topLeftOffset, scale);
-	},
-
-	_reset() {
-		this._update();
-		this._updateTransform(this._center, this._zoom);
-
-		for (const id in this._layers) {
-			this._layers[id]._reset();
-		}
-	},
-
 	_onZoomEnd() {
 		for (const id in this._layers) {
 			this._layers[id]._project();
@@ -110,6 +58,12 @@ export const Renderer = Layer.extend({
 	_updatePaths() {
 		for (const id in this._layers) {
 			this._layers[id]._update();
+		}
+	},
+
+	_onViewReset() {
+		for (const id in this._layers) {
+			this._layers[id]._reset();
 		}
 	},
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -16,6 +16,9 @@ import * as Util from '../../core/Util.js';
  *
  * Do not use this class directly, use `SVG` and `Canvas` instead.
  *
+ * The `continuous` option inherited from `BlanketOverlay` cannot be set to `true`
+ * (otherwise, renderers get out of place during a pinch-zoom operation).
+ *
  * @event update: Event
  * Fired when the renderer updates its bounds, center and zoom, for example when
  * its map has moved
@@ -24,7 +27,7 @@ import * as Util from '../../core/Util.js';
 export const Renderer = BlanketOverlay.extend({
 
 	initialize(options) {
-		Util.setOptions(this, options);
+		Util.setOptions(this, {...options, continuous: false});
 		Util.stamp(this);
 		this._layers = this._layers || {};
 	},

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -61,9 +61,11 @@ export const Renderer = BlanketOverlay.extend({
 	},
 
 	_onSettled() {
-		// Subclasses are responsible of implementing `_update()` and firing
-		// the 'update' event.
 		this._update();
 	},
+
+	// Subclasses are responsible of implementing `_update()`. It should fire
+	// the 'update' event whenever appropriate (before/after rendering).
+	_update: Util.falseFn,
 
 });

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -71,7 +71,6 @@ export const SVG = Renderer.extend({
 		    container = this._container;
 
 		// movement: update container viewBox so that we don't have to change coordinates of individual layers
-		DomUtil.setPosition(container, b.min);
 		container.setAttribute('viewBox', [b.min.x, b.min.y, size.x, size.y].join(' '));
 
 		this.fire('update');

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -66,7 +66,7 @@ export const SVG = Renderer.extend({
 	_update() {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
-		Renderer.prototype._update.call(this);
+		// Renderer.prototype._update.call(this);
 
 		const b = this._bounds,
 		    size = b.getSize(),

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -52,6 +52,17 @@ export const SVG = Renderer.extend({
 		delete this._svgSize;
 	},
 
+	_resizeContainer() {
+		const size = Renderer.prototype._resizeContainer.call(this);
+
+		// set size of svg-container if changed
+		if (!this._svgSize || !this._svgSize.equals(size)) {
+			this._svgSize = size;
+			this._container.setAttribute('width', size.x);
+			this._container.setAttribute('height', size.y);
+		}
+	},
+
 	_update() {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
@@ -60,13 +71,6 @@ export const SVG = Renderer.extend({
 		const b = this._bounds,
 		    size = b.getSize(),
 		    container = this._container;
-
-		// set size of svg-container if changed
-		if (!this._svgSize || !this._svgSize.equals(size)) {
-			this._svgSize = size;
-			container.setAttribute('width', size.x);
-			container.setAttribute('height', size.y);
-		}
 
 		// movement: update container viewBox so that we don't have to change coordinates of individual layers
 		DomUtil.setPosition(container, b.min);

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -66,8 +66,6 @@ export const SVG = Renderer.extend({
 	_update() {
 		if (this._map._animatingZoom && this._bounds) { return; }
 
-		// Renderer.prototype._update.call(this);
-
 		const b = this._bounds,
 		    size = b.getSize(),
 		    container = this._container;

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -1,6 +1,5 @@
 import {Renderer} from './Renderer.js';
 import * as DomUtil from '../../dom/DomUtil.js';
-import * as DomEvent from '../../dom/DomEvent.js';
 import {splitWords, stamp} from '../../core/Util.js';
 import {svgCreate, pointsToPath} from './SVG.Util.js';
 export {pointsToPath};
@@ -48,9 +47,7 @@ export const SVG = Renderer.extend({
 	},
 
 	_destroyContainer() {
-		this._container.remove();
-		DomEvent.off(this._container);
-		delete this._container;
+		Renderer.prototype._destroyContainer.call(this);
 		delete this._rootGroup;
 		delete this._svgSize;
 	},


### PR DESCRIPTION
Splits off the update-triggering logic from L.Renderer into a new L.BlanketOverlay class. L.Renderer now only holds logic for keeping a list of L.Paths.

Intended for #8608.

This is a quick&dirty implementation without major testing. At first glance it doesn't seem to break anything. But there's pending stuff:

- [x] Should there be a hook point for the `animzoom` and `zoom` events? `L.Canvas`/`L.SVG` doesn't use it (since redraws only happen at `zoomend`/`viewreset`), but WebGL-based stuff will want to trigger a redraw.
- [x] Should there be a further abstraction of `reset`/`update` concepts? The current implementation has some "unconventional" event handlers and code paths to cover browser inconsistencies when it comes to `<canvas>` synchronization, and I don't want to break any of that.
- [x] Cleanup of event handlers? Subclasses (including `L.Renderer`) should be responsible for attaching event handlers to `zoomend`.
