### PR TITLE
Remove `Browser.any3d`

### DIFF
--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -42,12 +42,6 @@ happen.makeEvent = (function (makeEvent) {
 	};
 })(happen.makeEvent);
 
-// We'll want to skip a couple of things when in PhantomJS, due to lack of CSS animations
-it.skipIfNo3d = L.Browser.any3d ? it : it.skip;
-
-// Viceversa: some tests we want only to run in browsers without CSS animations.
-it.skipIf3d = L.Browser.any3d ? it.skip : it;
-
 // A couple of tests need the browser to be touch-capable
 it.skipIfNotTouch = L.Browser.touch ? it : it.skip;
 

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -236,74 +236,40 @@ describe('Popup', () => {
 		expect(spy.callCount).to.be(2);
 	});
 
-	describe('should take into account icon popupAnchor option on', () => {
+	it('should take into account icon popupAnchor option', () => {
 		const latlng = center;
 		const offset = L.point(20, 30);
-		let autoPanBefore;
-		let popupAnchorBefore;
-		let icon;
-		let marker1;
-		let marker2;
 
-		before(() => {
-			autoPanBefore = L.Popup.prototype.options.autoPan;
-			L.Popup.prototype.options.autoPan = false;
-			popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
-			L.Icon.Default.prototype.options.popupAnchor = [0, 0];
-		});
+		const autoPanBefore = L.Popup.prototype.options.autoPan;
+		L.Popup.prototype.options.autoPan = false;
+		const popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
+		L.Icon.Default.prototype.options.popupAnchor = [0, 0];
 
-		beforeEach(() => {
-			icon = L.divIcon({popupAnchor: offset});
-			marker1 = L.marker(latlng);
-			marker2 = L.marker(latlng, {icon});
-		});
+		const icon = L.divIcon({popupAnchor: offset});
+		const marker1 = L.marker(latlng);
+		const marker2 = L.marker(latlng, {icon});
 
-		after(() => {
-			L.Popup.prototype.options.autoPan = autoPanBefore;
-			L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
-		});
+		marker1.bindPopup('Popup').addTo(map);
+		marker1.openPopup();
+		const defaultLeft = marker1._popup._container._leaflet_pos.x;
+		const defaultTop = marker1._popup._container._leaflet_pos.y;
+		marker2.bindPopup('Popup').addTo(map);
+		marker2.openPopup();
+		let offsetLeft = marker2._popup._container._leaflet_pos.x;
+		let offsetTop = marker2._popup._container._leaflet_pos.y;
+		expect(offsetLeft - offset.x).to.eql(defaultLeft);
+		expect(offsetTop - offset.y).to.eql(defaultTop);
 
-		it.skipIf3d('non-any3d browsers', () => {
-			marker1.bindPopup('Popup').addTo(map);
-			marker1.openPopup();
-			const defaultLeft = parseInt(marker1._popup._container.style.left, 10);
-			const defaultBottom = parseInt(marker1._popup._container.style.bottom, 10);
-			marker2.bindPopup('Popup').addTo(map);
-			marker2.openPopup();
-			let offsetLeft = parseInt(marker2._popup._container.style.left, 10);
-			let offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
-			expect(offsetLeft - offset.x).to.eql(defaultLeft);
-			expect(offsetBottom + offset.y).to.eql(defaultBottom);
+		// Now retry passing a popup instance to bindPopup
+		marker2.bindPopup(L.popup());
+		marker2.openPopup();
+		offsetLeft = marker2._popup._container._leaflet_pos.x;
+		offsetTop = marker2._popup._container._leaflet_pos.y;
+		expect(offsetLeft - offset.x).to.eql(defaultLeft);
+		expect(offsetTop - offset.y).to.eql(defaultTop);
 
-			// Now retry passing a popup instance to bindPopup
-			marker2.bindPopup(L.popup());
-			marker2.openPopup();
-			offsetLeft = parseInt(marker2._popup._container.style.left, 10);
-			offsetBottom = parseInt(marker2._popup._container.style.bottom, 10);
-			expect(offsetLeft - offset.x).to.eql(defaultLeft);
-			expect(offsetBottom + offset.y).to.eql(defaultBottom);
-		});
-
-		it.skipIfNo3d('any3d browsers', () => {
-			marker1.bindPopup('Popup').addTo(map);
-			marker1.openPopup();
-			const defaultLeft = marker1._popup._container._leaflet_pos.x;
-			const defaultTop = marker1._popup._container._leaflet_pos.y;
-			marker2.bindPopup('Popup').addTo(map);
-			marker2.openPopup();
-			let offsetLeft = marker2._popup._container._leaflet_pos.x;
-			let offsetTop = marker2._popup._container._leaflet_pos.y;
-			expect(offsetLeft - offset.x).to.eql(defaultLeft);
-			expect(offsetTop - offset.y).to.eql(defaultTop);
-
-			// Now retry passing a popup instance to bindPopup
-			marker2.bindPopup(L.popup());
-			marker2.openPopup();
-			offsetLeft = marker2._popup._container._leaflet_pos.x;
-			offsetTop = marker2._popup._container._leaflet_pos.y;
-			expect(offsetLeft - offset.x).to.eql(defaultLeft);
-			expect(offsetTop - offset.y).to.eql(defaultTop);
-		});
+		L.Popup.prototype.options.autoPan = autoPanBefore;
+		L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
 	});
 
 	it('prevents an underlying map click for Layer', () => {

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -579,9 +579,7 @@ describe('GridLayer', () => {
 			}
 		}
 
-		// NOTE: This test has different behaviour in PhantomJS and graphical
-		// browsers due to CSS animations!
-		it.skipIfNo3d('Loads 32, unloads 16 tiles zooming in 10-11', (done) => {
+		it('Loads 32, unloads 16 tiles zooming in 10-11', (done) => {
 			// Advance the time to !== 0 otherwise `tile.loaded` timestamp will appear to be falsy.
 			clock.tick(1);
 			// Date.now() is 1.
@@ -689,9 +687,7 @@ describe('GridLayer', () => {
 			clock.tick(250);
 		});
 
-		// NOTE: This test has different behaviour in PhantomJS and graphical
-		// browsers due to CSS animations!
-		it.skipIfNo3d('Loads 32, unloads 16 tiles zooming out 11-10', (done) => {
+		it('Loads 32, unloads 16 tiles zooming out 11-10', (done) => {
 			// Advance the time to !== 0 otherwise `tile.loaded` timestamp will appear to be falsy.
 			clock.tick(1);
 			// Date.now() is 1.
@@ -791,9 +787,7 @@ describe('GridLayer', () => {
 			clock.tick(250);
 		});
 
-		// NOTE: This test has different behaviour in PhantomJS and graphical
-		// browsers due to CSS animations!
-		it.skipIfNo3d('Loads 290, unloads 275 tiles on MAD-TRD flyTo()', function (done) {
+		it('Loads 290, unloads 275 tiles on MAD-TRD flyTo()', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
 			const mad = [40.40, -3.7], trd = [63.41, 10.41];
@@ -903,9 +897,6 @@ describe('GridLayer', () => {
 
 						// Wait for a frame to let _updateOpacity starting
 						// It will prune the 12 tiles outside the new bounds.
-						// PhantomJS has Browser.any3d === false, so it actually
-						// does not perform the fade animation and does not need
-						// this rAF, but it does not harm either.
 						L.Util.requestAnimFrame(() => {
 							expect(counts.tileunload).to.be(12);
 							done();
@@ -947,9 +938,6 @@ describe('GridLayer', () => {
 
 					// Wait for a frame to let _updateOpacity starting
 					// It will prune the 12 tiles outside the new bounds.
-					// PhantomJS has Browser.any3d === false, so it actually
-					// does not perform the fade animation and does not need
-					// this rAF, but it does not harm either.
 					L.Util.requestAnimFrame(() => {
 						expect(counts.tileunload).to.be(12);
 

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -246,9 +246,7 @@ describe('TileLayer', () => {
 			clock.tick(250);
 		});
 
-		// NOTE: This test has different behaviour in PhantomJS and graphical
-		// browsers due to CSS animations!
-		it.skipIfNo3d('Loads 290, unloads 275 kittens on MAD-TRD flyTo()', function (done) {
+		it('Loads 290, unloads 275 kittens on MAD-TRD flyTo()', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
 			const mad = [40.40, -3.7], trd = [63.41, 10.41];

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -380,7 +380,7 @@ describe('Map', () => {
 			expect(map.getBoundsZoom(bounds, false, padding)).to.be.equal(19);
 		});
 
-		it.skipIfNo3d('returns multiples of zoomSnap when zoomSnap > 0 on any3d browsers', () => {
+		it('returns multiples of zoomSnap when zoomSnap > 0', () => {
 			container.style.height = height;
 			map.options.zoomSnap = 0.5;
 			expect(map.getBoundsZoom(bounds, false, padding)).to.be.equal(19.5);
@@ -1442,18 +1442,7 @@ describe('Map', () => {
 			map.zoomOut(null, {animate: false});
 		});
 
-		it.skipIf3d('zoomIn ignores the zoomDelta option on non-any3d browsers', (done) => {
-			map.options.zoomSnap = 0.25;
-			map.options.zoomDelta = 0.25;
-			map.once('zoomend', () => {
-				expect(map.getZoom()).to.eql(11);
-				expect(map.getCenter()).to.eql(center);
-				done();
-			});
-			map.zoomIn(null, {animate: false});
-		});
-
-		it.skipIfNo3d('zoomIn respects the zoomDelta option on any3d browsers', (done) => {
+		it('zoomIn respects the zoomDelta option', (done) => {
 			map.options.zoomSnap = 0.25;
 			map.options.zoomDelta = 0.25;
 			map.setView(center, 10);
@@ -1465,7 +1454,7 @@ describe('Map', () => {
 			map.zoomIn(null, {animate: false});
 		});
 
-		it.skipIfNo3d('zoomOut respects the zoomDelta option on any3d browsers', (done) => {
+		it('zoomOut respects the zoomDelta option', (done) => {
 			map.options.zoomSnap = 0.25;
 			map.options.zoomDelta = 0.25;
 			map.setView(center, 10);
@@ -1477,7 +1466,7 @@ describe('Map', () => {
 			map.zoomOut(null, {animate: false});
 		});
 
-		it.skipIfNo3d('zoomIn snaps to zoomSnap on any3d browsers', (done) => {
+		it('zoomIn snaps to zoomSnap', (done) => {
 			map.options.zoomSnap = 0.25;
 			map.setView(center, 10);
 			map.once('zoomend', () => {
@@ -1488,7 +1477,7 @@ describe('Map', () => {
 			map.zoomIn(0.22, {animate: false});
 		});
 
-		it.skipIfNo3d('zoomOut snaps to zoomSnap on any3d browsers', (done) => {
+		it('zoomOut snaps to zoomSnap', (done) => {
 			map.options.zoomSnap = 0.25;
 			map.setView(center, 10);
 			map.once('zoomend', () => {
@@ -1531,20 +1520,10 @@ describe('Map', () => {
 			map.fitBounds(bounds, {animate: false});
 		});
 
-		it.skipIfNo3d('Snaps zoom to zoomSnap on any3d browsers', (done) => {
+		it('Snaps zoom to zoomSnap', (done) => {
 			map.options.zoomSnap = 0.25;
 			map.once('zoomend', () => {
 				expect(map.getZoom()).to.eql(2.75);
-				expect(map.getCenter().equals(boundsCenter, 0.05)).to.eql(true);
-				done();
-			});
-			map.fitBounds(bounds, {animate: false});
-		});
-
-		it.skipIf3d('Ignores zoomSnap on non-any3d browsers', (done) => {
-			map.options.zoomSnap = 0.25;
-			map.once('zoomend', () => {
-				expect(map.getZoom()).to.eql(2);
 				expect(map.getCenter().equals(boundsCenter, 0.05)).to.eql(true);
 				done();
 			});
@@ -1621,7 +1600,6 @@ describe('Map', () => {
 		});
 
 		it('Snaps to a number after adding tile layer', () => {
-			// expect(L.Browser.any3d).to.be.ok(); // precondition
 			map.addLayer(L.tileLayer(''));
 			expect(map.getZoom()).to.be(undefined);
 			map.fitBounds(bounds);
@@ -1629,7 +1607,6 @@ describe('Map', () => {
 		});
 
 		it('Snaps to a number after adding marker', () => {
-			// expect(L.Browser.any3d).to.be.ok(); // precondition
 			map.addLayer(L.marker(center));
 			expect(map.getZoom()).to.be(undefined);
 			map.fitBounds(bounds);

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -40,10 +40,6 @@ const webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSS
 // @property gecko3d: Boolean; `true` for gecko-based browsers supporting CSS transforms.
 const gecko3d = 'MozPerspective' in style;
 
-// @property any3d: Boolean
-// `true` for all browsers supporting CSS transforms.
-const any3d = !window.L_DISABLE_3D && (webkit3d || gecko3d);
-
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 const mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
 
@@ -131,7 +127,6 @@ export default {
 	win,
 	webkit3d,
 	gecko3d,
-	any3d,
 	mobile,
 	mobileWebkit,
 	mobileWebkit3d,

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -1,6 +1,5 @@
 import * as DomEvent from './DomEvent';
 import {Point} from '../geometry/Point';
-import Browser from '../core/Browser';
 
 /*
  * @namespace DomUtil
@@ -83,12 +82,7 @@ export function setPosition(el, point) {
 	el._leaflet_pos = point;
 	/* eslint-enable */
 
-	if (Browser.any3d) {
-		setTransform(el, point);
-	} else {
-		el.style.left = `${point.x}px`;
-		el.style.top = `${point.y}px`;
-	}
+	setTransform(el, point);
 }
 
 // @function getPosition(el: HTMLElement): Point

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -594,11 +594,7 @@ export const GridLayer = Layer.extend({
 		    translate = level.origin.multiplyBy(scale)
 		        .subtract(this._map._getNewPixelOrigin(center, zoom)).round();
 
-		if (Browser.any3d) {
-			DomUtil.setTransform(level.el, translate, scale);
-		} else {
-			DomUtil.setPosition(level.el, translate);
-		}
+		DomUtil.setTransform(level.el, translate, scale);
 	},
 
 	_resetGrid() {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -1,7 +1,6 @@
 import {Layer} from '../Layer';
 import * as DomUtil from '../../dom/DomUtil';
 import * as Util from '../../core/Util';
-import Browser from '../../core/Browser';
 import {Bounds} from '../../geometry/Bounds';
 
 
@@ -91,11 +90,7 @@ export const Renderer = Layer.extend({
 		    topLeftOffset = viewHalf.multiplyBy(-scale).add(currentCenterPoint)
 				  .subtract(this._map._getNewPixelOrigin(center, zoom));
 
-		if (Browser.any3d) {
-			DomUtil.setTransform(this._container, topLeftOffset, scale);
-		} else {
-			DomUtil.setPosition(this._container, topLeftOffset);
-		}
+		DomUtil.setTransform(this._container, topLeftOffset, scale);
 	},
 
 	_reset() {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -153,7 +153,7 @@ export const Map = Evented.extend({
 		this.callInitHooks();
 
 		// don't animate on browsers without hardware-accelerated transitions or old Android
-		this._zoomAnimated = Browser.any3d && this.options.zoomAnimation;
+		this._zoomAnimated = this.options.zoomAnimation;
 
 		// zoom transitions run with the same duration for all layers, so if one of transitionend events
 		// happens after starting zoom animation (propagating to the map pane), we know that it ended globally
@@ -217,14 +217,14 @@ export const Map = Evented.extend({
 	// @method zoomIn(delta?: Number, options?: Zoom options): this
 	// Increases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
 	zoomIn(delta, options) {
-		delta = delta || (Browser.any3d ? this.options.zoomDelta : 1);
+		delta = delta || this.options.zoomDelta;
 		return this.setZoom(this._zoom + delta, options);
 	},
 
 	// @method zoomOut(delta?: Number, options?: Zoom options): this
 	// Decreases the zoom of the map by `delta` ([`zoomDelta`](#map-zoomdelta) by default).
 	zoomOut(delta, options) {
-		delta = delta || (Browser.any3d ? this.options.zoomDelta : 1);
+		delta = delta || this.options.zoomDelta;
 		return this.setZoom(this._zoom - delta, options);
 	},
 
@@ -354,7 +354,7 @@ export const Map = Evented.extend({
 	flyTo(targetCenter, targetZoom, options) {
 
 		options = options || {};
-		if (options.animate === false || !Browser.any3d) {
+		if (options.animate === false) {
 			return this.setView(targetCenter, targetZoom, options);
 		}
 
@@ -869,7 +869,7 @@ export const Map = Evented.extend({
 		      se = bounds.getSouthEast(),
 		      size = this.getSize().subtract(padding),
 		      boundsSize = toBounds(this.project(se, zoom), this.project(nw, zoom)).getSize(),
-		      snap = Browser.any3d ? this.options.zoomSnap : 1,
+		      snap = this.options.zoomSnap,
 		      scalex = size.x / boundsSize.x,
 		      scaley = size.y / boundsSize.y,
 		      scale = inside ? Math.max(scalex, scaley) : Math.min(scalex, scaley);
@@ -1097,7 +1097,7 @@ export const Map = Evented.extend({
 	_initLayout() {
 		const container = this._container;
 
-		this._fadeAnimated = this.options.fadeAnimation && Browser.any3d;
+		this._fadeAnimated = this.options.fadeAnimation;
 
 		const classes = ['leaflet-container'];
 
@@ -1330,7 +1330,7 @@ export const Map = Evented.extend({
 			}
 		}
 
-		if (Browser.any3d && this.options.transform3DLimit) {
+		if (this.options.transform3DLimit) {
 			(remove ? this.off : this.on).call(this, 'moveend', this._onMoveEnd);
 		}
 	},
@@ -1589,7 +1589,7 @@ export const Map = Evented.extend({
 	_limitZoom(zoom) {
 		const min = this.getMinZoom(),
 		    max = this.getMaxZoom(),
-		    snap = Browser.any3d ? this.options.zoomSnap : 1;
+		    snap = this.options.zoomSnap;
 		if (snap) {
 			zoom = Math.round(zoom / snap) * snap;
 		}


### PR DESCRIPTION
Removes `Browser.any3d`, instead assumes CSS transforms are always supported. Since we raised our browser support target this should not be an issue.