### PR TITLE
`toGeoJSON()` should still work if no values in coords array

### DIFF
--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -887,6 +887,11 @@ describe('L.GeoJSON functions', () => {
 			expect(coords).to.eql([[1, 2, 3], [4, 5, 6], [1, 2, 3]]);
 			expect(coords[0] === coords[2]).to.not.ok();
 		});
+		it('still works if no values in coords array', () => {
+			expect(() => {
+				L.GeoJSON.latLngsToCoords([[]], 1, true);
+			}).to.not.throwException();
+		});
 	});
 
 	describe('#asFeature', () => {

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -287,7 +287,7 @@ export function latLngsToCoords(latlngs, levelsDeep, close, precision) {
 			latLngToCoords(latlngs[i], precision));
 	}
 
-	if (!levelsDeep && close) {
+	if (!levelsDeep && close && coords.length > 0) {
 		coords.push(coords[0].slice());
 	}
 


### PR DESCRIPTION
After adding `coords[0].slice()` in #7344 we have the problem that if `coords[0]` is `undefined` an error is thrown.

Must released in `1.9.4`