### PR TITLE
Fix loading issue of ImageOverlay in Safari

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -3,6 +3,7 @@ import * as Util from '../core/Util';
 import {toLatLngBounds} from '../geo/LatLngBounds';
 import {Bounds} from '../geometry/Bounds';
 import * as DomUtil from '../dom/DomUtil';
+import Browser from '../core/Browser';
 
 /*
  * @class ImageOverlay
@@ -190,6 +191,7 @@ export const ImageOverlay = Layer.extend({
 
 		img.onselectstart = Util.falseFn;
 		img.onmousemove = Util.falseFn;
+		img.decoding = Browser.safari ? 'async' : 'auto';
 
 		// @event load: Event
 		// Fired when the ImageOverlay layer has loaded its image


### PR DESCRIPTION
After some try & error testing, I found out that the problem of #5895 and #6322 can be fixed with [img.decoding = 'async'](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding). The problem occurs only in Safari.

Before: [Editor](https://plnkr.co/edit/sSHewakwgyaYYOWq)
![safari-img-loading-fail](https://user-images.githubusercontent.com/19800037/199123507-95853b20-6a52-4f3b-9e2b-b86f8f710a49.gif)

Solution: [Editor](https://plnkr.co/edit/stU9bAzQV1DHFahp)
![safari-img-loading-working](https://user-images.githubusercontent.com/19800037/199123529-b26aa47d-618e-4bb6-80a5-041d4c6c8406.gif)

fixes #5895, fixes #6322