### PR TITLE
Use OS name as part of cache key for jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,10 @@ jobs:
           NODE_ENV: ${{ startsWith(github.ref, 'refs/tags/v') && 'release' || '' }}
 
       - name: Cache setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
   build-docs:
     runs-on: ubuntu-latest
@@ -56,10 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -75,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -114,10 +114,10 @@ jobs:
             os: macos-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -133,10 +133,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Compress artifacts
         working-directory: dist
@@ -159,10 +159,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore setup
-        uses: actions/cache@v3.2.0
+        uses: actions/cache@v3
         with:
           path: ./*
-          key: ${{ github.ref }}-${{ github.sha }}-setup
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
 
       - name: Set up Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Resolves the issue we experienced under #8742 by adding the OS name to the cache key for `actions/cache`. For more information see https://github.com/actions/cache/issues/1043.