### PR TITLE
Convert control layers debug page to ESM

### DIFF
--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -1,50 +1,54 @@
-<!DOCTYPE html>
-<html>
-<head>
-	<title>Leaflet debug page</title>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Leaflet debug page - Control Layers</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
+		<link rel="stylesheet" href="../../dist/leaflet.css" />
+		<link rel="stylesheet" href="../css/screen.css" />
+	</head>
+	<body>
+		<div id="map"></div>
+		<style>
+			.grayscale-tile {
+				filter: grayscale(1);
+			}
+		</style>
+		<script type="module">
+			import {Map, TileLayer, Control, Circle, Polygon, GeoJSON} from '../../dist/leaflet-src.esm.js';
 
-	<link rel="stylesheet" href="../../dist/leaflet.css" />
+			const GrayscaleTileLayer = TileLayer.extend({
+				createTile(...args) {
+					const element = TileLayer.prototype.createTile.call(this, ...args);
+					element.classList.add('grayscale-tile');
+					return element;
+				}
+			});
 
-	<link rel="stylesheet" href="../css/screen.css" />
+			const map = new Map('map').setView([50.5, 0], 5);
+			const tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+			const regularTiles = new TileLayer(tileUrl).addTo(map);
+			const blackAndWhiteTiles = new GrayscaleTileLayer(tileUrl);
 
-	<script src="../../dist/leaflet-src.js"></script>
-</head>
-<body>
-	<div id="map"></div>
-
-	<script>
-		var geojson = {
-			"type": "Polygon",
-			"coordinates": [[
-				[5.4931640625, 51.781435604431195],
-				[0.9008789062499999, 53.35710874569601],
-				[-2.30712890625, 51.795027225829145],
-				[2.8125, 49.109837790524416],
-				[5.4931640625, 51.781435604431195]
-			]]
-		};
-
-		var map = L.map('map').setView([50.5, 0], 5);
-
-		var OSM_Mapnik = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-			maxZoom: 19,
-			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-		}).addTo(map);
-		var OSM_BlackAndWhite = L.tileLayer('http://{s}.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png', {
-			maxZoom: 18,
-			attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-		});
-
-		L.control.layers({
-			'OSM': OSM_Mapnik,
-			'OSM BW': OSM_BlackAndWhite
-		}, {
-			'Circle': L.circle([53, 4], 111111).addTo(map),
-			'Polygon': L.polygon([[48, -3], [50, -4], [52, 4]]),
-			'GeoJSON': L.geoJson(geojson),
-		}, {
-			collapsed: false
-		}).addTo(map);
-	</script>
-</body>
+			new Control.Layers({
+				'OSM': regularTiles,
+				'OSM BW': blackAndWhiteTiles
+			}, {
+				'Circle': new Circle([53, 4], 111111).addTo(map),
+				'Polygon': new Polygon([[48, -3], [50, -4], [52, 4]]),
+				'GeoJSON': new GeoJSON({
+					type: 'Polygon',
+					coordinates: [[
+						[5.4931640625, 51.781435604431195],
+						[0.9008789062499999, 53.35710874569601],
+						[-2.30712890625, 51.795027225829145],
+						[2.8125, 49.109837790524416],
+						[5.4931640625, 51.781435604431195]
+					]]
+				}),
+			}, {
+				collapsed: false
+			}).addTo(map);
+		</script>
+	</body>
 </html>


### PR DESCRIPTION
Converts the control layers page to ESM and cleans up the code so it's bit more modern. I've also replaced the old black and white tile layer as the tile server appears to be dead.