### PR TITLE
Convert `Class` to a JavaScript `class`

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -8,113 +8,111 @@ import * as Util from './Util.js';
 
 // Thanks to John Resig and Dean Edwards for inspiration!
 
-export function Class() {}
-
-Class.extend = function ({statics, includes, ...props}) {
-
+export class Class {
 	// @function extend(props: Object): Function
 	// [Extends the current class](#class-inheritance) given the properties to be included.
 	// Returns a Javascript function that is a class constructor (to be called with `new`).
-	const NewClass = function (...args) {
+	static extend({statics, includes, ...props}) {
+		const NewClass = function (...args) {
 
-		Util.setOptions(this);
+			Util.setOptions(this);
 
-		// call the constructor
-		if (this.initialize) {
-			this.initialize.apply(this, args);
+			// call the constructor
+			if (this.initialize) {
+				this.initialize.apply(this, args);
+			}
+
+			// call all constructor hooks
+			this.callInitHooks();
+		};
+
+		// inherit parent's prototype
+		Object.setPrototypeOf(NewClass.prototype, this.prototype);
+
+		// inherit parent's static properties
+		Object.setPrototypeOf(NewClass, this);
+
+		const parentProto = this.prototype;
+		const proto = NewClass.prototype;
+
+		// mix static properties into the class
+		if (statics) {
+			Util.extend(NewClass, statics);
 		}
 
-		// call all constructor hooks
-		this.callInitHooks();
-	};
-
-	// inherit parent's prototype
-	Object.setPrototypeOf(NewClass.prototype, this.prototype);
-
-	// inherit parent's static properties
-	Object.setPrototypeOf(NewClass, this);
-
-	const parentProto = this.prototype;
-	const proto = NewClass.prototype;
-
-	// mix static properties into the class
-	if (statics) {
-		Util.extend(NewClass, statics);
-	}
-
-	// mix includes into the prototype
-	if (includes) {
-		Util.extend.apply(null, [proto].concat(includes));
-	}
-
-	// mix given properties into the prototype
-	Util.extend(proto, props);
-
-	// merge options
-	if (proto.options) {
-		proto.options = parentProto.options ? Object.create(parentProto.options) : {};
-		Util.extend(proto.options, props.options);
-	}
-
-	proto._initHooks = [];
-
-	return NewClass;
-};
-
-
-// @function include(properties: Object): this
-// [Includes a mixin](#class-includes) into the current class.
-Class.include = function (props) {
-	const parentOptions = this.prototype.options;
-	Util.extend(this.prototype, props);
-	if (props.options) {
-		this.prototype.options = parentOptions;
-		this.mergeOptions(props.options);
-	}
-	return this;
-};
-
-// @function mergeOptions(options: Object): this
-// [Merges `options`](#class-options) into the defaults of the class.
-Class.mergeOptions = function (options) {
-	Util.extend(this.prototype.options, options);
-	return this;
-};
-
-// @function addInitHook(fn: Function): this
-// Adds a [constructor hook](#class-constructor-hooks) to the class.
-Class.addInitHook = function (fn, ...args) { // (Function) || (String, args...)
-	const init = typeof fn === 'function' ? fn : function () {
-		this[fn].apply(this, args);
-	};
-
-	this.prototype._initHooks = this.prototype._initHooks || [];
-	this.prototype._initHooks.push(init);
-	return this;
-};
-
-Class.prototype.callInitHooks = function () {
-	if (this._initHooksCalled) {
-		return;
-	}
-
-	// collect all prototypes in chain
-	const prototypes = [];
-	let current = this;
-
-	while ((current = Object.getPrototypeOf(current)) !== null) {
-		prototypes.push(current);
-	}
-
-	// reverse so the parent prototype is first
-	prototypes.reverse();
-
-	// call init hooks on each prototype
-	for (const proto of prototypes) {
-		for (const hook of proto._initHooks ?? []) {
-			hook.call(this);
+		// mix includes into the prototype
+		if (includes) {
+			Util.extend.apply(null, [proto].concat(includes));
 		}
+
+		// mix given properties into the prototype
+		Util.extend(proto, props);
+
+		// merge options
+		if (proto.options) {
+			proto.options = parentProto.options ? Object.create(parentProto.options) : {};
+			Util.extend(proto.options, props.options);
+		}
+
+		proto._initHooks = [];
+
+		return NewClass;
 	}
 
-	this._initHooksCalled = true;
-};
+	// @function include(properties: Object): this
+	// [Includes a mixin](#class-includes) into the current class.
+	static include(props) {
+		const parentOptions = this.prototype.options;
+		Util.extend(this.prototype, props);
+		if (props.options) {
+			this.prototype.options = parentOptions;
+			this.mergeOptions(props.options);
+		}
+		return this;
+	}
+
+	// @function mergeOptions(options: Object): this
+	// [Merges `options`](#class-options) into the defaults of the class.
+	static mergeOptions(options) {
+		Util.extend(this.prototype.options, options);
+		return this;
+	}
+
+	// @function addInitHook(fn: Function): this
+	// Adds a [constructor hook](#class-constructor-hooks) to the class.
+	static addInitHook(fn, ...args) { // (Function) || (String, args...)
+		const init = typeof fn === 'function' ? fn : function () {
+			this[fn].apply(this, args);
+		};
+
+		this.prototype._initHooks = this.prototype._initHooks || [];
+		this.prototype._initHooks.push(init);
+		return this;
+	}
+
+	callInitHooks() {
+		if (this._initHooksCalled) {
+			return;
+		}
+
+		// collect all prototypes in chain
+		const prototypes = [];
+		let current = this;
+
+		while ((current = Object.getPrototypeOf(current)) !== null) {
+			prototypes.push(current);
+		}
+
+		// reverse so the parent prototype is first
+		prototypes.reverse();
+
+		// call init hooks on each prototype
+		for (const proto of prototypes) {
+			for (const hook of proto._initHooks ?? []) {
+				hook.call(this);
+			}
+		}
+
+		this._initHooksCalled = true;
+	}
+}


### PR DESCRIPTION
Converts `Class`  into an actual [JavaScript `class`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes). This PR does not attempt to refactor the existing implementation in any other way aside from moving the methods into the class definition itself.

I tried to keep the diff as reasonable as possible, but Github is showing a lot of white-space changes. I would recommend to check out the branch and inspect the diff in your IDE.

Implements parts of #8806.