### PR TITLE
Replace `Util.create()` with `Object.create()`

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -155,7 +155,7 @@ describe('Util', () => {
 
 		it('creates a distinct options object', () => {
 			const opts = {},
-			    o = L.Util.create({options: opts});
+			    o = Object.create({options: opts});
 			L.Util.setOptions(o, {});
 			expect(o.options).not.to.equal(opts);
 		});
@@ -169,7 +169,7 @@ describe('Util', () => {
 
 		it('inherits options prototypally', () => {
 			const opts = {},
-			    o = L.Util.create({options: opts});
+			    o = Object.create({options: opts});
 			L.Util.setOptions(o, {});
 			opts.foo = 'bar';
 			expect(o.options.foo).to.eql('bar');

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -30,7 +30,7 @@ Class.extend = function (props) {
 
 	const parentProto = NewClass.__super__ = this.prototype;
 
-	const proto = Util.create(parentProto);
+	const proto = Object.create(parentProto);
 	proto.constructor = NewClass;
 
 	NewClass.prototype = proto;
@@ -59,7 +59,7 @@ Class.extend = function (props) {
 
 	// merge options
 	if (proto.options) {
-		proto.options = parentProto.options ? Util.create(parentProto.options) : {};
+		proto.options = parentProto.options ? Object.create(parentProto.options) : {};
 		Util.extend(proto.options, props.options);
 	}
 

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -18,16 +18,6 @@ export function extend(dest, ...args) {
 	return dest;
 }
 
-// @function create(proto: Object, properties?: Object): Object
-// Compatibility polyfill for [Object.create](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/create)
-export const create = Object.create || (function () {
-	function F() {}
-	return function (proto) {
-		F.prototype = proto;
-		return new F();
-	};
-})();
-
 // @property lastId: Number
 // Last unique ID used by [`stamp()`](#util-stamp)
 export let lastId = 0;
@@ -117,7 +107,7 @@ export function splitWords(str) {
 // Merges the given properties to the `options` of the `obj` object, returning the resulting options. See `Class options`. Has an `L.setOptions` shortcut.
 export function setOptions(obj, options) {
 	if (!Object.prototype.hasOwnProperty.call(obj, 'options')) {
-		obj.options = obj.options ? create(obj.options) : {};
+		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
 	for (const i in options) {
 		obj.options[i] = options[i];


### PR DESCRIPTION
Removes the `Util.create()` function and replaces it with the standard [`Object.create()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create) method. `Util.create()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also remove `Util.create()` as an API, thus this is a breaking change.