### PR TITLE
Added missing curly bracket in docs

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -3769,7 +3769,7 @@ open popups while making sure that only one popup is open at one time
 	.openOn(map);
 </code></pre>
 <p>or</p>
-<pre><code class="language-js">var popup = L.popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;')
+<pre><code class="language-js">var popup = L.popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;'})
 	.openOn(map);
 </code></pre>
 


### PR DESCRIPTION
<img width="799" alt="Screenshot 2022-12-31 at 17 06 20" src="https://user-images.githubusercontent.com/109139427/210137757-1c3d2bf3-f283-4fed-b64f-7617e683d954.png">

Added missing curly bracket in popup docs example