### PR TITLE
Remove `DomUtil.TRANSFORM` constant

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -175,22 +175,22 @@ describe('DomUtil', () => {
 
 		it('reset the 3d CSS transform when offset and scale aren\'t specified', () => {
 			L.DomUtil.setTransform(el);
-			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(0px, 0px, 0px)');
+			expect(el.style.transform).to.be('translate3d(0px, 0px, 0px)');
 		});
 
 		it('set the 3d CSS transform with just the specified point if scale isn\'t specified', () => {
 			L.DomUtil.setTransform(el, new L.Point(1, 1));
-			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(1px, 1px, 0px)');
+			expect(el.style.transform).to.be('translate3d(1px, 1px, 0px)');
 		});
 
 		it('set 3d CSS transform to translate3d(0px, 0px, 0) and add to it scale(${scalevalue}) if only scale is specified', () => {
 			L.DomUtil.setTransform(el, undefined, 5);
-			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(0px, 0px, 0px) scale(5)');
+			expect(el.style.transform).to.be('translate3d(0px, 0px, 0px) scale(5)');
 		});
 
 		it('set the 3d CSS transform with the specified point ant the corresponding scale', () => {
 			L.DomUtil.setTransform(el, new L.Point(1, 1), 5);
-			expect(el.style[L.DomUtil.TRANSFORM]).to.be('translate3d(1px, 1px, 0px) scale(5)');
+			expect(el.style.transform).to.be('translate3d(1px, 1px, 0px) scale(5)');
 		});
 	});
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -13,12 +13,6 @@ import Browser from '../core/Browser';
  * in HTML and SVG classes in SVG.
  */
 
-
-// @property TRANSFORM: String
-// Vendor-prefixed transform style name (e.g. `'webkitTransform'` for WebKit).
-export const TRANSFORM = testProp(
-	['transform', 'webkitTransform', 'OTransform', 'MozTransform', 'msTransform']);
-
 // webkitTransition comes first because some browser versions that drop vendor prefix don't do
 // the same for the transitionend event, in particular the Android 4.1 stock browser
 
@@ -122,7 +116,7 @@ export function testProp(props) {
 export function setTransform(el, offset, scale) {
 	const pos = offset || new Point(0, 0);
 
-	el.style[TRANSFORM] = `translate3d(${pos.x}px,${pos.y}px,0)${scale ? ` scale(${scale})` : ''}`;
+	el.style.transform = `translate3d(${pos.x}px,${pos.y}px,0)${scale ? ` scale(${scale})` : ''}`;
 }
 
 // @function setPosition(el: HTMLElement, position: Point)

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1623,13 +1623,12 @@ export const Map = Evented.extend({
 		this._panes.mapPane.appendChild(proxy);
 
 		this.on('zoomanim', function (e) {
-			const prop = DomUtil.TRANSFORM,
-			    transform = this._proxy.style[prop];
+			const transform = this._proxy.style.transform;
 
 			DomUtil.setTransform(this._proxy, this.project(e.center, e.zoom), this.getZoomScale(e.zoom, 1));
 
 			// workaround for case when transform is the same and so transitionend event is not fired
-			if (transform === this._proxy.style[prop] && this._animatingZoom) {
+			if (transform === this._proxy.style.transform && this._animatingZoom) {
 				this._onZoomTransitionEnd();
 			}
 		}, this);


### PR DESCRIPTION
Removes the `DomUtil.TRANSFORM` constant. Previously this would ensure the correct vendor prefix was used for the CSS property, but it is no longer required now that we have raised our target browsers.