### PR TITLE
Remove `DomUtil.getStyle()`

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -23,24 +23,6 @@ describe('DomUtil', () => {
 		});
 	});
 
-	describe('#getStyle', () => {
-		it('gets the value for a certain style attribute on an element,', () => {
-			el.style.color = 'black';
-			expect(L.DomUtil.getStyle(el, 'color')).to.eql('black');
-			el.style.color = 'green';
-			expect(L.DomUtil.getStyle(el, 'color')).to.eql('green');
-		});
-
-		it('returns empty string if style isn\'t defined', () => {
-			const e = document.createElement('div');
-			expect(L.DomUtil.getStyle(e, 'position')).to.be('');
-		});
-
-		it('returns undefined if style don\'t exist on HTML element or default css', () => {
-			expect(L.DomUtil.getStyle(el, 'random_name_for_style')).to.be(undefined);
-		});
-	});
-
 	describe('#create', () => {
 		it('creates an HTML element div without any class name', () => {
 			const e = L.DomUtil.create('div');
@@ -117,18 +99,18 @@ describe('DomUtil', () => {
 
 	describe('#setTransform', () => {
 		it('resets the transform style of an el.', () => {
-			expect(L.DomUtil.getStyle(el, 'transform')).to.be.equal('none');
+			expect(el.style.transform).to.be.equal('');
 
 			const offset = L.point(200, 200);
 			const scale = 10;
 			L.DomUtil.setTransform(el, offset, scale);
-			const transform = L.DomUtil.getStyle(el, 'transform');
-			expect(L.DomUtil.getStyle(el, 'transform')).to.be.equal(transform);
+			const transform = el.style.transform;
+			expect(el.style.transform).to.be.equal(transform);
 
 			const newScale = 20;
 			const newOffset = L.point(400, 400);
 			L.DomUtil.setTransform(el, newOffset, newScale);
-			expect(L.DomUtil.getStyle(el, 'transform')).to.not.be.equal(transform);
+			expect(el.style.transform).to.not.be.equal(transform);
 		});
 
 		it('reset the 3d CSS transform when offset and scale aren\'t specified', () => {
@@ -154,8 +136,8 @@ describe('DomUtil', () => {
 
 	describe('#setPosition, #getPosition', () => {
 		it('sets position of el to coordinates specified by position.', () => {
-			expect(L.DomUtil.getStyle(el, 'left')).to.be.equal('0px');
-			expect(L.DomUtil.getStyle(el, 'top')).to.be.equal('0px');
+			expect(el.style.left).to.be.equal('0px');
+			expect(el.style.top).to.be.equal('0px');
 
 			const x = 50;
 			const y = 55;

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -20,19 +20,6 @@ export function get(id) {
 	return typeof id === 'string' ? document.getElementById(id) : id;
 }
 
-// @function getStyle(el: HTMLElement, styleAttrib: String): String
-// Returns the value for a certain style attribute on an element,
-// including computed values or values set through CSS.
-export function getStyle(el, style) {
-	let value = el.style[style] || (el.currentStyle && el.currentStyle[style]);
-
-	if ((!value || value === 'auto') && document.defaultView) {
-		const css = document.defaultView.getComputedStyle(el, null);
-		value = css ? css[style] : null;
-	}
-	return value === 'auto' ? null : value;
-}
-
 // @function create(tagName: String, className?: String, container?: HTMLElement): HTMLElement
 // Creates an HTML element with `tagName`, sets its class to `className`, and optionally appends it to `container` element.
 export function create(tagName, className, container) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -270,7 +270,7 @@ export const Popup = DivOverlay.extend({
 		}
 
 		const map = this._map,
-		    marginBottom = parseInt(DomUtil.getStyle(this._container, 'marginBottom'), 10) || 0,
+		    marginBottom = parseInt(getComputedStyle(this._container).marginBottom, 10) || 0,
 		    containerHeight = this._container.offsetHeight + marginBottom,
 		    containerWidth = this._containerWidth,
 		    layerPos = new Point(this._containerLeft, -containerHeight - this._containerBottom);

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -53,11 +53,9 @@ export const IconDefault = Icon.extend({
 
 	_detectIconPath() {
 		const el = DomUtil.create('div',  'leaflet-default-icon-path', document.body);
-		let path = DomUtil.getStyle(el, 'background-image') ||
-		           DomUtil.getStyle(el, 'backgroundImage');	// IE8
+		const path = this._stripUrl(getComputedStyle(el).backgroundImage);
 
 		document.body.removeChild(el);
-		path = this._stripUrl(path);
 		if (path) { return path; }
 		const link = document.querySelector('link[href$="leaflet.css"]');
 		if (!link) { return ''; }

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1108,7 +1108,7 @@ export const Map = Evented.extend({
 
 		container.classList.add(...classes);
 
-		const position = DomUtil.getStyle(container, 'position');
+		const {position} = getComputedStyle(container);
 
 		if (position !== 'absolute' && position !== 'relative' && position !== 'fixed' && position !== 'sticky') {
 			container.style.position = 'relative';


### PR DESCRIPTION
Removes the `DomUtil.getStyle()` function and replaces it with [`getComputedStyle()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) where needed.

This function included code that was needed to handle older versions of Firefox and Internet Explorer, but now that we raised our browser target this is no longer required.