### PR TITLE
Provide file extensions when running ESLint

### DIFF
--- a/build/rollup-config.mjs
+++ b/build/rollup-config.mjs
@@ -19,7 +19,7 @@ const config = {
 			file: pkg.main,
 			format: 'umd',
 			name: 'leaflet',
-			banner: banner,
+			banner,
 			sourcemap: true,
 			freeze: false,
 			esModule: false
@@ -35,7 +35,7 @@ if (!watch) {
 		{
 			file: pkg.module,
 			format: 'es',
-			banner: banner,
+			banner,
 			sourcemap: true,
 			freeze: false
 		}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "docs": "node ./build/docs.mjs && node ./build/integrity.mjs",
     "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",
-    "lint": "eslint .",
+    "lint": "eslint . --ext js,mjs,cjs",
     "lintfix": "npm run lint -- --fix",
     "rollup": "rollup -c build/rollup-config.mjs",
     "watch": "rollup -w -c build/rollup-config.mjs",


### PR DESCRIPTION
Adds the extensions for ESLint explicitly when running the `lint` task. The default here is `.js` only, this caused some linting issues to slip through (which have been fixed here).