### PR TITLE
Fix CSS syntax error in leaflet.css

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -592,6 +592,5 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	.leaflet-control {
 		-webkit-print-color-adjust: exact;
 		print-color-adjust: exact;
-		}
 	}
 }


### PR DESCRIPTION
Removes an extra closing bracket introduced in https://github.com/Leaflet/Leaflet/pull/8600/ (probably due to the inconsistency of indentations throughout the file).

https://github.com/Leaflet/Leaflet/issues/7806 should help prevent errors such as this in the future.