### PR TITLE
Revamp synthetic dblclick event instantiation

### DIFF
--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -22,7 +22,8 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 
 		expect(spy.called).to.be.ok();
 		expect(spy.calledOnce).to.be.ok();
-		expect(spy.lastCall.args[0]._simulated).to.be.ok();
+		expect(spy.lastCall.args[0] instanceof MouseEvent).to.equal(true);
+		expect(spy.lastCall.args[0].isTrusted).to.equal(false);
 	});
 
 	it('does not fire dblclick when delay>200', () => {
@@ -60,7 +61,6 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		UIEventSimulator.fire('dblclick', container); // native dblclick expected
 		expect(spy.called).to.be.ok();
 		expect(spy.calledOnce).to.be.ok();
-		expect(spy.lastCall.args[0]._simulated).not.to.be.ok();
 	});
 
 	it('synthetic dblclick event has expected properties', () => {

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -54,7 +54,6 @@ function makeDblclick(ev) {
 	} else {
 		newEvent = new MouseEvent('dblclick', init);
 	}
-	newEvent._simulated = true; // for debug purposes
 	return newEvent;
 }
 

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -33,6 +33,7 @@ function makeDblclick(ev) {
 		region: ev.region,
 	};
 
+	let newEvent;
 	// The `click` event received should be a PointerEvent - but some
 	// Firefox versions still use MouseEvent.
 	if (ev instanceof PointerEvent) {
@@ -49,10 +50,12 @@ function makeDblclick(ev) {
 			pointerType: ev.pointerType,
 			isPrimary: ev.isPrimary,
 		};
-		return new PointerEvent('dblclick', init);
+		newEvent = new PointerEvent('dblclick', init);
 	} else {
-		return new MouseEvent('dblclick', init);
+		newEvent = new MouseEvent('dblclick', init);
 	}
+	newEvent._simulated = true; // for debug purposes
+	return newEvent;
 }
 
 const delay = 200;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -68,14 +68,14 @@ export function addDoubleTapListener(obj, handler) {
 	// So here we rely on that fact to avoid excessive 'dblclick' simulation when not needed.
 	let last = 0,
 	    detail;
-	function simDblclick(e) {
-		if (e.detail !== 1) {
-			detail = e.detail; // keep in sync to avoid false dblclick in some cases
+	function simDblclick(ev) {
+		if (ev.detail !== 1) {
+			detail = ev.detail; // keep in sync to avoid false dblclick in some cases
 			return;
 		}
 
-		if (e.pointerType === 'mouse' ||
-			(e.sourceCapabilities && !e.sourceCapabilities.firesTouchEvents)) {
+		if (ev.pointerType === 'mouse' ||
+			(ev.sourceCapabilities && !ev.sourceCapabilities.firesTouchEvents)) {
 
 			return;
 		}
@@ -85,7 +85,7 @@ export function addDoubleTapListener(obj, handler) {
 		// This ignores clicks on elements which are a label with a 'for'
 		// attribute (or children of such a label), but not children of
 		// a <input>.
-		const path = DomEvent.getPropagationPath(e);
+		const path = DomEvent.getPropagationPath(ev);
 		if (path.some(el => el instanceof HTMLLabelElement && el.attributes.for) &&
 			!path.some(el => (
 				el instanceof HTMLInputElement ||
@@ -99,7 +99,7 @@ export function addDoubleTapListener(obj, handler) {
 		if (now - last <= delay) {
 			detail++;
 			if (detail === 2) {
-				handler(makeDblclick(e));
+				ev.target.dispatchEvent(makeDblclick(ev));
 			}
 		} else {
 			detail = 1;

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -7,21 +7,52 @@ import * as DomEvent from './DomEvent.js';
  * (see https://github.com/Leaflet/Leaflet/issues/7012#issuecomment-595087386)
  */
 
-function makeDblclick(event) {
-	// in modern browsers `type` cannot be just overridden:
-	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only
-	const newEvent = {};
-	let prop, i;
-	for (i in event) {
-		prop = event[i];
-		newEvent[i] = prop && prop.bind ? prop.bind(event) : prop;
+function makeDblclick(ev) {
+	let init = {
+		// EventInit
+		bubbles: ev.bubbles,
+		cancelable: ev.cancelable,
+		composed: ev.composed,
+
+		// UIEventInit
+		detail: 2,
+		view: ev.view,
+
+		// mouseEventInit
+		screenX: ev.screenX,
+		screenY: ev.screenY,
+		clientX: ev.clientX,
+		clientY: ev.clientY,
+		ctrlKey: ev.ctrlKey,
+		shiftKey: ev.shiftKey,
+		altKey: ev.altKey,
+		metaKey: ev.metaKey,
+		button: ev.button,
+		buttons: ev.buttons,
+		relatedTarget: ev.relatedTarget,
+		region: ev.region,
+	};
+
+	// The `click` event received should be a PointerEvent - but some
+	// Firefox versions still use MouseEvent.
+	if (ev instanceof PointerEvent) {
+		init = {
+			...init,
+			pointerId: ev.pointerId,
+			width: ev.width,
+			height: ev.height,
+			pressure: ev.pressure,
+			tangentialPressure: ev.tangentialPressure,
+			tiltX: ev.tiltX,
+			tiltY: ev.tiltY,
+			twist: ev.twist,
+			pointerType: ev.pointerType,
+			isPrimary: ev.isPrimary,
+		};
+		return new PointerEvent('dblclick', init);
+	} else {
+		return new MouseEvent('dblclick', init);
 	}
-	event = newEvent;
-	newEvent.type = 'dblclick';
-	newEvent.detail = 2;
-	newEvent.isTrusted = false;
-	newEvent._simulated = true; // for debug purposes
-	return newEvent;
 }
 
 const delay = 200;


### PR DESCRIPTION
This is a ~~blind (i.e. totally untested)~~ attempt to fix #8631.

I'm just using my code pattern for initializing synthetic events (from https://gitlab.com/IvanSanchez/gleo/-/blob/master/src/Platina.mjs#L1109 ) - instead of iterating through the properties of the existing event, this creates a init dictionary with the properties defined in the DOM specs.

This might not be the best solution, though. Perhaps the "DOM event cloning" functionality should be moved to `DomEvent.js`, and be called from the dblclick code.