### PR TITLE
fix vector drifts when `zoomAnimation` is `false` and zooming via `flyTo` or pinch

### DIFF
--- a/debug/vector/vector-drift.html
+++ b/debug/vector/vector-drift.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Leaflet debug page</title>
+	<link rel="stylesheet" href="../../dist/leaflet.css" />
+	<link rel="stylesheet" href="../css/screen.css" />
+	<script src="../../dist/leaflet-src.js"></script>
+</head>
+<body>
+	<button id="btn-1">A</button>
+	<button id="btn-2">B</button>
+	<div id="map"></div>
+
+	<script>
+		var map = L.map('map', {
+			zoomAnimation: false,
+			// preferCanvas: true
+		}).setView([0, 0], 7);
+
+		var markerA = L.marker([1, 0]).addTo(map);
+		var markerB = L.marker([1, 2]).addTo(map);
+		L.polygon([
+			[0, 0],
+			[2, 0],
+			[2, 2],
+			[0, 2],
+			[0, 0],
+		])
+		.bindPopup('Hello world')
+		.addTo(map);
+
+		// or pinch zoom in mobile
+		document.getElementById('btn-1').addEventListener('click', function () {
+			map.flyTo(markerA.getLatLng(), 6);
+		});
+		document.getElementById('btn-2').addEventListener('click', function () {
+			map.flyTo(markerB.getLatLng(), 7);
+		});
+	</script>
+</body>
+</html>

--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -157,13 +157,75 @@ describe('Map.TouchZoom', () => {
 			.down().moveBy(-200, 0, 500).up(100);
 	});
 
-	it.skipIfNotTouch("Layer is rendered correctly while pinch zoom when zoomAnim is true", (done) => {
+	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is true', (done) => {
 		map.remove();
 
 		map = new L.Map(container, {
 			touchZoom: true,
 			inertia: false,
 			zoomAnimation: true
+		});
+
+		map.setView([0, 0], 8);
+
+		const polygon = L.polygon([
+			[0, 0],
+			[0, 1],
+			[1, 1],
+			[1, 0]
+		]).addTo(map);
+
+		let alreadyCalled = false;
+		const hand = new Hand({
+			timing: 'fastframe',
+			onStop() {
+				setTimeout(() => {
+					if (alreadyCalled) {
+						return; // Will recursivly call itself otherwise
+					}
+					alreadyCalled = true;
+
+					const renderedRect = polygon._path.getBoundingClientRect();
+
+					const width = renderedRect.width;
+					const height = renderedRect.height;
+
+					expect(height < 50).to.be(true);
+					expect(width < 50).to.be(true);
+					expect(height + width > 0).to.be(true);
+
+					const x = renderedRect.x;
+					const y = renderedRect.y;
+
+					expect(x).to.be.within(299, 301);
+					expect(y).to.be.within(270, 280);
+
+					// Fingers lifted after expects as bug goes away when lifted
+					this._fingers[0].up();
+					this._fingers[1].up();
+
+					done();
+				}, 100);
+			}
+		});
+
+		const f1 = hand.growFinger(touchEventType);
+		const f2 = hand.growFinger(touchEventType);
+
+		hand.sync(5);
+		f1.wait(100).moveTo(75, 300, 0)
+			.down().moveBy(200, 0, 500);
+		f2.wait(100).moveTo(525, 300, 0)
+			.down().moveBy(-200, 0, 500);
+	});
+
+	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is false', (done) => {
+		map.remove();
+
+		map = new L.Map(container, {
+			touchZoom: true,
+			inertia: false,
+			zoomAnimation: false
 		});
 
 		map.setView([0, 0], 8);

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -46,9 +46,8 @@ export const Renderer = Layer.extend({
 		if (!this._container) {
 			this._initContainer(); // defined by renderer implementations
 
-			if (this._zoomAnimated) {
-				this._container.classList.add('leaflet-zoom-animated');
-			}
+			// always keep transform-origin as 0 0
+			this._container.classList.add('leaflet-zoom-animated');
 		}
 
 		this.getPane().appendChild(this._container);


### PR DESCRIPTION
### Background

First I'd like to thank @mourner for the fix in #8103, which makes it work when `zoomAnimation` is `true`.

However, as mentioned in #7466, #8644, and my https://github.com/Leaflet/Leaflet/pull/8103#issuecomment-1235646390, it doesn't work when `zoomAnimation` is set as `false`.
You can refer to the test case `debug/vector/vector-drift.html` added in this PR to reproduce or the [online demo](https://plnkr.co/edit/qHqGIded24Z4MYtO) provided by #7466.

In this PR, I tried to set the `transform-origin` as `0 0` for the container of the SVG/Canvas renderer. By default, it might be `center`. I'm not sure if it is right way to fix this bug but it works indeed and looks simple.

closes #8117

### Comparison

| Platform | Before | After |
| :----: | :----: | :----: |
| Desktop | ![bug](https://user-images.githubusercontent.com/26999792/212246047-eb813b21-93d1-4144-aa29-046d64af27f0.gif) | ![fixed](https://user-images.githubusercontent.com/26999792/212246079-424489de-4267-42d7-a0d7-56c59d82a69c.gif) 
| Mobile | ![bug-mobile](https://user-images.githubusercontent.com/26999792/212246191-9af72c81-6de3-4ff4-9661-2cecd763b151.gif) | ![fixed-mobile](https://user-images.githubusercontent.com/26999792/212246209-99fd3c6d-a070-4710-b0c0-b6c9c9ea21b0.gif) |