### PR TITLE
Add a description of the Leaflet.inflatable-markers-group

### DIFF
--- a/docs/_plugins/clustering-decluttering/leaflet-inflatable-markers-group.md
+++ b/docs/_plugins/clustering-decluttering/leaflet-inflatable-markers-group.md
@@ -1,0 +1,15 @@
+---
+name: Leaflet.inflatable-markers-group
+category: clustering-decluttering
+repo: https://github.com/Meteo-Concept/leaflet-inflatable-markers-group
+author: Laurent Georget
+author-url: https://github.com/Meteo-Concept
+demo: https://meteo-concept.github.io/leaflet-inflatable-markers-group/
+compatible-v0:
+compatible-v1: true
+---
+
+An alternative to the most excellent Leaflet marker cluster plugin.
+This plugin gives markers two states : an inflated, normal, state and a deflated
+state which shows less information, takes up less space and is used to declutter
+the map.


### PR DESCRIPTION
Hi,

I've made a custom plugin to declutter maps. It's like an alternative to the Marker cluster plugin. The way it works is that all markers has two states : a expanded state ("inflated") and a reduced state ("deflated") with another design, more compact and with less information to declutter the map. Here's a demonstration: https://meteo-concept.github.io/leaflet-inflatable-markers-group/example1.

It's possible to inflate/deflate a marker by right-clicking on it. The markers also adapt their state when the map is zoomed in and out to show as many markers as possible in their inflated state without overlap.

We've been using for several months on our sites (like https://www.meteo.bzh/climatologie/normales for instance) and we hope it can be useful to others.

Cheers,