### PR TITLE
Add shadow-icon as svg icon and add white circle to marker-icon

### DIFF
--- a/src/images/marker-shadow.svg
+++ b/src/images/marker-shadow.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 817.2 820" style="enable-background:new 0 0 817.2 820;" xml:space="preserve">
+	<style type="text/css">
+		.shadow{fill-rule:evenodd;clip-rule:evenodd;fill:url(#gradient); fill-opacity:0.7; filter: blur(15px);}
+	</style>
+	<radialGradient id="gradient" cx="526.5995" cy="486.8359" r="478.1535" fx="275.8764" fy="893.9829" gradientUnits="userSpaceOnUse">
+		<stop  offset="0" style="stop-color:#5C5C5C;stop-opacity:0.9477"/>
+		<stop  offset="0.1123" style="stop-color:#474747;stop-opacity:0.7805"/>
+		<stop  offset="0.3403" style="stop-color:#202020;stop-opacity:0.4413"/>
+		<stop  offset="0.5232" style="stop-color:#090909;stop-opacity:0.1692"/>
+		<stop  offset="0.6369" style="stop-color:#000000;stop-opacity:0"/>
+	</radialGradient>
+	<path class="shadow" d="M778.8,483.2c-34.3,52.8-101.9,94.1-150.3,124.6L255.7,820L169,522l170.8-299.6l0-0.1l9.8-17.3
+		C421.3,94.6,585,56.3,702.5,132.5S850.3,372.8,778.8,483.2z"/>
+</svg>

--- a/src/images/marker-shadow.svg
+++ b/src/images/marker-shadow.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 23.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
 	 viewBox="0 0 817.2 820" style="enable-background:new 0 0 817.2 820;" xml:space="preserve">
 	<style type="text/css">
 		.shadow{fill-rule:evenodd;clip-rule:evenodd;fill:url(#gradient); fill-opacity:0.7; filter: blur(15px);}

--- a/src/images/marker.svg
+++ b/src/images/marker.svg
@@ -1,1 +1,20 @@
-<svg viewBox="0 0 500 820" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule: evenodd; clip-rule: evenodd; stroke-linecap: round;"><defs><linearGradient x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.30025e-15,-37.566,37.566,2.30025e-15,416.455,540.999)" id="map-marker-38-f"><stop offset="0" stop-color="rgb(18,111,198)"/><stop offset="1" stop-color="rgb(76,156,209)"/></linearGradient><linearGradient x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.16666e-15,-19.053,19.053,1.16666e-15,414.482,522.486)" id="map-marker-38-s"><stop offset="0" stop-color="rgb(46,108,151)"/><stop offset="1" stop-color="rgb(56,131,183)"/></linearGradient></defs><g transform="matrix(19.5417,0,0,19.5417,-7889.1,-9807.44)"><path d="M416.544,503.612C409.971,503.612 404.5,509.303 404.5,515.478C404.5,518.256 406.064,521.786 407.194,524.224L416.5,542.096L425.762,524.224C426.892,521.786 428.5,518.433 428.5,515.478C428.5,509.303 423.117,503.612 416.544,503.612ZM416.544,510.767C419.128,510.784 421.223,512.889 421.223,515.477C421.223,518.065 419.128,520.14 416.544,520.156C413.96,520.139 411.865,518.066 411.865,515.477C411.865,512.889 413.96,510.784 416.544,510.767Z" stroke-width="1.1px" fill="url(#map-marker-38-f)" stroke="url(#map-marker-38-s)"/></g></svg>
+<svg viewBox="0 0 500 820" version="1.1" xmlns="http://www.w3.org/2000/svg" xml:space="preserve"
+     style="fill-rule: evenodd; clip-rule: evenodd; stroke-linecap: round;">
+    <defs>
+        <linearGradient x1="0" y1="0" x2="1" y2="0" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.30025e-15,-37.566,37.566,2.30025e-15,416.455,540.999)" id="map-marker-38-f">
+            <stop offset="0" stop-color="rgb(18,111,198)"/>
+            <stop offset="1" stop-color="rgb(76,156,209)"/>
+        </linearGradient>
+        <linearGradient x1="0" y1="0" x2="1" y2="0"
+                        gradientUnits="userSpaceOnUse"
+                        gradientTransform="matrix(1.16666e-15,-19.053,19.053,1.16666e-15,414.482,522.486)"
+                        id="map-marker-38-s">
+            <stop offset="0" stop-color="rgb(46,108,151)"/>
+            <stop offset="1" stop-color="rgb(56,131,183)"/>
+        </linearGradient>
+    </defs>
+    <g transform="matrix(19.5417,0,0,19.5417,-7889.1,-9807.44)">
+        <path fill="#FFFFFF" d="M421.2,515.5c0,2.6-2.1,4.7-4.7,4.7c-2.6,0-4.7-2.1-4.7-4.7c0-2.6,2.1-4.7,4.7-4.7 C419.1,510.8,421.2,512.9,421.2,515.5z"/>
+        <path d="M416.544,503.612C409.971,503.612 404.5,509.303 404.5,515.478C404.5,518.256 406.064,521.786 407.194,524.224L416.5,542.096L425.762,524.224C426.892,521.786 428.5,518.433 428.5,515.478C428.5,509.303 423.117,503.612 416.544,503.612ZM416.544,510.767C419.128,510.784 421.223,512.889 421.223,515.477C421.223,518.065 419.128,520.14 416.544,520.156C413.96,520.139 411.865,518.066 411.865,515.477C411.865,512.889 413.96,510.784 416.544,510.767Z" stroke-width="1.1px" fill="url(#map-marker-38-f)" stroke="url(#map-marker-38-s)"/>
+    </g>
+</svg>


### PR DESCRIPTION
Follow up #8766

This is my best result of creating the shadow as svg.
Maybe the `viewBox` needs to be changed but here ends my knowledge.



**Shadow icon diff:**
Left `.png`, right `.svg`:

![grafik](https://user-images.githubusercontent.com/19800037/210139073-ab095278-390a-4985-80cd-73348993a578.png)

![grafik](https://user-images.githubusercontent.com/19800037/210139151-3c40553f-43df-4780-8d65-cb06df2ae509.png) ![grafik](https://user-images.githubusercontent.com/19800037/210139136-517524c7-f1d6-493d-a8b9-356be60b17ea.png)


