### PR TITLE
Replace `DomUtil.empty()` with `Element.replaceChildren()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -63,22 +63,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#empty', () => {
-		it('removes all children of element', () => {
-			L.DomUtil.create('div', 'test', el);
-			L.DomUtil.create('div', 'test1', el);
-			L.DomUtil.create('div', 'test2', el);
-			L.DomUtil.empty(el);
-			expect(el.childNodes.length).to.be(0);
-		});
-
-		it('does nothing if element doesn\'t have children', () => {
-			expect(el.childNodes.length).to.be(0);
-			L.DomUtil.empty(el);
-			expect(el.childNodes.length).to.be(0);
-		});
-	});
-
 	describe('#toFront', () => {
 		it('moves el to last child position parent element', () => {
 			const elm = L.DomUtil.create('div', 'childContainer', el);

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -256,8 +256,8 @@ export const Layers = Control.extend({
 	_update() {
 		if (!this._container) { return this; }
 
-		DomUtil.empty(this._baseLayersList);
-		DomUtil.empty(this._overlaysList);
+		this._baseLayersList.replaceChildren();
+		this._overlaysList.replaceChildren();
 
 		this._layerControlInputs = [];
 		let baseLayersPresent, overlaysPresent, i, obj, baseLayersCount = 0;

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -45,14 +45,6 @@ export function create(tagName, className, container) {
 	return el;
 }
 
-// @function empty(el: HTMLElement)
-// Removes all of `el`'s children elements from `el`
-export function empty(el) {
-	while (el.firstChild) {
-		el.removeChild(el.firstChild);
-	}
-}
-
 // @function toFront(el: HTMLElement)
 // Makes `el` the last child of its parent, so it renders in front of the other children.
 export function toFront(el) {

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -1,6 +1,5 @@
 import {Icon} from './Icon';
 import {toPoint as point} from '../../geometry/Point';
-import {empty} from '../../dom/DomUtil';
 
 /*
  * @class DivIcon
@@ -47,7 +46,7 @@ export const DivIcon = Icon.extend({
 		    options = this.options;
 
 		if (options.html instanceof Element) {
-			empty(div);
+			div.replaceChildren();
 			div.appendChild(options.html);
 		} else {
 			div.innerHTML = options.html !== false ? options.html : '';


### PR DESCRIPTION
Removes the `DomUtil.empty()` function and replaces it with the standard [`Element.replaceChildren()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/replaceChildren) method.