### PR TITLE
Update wheelPxFactor on Linux+Chrome

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -264,11 +264,10 @@ export function getMousePosition(e, container) {
 // @function getWheelPxFactor(): Number
 // Gets the wheel pixel factor based on the devicePixelRatio
 export function getWheelPxFactor() {
-	// We need double the scroll pixels (see #7403 and #4538) for all Browsers
-	// except OSX (Mac) -> 3x, Chrome running on Linux 1x
+	// We need double the scroll pixels (see #8859, #7403 and #4538) for all Browsers
+	// except OSX (Mac) -> 3x
 	const ratio = window.devicePixelRatio;
-	return Browser.linux && Browser.chrome ? ratio :
-		Browser.mac ? ratio * 3 :
+	return Browser.mac ? ratio * 3 :
 		ratio > 0 ? 2 * ratio : 1;
 }
 


### PR DESCRIPTION
Fixes #8859.

Judging from the table at https://github.com/Leaflet/Leaflet/issues/7403#issuecomment-1101669097 and https://github.com/Leaflet/Leaflet/issues/8859#issuecomment-1439989299 , something has changed between chrome  v100 and v109 (rather, from the underlying blink engine, since it applies to Edge too). 

v100 was doing a `deltaY` of `225`, whereas v109 now does `120`, so it's just enough to *un*cover the linux+chrome hack.

I'd like somebody else (with a linux box and chrome/chromium >=v109) to test that this in indeed the case.