### PR TITLE
Replace `Util.trim()` with `String.prototype.trim()`

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -101,16 +101,10 @@ export function formatNum(num, precision) {
 	return Math.round(num * pow) / pow;
 }
 
-// @function trim(str: String): String
-// Compatibility polyfill for [String.prototype.trim](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/Trim)
-export function trim(str) {
-	return str.trim ? str.trim() : str.replace(/^\s+|\s+$/g, '');
-}
-
 // @function splitWords(str: String): String[]
 // Trims and splits the string on whitespace and returns the array of parts.
 export function splitWords(str) {
-	return trim(str).split(/\s+/);
+	return str.trim().split(/\s+/);
 }
 
 // @function setOptions(obj: Object, options: Object): Object

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -131,7 +131,7 @@ export function removeClass(el, name) {
 	if (el.classList !== undefined) {
 		el.classList.remove(name);
 	} else {
-		setClass(el, Util.trim((` ${getClass(el)} `).replace(` ${name} `, ' ')));
+		setClass(el, ` ${getClass(el)} `.replace(` ${name} `, ' ').trim());
 	}
 }
 


### PR DESCRIPTION
Removes the `Util.trim()` function and replaces it with the standard [`String.prototype.trim()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) method. `Util.trim()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also remove `Util.trim()` as an API, thus this is a breaking change.