### PR TITLE
Remove SVG feature detection code

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -4,7 +4,6 @@ import {Map} from '../map/Map';
 import * as Util from '../core/Util';
 import * as DomEvent from '../dom/DomEvent';
 import * as DomUtil from '../dom/DomUtil';
-import Browser from '../core/Browser';
 
 const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" class="leaflet-attribution-flag"><path fill="#4C7BE1" d="M0 0h12v4H0z"/><path fill="#FFD500" d="M0 4h12v3H0z"/><path fill="#E0BC00" d="M0 7h12v1H0z"/></svg>';
 
@@ -28,7 +27,7 @@ export const Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: `<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">${Browser.inlineSvg ? `${ukrainianFlag} ` : ''}Leaflet</a>`
+		prefix: `<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag} Leaflet</a>`
 	},
 
 	initialize(options) {

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -1,5 +1,4 @@
 import * as Util from './Util';
-import {svgCreate} from '../layer/vector/SVG.Util';
 
 /*
  * @namespace Browser
@@ -98,16 +97,6 @@ const canvas = (function () {
 	return !!document.createElement('canvas').getContext;
 }());
 
-// @property svg: Boolean
-// `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
-const svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
-
-const inlineSvg = !!svg && (function () {
-	const div = document.createElement('div');
-	div.innerHTML = '<svg/>';
-	return (div.firstChild && div.firstChild.namespaceURI) === 'http://www.w3.org/2000/svg';
-})();
-
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
 const mac = navigator.platform.startsWith('Mac');
 
@@ -137,8 +126,6 @@ export default {
 	retina,
 	passiveEvents,
 	canvas,
-	svg,
-	inlineSvg,
 	mac,
 	linux
 };

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -1,7 +1,6 @@
 import {Renderer} from './Renderer';
 import * as DomUtil from '../../dom/DomUtil';
 import * as DomEvent from '../../dom/DomEvent';
-import Browser from '../../core/Browser';
 import {splitWords, stamp} from '../../core/Util';
 import {svgCreate, pointsToPath} from './SVG.Util';
 export {pointsToPath};
@@ -190,5 +189,5 @@ export const SVG = Renderer.extend({
 // @factory L.svg(options?: Renderer options)
 // Creates a SVG renderer with the given options.
 export function svg(options) {
-	return Browser.svg ? new SVG(options) : null;
+	return new SVG(options);
 }


### PR DESCRIPTION
Removes feature detection code for SVG from `Browser`, specifically `svg` and `inlineSvg`. These are no longer needed as all the browsers we are targeting support these features.