### PR TITLE
Remove browser specific detection code for CSS transforms

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -16,8 +16,6 @@ import {svgCreate} from '../layer/vector/SVG.Util';
  * ```
  */
 
-const style = document.documentElement.style;
-
 // @property webkit: Boolean;
 // `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
 const webkit = userAgentContains('webkit');
@@ -34,21 +32,11 @@ const safari = !chrome && userAgentContains('safari');
 // @property win: Boolean; `true` when the browser is running in a Windows platform
 const win = navigator.platform.startsWith('Win');
 
-// @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
-const webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix());
-
-// @property gecko3d: Boolean; `true` for gecko-based browsers supporting CSS transforms.
-const gecko3d = 'MozPerspective' in style;
-
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 const mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
 
 // @property mobileWebkit: Boolean; `true` for all webkit-based browsers in a mobile device.
 const mobileWebkit = mobile && webkit;
-
-// @property mobileWebkit3d: Boolean
-// `true` for all webkit-based browsers in a mobile device supporting CSS transforms.
-const mobileWebkit3d = mobile && webkit3d;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
@@ -125,11 +113,8 @@ export default {
 	gecko,
 	safari,
 	win,
-	webkit3d,
-	gecko3d,
 	mobile,
 	mobileWebkit,
-	mobileWebkit3d,
 	pointer,
 	touch,
 	touchNative,


### PR DESCRIPTION
Removes the remaining browser specific detection code for CSS transforms from `Browser`. Specifically `webkit3d`, `mobileWebkit3d` and `gecko3d`.