### PR TITLE
Remove `DomUtil.testProp()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -115,17 +115,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#testProp', () => {
-		it('check array of style names return first valid style name for element', () => {
-			const hasProp = L.DomUtil.testProp(['-webkit-transform', '-webkit-transform', '-ms-tranform', '-o-transform']);
-			expect(hasProp).to.match(/(?:-webkit-transform|-webkit-transform|-ms-tranform|-o-transform)/);
-		});
-
-		it('returns false if property doesn\'t exist', () => {
-			expect(L.DomUtil.testProp(['testprop'])).to.be(false);
-		});
-	});
-
 	describe('#setTransform', () => {
 		it('resets the transform style of an el.', () => {
 			expect(L.DomUtil.getStyle(el, 'transform')).to.be.equal('none');

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -63,21 +63,6 @@ export function toBack(el) {
 	}
 }
 
-// @function testProp(props: String[]): String|false
-// Goes through the array of style names and returns the first name
-// that is a valid style name for an element. If no such name is found,
-// it returns false. Useful for vendor-prefixed styles like `transform`.
-export function testProp(props) {
-	const style = document.documentElement.style;
-
-	for (let i = 0; i < props.length; i++) {
-		if (props[i] in style) {
-			return props[i];
-		}
-	}
-	return false;
-}
-
 // @function setTransform(el: HTMLElement, offset: Point, scale?: Number)
 // Resets the 3D CSS transform of `el` so it is translated by `offset` pixels
 // and optionally scaled by `scale`. Does not have an effect if the


### PR DESCRIPTION
Removes `DomUtil.testProp()` which was previously used to test for vendor-prefixed styles. Now that we have a more modern browser support target this is no longer required.