### PR TITLE
Upgrade Bundlemon to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,6 @@ jobs:
       - name: Run bundlemon task
         run: npm run bundlemon
         env:
-          BUNDLEMON_PROJECT_ID: 61e0545915f6c3000980d0ed
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
   test:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@mapbox/eslint-plugin-script-tags": "^1.0.0",
         "@rollup/plugin-json": "^5.0.0",
-        "bundlemon": "^1.4.0",
+        "bundlemon": "^2.0.0",
         "eslint": "^8.23.1",
         "eslint-config-mourner": "^3.0.0",
         "happen": "~0.3.2",
@@ -579,13 +579,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -692,33 +700,36 @@
       "dev": true
     },
     "node_modules/bundlemon": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bundlemon/-/bundlemon-1.4.0.tgz",
-      "integrity": "sha512-A5mzeMZrnUzKNNo8ng1PFlxZr57XM2HDsaX07kJ1u59BDWn2JFYNeUIUSXhmLdoqBHK9Ln7wTLXDnoqOlcJP5A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bundlemon/-/bundlemon-2.0.0.tgz",
+      "integrity": "sha512-E6n9V900ArGDhuxGo1NfxAImb7FaZl4/Ffi5IDW1s1h+i2fdSilXdoiMu4la/6GHHYiIr1R6CXwengMnFEfPSA==",
       "dev": true,
       "dependencies": {
-        "axios": "^0.21.1",
+        "axios": "^1.1.3",
         "brotli-size": "^4.0.0",
-        "bundlemon-utils": "^1.0.0",
-        "bytes": "^3.1.0",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "cosmiconfig": "^7.0.0",
+        "bundlemon-utils": "^1.2.0-rc.4",
+        "bytes": "^3.1.2",
+        "chalk": "^4.0.0",
+        "commander": "^9.4.0",
+        "cosmiconfig": "^7.0.1",
         "gzip-size": "^6.0.0",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "yup": "^0.32.11"
       },
       "bin": {
         "bundlemon": "bin/bundlemon.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/LironEr"
       }
     },
     "node_modules/bundlemon-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bundlemon-utils/-/bundlemon-utils-1.1.0.tgz",
-      "integrity": "sha512-xkUfcY3+rXdi1WhM/N7VY8u88kw7FWBHja0ZjAPFm5hhvgNIBOzVng/8fvpleVyjCkErwSsxRg92dOzMfttNMw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bundlemon-utils/-/bundlemon-utils-1.2.0.tgz",
+      "integrity": "sha512-yC8DPG8y6WyBxLYbwRs6yydPtcsWfgGmbUI8+LDPUa+zcMVCGSZOszysJ7SJGlnN7dI7PW+8Ed7RtWpOZI2hOQ==",
       "dev": true,
       "dependencies": {
         "bytes": "^3.1.0"
@@ -960,13 +971,25 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true,
       "engines": {
-        "node": ">= 12"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/comment-patterns": {
@@ -1152,6 +1175,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -1710,6 +1742,20 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -2583,15 +2629,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/lint-staged"
-      }
-    },
-    "node_modules/lint-staged/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/lint-staged/node_modules/yaml": {
@@ -3468,6 +3505,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/prosthetic-hand/-/prosthetic-hand-1.4.0.tgz",
       "integrity": "sha512-H0YgNfPFkO6x00Viw8+6LnqYisivAt8i3enoLnCxRUlT80DM/9i99BVBcKGUosPJ635CxlJMsYbjYLHCFpvF2w==",
+      "dev": true
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "node_modules/punycode": {
@@ -5022,13 +5065,21 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.1.3.tgz",
+      "integrity": "sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -5121,27 +5172,27 @@
       "dev": true
     },
     "bundlemon": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/bundlemon/-/bundlemon-1.4.0.tgz",
-      "integrity": "sha512-A5mzeMZrnUzKNNo8ng1PFlxZr57XM2HDsaX07kJ1u59BDWn2JFYNeUIUSXhmLdoqBHK9Ln7wTLXDnoqOlcJP5A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bundlemon/-/bundlemon-2.0.0.tgz",
+      "integrity": "sha512-E6n9V900ArGDhuxGo1NfxAImb7FaZl4/Ffi5IDW1s1h+i2fdSilXdoiMu4la/6GHHYiIr1R6CXwengMnFEfPSA==",
       "dev": true,
       "requires": {
-        "axios": "^0.21.1",
+        "axios": "^1.1.3",
         "brotli-size": "^4.0.0",
-        "bundlemon-utils": "^1.0.0",
-        "bytes": "^3.1.0",
-        "chalk": "^4.1.1",
-        "commander": "^8.0.0",
-        "cosmiconfig": "^7.0.0",
+        "bundlemon-utils": "^1.2.0-rc.4",
+        "bytes": "^3.1.2",
+        "chalk": "^4.0.0",
+        "commander": "^9.4.0",
+        "cosmiconfig": "^7.0.1",
         "gzip-size": "^6.0.0",
-        "micromatch": "^4.0.4",
+        "micromatch": "^4.0.5",
         "yup": "^0.32.11"
       }
     },
     "bundlemon-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bundlemon-utils/-/bundlemon-utils-1.1.0.tgz",
-      "integrity": "sha512-xkUfcY3+rXdi1WhM/N7VY8u88kw7FWBHja0ZjAPFm5hhvgNIBOzVng/8fvpleVyjCkErwSsxRg92dOzMfttNMw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bundlemon-utils/-/bundlemon-utils-1.2.0.tgz",
+      "integrity": "sha512-yC8DPG8y6WyBxLYbwRs6yydPtcsWfgGmbUI8+LDPUa+zcMVCGSZOszysJ7SJGlnN7dI7PW+8Ed7RtWpOZI2hOQ==",
       "dev": true,
       "requires": {
         "bytes": "^3.1.0"
@@ -5319,10 +5370,19 @@
         "wcwidth": "^1.0.0"
       }
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
       "dev": true
     },
     "comment-patterns": {
@@ -5468,6 +5528,12 @@
       "requires": {
         "clone": "^1.0.2"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
     },
     "depd": {
       "version": "2.0.0",
@@ -5907,6 +5973,17 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -6568,12 +6645,6 @@
         "yaml": "^2.1.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "9.4.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
-          "dev": true
-        },
         "yaml": {
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
@@ -7236,6 +7307,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/prosthetic-hand/-/prosthetic-hand-1.4.0.tgz",
       "integrity": "sha512-H0YgNfPFkO6x00Viw8+6LnqYisivAt8i3enoLnCxRUlT80DM/9i99BVBcKGUosPJ635CxlJMsYbjYLHCFpvF2w==",
+      "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
     "punycode": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@mapbox/eslint-plugin-script-tags": "^1.0.0",
     "@rollup/plugin-json": "^5.0.0",
-    "bundlemon": "^1.4.0",
+    "bundlemon": "^2.0.0",
     "eslint": "^8.23.1",
     "eslint-config-mourner": "^3.0.0",
     "happen": "~0.3.2",


### PR DESCRIPTION
Upgrades Bundlemon to the latest version, closes #8673. For more information see the [release notes](https://github.com/LironEr/bundlemon/releases/tag/bundlemon%402.0.0) and [migration guide](https://github.com/LironEr/bundlemon/blob/bundlemon%402.0.0/docs/migration-v1-to-v2.md).