### PR TITLE
Remove `indexOf()` function from Util

### DIFF
--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -34,7 +34,7 @@ happen.makeEvent = (function (makeEvent) {
 		if (o.type.substring(0, 7) === 'pointer') {
 			evt.pointerId = o.pointerId;
 			evt.pointerType = o.pointerType;
-		} else if (o.type.indexOf('wheel') > -1) {
+		} else if (o.type.includes('wheel')) {
 			evt.deltaY = evt.deltaY || o.deltaY;
 			evt.deltaMode = evt.deltaMode || o.deltaMode;
 		}

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -348,7 +348,7 @@ describe('TileLayer', () => {
 			const layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png').addTo(map);
 
 			eachImg(layer, (img) => {
-				expect(['a', 'b', 'c'].indexOf(img.src[7]) >= 0).to.eql(true);
+				expect(['a', 'b', 'c'].includes(img.src[7])).to.eql(true);
 			});
 		});
 
@@ -358,7 +358,7 @@ describe('TileLayer', () => {
 			}).addTo(map);
 
 			eachImg(layer, (img) => {
-				expect(['q', 'r', 's'].indexOf(img.src[7]) >= 0).to.eql(true);
+				expect(['q', 'r', 's'].includes(img.src[7])).to.eql(true);
 			});
 		});
 

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -73,7 +73,7 @@ export const Control = Class.extend({
 
 		DomUtil.addClass(container, 'leaflet-control');
 
-		if (pos.indexOf('bottom') !== -1) {
+		if (pos.includes('bottom')) {
 			corner.insertBefore(container, corner.firstChild);
 		} else {
 			corner.appendChild(container);

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -32,7 +32,7 @@ const gecko = userAgentContains('gecko') && !webkit;
 const safari = !chrome && userAgentContains('safari');
 
 // @property win: Boolean; `true` when the browser is running in a Windows platform
-const win = navigator.platform.indexOf('Win') === 0;
+const win = navigator.platform.startsWith('Win');
 
 // @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
 const webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix());
@@ -113,13 +113,13 @@ const inlineSvg = !!svg && (function () {
 })();
 
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
-const mac = navigator.platform.indexOf('Mac') === 0;
+const mac = navigator.platform.startsWith('Mac');
 
 // @property mac: Boolean; `true` when the browser is running in a Linux platform
-const linux = navigator.platform.indexOf('Linux') === 0;
+const linux = navigator.platform.startsWith('Linux');
 
 function userAgentContains(str) {
-	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
+	return navigator.userAgent.toLowerCase().includes(str);
 }
 
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -135,7 +135,7 @@ export function getParamString(obj, existingUrl, uppercase) {
 	for (const i in obj) {
 		params.push(`${encodeURIComponent(uppercase ? i.toUpperCase() : i)}=${encodeURIComponent(obj[i])}`);
 	}
-	return ((!existingUrl || existingUrl.indexOf('?') === -1) ? '?' : '&') + params.join('&');
+	return ((!existingUrl || !existingUrl.includes('?')) ? '?' : '&') + params.join('&');
 }
 
 const templateRe = /\{ *([\w_ -]+) *\}/g;
@@ -164,15 +164,6 @@ export function template(str, data) {
 export const isArray = Array.isArray || function (obj) {
 	return (Object.prototype.toString.call(obj) === '[object Array]');
 };
-
-// @function indexOf(array: Array, el: Object): Number
-// Compatibility polyfill for [Array.prototype.indexOf](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf)
-export function indexOf(array, el) {
-	for (let i = 0; i < array.length; i++) {
-		if (array[i] === el) { return i; }
-	}
-	return -1;
-}
 
 // @property emptyImageUrl: String
 // Data URI string containing a base64-encoded empty GIF image.

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -71,7 +71,7 @@ export function off(obj, types, fn, context) {
 		types = Util.splitWords(types);
 
 		if (arguments.length === 2) {
-			batchRemove(obj, type => Util.indexOf(types, type) !== -1);
+			batchRemove(obj, type => types.includes(type));
 		} else {
 			for (let i = 0, len = types.length; i < len; i++) {
 				removeOne(obj, types[i], fn, context);
@@ -108,7 +108,7 @@ function addOne(obj, type, fn, context) {
 
 	const originalHandler = handler;
 
-	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
+	if (!Browser.touchNative && Browser.pointer && type.startsWith('touch')) {
 		// Needs DomEvent.Pointer.js
 		handler = addPointerListener(obj, type, handler);
 
@@ -147,7 +147,7 @@ function removeOne(obj, type, fn, context, id) {
 
 	if (!handler) { return this; }
 
-	if (!Browser.touchNative && Browser.pointer && type.indexOf('touch') === 0) {
+	if (!Browser.touchNative && Browser.pointer && type.startsWith('touch')) {
 		removePointerListener(obj, type, handler);
 
 	} else if (Browser.touch && (type === 'dblclick')) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1449,7 +1449,7 @@ export const Map = Evented.extend({
 		for (let i = 0; i < targets.length; i++) {
 			targets[i].fire(type, data, true);
 			if (data.originalEvent._stopped ||
-				(targets[i].options.bubblingMouseEvents === false && Util.indexOf(this._mouseEvents, type) !== -1)) { return; }
+				(targets[i].options.bubblingMouseEvents === false && this._mouseEvents.includes(type))) { return; }
 		}
 	},
 
@@ -1645,7 +1645,7 @@ export const Map = Evented.extend({
 	},
 
 	_catchTransitionEnd(e) {
-		if (this._animatingZoom && e.propertyName.indexOf('transform') >= 0) {
+		if (this._animatingZoom && e.propertyName.includes('transform')) {
 			this._onZoomTransitionEnd();
 		}
 	},


### PR DESCRIPTION
Removes the `indexOf()` function from the utilities, refactors code to use more modern APIs.