### PR TITLE
Replace `DomUtil.removeClass()` with `classList.remove()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -146,22 +146,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#removeClass', () => {
-		it('removes the class from an HTML element', () => {
-			const element = document.createElement('div');
-			element.classList.add('newClass');
-			L.DomUtil.removeClass(element, 'newClass');
-			expect(element.classList.value).to.be('');
-		});
-
-		it('removes the class from an SVG element', () => {
-			const element = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-			element.classList.add('newClass');
-			L.DomUtil.removeClass(element, 'newClass');
-			expect(element.classList.value).to.be('');
-		});
-	});
-
 	describe('#testProp', () => {
 		it('check array of style names return first valid style name for element', () => {
 			const hasProp = L.DomUtil.testProp(['-webkit-transform', '-webkit-transform', '-ms-tranform', '-o-transform']);

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -157,7 +157,7 @@ export const Layers = Control.extend({
 			this._section.classList.add('leaflet-control-layers-scrollbar');
 			this._section.style.height = `${acceptableHeight}px`;
 		} else {
-			DomUtil.removeClass(this._section, 'leaflet-control-layers-scrollbar');
+			this._section.classList.remove('leaflet-control-layers-scrollbar');
 		}
 		this._checkDisabledLayers();
 		return this;
@@ -166,7 +166,7 @@ export const Layers = Control.extend({
 	// @method collapse(): this
 	// Collapse the control container if expanded.
 	collapse() {
-		DomUtil.removeClass(this._container, 'leaflet-control-layers-expanded');
+		this._container.classList.remove('leaflet-control-layers-expanded');
 		return this;
 	},
 

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -106,8 +106,8 @@ export const Zoom = Control.extend({
 		const map = this._map,
 		    className = 'leaflet-disabled';
 
-		DomUtil.removeClass(this._zoomInButton, className);
-		DomUtil.removeClass(this._zoomOutButton, className);
+		this._zoomInButton.classList.remove(className);
+		this._zoomOutButton.classList.remove(className);
 		this._zoomInButton.setAttribute('aria-disabled', 'false');
 		this._zoomOutButton.setAttribute('aria-disabled', 'false');
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -100,10 +100,6 @@ export function toBack(el) {
 	}
 }
 
-// @function removeClass(el: Element, name: String)
-// Removes `name` from the element's `class` attribute.
-export const removeClass = (el, name) => el.classList.remove(name);
-
 // @function testProp(props: String[]): String|false
 // Goes through the array of style names and returns the first name
 // that is a valid style name for an element. If no such name is found,

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -189,10 +189,10 @@ export const Draggable = Evented.extend({
 	},
 
 	finishDrag(noInertia) {
-		DomUtil.removeClass(document.body, 'leaflet-dragging');
+		document.body.classList.remove('leaflet-dragging');
 
 		if (this._lastTarget) {
-			DomUtil.removeClass(this._lastTarget, 'leaflet-drag-target');
+			this._lastTarget.classList.remove('leaflet-drag-target');
 			this._lastTarget = null;
 		}
 

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -133,7 +133,7 @@ export const DivOverlay = Layer.extend({
 		}
 
 		if (this.options.interactive) {
-			DomUtil.removeClass(this._container, 'leaflet-interactive');
+			this._container.classList.remove('leaflet-interactive');
 			this.removeInteractiveTarget(this._container);
 		}
 	},

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -246,7 +246,7 @@ export const Popup = DivOverlay.extend({
 			style.height = `${maxHeight}px`;
 			container.classList.add(scrolledClass);
 		} else {
-			DomUtil.removeClass(container, scrolledClass);
+			container.classList.remove(scrolledClass);
 		}
 
 		this._containerWidth = this._container.offsetWidth;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -183,10 +183,12 @@ export const Tooltip = DivOverlay.extend({
 
 		pos = pos.subtract(toPoint(subX, subY, true)).add(offset).add(anchor);
 
-		DomUtil.removeClass(container, 'leaflet-tooltip-right');
-		DomUtil.removeClass(container, 'leaflet-tooltip-left');
-		DomUtil.removeClass(container, 'leaflet-tooltip-top');
-		DomUtil.removeClass(container, 'leaflet-tooltip-bottom');
+		container.classList.remove(
+			'leaflet-tooltip-right',
+			'leaflet-tooltip-left',
+			'leaflet-tooltip-top',
+			'leaflet-tooltip-bottom'
+		);
 		container.classList.add(`leaflet-tooltip-${direction}`);
 		DomUtil.setPosition(container, pos);
 	},

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -54,7 +54,7 @@ export const MarkerDrag = Handler.extend({
 		}, this).disable();
 
 		if (this._marker._icon) {
-			DomUtil.removeClass(this._marker._icon, 'leaflet-marker-draggable');
+			this._marker._icon.classList.remove('leaflet-marker-draggable');
 		}
 	},
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -381,7 +381,7 @@ export const Canvas = Renderer.extend({
 		const layer = this._hoveredLayer;
 		if (layer) {
 			// if we're leaving the layer, fire mouseout
-			DomUtil.removeClass(this._container, 'leaflet-interactive');
+			this._container.classList.remove('leaflet-interactive');
 			this._fireEvent([layer], e, 'mouseout');
 			this._hoveredLayer = null;
 			this._mouseHoverThrottled = false;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1601,7 +1601,7 @@ export const Map = Evented.extend({
 	},
 
 	_onPanTransitionEnd() {
-		DomUtil.removeClass(this._mapPane, 'leaflet-pan-anim');
+		this._mapPane.classList.remove('leaflet-pan-anim');
 		this.fire('moveend');
 	},
 
@@ -1723,7 +1723,7 @@ export const Map = Evented.extend({
 		if (!this._animatingZoom) { return; }
 
 		if (this._mapPane) {
-			DomUtil.removeClass(this._mapPane, 'leaflet-zoom-anim');
+			this._mapPane.classList.remove('leaflet-zoom-anim');
 		}
 
 		this._animatingZoom = false;

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -102,7 +102,7 @@ export const BoxZoom = Handler.extend({
 	_finish() {
 		if (this._moved) {
 			DomUtil.remove(this._box);
-			DomUtil.removeClass(this._container, 'leaflet-crosshair');
+			this._container.classList.remove('leaflet-crosshair');
 		}
 
 		DomUtil.enableTextSelection();

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -2,7 +2,6 @@ import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
 import {Draggable} from '../../dom/Draggable';
 import * as Util from '../../core/Util';
-import * as DomUtil from '../../dom/DomUtil';
 import {toLatLngBounds as latLngBounds} from '../../geo/LatLngBounds';
 import {toBounds} from '../../geometry/Bounds';
 
@@ -80,8 +79,7 @@ export const Drag = Handler.extend({
 	},
 
 	removeHooks() {
-		DomUtil.removeClass(this._map._container, 'leaflet-grab');
-		DomUtil.removeClass(this._map._container, 'leaflet-touch-drag');
+		this._map._container.classList.remove('leaflet-grab', 'leaflet-touch-drag');
 		this._draggable.disable();
 	},
 

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -2,7 +2,6 @@ import {Map} from '../Map';
 import {Handler} from '../../core/Handler';
 import * as DomEvent from '../../dom/DomEvent';
 import * as Util from '../../core/Util';
-import * as DomUtil from '../../dom/DomUtil';
 import Browser from '../../core/Browser';
 
 /*
@@ -33,7 +32,7 @@ export const TouchZoom = Handler.extend({
 	},
 
 	removeHooks() {
-		DomUtil.removeClass(this._map._container, 'leaflet-touch-zoom');
+		this._map._container.classList.remove('leaflet-touch-zoom');
 		DomEvent.off(this._map._container, 'touchstart', this._onTouchStart, this);
 	},
 


### PR DESCRIPTION
Removes the `DomUtil.removeClass()` function and replaces it with the standard [`classList.remove()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList) method. `DomUtil.removeClass()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also removes `DomUtil.removeClass()` as an API, thus this is a breaking change. See #8685 for more background information.