### PR TITLE
docs: fix markdown link of `ImageOverlay.decoding`

### DIFF
--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -57,7 +57,7 @@ export const ImageOverlay = Layer.extend({
 
 		// @option decoding: String = 'auto'
 		// Tells the browser whether to decode the image in a synchronous fashion,
-		// as per the [`decoding` HTML attribute (https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
+		// as per the [`decoding`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding) HTML attribute.
 		// If the image overlay is flickering when being added/removed, set
 		// this option to `'sync'`.
 		decoding: 'auto'

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -57,7 +57,7 @@ export const ImageOverlay = Layer.extend({
 
 		// @option decoding: String = 'auto'
 		// Tells the browser whether to decode the image in a synchronous fashion,
-		// as per the [`decoding`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding) HTML attribute.
+		// as per the [`decoding` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
 		// If the image overlay is flickering when being added/removed, set
 		// this option to `'sync'`.
 		decoding: 'auto'


### PR DESCRIPTION
| Before | After |
| :----: | :----: |
| ![image](https://user-images.githubusercontent.com/26999792/202391845-4e40c782-331c-40a8-b78b-70c1504eaf41.png) | ![image](https://user-images.githubusercontent.com/26999792/202391879-9976c84c-0ee8-46b5-a26f-1977f4c8927f.png) |
