### PR TITLE
test native ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "eslint": "^8.23.1",
     "eslint-config-mourner": "^3.0.0",
     "eslint-plugin-import": "^2.27.5",
+    "http-server": "^14.1.1",
     "husky": "^8.0.1",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
@@ -43,6 +44,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
+    "debug": "http-server --port 3000 -c-1",
     "docs": "node ./build/docs.mjs && node ./build/integrity.mjs",
     "test": "karma start ./spec/karma.conf.js",
     "build": "npm run rollup && npm run uglify",

--- a/spec/esm.html
+++ b/spec/esm.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Leaflet Spec Runner</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css">
+	<link rel="stylesheet" type="text/css" href="../dist/leaflet.css">
+</head>
+<body>
+	<div id="mocha"></div>
+	<script src="../node_modules/expect.js/index.js"></script>
+	<script src="../node_modules/mocha/mocha.js"></script>
+	<script src="../node_modules/ui-event-simulator/ui-event-simulator.js"></script>
+	<script src="../node_modules/prosthetic-hand/dist/prosthetic-hand.js"></script>
+	<script src="../node_modules/sinon/pkg/sinon.js"></script>
+
+	<!-- source files -->
+	<script type="module">
+		// Trick Leaflet into believing we have a touchscreen (for desktop)
+		if (window.TouchEvent) { window.ontouchstart = function(){} };
+		var oldL = window.L;
+	</script>
+
+	<script type="module">
+		import * as L from '../../src/Leaflet.js';
+		window.L = L;
+	</script>
+
+	<script type="module">
+		// sets the default imagePath to the project path like "/Leaflet/dist/images/"
+		// same as in after.js but not static
+		L.Icon.Default.imagePath = window.location.pathname.split('/').slice(0, -2).join('/') + '/dist/images/';
+	</script>
+
+	<script class="mocha-init" type="module">
+		mocha.setup('bdd');
+		mocha.checkLeaks();
+	</script>
+
+	<!-- spec files -->
+	<script defer src="suites/SpecHelper.js"></script>
+
+	<!-- /control -->
+	<script defer src="suites/control/Control.AttributionSpec.js"></script>
+	<script defer src="suites/control/Control.LayersSpec.js"></script>
+	<script defer src="suites/control/Control.ScaleSpec.js"></script>
+	<script defer src="suites/control/ControlSpec.js"></script>
+
+	<!-- /core -->
+	<script defer src="suites/core/ClassSpec.js"></script>
+	<script defer src="suites/core/EventsSpec.js"></script>
+	<script defer src="suites/core/GeneralSpec.js"></script>
+	<script defer src="suites/core/UtilSpec.js"></script>
+
+	<!-- /dom -->
+	<script defer src="suites/dom/DomEvent.DoubleTapSpec.js"></script>
+	<script defer src="suites/dom/DomEvent.PointerSpec.js"></script>
+	<script defer src="suites/dom/DomEventSpec.js"></script>
+	<script defer src="suites/dom/DomUtilSpec.js"></script>
+
+	<!-- /geo -->
+	<script defer src="suites/geo/LatLngBoundsSpec.js"></script>
+	<script defer src="suites/geo/LatLngSpec.js"></script>
+
+	<!-- /geo/crs -->
+	<script defer src="suites/geo/crs/CRSSpec.js"></script>
+
+	<!-- /geo/projection -->
+	<script defer src="suites/geo/projection/ProjectionSpec.js"></script>
+
+	<!-- /geometry -->
+	<script defer src="suites/geometry/BoundsSpec.js"></script>
+	<script defer src="suites/geometry/LineUtilSpec.js"></script>
+	<script defer src="suites/geometry/PointSpec.js"></script>
+	<script defer src="suites/geometry/PolyUtilSpec.js"></script>
+	<script defer src="suites/geometry/TransformationSpec.js"></script>
+
+	<!-- /layer -->
+	<script defer src="suites/layer/FeatureGroupSpec.js"></script>
+	<script defer src="suites/layer/GeoJSONSpec.js"></script>
+	<script defer src="suites/layer/ImageOverlaySpec.js"></script>
+	<script defer src="suites/layer/LayerGroupSpec.js"></script>
+	<script defer src="suites/layer/PopupSpec.js"></script>
+	<script defer src="suites/layer/TooltipSpec.js"></script>
+	<script defer src="suites/layer/VideoOverlaySpec.js"></script>
+
+	<!-- /layer/marker/ -->
+	<script defer src="suites/layer/marker/Icon.DefaultSpec.js"></script>
+	<script defer src="suites/layer/marker/Marker.DragSpec.js"></script>
+	<script defer src="suites/layer/marker/MarkerSpec.js"></script>
+
+	<!-- /layer/tile -->
+	<script defer src="suites/layer/tile/GridLayerSpec.js"></script>
+	<script defer src="suites/layer/tile/TileLayerSpec.js"></script>
+
+	<!-- /layer/vector/ -->
+	<script defer src="suites/layer/vector/CanvasSpec.js"></script>
+	<script defer src="suites/layer/vector/CircleMarkerSpec.js"></script>
+	<script defer src="suites/layer/vector/CircleSpec.js"></script>
+	<script defer src="suites/layer/vector/PathSpec.js"></script>
+	<script defer src="suites/layer/vector/PolygonSpec.js"></script>
+	<script defer src="suites/layer/vector/PolylineSpec.js"></script>
+	<script defer src="suites/layer/vector/RectangleSpec.js"></script>
+
+	<!-- /map -->
+	<script defer src="suites/map/MapSpec.js"></script>
+
+	<!-- /map/handler -->
+	<script defer src="suites/map/handler/Map.BoxZoom.js"></script>
+	<script defer src="suites/map/handler/Map.DoubleClickZoomSpec.js"></script>
+	<script defer src="suites/map/handler/Map.DragSpec.js"></script>
+	<script defer src="suites/map/handler/Map.KeyboardSpec.js"></script>
+	<script defer src="suites/map/handler/Map.ScrollWheelZoomSpec.js"></script>
+	<script defer src="suites/map/handler/Map.TapHoldSpec.js"></script>
+	<script defer src="suites/map/handler/Map.TouchZoomSpec.js"></script>
+
+	<script class="mocha-exec" type="module">
+		window.mocha
+				.globals([ '_leaflet_events' ]) // acceptable globals - fixing gloabl leaks
+				.run();
+	</script>
+
+</body>
+</html>

