### PR TITLE
Fix rounding errors in center calculation for small layers

### DIFF
--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -115,11 +115,10 @@ describe('LineUtil', function () {
 	});
 
 	describe('#polylineCenter', function () {
-		var map, crs, zoom;
+		var map, crs;
 		beforeEach(function () {
 			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
-			zoom = map.getZoom();
 		});
 
 		afterEach(function () {
@@ -130,95 +129,25 @@ describe('LineUtil', function () {
 
 		it('computes center of line', function () {
 			var latlngs = [[80, 0], [80, 90]];
-			var center = L.LineUtil.polylineCenter(latlngs, crs, zoom);
+			var center = L.LineUtil.polylineCenter(latlngs, crs);
 			expect(center).to.be.nearLatLng([80, 45]);
 		});
 
-		it('computes center of line with maxZoom', function () {
-			L.gridLayer({maxZoom: 18}).addTo(map);
-			var latlngs = [[80, 0], [80, 90]];
-			var center = L.LineUtil.polylineCenter(latlngs, crs, map.getMaxZoom());
-			expect(center).to.be.nearLatLng([80, 45]);
-		});
-
-		it('computes center of a small line and test it on every zoom', function () {
+		it('computes center of a small line', function () {
 			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
 			var layer = L.polyline(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small line and test it on every zoom - CRS.EPSG3395', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG3395, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polyline(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small line and test it on every zoom - CRS.EPSG4326', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG4326, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polyline(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small line and test it on every zoom - CRS.Simple', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.Simple, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polyline(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
+			expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
 		});
 
 		it('throws error if latlngs not passed', function () {
 			expect(function () {
-				L.LineUtil.polylineCenter(null, crs, zoom);
+				L.LineUtil.polylineCenter(null, crs);
 			}).to.throwException('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', function () {
 			expect(function () {
-				L.LineUtil.polylineCenter([], crs, zoom);
+				L.LineUtil.polylineCenter([], crs);
 			}).to.throwException('latlngs not passed');
 		});
 
@@ -234,7 +163,7 @@ describe('LineUtil', function () {
 				[[80, 0], [80, 90]]
 			];
 			var spy = sinon.spy(console, 'warn');
-			var center = L.LineUtil.polylineCenter(latlngs, crs, zoom);
+			var center = L.LineUtil.polylineCenter(latlngs, crs);
 			console.warn.restore();
 			expect(spy.calledOnce).to.be.ok();
 			expect(center).to.be.nearLatLng([80, 45]);

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -59,91 +59,27 @@ describe('PolyUtil', function () {
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
 		});
 
-		it('computes center of polygon with maxZoom', function () {
-			L.gridLayer({maxZoom: 18}).addTo(map);
-			var latlngs = [[0, 0], [10, 0], [10, 10], [0, 10]];
-			var center = L.PolyUtil.polygonCenter(latlngs, crs, map.getMaxZoom());
-			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
+		it('computes center of a small polygon', function () {
+			var latlngs = [[42.87097909758862, -81.12594320566181], [42.87108302016597, -81.12594320566181], [42.87108302016597, -81.12576504805303], [42.87097909758862, -81.12576504805303]];
+			var layer = L.polygon(latlngs).addTo(map);
+			expect(layer.getCenter()).to.be.nearLatLng([42.87103105887729, -81.12585412685742]);
 		});
 
-		it('computes center of a small polygon and test it on every zoom', function () {
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
+		it('computes center of a big polygon', function () {
+			var latlngs = [[90, -180], [90, 180], [-90, 180], [-90, -180]];
 			var layer = L.polygon(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small polygon and test it on every zoom - CRS.EPSG3395', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG3395, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polygon(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small polygon and test it on every zoom - CRS.EPSG4326', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.EPSG4326, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polygon(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
-		});
-
-		it('computes center of a small polygon and test it on every zoom - CRS.Simple', function () {
-			map.remove();
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, crs: L.CRS.Simple, zoomAnimation: false});
-
-			var latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-
-			var layer = L.polygon(latlngs).addTo(map);
-			var i = 0;
-			function check() {
-				expect(layer.getCenter()).to.be.nearLatLng([50.49949394037396, 30.50989603626345]);
-				i++;
-				if (i < 30) { map.setZoom(i); }
-			}
-
-			map.on('zoomend', check);
-			map.setView(layer.getCenter(), i);
+			expect(layer.getCenter()).to.be.nearLatLng([0, 0]);
 		});
 
 		it('throws error if latlngs not passed', function () {
 			expect(function () {
-				L.PolyUtil.polygonCenter(null,  crs, zoom);
+				L.PolyUtil.polygonCenter(null,  crs);
 			}).to.throwException('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', function () {
 			expect(function () {
-				L.PolyUtil.polygonCenter([], crs, zoom);
+				L.PolyUtil.polygonCenter([], crs);
 			}).to.throwException('latlngs not passed');
 		});
 
@@ -152,7 +88,7 @@ describe('PolyUtil', function () {
 				[[0, 0], [10, 0], [10, 10], [0, 10]]
 			];
 			var spy = sinon.spy(console, 'warn');
-			var center = L.PolyUtil.polygonCenter(latlngs, crs, zoom);
+			var center = L.PolyUtil.polygonCenter(latlngs, crs);
 			console.warn.restore();
 			expect(spy.calledOnce).to.be.ok();
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -1,6 +1,8 @@
 import {Point, toPoint} from './Point';
 import * as Util from '../core/Util';
 import {toLatLng} from '../geo/LatLng';
+import {centroid} from './PolyUtil';
+import {toLatLngBounds} from '../geo/LatLngBounds';
 
 
 /*
@@ -257,9 +259,20 @@ export function polylineCenter(latlngs, crs) {
 		latlngs = latlngs[0];
 	}
 
+	var centroidLatLng = toLatLng([0, 0]);
+
+	var bounds = toLatLngBounds(latlngs);
+	var areaBounds = bounds.getNorthWest().distanceTo(bounds.getSouthWest()) * bounds.getNorthEast().distanceTo(bounds.getNorthWest());
+	// tests showed that below 1700 rounding errors are happening
+	if (areaBounds < 1700) {
+		// getting a inexact center, to move the latlngs near to [0, 0] to prevent rounding errors
+		centroidLatLng = centroid(latlngs);
+	}
+
 	var points = [];
-	for (var j in latlngs) {
-		points.push(crs.project(toLatLng(latlngs[j])));
+	for (var k in latlngs) {
+		var latlng = toLatLng(latlngs[k]);
+		points.push(crs.project(toLatLng([latlng.lat - centroidLatLng.lat, latlng.lng - centroidLatLng.lng])));
 	}
 
 	var len = points.length;
@@ -288,5 +301,7 @@ export function polylineCenter(latlngs, crs) {
 			}
 		}
 	}
-	return crs.unproject(toPoint(center));
+
+	var latlngCenter = crs.unproject(toPoint(center));
+	return toLatLng([latlngCenter.lat + centroidLatLng.lat, latlngCenter.lng + centroidLatLng.lng]);
 }

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -119,7 +119,8 @@ export function centroid(coords) {
 	var latSum = 0;
 	var lngSum = 0;
 	var len = 0;
-	for (const coord of coords) {
+	for (var coord of coords) {
+
 		var latlng = toLatLng(coord);
 		latSum += latlng.lat;
 		lngSum += latlng.lng;

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -119,9 +119,8 @@ export function centroid(coords) {
 	var latSum = 0;
 	var lngSum = 0;
 	var len = 0;
-	for (var coord of coords) {
-
-		var latlng = toLatLng(coord);
+	for (var i = 0; i < coords.length; i++) {
+		var latlng = toLatLng(coords[i]);
 		latSum += latlng.lat;
 		lngSum += latlng.lng;
 		len++;

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -1,6 +1,7 @@
 import * as LineUtil from './LineUtil';
 import {toLatLng} from '../geo/LatLng';
 import {toPoint} from './Point';
+import {toLatLngBounds} from '../geo/LatLngBounds';
 /*
  * @namespace PolyUtil
  * Various utility functions for polygon geometries.
@@ -55,7 +56,7 @@ export function clipPolygon(points, bounds, round) {
 	return points;
 }
 
-/* @function polygonCenter(latlngs: LatLng[] crs: CRS): LatLng
+/* @function polygonCenter(latlngs: LatLng[], crs: CRS): LatLng
  * Returns the center ([centroid](http://en.wikipedia.org/wiki/Centroid)) of the passed LatLngs (first ring) from a polygon.
  */
 export function polygonCenter(latlngs, crs) {
@@ -70,9 +71,20 @@ export function polygonCenter(latlngs, crs) {
 		latlngs = latlngs[0];
 	}
 
+	var centroidLatLng = toLatLng([0, 0]);
+
+	var bounds = toLatLngBounds(latlngs);
+	var areaBounds = bounds.getNorthWest().distanceTo(bounds.getSouthWest()) * bounds.getNorthEast().distanceTo(bounds.getNorthWest());
+	// tests showed that below 1700 rounding errors are happening
+	if (areaBounds < 1700) {
+		// getting a inexact center, to move the latlngs near to [0, 0] to prevent rounding errors
+		centroidLatLng = centroid(latlngs);
+	}
+
 	var points = [];
 	for (var k in latlngs) {
-		points.push(crs.project(toLatLng(latlngs[k])));
+		var latlng = toLatLng(latlngs[k]);
+		points.push(crs.project(toLatLng([latlng.lat - centroidLatLng.lat, latlng.lng - centroidLatLng.lng])));
 	}
 
 	var len = points.length;
@@ -95,5 +107,23 @@ export function polygonCenter(latlngs, crs) {
 	} else {
 		center = [x / area, y / area];
 	}
-	return crs.unproject(toPoint(center));
+
+	var latlngCenter = crs.unproject(toPoint(center));
+	return toLatLng([latlngCenter.lat + centroidLatLng.lat, latlngCenter.lng + centroidLatLng.lng]);
+}
+
+/* @function centroid(latlngs: LatLng[]): LatLng
+ * Returns the 'center of mass' of the passed LatLngs.
+ */
+export function centroid(coords) {
+	var latSum = 0;
+	var lngSum = 0;
+	var len = 0;
+	coords.forEach(function (coord) {
+		var latlng = toLatLng(coord);
+		latSum += latlng.lat;
+		lngSum += latlng.lng;
+		len++;
+	});
+	return toLatLng([latSum / len, lngSum / len]);
 }

--- a/src/geometry/PolyUtil.js
+++ b/src/geometry/PolyUtil.js
@@ -119,11 +119,11 @@ export function centroid(coords) {
 	var latSum = 0;
 	var lngSum = 0;
 	var len = 0;
-	coords.forEach(function (coord) {
+	for (const coord of coords) {
 		var latlng = toLatLng(coord);
 		latSum += latlng.lat;
 		lngSum += latlng.lng;
 		len++;
-	});
+	}
 	return toLatLng([latSum / len, lngSum / len]);
 }


### PR DESCRIPTION
For small areas, the center was to far away of the layer. It looks like the reason are rounding errors (Thx to turf.js for the idea: https://github.com/Turfjs/turf/blob/master/packages/turf-center-of-mass/index.ts#L39). But this solution doesn't work good for normal / larger areas, so I added a check if the area of the bounds are small then `1700` it using the rounding preventing solution.

To solve this I needed to add the new function `PolyUtil.centroid`.

This needs merged in the `main` banche too.

error:
![grafik](https://user-images.githubusercontent.com/19800037/211090134-ce69fd79-5b93-4dbf-9d68-620f04174d68.png)

fixed:
![grafik](https://user-images.githubusercontent.com/19800037/211090702-518f3eb8-29cc-4659-af95-96a1a4b9ece4.png)

```
L.polygon([[42.87097909758862, -81.12594320566181], [42.87108302016597, -81.12594320566181], [42.87108302016597, -81.12576504805303], [42.87097909758862, -81.12576504805303]]).addTo(map);
```

Fixes #8783

PS: I also cleaned up some unnecessary tests.
