### PR TITLE
Convert geolocation debug page to ESM

### DIFF
--- a/debug/map/geolocation.html
+++ b/debug/map/geolocation.html
@@ -1,33 +1,25 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Leaflet geolocation debug page</title>
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Leaflet debug page - Geolocation</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
+		<link rel="stylesheet" href="../../dist/leaflet.css" />
+		<link rel="stylesheet" href="../css/screen.css" />
+	</head>
+	<body>
+		<div id="map"></div>
+		<script type="module">
+			import {TileLayer, Map} from '../../dist/leaflet-src.esm.js';
 
-    <link rel="stylesheet" href="../../dist/leaflet.css" />
+			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+			const osm = new TileLayer(osmUrl, {maxZoom: 18});
+			const map = new Map('map', {zoom: 15, layers: [osm]});
+			
+			map.on('locationerror', console.error);
+			map.on('locationfound', console.log);
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <link rel="stylesheet" href="../css/screen.css" />
-    <script src="../../dist/leaflet-src.js"></script>
-</head>
-<body>
-
-    <div id="map"></div>
-
-    <script>
-
-        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-            osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
-
-        var map = new L.Map('map', {zoom: 15, layers: [osm]});
-
-        function logEvent(e) { console.log(e.type); }
-        map.on('locationerror', logEvent);
-        map.on('locationfound', logEvent);
-
-        map.locate({setView: true});
-
-    </script>
-</body>
+			map.locate({setView: true});
+		</script>
+	</body>
 </html>


### PR DESCRIPTION
Converts the gelocation debug page to ESM and cleans up the code so it's bit more modern.