### PR TITLE
Remove `L_NO_TOUCH` global switch

### DIFF
--- a/build/docs-misc.leafdoc
+++ b/build/docs-misc.leafdoc
@@ -1,25 +1,5 @@
 Miscellaneous bits of documentation that don't really fit anywhere else
 
-
-
-@namespace Global Switches
-
-Global switches are created for rare cases and generally make
-Leaflet to not detect a particular browser feature even if it's
-there. You need to set the switch as a global variable to true
-before including Leaflet on the page, like this:
-
-```html
-<script>L_NO_TOUCH = true;</script>
-<script src="leaflet.js"></script>
-```
-
-| Switch         |   Description    |
-| -------------- | ---------------- |
-| `L_NO_TOUCH`   | Forces Leaflet to not use touch events even if it detects them. |
-| `L_DISABLE_3D` | Forces Leaflet to not use hardware-accelerated CSS 3D transforms for positioning (which may cause glitches in some rare environments) even if they're supported. |
-
-
 @namespace noConflict
 
 This method restores the `L` global variable to the original value

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -64,7 +64,7 @@ const touchNative = 'ontouchstart' in window || !!window.TouchEvent;
 // @property touch: Boolean
 // `true` for all browsers supporting either [touch](#browser-touch) or [pointer](#browser-pointer) events.
 // Note: pointer events will be preferred (if available), and processed for all `touch*` listeners.
-const touch = !window.L_NO_TOUCH && (touchNative || pointer);
+const touch = touchNative || pointer;
 
 // @property mobileGecko: Boolean
 // `true` for gecko-based browsers running in a mobile device.


### PR DESCRIPTION
Removes the ability to disable touch interactions by setting the global `L_NO_TOUCH` variable (a.k.a. switch). Also removes assorted documentation for it and the `L_DISABLE_3D` switch (which was already removed).