### PR TITLE
Drop  `__super__` property from Class

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -28,7 +28,7 @@ Class.extend = function (props) {
 		this.callInitHooks();
 	};
 
-	const parentProto = NewClass.__super__ = this.prototype;
+	const parentProto = this.prototype;
 
 	const proto = Object.create(parentProto);
 	proto.constructor = NewClass;
@@ -37,7 +37,7 @@ Class.extend = function (props) {
 
 	// inherit parent's statics
 	for (const i in this) {
-		if (Object.hasOwn(this, i) && i !== 'prototype' && i !== '__super__') {
+		if (Object.hasOwn(this, i) && i !== 'prototype') {
 			NewClass[i] = this[i];
 		}
 	}


### PR DESCRIPTION
Removes the `__super__` property from classes. This [was used in CoffeeScript](https://github.com/Leaflet/Leaflet/commit/c3ee79b01d44484745fe59e91be88b1b502bd80e) to determine the super class in their own class system, but has since been superseded by [standardized ECMAScript classes](https://coffeescript.org/#classes).