### PR TITLE
Replace `DomUtil.hasClass()` with `classList.contains()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -146,20 +146,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#hasClass', () => {
-		it('determines if an HTML element has a class', () => {
-			const element = document.createElement('div');
-			element.classList.add('newClass', 'someOtherClass');
-			expect(L.DomUtil.hasClass(element, 'newClass')).to.be(true);
-		});
-
-		it('determines if an SVG element has a class', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			element.classList.add('newClass', 'someOtherClass');
-			expect(L.DomUtil.hasClass(element, 'newClass')).to.be(true);
-		});
-	});
-
 	describe('#addClass', () => {
 		it('adds a class to an HTML element', () => {
 			const element = document.createElement('div');

--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -90,7 +90,7 @@ describe('ImageOverlay', () => {
 
 		describe('className', () => {
 			it('should set image\'s class', () => {
-				expect(L.DomUtil.hasClass(overlay._image, 'my-custom-image-class')).to.be(true);
+				expect(overlay._image.classList.contains('my-custom-image-class')).to.be(true);
 			});
 		});
 	});

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -397,7 +397,7 @@ describe('Popup', () => {
 		const popup = new L.Popup(center, {className: 'testClass'})
 			.addTo(map);
 		expect(map.hasLayer(popup)).to.be(true);
-		expect(L.DomUtil.hasClass(popup.getElement(), 'testClass')).to.be(true);
+		expect(popup.getElement().classList.contains('testClass')).to.be(true);
 	});
 
 	it('adds popup with passed content in options while initializing', () => {

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -166,13 +166,13 @@ describe('Tooltip', () => {
 	it('has class leaflet-interactive', () => {
 		const layer = L.marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true, interactive: true});
-		expect(L.DomUtil.hasClass(layer._tooltip._container, 'leaflet-interactive')).to.be(true);
+		expect(layer._tooltip._container.classList.contains('leaflet-interactive')).to.be(true);
 	});
 
 	it('has not class leaflet-interactive', () => {
 		const layer = L.marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true});
-		expect(L.DomUtil.hasClass(layer._tooltip._container, 'leaflet-interactive')).to.be(false);
+		expect(layer._tooltip._container.classList.contains('leaflet-interactive')).to.be(false);
 	});
 
 	it('can be forced on left direction', () => {
@@ -493,7 +493,7 @@ describe('Tooltip', () => {
 		const tooltip = new L.Tooltip(center, {className: 'testClass'})
 			.addTo(map);
 		expect(map.hasLayer(tooltip)).to.be(true);
-		expect(L.DomUtil.hasClass(tooltip.getElement(), 'testClass')).to.be(true);
+		expect(tooltip.getElement().classList.contains('testClass')).to.be(true);
 	});
 
 	it('adds tooltip with passed content in options while initializing', () => {

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -190,7 +190,7 @@ describe('GridLayer', () => {
 			it('does not add the .leaflet-tile-loaded class to tile elements', (done) => {
 				let count = 0;
 				grid.on('tileerror', (e) => {
-					if (!L.DomUtil.hasClass(e.tile, 'leaflet-tile-loaded')) {
+					if (!e.tile.classList.contains('leaflet-tile-loaded')) {
 						count++;
 					}
 					if (keys.length === 4) {

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -101,10 +101,6 @@ export function toBack(el) {
 	}
 }
 
-// @function hasClass(el: Element, name: String): Boolean
-// Returns `true` if the element's `class` attribute contains `name`.
-export const hasClass = (el, name) => el.classList.contains(name);
-
 // @function addClass(el: Element, name: String)
 // Adds `name` to the element's `class` attribute.
 // Multiple values can be added by providing a value for `name` delimited by a space character.

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -78,7 +78,7 @@ export const Draggable = Evented.extend({
 
 		this._moved = false;
 
-		if (DomUtil.hasClass(this._element, 'leaflet-zoom-anim')) { return; }
+		if (this._element.classList.contains('leaflet-zoom-anim')) { return; }
 
 		if (e.touches && e.touches.length !== 1) {
 			// Finish dragging to avoid conflict with touchZoom


### PR DESCRIPTION
Removes the `DomUtil.hasClass()` function and replaces it with the standard [`classList.contains()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) method. `DomUtil.hasClass()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also remove `DomUtil.hasClass()` as an API, thus this is a breaking change. See #8685 for more background information.