### PR TITLE
Destructure `statics` and `includes` from class properties

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -10,7 +10,7 @@ import * as Util from './Util';
 
 export function Class() {}
 
-Class.extend = function (props) {
+Class.extend = function ({statics, includes, ...props}) {
 
 	// @function extend(props: Object): Function
 	// [Extends the current class](#class-inheritance) given the properties to be included.
@@ -43,19 +43,17 @@ Class.extend = function (props) {
 	}
 
 	// mix static properties into the class
-	if (props.statics) {
-		Util.extend(NewClass, props.statics);
+	if (statics) {
+		Util.extend(NewClass, statics);
 	}
 
 	// mix includes into the prototype
-	if (props.includes) {
-		Util.extend.apply(null, [proto].concat(props.includes));
+	if (includes) {
+		Util.extend.apply(null, [proto].concat(includes));
 	}
 
 	// mix given properties into the prototype
 	Util.extend(proto, props);
-	delete proto.statics;
-	delete proto.includes;
 
 	// merge options
 	if (proto.options) {


### PR DESCRIPTION
 Destructures `statics` and `includes` from class properties. This avoids the need to delete these fields from the prototype after extending.
 
 Part of a series of PRs to land the work from #8806 for standardized ECMAScript classes incrementally.