### PR TITLE
Remove vendor prefixes when setting `userSelect` style

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -134,21 +134,14 @@ if ('onselectstart' in document) {
 		DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
 	};
 } else {
-	const userSelectProperty = testProp(
-		['userSelect', 'WebkitUserSelect', 'OUserSelect', 'MozUserSelect', 'msUserSelect']);
-
 	disableTextSelection = function () {
-		if (userSelectProperty) {
-			const style = document.documentElement.style;
-			_userSelect = style[userSelectProperty];
-			style[userSelectProperty] = 'none';
-		}
+		const style = document.documentElement.style;
+		_userSelect = style.userSelect;
+		style.userSelect = 'none';
 	};
 	enableTextSelection = function () {
-		if (userSelectProperty) {
-			document.documentElement.style[userSelectProperty] = _userSelect;
-			_userSelect = undefined;
-		}
+		document.documentElement.style.userSelect = _userSelect;
+		_userSelect = undefined;
 	};
 }
 


### PR DESCRIPTION
Removes vendor prefixes for `userSelect` style when disabling or re-enabling text selection. Since this property is now supported by all major browsers it's no longer required to add a vendor prefix.