### PR TITLE
Replace `DomUtil.remove()` with `Element.remove()`

### DIFF
--- a/docs/examples/extending/extending-2-layers.md
+++ b/docs/examples/extending/extending-2-layers.md
@@ -181,7 +181,7 @@ In other words: the map calls the `onAdd()` method of the layer, then the layer 
 		},
 
 		onRemove: function(map) {
-			L.DomUtil.remove(this._container);
+			this._container.remove();
 			map.off('zoomend viewreset', this._update, this);
 		},
 

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -63,21 +63,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-
-	describe('#remove', () => {
-		it('removes element', () => {
-			const e = L.DomUtil.create('div', 'test', el);
-			L.DomUtil.remove(e);
-			expect(el.contains(e)).to.be(false);
-		});
-
-		it('does nothing if element hasn\'t a parent', () => {
-			const e = L.DomUtil.create('div', 'test');
-			L.DomUtil.remove(e);
-			expect(document.body.contains(e)).to.be(false);
-		});
-	});
-
 	describe('#empty', () => {
 		it('removes all children of element', () => {
 			L.DomUtil.create('div', 'test', el);

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1983,7 +1983,7 @@ describe('Map', () => {
 			parent.appendChild(child);
 			container.appendChild(parent);
 			L.DomEvent.on(child, 'click', () => {
-				L.DomUtil.remove(parent);
+				parent.remove();
 			});
 			expect(() => {
 				happen.once(child, {type: 'click'});

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -91,7 +91,7 @@ export const Control = Class.extend({
 			return this;
 		}
 
-		DomUtil.remove(this._container);
+		this._container.remove();
 
 		if (this.onRemove) {
 			this.onRemove(this._map);
@@ -165,9 +165,9 @@ Map.include({
 
 	_clearControlPos() {
 		for (const i in this._controlCorners) {
-			DomUtil.remove(this._controlCorners[i]);
+			this._controlCorners[i].remove();
 		}
-		DomUtil.remove(this._controlContainer);
+		this._controlContainer.remove();
 		delete this._controlCorners;
 		delete this._controlContainer;
 	}

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -45,15 +45,6 @@ export function create(tagName, className, container) {
 	return el;
 }
 
-// @function remove(el: HTMLElement)
-// Removes `el` from its parent element
-export function remove(el) {
-	const parent = el.parentNode;
-	if (parent) {
-		parent.removeChild(el);
-	}
-}
-
 // @function empty(el: HTMLElement)
 // Removes all of `el`'s children elements from `el`
 export function empty(el) {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -127,9 +127,9 @@ export const DivOverlay = Layer.extend({
 	onRemove(map) {
 		if (map._fadeAnimated) {
 			this._container.style.opacity = 0;
-			this._removeTimeout = setTimeout(DomUtil.remove.bind(null, this._container), 200);
+			this._removeTimeout = setTimeout(() => this._container.remove(), 200);
 		} else {
-			DomUtil.remove(this._container);
+			this._container.remove();
 		}
 
 		if (this.options.interactive) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -89,7 +89,7 @@ export const ImageOverlay = Layer.extend({
 	},
 
 	onRemove() {
-		DomUtil.remove(this._image);
+		this._image.remove();
 		if (this.options.interactive) {
 			this.removeInteractiveTarget(this._image);
 		}

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -292,7 +292,7 @@ export const Marker = Layer.extend({
 			DomEvent.off(this._icon, 'focus', this._panOnFocus, this);
 		}
 
-		DomUtil.remove(this._icon);
+		this._icon.remove();
 		this.removeInteractiveTarget(this._icon);
 
 		this._icon = null;
@@ -300,7 +300,7 @@ export const Marker = Layer.extend({
 
 	_removeShadow() {
 		if (this._shadow) {
-			DomUtil.remove(this._shadow);
+			this._shadow.remove();
 		}
 		this._shadow = null;
 	},

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -168,7 +168,7 @@ export const GridLayer = Layer.extend({
 
 	onRemove(map) {
 		this._removeAllTiles();
-		DomUtil.remove(this._container);
+		this._container.remove();
 		map._removeZoomLimit(this);
 		this._container = null;
 		this._tileZoom = undefined;
@@ -371,7 +371,7 @@ export const GridLayer = Layer.extend({
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
 				this._onUpdateLevel(z);
 			} else {
-				DomUtil.remove(this._levels[z].el);
+				this._levels[z].el.remove();
 				this._removeTilesAtZoom(z);
 				this._onRemoveLevel(z);
 				delete this._levels[z];
@@ -462,7 +462,7 @@ export const GridLayer = Layer.extend({
 
 	_invalidateAll() {
 		for (const z in this._levels) {
-			DomUtil.remove(this._levels[z].el);
+			this._levels[z].el.remove();
 			this._onRemoveLevel(Number(z));
 			delete this._levels[z];
 		}
@@ -770,7 +770,7 @@ export const GridLayer = Layer.extend({
 		const tile = this._tiles[key];
 		if (!tile) { return; }
 
-		DomUtil.remove(tile.el);
+		tile.el.remove();
 
 		delete this._tiles[key];
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -2,8 +2,6 @@ import {GridLayer} from './GridLayer';
 import Browser from '../../core/Browser';
 import * as Util from '../../core/Util';
 import * as DomEvent from '../../dom/DomEvent';
-import * as DomUtil from '../../dom/DomUtil';
-
 
 /*
  * @class TileLayer
@@ -243,7 +241,7 @@ export const TileLayer = GridLayer.extend({
 				if (!tile.complete) {
 					tile.src = Util.emptyImageUrl;
 					const coords = this._tiles[i].coords;
-					DomUtil.remove(tile);
+					tile.remove();
 					delete this._tiles[i];
 					// @event tileabort: TileEvent
 					// Fired when a tile was loading but is now not wanted.

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -80,7 +80,7 @@ export const Canvas = Renderer.extend({
 	_destroyContainer() {
 		Util.cancelAnimFrame(this._redrawRequest);
 		delete this._ctx;
-		DomUtil.remove(this._container);
+		this._container.remove();
 		DomEvent.off(this._container);
 		delete this._container;
 	},

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -49,7 +49,7 @@ export const SVG = Renderer.extend({
 	},
 
 	_destroyContainer() {
-		DomUtil.remove(this._container);
+		this._container.remove();
 		DomEvent.off(this._container);
 		delete this._container;
 		delete this._rootGroup;
@@ -106,7 +106,7 @@ export const SVG = Renderer.extend({
 	},
 
 	_removePath(layer) {
-		DomUtil.remove(layer._path);
+		layer._path.remove();
 		layer.removeInteractiveTarget(layer._path);
 		delete this._layers[stamp(layer)];
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -760,7 +760,7 @@ export const Map = Evented.extend({
 
 		this._stop();
 
-		DomUtil.remove(this._mapPane);
+		this._mapPane.remove();
 
 		if (this._clearControlPos) {
 			this._clearControlPos();
@@ -784,7 +784,7 @@ export const Map = Evented.extend({
 			this._layers[i].remove();
 		}
 		for (i in this._panes) {
-			DomUtil.remove(this._panes[i]);
+			this._panes[i].remove();
 		}
 
 		this._layers = [];
@@ -1639,7 +1639,7 @@ export const Map = Evented.extend({
 	},
 
 	_destroyAnimProxy() {
-		DomUtil.remove(this._proxy);
+		this._proxy.remove();
 		this.off('load moveend', this._animMoveEnd, this);
 		delete this._proxy;
 	},

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -41,7 +41,7 @@ export const BoxZoom = Handler.extend({
 	},
 
 	_destroy() {
-		DomUtil.remove(this._pane);
+		this._pane.remove();
 		delete this._pane;
 	},
 
@@ -101,7 +101,7 @@ export const BoxZoom = Handler.extend({
 
 	_finish() {
 		if (this._moved) {
-			DomUtil.remove(this._box);
+			this._box.remove();
 			this._container.classList.remove('leaflet-crosshair');
 		}
 


### PR DESCRIPTION
Removes the `DomUtil.remove()` function and replaces it with the standard [`Element.remove()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/remove) method. `DomUtil.remove()` was a polyfill, which is no longer required now that we have raised our target browsers.

This also removes `DomUtil.remove()` as an API, thus this is a breaking change.