### PR TITLE
Always build ESM version in watch mode

### DIFF
--- a/build/rollup-config.mjs
+++ b/build/rollup-config.mjs
@@ -7,7 +7,6 @@ import {simpleGit} from 'simple-git';
 // See: https://rollupjs.org/guide/en/#importing-packagejson
 const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
 const release = process.env.NODE_ENV === 'release';
-const watch = process.argv.includes('-w') || process.argv.includes('--watch');
 const version = await getVersion();
 const banner = createBanner(version);
 
@@ -23,15 +22,7 @@ const config = {
 			sourcemap: true,
 			freeze: false,
 			esModule: false
-		}
-	],
-	plugins: [
-		release ? json() : rollupGitVersion()
-	]
-};
-
-if (!watch) {
-	config.output.push(
+		},
 		{
 			file: pkg.module,
 			format: 'es',
@@ -39,8 +30,11 @@ if (!watch) {
 			sourcemap: true,
 			freeze: false
 		}
-	);
-}
+	],
+	plugins: [
+		release ? json() : rollupGitVersion()
+	]
+};
 
 export default config;
 


### PR DESCRIPTION
Ensures that the ESM version is also built when running Rollup in watch mode (`npm run watch`). This is becoming relevant as we are increasingly relying on ESM during development.