### PR TITLE
Replace `Util.isArray()` with `Array.isArray()`

### DIFF
--- a/docs/examples/crs-simple/crs-simple-example3.md
+++ b/docs/examples/crs-simple/crs-simple-example3.md
@@ -12,7 +12,7 @@ title: CRS.Simple example
 	const yx = L.latLng;
 
 	function xy(x, y) {
-		if (L.Util.isArray(x)) { // When doing xy([x, y]);
+		if (Array.isArray(x)) { // When doing xy([x, y]);
 			return yx(x[1], x[0]);
 		}
 		return yx(y, x); // When doing xy(x, y);

--- a/docs/examples/crs-simple/crs-simple.md
+++ b/docs/examples/crs-simple/crs-simple.md
@@ -92,7 +92,7 @@ If working with `[y, x]` coordinates with something named `L.LatLng` doesn't mak
 	var yx = L.latLng;
 
 	var xy = function(x, y) {
-		if (L.Util.isArray(x)) {    // When doing xy([x, y]);
+		if (Array.isArray(x)) {    // When doing xy([x, y]);
 			return yx(x[1], x[0]);
 		}
 		return yx(y, x);  // When doing xy(x, y);

--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -210,12 +210,4 @@ describe('Util', () => {
 			expect(L.Util.template('{Day Of Month}', {'Day Of Month': 30})).to.eql('30');
 		});
 	});
-
-	describe('#isArray', () => {
-		expect(L.Util.isArray([1, 2, 3])).to.be(true);
-		/* eslint no-array-constructor: 0 */
-		expect(L.Util.isArray(new Array(1, 2, 3))).to.be(true);
-		expect(L.Util.isArray('blabla')).to.be(false);
-		expect(L.Util.isArray({0: 1, 1: 2})).to.be(false);
-	});
 });

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -159,12 +159,6 @@ export function template(str, data) {
 	});
 }
 
-// @function isArray(obj): Boolean
-// Compatibility polyfill for [Array.isArray](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray)
-export const isArray = Array.isArray || function (obj) {
-	return (Object.prototype.toString.call(obj) === '[object Array]');
-};
-
 // @property emptyImageUrl: String
 // Data URI string containing a base64-encoded empty GIF image.
 // Used as a hack to free memory from unused images on WebKit-powered

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -114,7 +114,7 @@ export function toLatLng(a, b, c) {
 	if (a instanceof LatLng) {
 		return a;
 	}
-	if (Util.isArray(a) && typeof a[0] !== 'object') {
+	if (Array.isArray(a) && typeof a[0] !== 'object') {
 		if (a.length === 3) {
 			return new LatLng(a[0], a[1], a[2]);
 		}

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -1,5 +1,4 @@
 import {Point, toPoint} from './Point';
-import * as Util from '../core/Util';
 import {toLatLng} from '../geo/LatLng';
 
 
@@ -235,7 +234,7 @@ export function _sqClosestPointOnSegment(p, p1, p2, sqDist) {
 // @function isFlat(latlngs: LatLng[]): Boolean
 // Returns true if `latlngs` is a flat array, false is nested.
 export function isFlat(latlngs) {
-	return !Util.isArray(latlngs[0]) || (typeof latlngs[0][0] !== 'object' && typeof latlngs[0][0] !== 'undefined');
+	return !Array.isArray(latlngs[0]) || (typeof latlngs[0][0] !== 'object' && typeof latlngs[0][0] !== 'undefined');
 }
 
 /* @function polylineCenter(latlngs: LatLng[], crs: CRS): LatLng

--- a/src/geometry/Point.js
+++ b/src/geometry/Point.js
@@ -1,4 +1,4 @@
-import {isArray, formatNum} from '../core/Util';
+import {formatNum} from '../core/Util';
 
 /*
  * @class Point
@@ -207,7 +207,7 @@ export function toPoint(x, y, round) {
 	if (x instanceof Point) {
 		return x;
 	}
-	if (isArray(x)) {
+	if (Array.isArray(x)) {
 		return new Point(x[0], x[1]);
 	}
 	if (x === undefined || x === null) {

--- a/src/geometry/Transformation.js
+++ b/src/geometry/Transformation.js
@@ -1,5 +1,4 @@
 import {Point} from './Point';
-import * as Util from '../core/Util';
 
 /*
  * @class Transformation
@@ -23,7 +22,7 @@ import * as Util from '../core/Util';
 // factory new L.Transformation(a: Number, b: Number, c: Number, d: Number)
 // Creates a `Transformation` object with the given coefficients.
 export function Transformation(a, b, c, d) {
-	if (Util.isArray(a)) {
+	if (Array.isArray(a)) {
 		// use array properties
 		this._a = a[0];
 		this._b = a[1];

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -42,7 +42,7 @@ export const DivOverlay = Layer.extend({
 	},
 
 	initialize(options, source) {
-		if (options && (options instanceof LatLng || Util.isArray(options))) {
+		if (options && (options instanceof LatLng || Array.isArray(options))) {
 			this._latlng = toLatLng(options);
 			Util.setOptions(this, source);
 		} else {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -96,7 +96,7 @@ export const GeoJSON = FeatureGroup.extend({
 	// @method addData( <GeoJSON> data ): this
 	// Adds a GeoJSON object to the layer.
 	addData(geojson) {
-		const features = Util.isArray(geojson) ? geojson : geojson.features;
+		const features = Array.isArray(geojson) ? geojson : geojson.features;
 		let i, len, feature;
 
 		if (features) {

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -219,7 +219,7 @@ Map.include({
 	},
 
 	_addLayers(layers) {
-		layers = layers ? (Util.isArray(layers) ? layers : [layers]) : [];
+		layers = layers ? (Array.isArray(layers) ? layers : [layers]) : [];
 
 		for (let i = 0, len = layers.length; i < len; i++) {
 			this.addLayer(layers[i]);

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -75,7 +75,7 @@ export const VideoOverlay = ImageOverlay.extend({
 			return;
 		}
 
-		if (!Util.isArray(this._url)) { this._url = [this._url]; }
+		if (!Array.isArray(this._url)) { this._url = [this._url]; }
 
 		if (!this.options.keepAspectRatio && Object.prototype.hasOwnProperty.call(vid.style, 'objectFit')) {
 			vid.style['objectFit'] = 'fill';


### PR DESCRIPTION
Removes the `Util.isArray()` function and replaces it with the standard [`Array.isArray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray) method. `Util.isArray()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also remove `Util.isArray()` as an API, thus this is a breaking change.