### PR TITLE
Run CI on latest version of Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -107,7 +107,7 @@ jobs:
           - browser: FirefoxNoTouch
           - browser: FirefoxRetina
           - browser: Chrome1280x1024
-            os: windows-2019
+            os: windows-latest
           - browser: Chrome1280x1024
             os: macos-latest
           - browser: SafariNative


### PR DESCRIPTION
Since we no longer need to run our tests on Internet Explorer we can use the latest version of Windows for CI.