### PR TITLE
docs: minor typo in code example

### DIFF
--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -34,7 +34,7 @@ import {FeatureGroup} from './FeatureGroup';
  * ```
  * or
  * ```js
- * var popup = L.popup(latlng, {content: '<p>Hello world!<br />This is a nice popup.</p>')
+ * var popup = L.popup(latlng, {content: '<p>Hello world!<br />This is a nice popup.</p>'})
  * 	.openOn(map);
  * ```
  */


### PR DESCRIPTION
Hi,
I found a very very minor typo in a code example in the Docs.
This PR fixes it :)