### PR TITLE
Move `callInitHooks()` to prototype of `Class`

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -65,22 +65,6 @@ Class.extend = function (props) {
 
 	proto._initHooks = [];
 
-	// add method for calling all hooks
-	proto.callInitHooks = function () {
-
-		if (this._initHooksCalled) { return; }
-
-		if (parentProto.callInitHooks) {
-			parentProto.callInitHooks.call(this);
-		}
-
-		this._initHooksCalled = true;
-
-		for (let i = 0, len = proto._initHooks.length; i < len; i++) {
-			proto._initHooks[i].call(this);
-		}
-	};
-
 	return NewClass;
 };
 
@@ -114,4 +98,30 @@ Class.addInitHook = function (fn, ...args) { // (Function) || (String, args...)
 	this.prototype._initHooks = this.prototype._initHooks || [];
 	this.prototype._initHooks.push(init);
 	return this;
+};
+
+Class.prototype.callInitHooks = function () {
+	if (this._initHooksCalled) {
+		return;
+	}
+
+	// collect all prototypes in chain
+	const prototypes = [];
+	let current = this;
+
+	while ((current = Object.getPrototypeOf(current)) !== null) {
+		prototypes.push(current);
+	}
+
+	// reverse so the parent prototype is first
+	prototypes.reverse();
+
+	// call init hooks on each prototype
+	for (const proto of prototypes) {
+		for (const hook of proto._initHooks ?? []) {
+			hook.call(this);
+		}
+	}
+
+	this._initHooksCalled = true;
 };


### PR DESCRIPTION
Moves the `callInitHooks()` method to the prototype of `Class` instead of defining it every time a class is `extend()`ed. The method is also re-implemented to remove the reliance on variables defined in the scope of `extend()`.

Part of a series of PRs to land the work from #8806 for standardized ECMAScript classes incrementally.