### PR TITLE
Remove `noConflict()`

### DIFF
--- a/build/docs-misc.leafdoc
+++ b/build/docs-misc.leafdoc
@@ -20,26 +20,6 @@ before including Leaflet on the page, like this:
 | `L_DISABLE_3D` | Forces Leaflet to not use hardware-accelerated CSS 3D transforms for positioning (which may cause glitches in some rare environments) even if they're supported. |
 
 
-@namespace noConflict
-
-This method restores the `L` global variable to the original value
-it had before Leaflet inclusion, and returns the real Leaflet
-namespace so you can put it elsewhere, like this:
-
-```html
-<script src='libs/l.js'>
-<!-- L points to some other library -->
-
-<script src='leaflet.js'>
-<!-- you include Leaflet, it replaces the L variable to Leaflet namespace -->
-
-<script>
-var Leaflet = L.noConflict();
-// now L points to that other library again, and you can use Leaflet.Map etc.
-</script>
-```
-
-
 @namespace version
 
 A constant that represents the Leaflet version in use.

--- a/build/leafdoc-templates/html.hbs
+++ b/build/leafdoc-templates/html.hbs
@@ -119,8 +119,7 @@ bodyclass: api-page
 		<h4>Misc</h4>
 		<ul>
 			<li><a href="#event-objects">Event objects</a></li>
-				<li><a href="#global-switches">global switches</a></li>
-			<li><a href="#noconflict">noConflict</a></li>
+			<li><a href="#global-switches">Global switches</a></li>
 			<li><a href="#version">version</a></li>
 		</ul>
 	</div>

--- a/spec/index.html
+++ b/spec/index.html
@@ -25,12 +25,6 @@
 	<script src="../dist/leaflet-src.js"></script>
 
 	<script>
-		// noConflict is defined in the rollup-config or in karma.conf.js, both are nor called while executing this
-		L.noConflict = function() {
-			window.L = oldL;
-			return this;
-		};
-
 		// sets the default imagePath to the project path like "/Leaflet/dist/images/"
 		// same as in after.js but not static
 		L.Icon.Default.imagePath = '/' + window.location.pathname.split('/')[1] + '/dist/images/';

--- a/spec/suites/core/GeneralSpec.js
+++ b/spec/suites/core/GeneralSpec.js
@@ -1,11 +1,4 @@
 describe('General', () => {
-	it('noConflict', () => {
-		const leaflet = L;
-		expect(L.noConflict()).to.eql(leaflet);
-		expect(L).to.eql(undefined);
-		L = leaflet;
-	});
-
 	it('namespace extension', () => {
 		L.Util.foo = 'bar';
 		L.Foo = 'Bar';

--- a/src/LeafletWithGlobals.js
+++ b/src/LeafletWithGlobals.js
@@ -1,18 +1,9 @@
 import * as L from './Leaflet';
 export * from './Leaflet';
 
-const globalL = L.extend(L, {noConflict});
-export default globalL;
+export default L;
 
-const globalObject = getGlobalObject();
-const oldL = globalObject.L;
-
-globalObject.L = globalL;
-
-export function noConflict() {
-	globalObject.L = oldL;
-	return globalL;
-}
+getGlobalObject().L = L;
 
 function getGlobalObject() {
 	if (typeof globalThis !== 'undefined') { return globalThis; }


### PR DESCRIPTION
Removes the `noConflict()` function, which is no longer required now that we're moving away from globals.