### PR TITLE
Stop inheriting `filter` CSS property on tiles

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -72,7 +72,6 @@
 	-webkit-tap-highlight-color: rgba(51, 181, 229, 0.4);
 }
 .leaflet-tile {
-	filter: inherit;
 	visibility: hidden;
 	}
 .leaflet-tile-loaded {


### PR DESCRIPTION
Removes the inheritance of the `filter` property on map tiles. This property was initially added in #451 as a fix for IE6-9, however since then this property has been standardized as an entirely different API. 

This has been causing issues (#8630), and the best course of action seems to be to simply remove this code entirely.

Since users might be relying on this implicitly, I have marked this a breaking. But perhaps I am being over presumptuous (do let me know). 