### PR TITLE
Remove `DomUtil.setClass()` method

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -188,22 +188,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#setClass', () => {
-		it('sets the class on an HTML element', () => {
-			const element = document.createElement('div');
-			element.classList.add('someOtherClass');
-			L.DomUtil.setClass(element, 'newClass');
-			expect(element.classList.value).to.be('newClass');
-		});
-
-		it('sets the class on an SVG element', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			element.classList.add('someOtherClass');
-			L.DomUtil.setClass(element, 'newClass');
-			expect(element.classList.value).to.be('newClass');
-		});
-	});
-
 	describe('#setOpacity', () => {
 		it('sets opacity of element', () => {
 			L.DomUtil.setOpacity(el, 1);
@@ -212,12 +196,6 @@ describe('DomUtil', () => {
 			expect(el.style.opacity).to.equal('0.5');
 			L.DomUtil.setOpacity(el, '0');
 			expect(el.style.opacity).to.equal('0');
-		});
-
-		it('replaces the class of SGV element by the specified argument', () => {
-			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-			L.DomUtil.setClass(svg, 'testclass');
-			expect(svg.className.baseVal).to.be('testclass');
 		});
 	});
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -113,10 +113,6 @@ export function addClass(el, name) {
 // Removes `name` from the element's `class` attribute.
 export const removeClass = (el, name) => el.classList.remove(name);
 
-// @function setClass(el: Element, name: String)
-// Sets the element's `class` attribute to the value of `name`.
-export const setClass = (el, name) => { el.classList.value = name; };
-
 // @function setOpacity(el: HTMLElement, opacity: Number)
 // Set the opacity of an element (including old IE support).
 // `opacity` must be a number from `0` to `1`.


### PR DESCRIPTION
Removes the `DomUtil.setClass()` function, users should set the [`classList.value`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) property instead. `DomUtil.setClass()` was a polyfill, which is no longer required now that we have raised our target browsers.

This removes `DomUtil.setClass()` as an API, thus this is a breaking change. See #8685 for more background information.