### PR TITLE
Use `Object.setPrototypeOf()` to extend `Class`

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -28,19 +28,14 @@ Class.extend = function (props) {
 		this.callInitHooks();
 	};
 
+	// inherit parent's prototype
+	Object.setPrototypeOf(NewClass.prototype, this.prototype);
+
+	// inherit parent's static properties
+	Object.setPrototypeOf(NewClass, this);
+
 	const parentProto = this.prototype;
-
-	const proto = Object.create(parentProto);
-	proto.constructor = NewClass;
-
-	NewClass.prototype = proto;
-
-	// inherit parent's statics
-	for (const i in this) {
-		if (Object.hasOwn(this, i) && i !== 'prototype') {
-			NewClass[i] = this[i];
-		}
-	}
+	const proto = NewClass.prototype;
 
 	// mix static properties into the class
 	if (props.statics) {


### PR DESCRIPTION
Changes the logic for inheritance of `Class` to use the more modern [`Object.setPrototypeOf()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf). The same method is now used to 'inherit' the static properties of a parent class, rather than copying it over manually.

Part of a series of PRs to land the work from #8806 for standardized ECMAScript classes incrementally.