### PR TITLE
Replace `DomUtil.addClass()` with `classList.add()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -146,32 +146,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#addClass', () => {
-		it('adds a class to an HTML element', () => {
-			const element = document.createElement('div');
-			L.DomUtil.addClass(element, 'newClass');
-			expect(element.classList.value).to.be('newClass');
-		});
-
-		it('adds multiple classes to an HTML element', () => {
-			const element = document.createElement('div');
-			L.DomUtil.addClass(element, 'newClass someOtherClass');
-			expect(element.classList.value).to.be('newClass someOtherClass');
-		});
-
-		it('adds a class to an SVG element', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			L.DomUtil.addClass(element, 'newClass');
-			expect(element.classList.value).to.be('newClass');
-		});
-
-		it('adds multiple classes to an SVG element', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			L.DomUtil.addClass(element, 'newClass someOtherClass');
-			expect(element.classList.value).to.be('newClass someOtherClass');
-		});
-	});
-
 	describe('#removeClass', () => {
 		it('removes the class from an HTML element', () => {
 			const element = document.createElement('div');

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -150,11 +150,11 @@ export const Layers = Control.extend({
 	// @method expand(): this
 	// Expand the control container if collapsed.
 	expand() {
-		DomUtil.addClass(this._container, 'leaflet-control-layers-expanded');
+		this._container.classList.add('leaflet-control-layers-expanded');
 		this._section.style.height = null;
 		const acceptableHeight = this._map.getSize().y - (this._container.offsetTop + 50);
 		if (acceptableHeight < this._section.clientHeight) {
-			DomUtil.addClass(this._section, 'leaflet-control-layers-scrollbar');
+			this._section.classList.add('leaflet-control-layers-scrollbar');
 			this._section.style.height = `${acceptableHeight}px`;
 		} else {
 			DomUtil.removeClass(this._section, 'leaflet-control-layers-scrollbar');

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -112,11 +112,11 @@ export const Zoom = Control.extend({
 		this._zoomOutButton.setAttribute('aria-disabled', 'false');
 
 		if (this._disabled || map._zoom === map.getMinZoom()) {
-			DomUtil.addClass(this._zoomOutButton, className);
+			this._zoomOutButton.classList.add(className);
 			this._zoomOutButton.setAttribute('aria-disabled', 'true');
 		}
 		if (this._disabled || map._zoom === map.getMaxZoom()) {
-			DomUtil.addClass(this._zoomInButton, className);
+			this._zoomInButton.classList.add(className);
 			this._zoomInButton.setAttribute('aria-disabled', 'true');
 		}
 	}

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -71,7 +71,7 @@ export const Control = Class.extend({
 		    pos = this.getPosition(),
 		    corner = map._controlCorners[pos];
 
-		DomUtil.addClass(container, 'leaflet-control');
+		container.classList.add('leaflet-control');
 
 		if (pos.includes('bottom')) {
 			corner.insertBefore(container, corner.firstChild);

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -1,5 +1,4 @@
 import * as DomEvent from './DomEvent';
-import * as Util from '../core/Util';
 import {Point} from '../geometry/Point';
 import Browser from '../core/Browser';
 
@@ -99,14 +98,6 @@ export function toBack(el) {
 	if (parent && parent.firstChild !== el) {
 		parent.insertBefore(el, parent.firstChild);
 	}
-}
-
-// @function addClass(el: Element, name: String)
-// Adds `name` to the element's `class` attribute.
-// Multiple values can be added by providing a value for `name` delimited by a space character.
-export function addClass(el, name) {
-	const classes = Util.splitWords(name);
-	el.classList.add(...classes);
 }
 
 // @function removeClass(el: Element, name: String)

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -149,7 +149,7 @@ export const Draggable = Evented.extend({
 
 			this._moved = true;
 
-			DomUtil.addClass(document.body, 'leaflet-dragging');
+			document.body.classList.add('leaflet-dragging');
 
 			this._lastTarget = e.target || e.srcElement;
 			// IE and Edge do not give the <use> element, so fetch it
@@ -157,7 +157,7 @@ export const Draggable = Evented.extend({
 			if (window.SVGElementInstance && this._lastTarget instanceof window.SVGElementInstance) {
 				this._lastTarget = this._lastTarget.correspondingUseElement;
 			}
-			DomUtil.addClass(this._lastTarget, 'leaflet-drag-target');
+			this._lastTarget.classList.add('leaflet-drag-target');
 		}
 
 		this._newPos = this._startPos.add(offset);

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -119,7 +119,7 @@ export const DivOverlay = Layer.extend({
 		this.bringToFront();
 
 		if (this.options.interactive) {
-			DomUtil.addClass(this._container, 'leaflet-interactive');
+			this._container.classList.add('leaflet-interactive');
 			this.addInteractiveTarget(this._container);
 		}
 	},

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -80,7 +80,7 @@ export const ImageOverlay = Layer.extend({
 		}
 
 		if (this.options.interactive) {
-			DomUtil.addClass(this._image, 'leaflet-interactive');
+			this._image.classList.add('leaflet-interactive');
 			this.addInteractiveTarget(this._image);
 		}
 
@@ -191,9 +191,9 @@ export const ImageOverlay = Layer.extend({
 		const wasElementSupplied = this._url.tagName === 'IMG';
 		const img = this._image = wasElementSupplied ? this._url : DomUtil.create('img');
 
-		DomUtil.addClass(img, 'leaflet-image-layer');
-		if (this._zoomAnimated) { DomUtil.addClass(img, 'leaflet-zoom-animated'); }
-		if (this.options.className) { DomUtil.addClass(img, this.options.className); }
+		img.classList.add('leaflet-image-layer');
+		if (this._zoomAnimated) { img.classList.add('leaflet-zoom-animated'); }
+		if (this.options.className) { img.classList.add(...Util.splitWords(this.options.className)); }
 
 		img.onselectstart = Util.falseFn;
 		img.onmousemove = Util.falseFn;

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -244,7 +244,7 @@ export const Popup = DivOverlay.extend({
 
 		if (maxHeight && height > maxHeight) {
 			style.height = `${maxHeight}px`;
-			DomUtil.addClass(container, scrolledClass);
+			container.classList.add(scrolledClass);
 		} else {
 			DomUtil.removeClass(container, scrolledClass);
 		}

--- a/src/layer/SVGOverlay.js
+++ b/src/layer/SVGOverlay.js
@@ -1,5 +1,4 @@
 import {ImageOverlay} from './ImageOverlay';
-import * as DomUtil from '../dom/DomUtil';
 import * as Util from '../core/Util';
 
 /*
@@ -27,9 +26,9 @@ export const SVGOverlay = ImageOverlay.extend({
 	_initImage() {
 		const el = this._image = this._url;
 
-		DomUtil.addClass(el, 'leaflet-image-layer');
-		if (this._zoomAnimated) { DomUtil.addClass(el, 'leaflet-zoom-animated'); }
-		if (this.options.className) { DomUtil.addClass(el, this.options.className); }
+		el.classList.add('leaflet-image-layer');
+		if (this._zoomAnimated) { el.classList.add('leaflet-zoom-animated'); }
+		if (this.options.className) { el.classList.add(...Util.splitWords(this.options.className)); }
 
 		el.onselectstart = Util.falseFn;
 		el.onmousemove = Util.falseFn;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -187,7 +187,7 @@ export const Tooltip = DivOverlay.extend({
 		DomUtil.removeClass(container, 'leaflet-tooltip-left');
 		DomUtil.removeClass(container, 'leaflet-tooltip-top');
 		DomUtil.removeClass(container, 'leaflet-tooltip-bottom');
-		DomUtil.addClass(container, `leaflet-tooltip-${direction}`);
+		container.classList.add(`leaflet-tooltip-${direction}`);
 		DomUtil.setPosition(container, pos);
 	},
 

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -53,9 +53,9 @@ export const VideoOverlay = ImageOverlay.extend({
 		const wasElementSupplied = this._url.tagName === 'VIDEO';
 		const vid = this._image = wasElementSupplied ? this._url : DomUtil.create('video');
 
-		DomUtil.addClass(vid, 'leaflet-image-layer');
-		if (this._zoomAnimated) { DomUtil.addClass(vid, 'leaflet-zoom-animated'); }
-		if (this.options.className) { DomUtil.addClass(vid, this.options.className); }
+		vid.classList.add('leaflet-image-layer');
+		if (this._zoomAnimated) { vid.classList.add('leaflet-zoom-animated'); }
+		if (this.options.className) { vid.classList.add(...Util.splitWords(this.options.className)); }
 
 		vid.onselectstart = Util.falseFn;
 		vid.onmousemove = Util.falseFn;

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -42,7 +42,7 @@ export const MarkerDrag = Handler.extend({
 			dragend: this._onDragEnd
 		}, this).enable();
 
-		DomUtil.addClass(icon, 'leaflet-marker-draggable');
+		icon.classList.add('leaflet-marker-draggable');
 	},
 
 	removeHooks() {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -231,7 +231,7 @@ export const Marker = Layer.extend({
 			}
 		}
 
-		DomUtil.addClass(icon, classToAdd);
+		icon.classList.add(classToAdd);
 
 		if (options.keyboard) {
 			icon.tabIndex = '0';
@@ -260,7 +260,7 @@ export const Marker = Layer.extend({
 		}
 
 		if (newShadow) {
-			DomUtil.addClass(newShadow, classToAdd);
+			newShadow.classList.add(classToAdd);
 			newShadow.alt = '';
 		}
 		this._shadow = newShadow;
@@ -336,7 +336,7 @@ export const Marker = Layer.extend({
 
 		if (!this.options.interactive) { return; }
 
-		DomUtil.addClass(this._icon, 'leaflet-interactive');
+		this._icon.classList.add('leaflet-interactive');
 
 		this.addInteractiveTarget(this._icon);
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -783,7 +783,7 @@ export const GridLayer = Layer.extend({
 	},
 
 	_initTile(tile) {
-		DomUtil.addClass(tile, 'leaflet-tile');
+		tile.classList.add('leaflet-tile');
 
 		const tileSize = this.getTileSize();
 		tile.style.width = `${tileSize.x}px`;
@@ -853,7 +853,7 @@ export const GridLayer = Layer.extend({
 		}
 
 		if (!err) {
-			DomUtil.addClass(tile.el, 'leaflet-tile-loaded');
+			tile.el.classList.add('leaflet-tile-loaded');
 
 			// @event tileload: TileEvent
 			// Fired when a tile loads.

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -406,7 +406,7 @@ export const Canvas = Renderer.extend({
 			this._handleMouseOut(e);
 
 			if (candidateHoveredLayer) {
-				DomUtil.addClass(this._container, 'leaflet-interactive'); // change cursor
+				this._container.classList.add('leaflet-interactive'); // change cursor
 				this._fireEvent([candidateHoveredLayer], e, 'mouseover');
 				this._hoveredLayer = candidateHoveredLayer;
 			}

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -48,7 +48,7 @@ export const Renderer = Layer.extend({
 			this._initContainer(); // defined by renderer implementations
 
 			if (this._zoomAnimated) {
-				DomUtil.addClass(this._container, 'leaflet-zoom-animated');
+				this._container.classList.add('leaflet-zoom-animated');
 			}
 		}
 

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -2,7 +2,7 @@ import {Renderer} from './Renderer';
 import * as DomUtil from '../../dom/DomUtil';
 import * as DomEvent from '../../dom/DomEvent';
 import Browser from '../../core/Browser';
-import {stamp} from '../../core/Util';
+import {splitWords, stamp} from '../../core/Util';
 import {svgCreate, pointsToPath} from './SVG.Util';
 export {pointsToPath};
 
@@ -88,11 +88,11 @@ export const SVG = Renderer.extend({
 		// @option className: String = null
 		// Custom class name set on an element. Only for SVG renderer.
 		if (layer.options.className) {
-			DomUtil.addClass(path, layer.options.className);
+			path.classList.add(...splitWords(layer.options.className));
 		}
 
 		if (layer.options.interactive) {
-			DomUtil.addClass(path, 'leaflet-interactive');
+			path.classList.add('leaflet-interactive');
 		}
 
 		this._updateStyle(layer);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -336,7 +336,7 @@ export const Map = Evented.extend({
 
 		// animate pan unless animate: false specified
 		if (options.animate !== false) {
-			DomUtil.addClass(this._mapPane, 'leaflet-pan-anim');
+			this._mapPane.classList.add('leaflet-pan-anim');
 
 			const newPos = this._getMapPanePos().subtract(offset).round();
 			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
@@ -1099,11 +1099,14 @@ export const Map = Evented.extend({
 
 		this._fadeAnimated = this.options.fadeAnimation && Browser.any3d;
 
-		DomUtil.addClass(container, `leaflet-container${
-			Browser.touch ? ' leaflet-touch' : ''
-		}${Browser.retina ? ' leaflet-retina' : ''
-		}${Browser.safari ? ' leaflet-safari' : ''
-		}${this._fadeAnimated ? ' leaflet-fade-anim' : ''}`);
+		const classes = ['leaflet-container'];
+
+		if (Browser.touch) { classes.push('leaflet-touch'); }
+		if (Browser.retina) { classes.push('leaflet-retina'); }
+		if (Browser.safari) { classes.push('leaflet-safari'); }
+		if (this._fadeAnimated) { classes.push('leaflet-fade-anim'); }
+
+		container.classList.add(...classes);
 
 		const position = DomUtil.getStyle(container, 'position');
 
@@ -1157,8 +1160,8 @@ export const Map = Evented.extend({
 		this.createPane('popupPane');
 
 		if (!this.options.markerZoomAnimation) {
-			DomUtil.addClass(panes.markerPane, 'leaflet-zoom-hide');
-			DomUtil.addClass(panes.shadowPane, 'leaflet-zoom-hide');
+			panes.markerPane.classList.add('leaflet-zoom-hide');
+			panes.shadowPane.classList.add('leaflet-zoom-hide');
 		}
 	},
 
@@ -1694,7 +1697,7 @@ export const Map = Evented.extend({
 			this._animateToCenter = center;
 			this._animateToZoom = zoom;
 
-			DomUtil.addClass(this._mapPane, 'leaflet-zoom-anim');
+			this._mapPane.classList.add('leaflet-zoom-anim');
 		}
 
 		// @section Other Events

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -83,7 +83,7 @@ export const BoxZoom = Handler.extend({
 			this._moved = true;
 
 			this._box = DomUtil.create('div', 'leaflet-zoom-box', this._container);
-			DomUtil.addClass(this._container, 'leaflet-crosshair');
+			this._container.classList.add('leaflet-crosshair');
 
 			this._map.fire('boxzoomstart');
 		}

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -73,7 +73,7 @@ export const Drag = Handler.extend({
 				map.whenReady(this._onZoomEnd, this);
 			}
 		}
-		DomUtil.addClass(this._map._container, 'leaflet-grab leaflet-touch-drag');
+		this._map._container.classList.add('leaflet-grab', 'leaflet-touch-drag');
 		this._draggable.enable();
 		this._positions = [];
 		this._times = [];

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -28,7 +28,7 @@ Map.mergeOptions({
 
 export const TouchZoom = Handler.extend({
 	addHooks() {
-		DomUtil.addClass(this._map._container, 'leaflet-touch-zoom');
+		this._map._container.classList.add('leaflet-touch-zoom');
 		DomEvent.on(this._map._container, 'touchstart', this._onTouchStart, this);
 	},
 


### PR DESCRIPTION
Removes the `DomUtil.addClass()` function and replaces it with the standard [`classList.add()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) method. `DomUtil.addClass()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also removes `DomUtil.addClass()` as an API, thus this is a breaking change. See #8685 for more background information.