### PR TITLE
Hold element positions in WeakMap

### DIFF
--- a/docs/examples/extending/pixelorigin.md
+++ b/docs/examples/extending/pixelorigin.md
@@ -66,7 +66,7 @@ title: Grid coordinates
 		const pixelOrigin = map.getPixelOrigin();
 		const markerPixelCoords = map.project(trd, map.getZoom());
 		const markerAnchor = marker.options.icon.options.iconAnchor;
-		const markerOffset = marker._icon._leaflet_pos;
+		const markerOffset = L.DomUtil.getPosition(marker._icon);
 
 		document.getElementById('info').innerHTML =
 			'<div style="color: green">CRS origin: 0,0</div>' +

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -251,20 +251,20 @@ describe('Popup', () => {
 
 		marker1.bindPopup('Popup').addTo(map);
 		marker1.openPopup();
-		const defaultLeft = marker1._popup._container._leaflet_pos.x;
-		const defaultTop = marker1._popup._container._leaflet_pos.y;
+		const defaultLeft = L.DomUtil.getPosition(marker1._popup._container).x;
+		const defaultTop = L.DomUtil.getPosition(marker1._popup._container).y;
 		marker2.bindPopup('Popup').addTo(map);
 		marker2.openPopup();
-		let offsetLeft = marker2._popup._container._leaflet_pos.x;
-		let offsetTop = marker2._popup._container._leaflet_pos.y;
+		let offsetLeft = L.DomUtil.getPosition(marker2._popup._container).x;
+		let offsetTop = L.DomUtil.getPosition(marker2._popup._container).y;
 		expect(offsetLeft - offset.x).to.eql(defaultLeft);
 		expect(offsetTop - offset.y).to.eql(defaultTop);
 
 		// Now retry passing a popup instance to bindPopup
 		marker2.bindPopup(L.popup());
 		marker2.openPopup();
-		offsetLeft = marker2._popup._container._leaflet_pos.x;
-		offsetTop = marker2._popup._container._leaflet_pos.y;
+		offsetLeft = L.DomUtil.getPosition(marker2._popup._container).x;
+		offsetTop = L.DomUtil.getPosition(marker2._popup._container).y;
 		expect(offsetLeft - offset.x).to.eql(defaultLeft);
 		expect(offsetTop - offset.y).to.eql(defaultTop);
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -59,16 +59,14 @@ export function setTransform(el, offset, scale) {
 	el.style.transform = `translate3d(${pos.x}px,${pos.y}px,0)${scale ? ` scale(${scale})` : ''}`;
 }
 
+const positions = new WeakMap();
+
 // @function setPosition(el: HTMLElement, position: Point)
 // Sets the position of `el` to coordinates specified by `position`,
 // using CSS translate or top/left positioning depending on the browser
 // (used by Leaflet internally to position its layers).
 export function setPosition(el, point) {
-
-	/*eslint-disable */
-	el._leaflet_pos = point;
-	/* eslint-enable */
-
+	positions.set(el, point);
 	setTransform(el, point);
 }
 
@@ -77,8 +75,7 @@ export function setPosition(el, point) {
 export function getPosition(el) {
 	// this method is only used for elements previously positioned using setPosition,
 	// so it's safe to cache the position for performance
-
-	return el._leaflet_pos || new Point(0, 0);
+	return positions.get(el) ?? new Point(0, 0);
 }
 
 const documentStyle = document.documentElement.style;


### PR DESCRIPTION
Stores positions set with `DomUtil.setPosition()` in a [`WeakMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) instead of setting a custom 'private' property (`_leaflet_pos`) on the DOM element itself.