### PR TITLE
Remove deprecated `which` and change `button` to main-button

### DIFF
--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -157,7 +157,7 @@ describe('Map.TouchZoom', () => {
 			.down().moveBy(-200, 0, 500).up(100);
 	});
 
-	it.skipIfNotTouch("Layer is rendered correctly while pinch zoom when zoomAnim is true", (done) => {
+	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is true', (done) => {
 		map.remove();
 
 		map = new L.Map(container, {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -88,7 +88,7 @@ export const Draggable = Evented.extend({
 			return;
 		}
 
-		if (Draggable._dragging || e.shiftKey || ((e.which !== 1) && (e.button !== 1) && !e.touches)) { return; }
+		if (Draggable._dragging || e.shiftKey || ((e.button !== 0) && !e.touches)) { return; }
 		Draggable._dragging = this;  // Prevent dragging multiple objects at once.
 
 		if (this._preventOutline) {

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -58,7 +58,7 @@ export const BoxZoom = Handler.extend({
 	},
 
 	_onMouseDown(e) {
-		if (!e.shiftKey || ((e.which !== 1) && (e.button !== 1))) { return false; }
+		if (!e.shiftKey || (e.button !== 0)) { return false; }
 
 		// Clear the deferred resetState if it hasn't executed yet, otherwise it
 		// will interrupt the interaction and orphan a box element in the container.
@@ -117,7 +117,7 @@ export const BoxZoom = Handler.extend({
 	},
 
 	_onMouseUp(e) {
-		if ((e.which !== 1) && (e.button !== 1)) { return; }
+		if (e.button !== 0) { return; }
 
 		this._finish();
 


### PR DESCRIPTION
To determine the left mouse button we used [which](https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which) but it is deprecated. So we need to use [button](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button). We already have it implemented but for some reason we had `exit if button !== 1` which means it is only true if the middle mouse button is used.

`which`:

    0: No button
    1: Left button
    2: Middle button (if present)
    3: Right button

`button`:

    0: Main button pressed, usually the left button or the un-initialized state
    1: Auxiliary button pressed, usually the wheel button or the middle button (if present)
    2: Secondary button pressed, usually the right button
    3: Fourth button, typically the Browser Back button
    4: Fifth button, typically the Browser Forward button


@mourner this was already implemented a long time ago but you reverted it, do you maybe have an idea why?
![grafik](https://user-images.githubusercontent.com/19800037/212394053-314a5fc4-9d1c-4388-907f-0e9e4c4cd248.png)

https://github.com/Leaflet/Leaflet/commit/0d1716d7964491ae894b58ef006cda9dd07d078f
https://github.com/Leaflet/Leaflet/commit/21a748123f7411ed8a0be5824e2366b71c7b6b8b