### PR TITLE
Remove `DomUtil.setOpacity`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -188,17 +188,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#setOpacity', () => {
-		it('sets opacity of element', () => {
-			L.DomUtil.setOpacity(el, 1);
-			expect(el.style.opacity).to.equal('1');
-			L.DomUtil.setOpacity(el, 0.5);
-			expect(el.style.opacity).to.equal('0.5');
-			L.DomUtil.setOpacity(el, '0');
-			expect(el.style.opacity).to.equal('0');
-		});
-	});
-
 	describe('#testProp', () => {
 		it('check array of style names return first valid style name for element', () => {
 			const hasProp = L.DomUtil.testProp(['-webkit-transform', '-webkit-transform', '-ms-tranform', '-o-transform']);

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -113,40 +113,6 @@ export function addClass(el, name) {
 // Removes `name` from the element's `class` attribute.
 export const removeClass = (el, name) => el.classList.remove(name);
 
-// @function setOpacity(el: HTMLElement, opacity: Number)
-// Set the opacity of an element (including old IE support).
-// `opacity` must be a number from `0` to `1`.
-export function setOpacity(el, value) {
-	if ('opacity' in el.style) {
-		el.style.opacity = value;
-	} else if ('filter' in el.style) {
-		_setOpacityIE(el, value);
-	}
-}
-
-function _setOpacityIE(el, value) {
-	let filter = false;
-	const filterName = 'DXImageTransform.Microsoft.Alpha';
-
-	// filters collection throws an error if we try to retrieve a filter that doesn't exist
-	try {
-		filter = el.filters.item(filterName);
-	} catch (e) {
-		// don't set opacity to 1 if we haven't already set an opacity,
-		// it isn't needed and breaks transparent pngs.
-		if (value === 1) { return; }
-	}
-
-	value = Math.round(value * 100);
-
-	if (filter) {
-		filter.Enabled = (value !== 100);
-		filter.Opacity = value;
-	} else {
-		el.style.filter += ` progid:${filterName}(opacity=${value})`;
-	}
-}
-
 // @function testProp(props: String[]): String|false
 // Goes through the array of style names and returns the first name
 // that is a valid style name for an element. If no such name is found,

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -105,7 +105,7 @@ export const DivOverlay = Layer.extend({
 		}
 
 		if (map._fadeAnimated) {
-			DomUtil.setOpacity(this._container, 0);
+			this._container.style.opacity = 0;
 		}
 
 		clearTimeout(this._removeTimeout);
@@ -113,7 +113,7 @@ export const DivOverlay = Layer.extend({
 		this.update();
 
 		if (map._fadeAnimated) {
-			DomUtil.setOpacity(this._container, 1);
+			this._container.style.opacity = 1;
 		}
 
 		this.bringToFront();
@@ -126,7 +126,7 @@ export const DivOverlay = Layer.extend({
 
 	onRemove(map) {
 		if (map._fadeAnimated) {
-			DomUtil.setOpacity(this._container, 0);
+			this._container.style.opacity = 0;
 			this._removeTimeout = setTimeout(DomUtil.remove.bind(null, this._container), 200);
 		} else {
 			DomUtil.remove(this._container);

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -243,7 +243,7 @@ export const ImageOverlay = Layer.extend({
 	},
 
 	_updateOpacity() {
-		DomUtil.setOpacity(this._image, this.options.opacity);
+		this._image.style.opacity = this.options.opacity;
 	},
 
 	_updateZIndex() {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -200,7 +200,7 @@ export const Tooltip = DivOverlay.extend({
 		this.options.opacity = opacity;
 
 		if (this._container) {
-			DomUtil.setOpacity(this._container, opacity);
+			this._container.style.opacity = opacity;
 		}
 	},
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -370,11 +370,11 @@ export const Marker = Layer.extend({
 		const opacity = this.options.opacity;
 
 		if (this._icon) {
-			DomUtil.setOpacity(this._icon, opacity);
+			this._icon.style.opacity = opacity;
 		}
 
 		if (this._shadow) {
-			DomUtil.setOpacity(this._shadow, opacity);
+			this._shadow.style.opacity = opacity;
 		}
 	},
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -310,7 +310,7 @@ export const GridLayer = Layer.extend({
 	_updateOpacity() {
 		if (!this._map) { return; }
 
-		DomUtil.setOpacity(this._container, this.options.opacity);
+		this._container.style.opacity = this.options.opacity;
 
 		const now = +new Date();
 		let nextFrame = false,
@@ -322,7 +322,7 @@ export const GridLayer = Layer.extend({
 
 			const fade = Math.min(1, (now - tile.loaded) / 200);
 
-			DomUtil.setOpacity(tile.el, fade);
+			tile.el.style.opacity = fade;
 			if (fade < 1) {
 				nextFrame = true;
 			} else {
@@ -844,7 +844,7 @@ export const GridLayer = Layer.extend({
 
 		tile.loaded = +new Date();
 		if (this._map._fadeAnimated) {
-			DomUtil.setOpacity(tile.el, 0);
+			tile.el.style.opacity = 0;
 			Util.cancelAnimFrame(this._fadeFrame);
 			this._fadeFrame = Util.requestAnimFrame(this._updateOpacity, this);
 		} else {


### PR DESCRIPTION
Also joining in on the fun of removing code. 😊 Removes `DomUtil` `setOpacity`, which was a polyfill for IE, but it's no longer needed in v2. This is a breaking change.