### PR TITLE
Use Node.js version 18 for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 permissions:
   contents: read
 env:
-  NODE_VERSION: 16
+  NODE_VERSION: 18
 jobs:
   setup:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Updates the CI to use Node.js version 18. This version has been [promoted to LTS](https://nodejs.org/en/blog/release/v18.12.0/).