### PR TITLE
Remove Windows platform detection

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -28,9 +28,6 @@ const gecko = userAgentContains('gecko') && !webkit;
 // @property safari: Boolean; `true` for the Safari browser.
 const safari = !chrome && userAgentContains('safari');
 
-// @property win: Boolean; `true` when the browser is running in a Windows platform
-const win = navigator.platform.startsWith('Win');
-
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 const mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
 
@@ -95,7 +92,6 @@ export default {
 	chrome,
 	gecko,
 	safari,
-	win,
 	mobile,
 	mobileWebkit,
 	pointer,


### PR DESCRIPTION
Removes `Browser.win` (Windows platform detection), this is no longer used internally. Users should do feature detection instead where possible. This code was also dependent on [`navigator.platform`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform), which is no longer recommended and may be dropped in the future.