### PR TITLE
Lock `actions/cache` to version 3.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           NODE_ENV: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
 
       - name: Cache setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Restore setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Restore setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup
@@ -114,7 +114,7 @@ jobs:
             os: macos-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Restore setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Restore setup
-        uses: actions/cache@v3
+        uses: actions/cache@v3.2.0
         with:
           path: ./*
           key: ${{ github.ref }}-${{ github.sha }}-setup


### PR DESCRIPTION
A new release of `actions/cache` (3.2.1) seems to have broken our CI as machines running on Windows are no longer able to properly restore the cached files. This PR pins the the action to an older version that does not have this issue.