### PR TITLE
Remove passive event detection

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -1,5 +1,3 @@
-import * as Util from './Util';
-
 /*
  * @namespace Browser
  * @aka L.Browser
@@ -58,24 +56,6 @@ const mobileGecko = mobile && gecko;
 // `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom is more than 100%.
 const retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1;
 
-// @property passiveEvents: Boolean
-// `true` for browsers that support passive events.
-const passiveEvents = (function () {
-	let supportsPassiveOption = false;
-	try {
-		const opts = Object.defineProperty({}, 'passive', {
-			get() { // eslint-disable-line getter-return
-				supportsPassiveOption = true;
-			}
-		});
-		window.addEventListener('testPassiveEventSupport', Util.falseFn, opts);
-		window.removeEventListener('testPassiveEventSupport', Util.falseFn, opts);
-	} catch (e) {
-		// Errors can safely be ignored since this is only a browser support test.
-	}
-	return supportsPassiveOption;
-}());
-
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
 const mac = navigator.platform.startsWith('Mac');
 
@@ -99,7 +79,6 @@ export default {
 	touchNative,
 	mobileGecko,
 	retina,
-	passiveEvents,
 	mac,
 	linux
 };

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -118,7 +118,7 @@ function addOne(obj, type, fn, context) {
 	} else if ('addEventListener' in obj) {
 
 		if (type === 'touchstart' || type === 'touchmove' || type === 'wheel' ||  type === 'mousewheel') {
-			obj.addEventListener(mouseSubst[type] || type, handler, Browser.passiveEvents ? {passive: false} : false);
+			obj.addEventListener(mouseSubst[type] || type, handler, {passive: false});
 
 		} else if (type === 'mouseenter' || type === 'mouseleave') {
 			handler = function (e) {


### PR DESCRIPTION
Removes code to detect support for [`passive`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#passive) event listeners. Since all the browsers in our support target now have support for this it's no longer required to detect this functionality.

Also removes the detection code from `Browser.passiveEvents`.