### PR TITLE
Fix implementation for disabling & enabling text selection

### DIFF
--- a/debug/tests/text-selection.html
+++ b/debug/tests/text-selection.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Leaflet debug page</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <script src="../../dist/leaflet-src.js"></script>
+  </head>
+  <body>
+    <button type="button" onclick="L.DomUtil.disableTextSelection();">Disable text selection</button>
+    <button type="button" onclick="L.DomUtil.enableTextSelection();">Enable text selection</button>
+    <p>The quick brown fox jumps over the lazy dog.</p>
+  </body>
+</html>

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -249,28 +249,33 @@ describe('DomUtil', () => {
 		});
 	});
 
-
 	describe('#disableTextSelection, #enableTextSelection', () => {
-		it('disable / enable the selectstart DOM events for the user ', () => {
-			let selectionPrevented;
-			function checkPrevented(e) {
-				if (e.defaultPrevented) {
-					selectionPrevented = true;
-				} else {
-					selectionPrevented = false;
-				}
-			}
-			const child = document.createElement('div');
-			el.appendChild(child);
+		const documentStyle = document.documentElement.style;
+		// Safari still needs a vendor prefix, we need to detect with property name is supported.
+		const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
 
+		beforeEach(() => expect(documentStyle[userSelectProp]).to.be(''));
+		afterEach(() => { documentStyle[userSelectProp] = ''; });
+
+		it('disables and enables text selection', () => {
 			L.DomUtil.disableTextSelection();
-			window.addEventListener('selectstart', checkPrevented);
-			happen.once(child, {type: 'selectstart'});
-			expect(selectionPrevented).to.be.ok();
-
+			expect(documentStyle[userSelectProp]).to.be('none');
 			L.DomUtil.enableTextSelection();
-			happen.once(child, {type: 'selectstart'});
-			expect(selectionPrevented).to.not.be.ok();
+			expect(documentStyle[userSelectProp]).to.be('');
+		});
+
+		it('restores the text selection previously set', () => {
+			documentStyle[userSelectProp] = 'text';
+			L.DomUtil.disableTextSelection();
+			L.DomUtil.enableTextSelection();
+			expect(documentStyle[userSelectProp]).to.be('text');
+		});
+
+		it('restores the text selection previously set when disabling multiple times', () => {
+			L.DomUtil.disableTextSelection();
+			L.DomUtil.disableTextSelection();
+			L.DomUtil.enableTextSelection();
+			expect(documentStyle[userSelectProp]).to.be('');
 		});
 	});
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -100,45 +100,45 @@ export function getPosition(el) {
 	return el._leaflet_pos || new Point(0, 0);
 }
 
+const documentStyle = document.documentElement.style;
+// Safari still needs a vendor prefix, we need to detect with property name is supported.
+const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
+let prevUserSelect;
+
 // @function disableTextSelection()
-// Prevents the user from generating `selectstart` DOM events, usually generated
-// when the user drags the mouse through a page with text. Used internally
+// Prevents the user from selecting text in the document. Used internally
 // by Leaflet to override the behaviour of any click-and-drag interaction on
 // the map. Affects drag interactions on the whole document.
+export function disableTextSelection() {
+	const value = documentStyle[userSelectProp];
+
+	if (value === 'none') {
+		return;
+	}
+
+	prevUserSelect = value;
+	documentStyle[userSelectProp] = 'none';
+}
 
 // @function enableTextSelection()
 // Cancels the effects of a previous [`L.DomUtil.disableTextSelection`](#domutil-disabletextselection).
-export let disableTextSelection;
-export let enableTextSelection;
-let _userSelect;
-if ('onselectstart' in document) {
-	disableTextSelection = function () {
-		DomEvent.on(window, 'selectstart', DomEvent.preventDefault);
-	};
-	enableTextSelection = function () {
-		DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
-	};
-} else {
-	disableTextSelection = function () {
-		const style = document.documentElement.style;
-		_userSelect = style.userSelect;
-		style.userSelect = 'none';
-	};
-	enableTextSelection = function () {
-		document.documentElement.style.userSelect = _userSelect;
-		_userSelect = undefined;
-	};
+export function enableTextSelection() {
+	if (typeof prevUserSelect === 'undefined') {
+		return;
+	}
+
+	documentStyle[userSelectProp] = prevUserSelect;
+	prevUserSelect = undefined;
 }
 
 // @function disableImageDrag()
-// As [`L.DomUtil.disableTextSelection`](#domutil-disabletextselection), but
-// for `dragstart` DOM events, usually generated when the user drags an image.
+// Prevents the user from generating `dragstart` DOM events, usually generated when the user drags an image.
 export function disableImageDrag() {
 	DomEvent.on(window, 'dragstart', DomEvent.preventDefault);
 }
 
 // @function enableImageDrag()
-// Cancels the effects of a previous [`L.DomUtil.disableImageDrag`](#domutil-disabletextselection).
+// Cancels the effects of a previous [`L.DomUtil.disableImageDrag`](#domutil-disableimagedrag).
 export function enableImageDrag() {
 	DomEvent.off(window, 'dragstart', DomEvent.preventDefault);
 }


### PR DESCRIPTION
Changes the implementation of `DomUtil.disableTextSelection()` and `DomUtil.enableTextSelection()` to exclusively use the [`user-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) CSS property.

Previously this was detecting the `selectstart` event and then using `event.preventDefault()` to ensure the user was not able to select text. This approach however was flawed as Safari on iOS now supports this event, but does not prevent the user from selecting text when the event is prevented.

Also fixes a bug where it was possible to call `DomUtil.disableTextSelection()` twice in a row allowing the internal value for restoring text selection to be incorrectly set to `none`. This then caused `DomUtil.enableTextSelection()` to 'restore' this incorrect value.

Documentation for `DomUtil.disableImageDrag()` and `DomUtil.enableImageDrag()` has also been adjusted as it contained a incorrect references.

Closes #8740