### PR TITLE
Remove Opera from browser detection

### DIFF
--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -92,9 +92,7 @@ css: "#map {
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.opera) {
-			layer.bringToFront();
-		}
+		layer.bringToFront();
 
 		info.update(layer.feature.properties);
 	}

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -94,9 +94,7 @@ Now let's make the states highlighted visually in some way when they are hovered
 			fillOpacity: 0.7
 		});
 
-		if (!L.Browser.opera) {
-			layer.bringToFront();
-		}
+		layer.bringToFront();
 	}
 
 Here we get access to the layer that was hovered through `e.target`, set a thick grey border on the layer as our highlight effect, also bringing it to the front so that the border doesn't clash with nearby states.

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -22,23 +22,16 @@ const style = document.documentElement.style;
 // `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
 const webkit = userAgentContains('webkit');
 
-// @property opera: Boolean; `true` for the Opera browser
-const opera = !!window.opera;
-
 // @property chrome: Boolean; `true` for the Chrome browser.
 const chrome = userAgentContains('chrome');
 
 // @property gecko: Boolean; `true` for gecko-based browsers like Firefox.
-const gecko = userAgentContains('gecko') && !webkit && !opera;
+const gecko = userAgentContains('gecko') && !webkit;
 
 // @property safari: Boolean; `true` for the Safari browser.
 const safari = !chrome && userAgentContains('safari');
 
 const phantom = userAgentContains('phantom');
-
-// @property opera12: Boolean
-// `true` for the Opera browser supporting CSS transforms (version 12 or later).
-const opera12 = 'OTransition' in style;
 
 // @property win: Boolean; `true` when the browser is running in a Windows platform
 const win = navigator.platform.indexOf('Win') === 0;
@@ -51,7 +44,7 @@ const gecko3d = 'MozPerspective' in style;
 
 // @property any3d: Boolean
 // `true` for all browsers supporting CSS transforms.
-const any3d = !window.L_DISABLE_3D && (webkit3d || gecko3d) && !opera12 && !phantom;
+const any3d = !window.L_DISABLE_3D && (webkit3d || gecko3d) && !phantom;
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 const mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
@@ -78,9 +71,6 @@ const touchNative = 'ontouchstart' in window || !!window.TouchEvent;
 // `true` for all browsers supporting either [touch](#browser-touch) or [pointer](#browser-pointer) events.
 // Note: pointer events will be preferred (if available), and processed for all `touch*` listeners.
 const touch = !window.L_NO_TOUCH && (touchNative || pointer);
-
-// @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
-const mobileOpera = mobile && opera;
 
 // @property mobileGecko: Boolean
 // `true` for gecko-based browsers running in a mobile device.
@@ -137,12 +127,10 @@ function userAgentContains(str) {
 
 export default {
 	webkit,
-	opera,
 	chrome,
 	gecko,
 	safari,
 	phantom,
-	opera12,
 	win,
 	webkit3d,
 	gecko3d,
@@ -153,7 +141,6 @@ export default {
 	pointer,
 	touch,
 	touchNative,
-	mobileOpera,
 	mobileGecko,
 	retina,
 	passiveEvents,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -155,9 +155,8 @@ export const Map = Evented.extend({
 
 		this.callInitHooks();
 
-		// don't animate on browsers without hardware-accelerated transitions or old Android/Opera
-		this._zoomAnimated = DomUtil.TRANSITION && Browser.any3d && !Browser.mobileOpera &&
-				this.options.zoomAnimation;
+		// don't animate on browsers without hardware-accelerated transitions or old Android
+		this._zoomAnimated = DomUtil.TRANSITION && Browser.any3d && this.options.zoomAnimation;
 
 		// zoom transitions run with the same duration for all layers, so if one of transitionend events
 		// happens after starting zoom animation (propagating to the map pane), we know that it ended globally


### PR DESCRIPTION
Removes Opera from the browser detection code and removes all related code based on these checks. This removes the following APIs:

- `L.Browser.opera`
- `L.Browser.opera12`
- `L.Browser.mobileOpera`