### PR TITLE
Remove `Browser.canvas` feature detection

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1873,9 +1873,7 @@ describe('Map', () => {
 			expect(called).to.eql(4);
 		});
 
-		it('prevents default action of contextmenu if there is any listener', function () {
-			if (!L.Browser.canvas) { this.skip(); }
-
+		it('prevents default action of contextmenu if there is any listener', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
 			map = L.map(container, {

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -92,12 +92,6 @@ const passiveEvents = (function () {
 	return supportsPassiveOption;
 }());
 
-// @property canvas: Boolean
-// `true` when the browser supports [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).
-const canvas = (function () {
-	return !!document.createElement('canvas').getContext;
-}());
-
 // @property svg: Boolean
 // `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
 const svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
@@ -136,7 +130,6 @@ export default {
 	mobileGecko,
 	retina,
 	passiveEvents,
-	canvas,
 	svg,
 	inlineSvg,
 	mac,

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -490,5 +490,5 @@ export const Canvas = Renderer.extend({
 // @factory L.canvas(options?: Renderer options)
 // Creates a Canvas renderer with the given options.
 export function canvas(options) {
-	return Browser.canvas ? new Canvas(options) : null;
+	return new Canvas(options);
 }


### PR DESCRIPTION
Removes the `Browser.canvas` API  to detect HTML canvas support. Our new browser support target will always support this feature, so it is no longer required to detect it.