--- a/spec/index.html
+++ b/spec/index.html
@@ -27,7 +27,7 @@
 	<script>
 		// sets the default imagePath to the project path like "/Leaflet/dist/images/"
 		// same as in after.js but not static
-		L.Icon.Default.imagePath = '/' + window.location.pathname.split('/')[1] + '/dist/images/';
+		L.Icon.Default.imagePath = window.location.pathname.split('/').slice(0, -2).join('/') + '/dist/images/';
 	</script>
 
 	<script class="mocha-init">

--- a/src/Leaflet.js
+++ b/src/Leaflet.js
@@ -1,6 +1,5 @@
 
-import {version} from '../package.json';
-export {version};
+export const version = '1.9.2';
 
 // control
 export * from './control/index.js';


### PR DESCRIPTION
Leaving this here as follow up to #8837. To try this out run `npm run debug` and open http://localhost:3000/spec/esm. 

Looks like the test suite almost works, weirdly I see a few different errors in both the bundled and native versions, and the total test count differs by 2.

Bundled:
![Screen Shot 2023-02-09 at 5 36 55 PM](https://user-images.githubusercontent.com/452396/217955223-4e2b7076-9e07-4347-b4c9-fadd94380f33.png)

Native:
![leaflet-esm-native](https://user-images.githubusercontent.com/452396/217954185-9112b855-942a-41a5-9ce9-5c917a3254f3.png)

