### PR TITLE
Replace `DomUtil.getClass()` with `classList.value`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -204,20 +204,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#getClass', () => {
-		it('gets the class of an HTML element', () => {
-			const element = document.createElement('div');
-			element.classList.add('newClass');
-			expect(L.DomUtil.getClass(element)).to.equal('newClass');
-		});
-
-		it('gets the class of an SVG element', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			element.classList.add('newClass');
-			expect(L.DomUtil.getClass(element)).to.equal('newClass');
-		});
-	});
-
 	describe('#setOpacity', () => {
 		it('sets opacity of element', () => {
 			L.DomUtil.setOpacity(el, 1);
@@ -232,16 +218,6 @@ describe('DomUtil', () => {
 			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 			L.DomUtil.setClass(svg, 'testclass');
 			expect(svg.className.baseVal).to.be('testclass');
-		});
-
-		it('gets the class name of SVG element', () => {
-			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-			svg.className.baseVal = 'testclass';
-			expect(L.DomUtil.getClass(svg)).to.be('testclass');
-		});
-
-		it('returns empty string if it has no classes', () => {
-			expect(L.DomUtil.getClass(el)).to.be('');
 		});
 	});
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -117,10 +117,6 @@ export const removeClass = (el, name) => el.classList.remove(name);
 // Sets the element's `class` attribute to the value of `name`.
 export const setClass = (el, name) => { el.classList.value = name; };
 
-// @function getClass(el: Element): String
-// Returns the value of the element's `class` attribute.
-export const getClass = el => el.classList.value;
-
 // @function setOpacity(el: HTMLElement, opacity: Number)
 // Set the opacity of an element (including old IE support).
 // `opacity` must be a number from `0` to `1`.


### PR DESCRIPTION
Removes the `DomUtil.getClass()` function and replaces it with the standard [`classList.value`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) property. `DomUtil.getClass()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also remove `DomUtil.getClass()` as an API, thus this is a breaking change. See #8685 for more background information.