### PR TITLE
Prefer `Object.hasOwn()` over `Object.prototype.hasOwnProperty()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
 		'wrap-iife': 'off',
 		// TODO: Re-enable the rules below and fix the linting issues.
 		'no-invalid-this': 'off',
+		'prefer-object-has-own': 'error',
 		'prefer-spread': 'off'
 	},
 	overrides: [

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -37,7 +37,7 @@ Class.extend = function (props) {
 
 	// inherit parent's statics
 	for (const i in this) {
-		if (Object.prototype.hasOwnProperty.call(this, i) && i !== 'prototype' && i !== '__super__') {
+		if (Object.hasOwn(this, i) && i !== 'prototype' && i !== '__super__') {
 			NewClass[i] = this[i];
 		}
 	}

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -100,7 +100,7 @@ export function splitWords(str) {
 // @function setOptions(obj: Object, options: Object): Object
 // Merges the given properties to the `options` of the `obj` object, returning the resulting options. See `Class options`. Has an `L.setOptions` shortcut.
 export function setOptions(obj, options) {
-	if (!Object.prototype.hasOwnProperty.call(obj, 'options')) {
+	if (!Object.hasOwn(obj, 'options')) {
 		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
 	for (const i in options) {

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -77,7 +77,7 @@ export const VideoOverlay = ImageOverlay.extend({
 
 		if (!Array.isArray(this._url)) { this._url = [this._url]; }
 
-		if (!this.options.keepAspectRatio && Object.prototype.hasOwnProperty.call(vid.style, 'objectFit')) {
+		if (!this.options.keepAspectRatio && Object.hasOwn(vid.style, 'objectFit')) {
 			vid.style['objectFit'] = 'fill';
 		}
 		vid.autoplay = !!this.options.autoplay;

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -105,7 +105,7 @@ export const Path = Layer.extend({
 		Util.setOptions(this, style);
 		if (this._renderer) {
 			this._renderer._updateStyle(this);
-			if (this.options.stroke && style && Object.prototype.hasOwnProperty.call(style, 'weight')) {
+			if (this.options.stroke && style && Object.hasOwn(style, 'weight')) {
 				this._updateBounds();
 			}
 		}


### PR DESCRIPTION
Replaces calls to `Object.prototype.hasOwnProperty()` with it's intended replacement [`Object.hasOwn()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn). This results in less and more readable code.

Also includes a linting rule to enforce this preference.