### PR TITLE
Use the `classList` API for class manipulation methods in `DomUtil`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -23,35 +23,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#addClass, #removeClass, #hasClass', () => {
-		it('has defined class for test element', () => {
-			el.className = 'bar foo baz ';
-			expect(L.DomUtil.hasClass(el, 'foo')).to.be.ok();
-			expect(L.DomUtil.hasClass(el, 'bar')).to.be.ok();
-			expect(L.DomUtil.hasClass(el, 'baz')).to.be.ok();
-			expect(L.DomUtil.hasClass(el, 'boo')).to.not.be.ok();
-		});
-
-		it('adds or removes the class', () => {
-			el.className = '';
-			L.DomUtil.addClass(el, 'foo');
-
-			expect(el.className).to.eql('foo');
-			expect(L.DomUtil.hasClass(el, 'foo')).to.be.ok();
-
-			L.DomUtil.addClass(el, 'bar');
-			expect(el.className).to.eql('foo bar');
-			expect(L.DomUtil.hasClass(el, 'foo')).to.be.ok();
-
-			L.DomUtil.removeClass(el, 'foo');
-			expect(el.className).to.eql('bar');
-			expect(L.DomUtil.hasClass(el, 'foo')).to.not.be.ok();
-
-			el.className = 'foo bar barz';
-			L.DomUtil.removeClass(el, 'bar');
-			expect(el.className).to.eql('foo barz');
-		});
-	});
 	describe('#getStyle', () => {
 		it('gets the value for a certain style attribute on an element,', () => {
 			el.style.color = 'black';
@@ -175,17 +146,89 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#setClass, #getClass', () => {
-		it('sets the elements class', () => {
-			expect(el.classList.contains('newClass')).to.not.be.ok();
-			L.DomUtil.setClass(el, 'newClass');
-			expect(el.classList.contains('newClass')).to.be.ok();
+	describe("#hasClass", () => {
+		it('determines if an HTML element has a class', () => {
+			const element = document.createElement('div');
+			element.classList.add('newClass', 'someOtherClass');
+			expect(L.DomUtil.hasClass(element, 'newClass')).to.be(true);
 		});
 
-		it('gets the elements class', () => {
-			expect(L.DomUtil.getClass(el)).to.not.equal('newClass');
-			L.DomUtil.setClass(el, 'newClass');
-			expect(L.DomUtil.getClass(el)).to.equal('newClass');
+		it('determines if an SVG element has a class', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			element.classList.add('newClass', 'someOtherClass');
+			expect(L.DomUtil.hasClass(element, 'newClass')).to.be(true);
+		});
+	});
+
+	describe("#addClass", () => {
+		it('adds a class to an HTML element', () => {
+			const element = document.createElement('div');
+			L.DomUtil.addClass(element, 'newClass');
+			expect(element.classList.value).to.be('newClass');
+		});
+
+		it('adds multiple classes to an HTML element', () => {
+			const element = document.createElement('div');
+			L.DomUtil.addClass(element, 'newClass someOtherClass');
+			expect(element.classList.value).to.be('newClass someOtherClass');
+		});
+
+		it('adds a class to an SVG element', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			L.DomUtil.addClass(element, 'newClass');
+			expect(element.classList.value).to.be('newClass');
+		});
+
+		it('adds multiple classes to an SVG element', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			L.DomUtil.addClass(element, 'newClass someOtherClass');
+			expect(element.classList.value).to.be('newClass someOtherClass');
+		});
+	});
+
+	describe('#removeClass', () => {
+		it('removes the class from an HTML element', () => {
+			const element = document.createElement('div');
+			element.classList.add('newClass');
+			L.DomUtil.removeClass(element, 'newClass');
+			expect(element.classList.value).to.be('');
+		});
+
+		it('removes the class from an SVG element', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			element.classList.add('newClass');
+			L.DomUtil.removeClass(element, 'newClass');
+			expect(element.classList.value).to.be('');
+		});
+	});
+
+	describe('#setClass', () => {
+		it('sets the class on an HTML element', () => {
+			const element = document.createElement('div');
+			element.classList.add('someOtherClass');
+			L.DomUtil.setClass(element, 'newClass');
+			expect(element.classList.value).to.be('newClass');
+		});
+
+		it('sets the class on an SVG element', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			element.classList.add('someOtherClass');
+			L.DomUtil.setClass(element, 'newClass');
+			expect(element.classList.value).to.be('newClass');
+		});
+	});
+
+	describe('#getClass', () => {
+		it('gets the class of an HTML element', () => {
+			const element = document.createElement('div');
+			element.classList.add('newClass');
+			expect(L.DomUtil.getClass(element)).to.equal('newClass');
+		});
+
+		it('gets the class of an SVG element', () => {
+			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			element.classList.add('newClass');
+			expect(L.DomUtil.getClass(element)).to.equal('newClass');
 		});
 	});
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -101,61 +101,29 @@ export function toBack(el) {
 	}
 }
 
-// @function hasClass(el: HTMLElement, name: String): Boolean
-// Returns `true` if the element's class attribute contains `name`.
-export function hasClass(el, name) {
-	if (el.classList !== undefined) {
-		return el.classList.contains(name);
-	}
-	const className = getClass(el);
-	return className.length > 0 && new RegExp(`(^|\\s)${name}(\\s|$)`).test(className);
-}
+// @function hasClass(el: Element, name: String): Boolean
+// Returns `true` if the element's `class` attribute contains `name`.
+export const hasClass = (el, name) => el.classList.contains(name);
 
-// @function addClass(el: HTMLElement, name: String)
-// Adds `name` to the element's class attribute.
+// @function addClass(el: Element, name: String)
+// Adds `name` to the element's `class` attribute.
+// Multiple values can be added by providing a value for `name` delimited by a space character.
 export function addClass(el, name) {
-	if (el.classList !== undefined) {
-		const classes = Util.splitWords(name);
-		for (let i = 0, len = classes.length; i < len; i++) {
-			el.classList.add(classes[i]);
-		}
-	} else if (!hasClass(el, name)) {
-		const className = getClass(el);
-		setClass(el, (className ? `${className} ` : '') + name);
-	}
+	const classes = Util.splitWords(name);
+	el.classList.add(...classes);
 }
 
-// @function removeClass(el: HTMLElement, name: String)
-// Removes `name` from the element's class attribute.
-export function removeClass(el, name) {
-	if (el.classList !== undefined) {
-		el.classList.remove(name);
-	} else {
-		setClass(el, ` ${getClass(el)} `.replace(` ${name} `, ' ').trim());
-	}
-}
+// @function removeClass(el: Element, name: String)
+// Removes `name` from the element's `class` attribute.
+export const removeClass = (el, name) => el.classList.remove(name);
 
-// @function setClass(el: HTMLElement, name: String)
-// Sets the element's class.
-export function setClass(el, name) {
-	if (el.className.baseVal === undefined) {
-		el.className = name;
-	} else {
-		// in case of SVG element
-		el.className.baseVal = name;
-	}
-}
+// @function setClass(el: Element, name: String)
+// Sets the element's `class` attribute to the value of `name`.
+export const setClass = (el, name) => { el.classList.value = name; };
 
-// @function getClass(el: HTMLElement): String
-// Returns the element's class.
-export function getClass(el) {
-	// Check if the element is an SVGElementInstance and use the correspondingElement instead
-	// (Required for linked SVG elements in IE11.)
-	if (el.correspondingElement) {
-		el = el.correspondingElement;
-	}
-	return el.className.baseVal === undefined ? el.className : el.className.baseVal;
-}
+// @function getClass(el: Element): String
+// Returns the value of the element's `class` attribute.
+export const getClass = el => el.classList.value;
 
 // @function setOpacity(el: HTMLElement, opacity: Number)
 // Set the opacity of an element (including old IE support).


### PR DESCRIPTION
Changes the methods for class manipulation (`hasClass`, `addClass`, `removeClass`, `setClass` and `getClass`) in `DomUtil` to use the [`classList` API](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) exclusively. Includes the following changes:

- Changes the type annotation to use the `Element` class, from which both `HTMLElement` and `SVGElement` extend.
- Updates the documentation for these methods to be more unified and explicit.
- Drops Internet Explorer specific hack for getting a class name.
- Drops deprecated usage of the [`SVGElement.className` property](https://developer.mozilla.org/en-US/docs/Web/API/SVGElement#svgelement.classname).
- Improves testing coverage by testing both `HTMLElement` and `SVGElement` and splitting out the test cases.

Although I think this is a nice cleanup, most of these methods are now light-weight wrappers around the `classList` API. So lightweight in fact that we might as well use this API directly.

Therefore, before merging this PR I would like to know from the core members if we are perhaps better off without these methods for 2.0.