### PR TITLE
Move initialization logic for sub-classes to `Class` constructor

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -13,21 +13,7 @@ export class Class {
 	// [Extends the current class](#class-inheritance) given the properties to be included.
 	// Returns a Javascript function that is a class constructor (to be called with `new`).
 	static extend({statics, includes, ...props}) {
-		const NewClass = function (...args) {
-
-			Util.setOptions(this);
-
-			// call the constructor
-			if (this.initialize) {
-				this.initialize.apply(this, args);
-			}
-
-			// call all constructor hooks
-			this.callInitHooks();
-		};
-
-		// inherit parent's prototype
-		Object.setPrototypeOf(NewClass.prototype, this.prototype);
+		const NewClass = class extends this {};
 
 		// inherit parent's static properties
 		Object.setPrototypeOf(NewClass, this);
@@ -88,6 +74,20 @@ export class Class {
 		this.prototype._initHooks = this.prototype._initHooks || [];
 		this.prototype._initHooks.push(init);
 		return this;
+	}
+
+	_initHooksCalled = false;
+
+	constructor(...args) {
+		Util.setOptions(this);
+
+		// call the constructor
+		if (this.initialize) {
+			this.initialize(...args);
+		}
+
+		// call all constructor hooks
+		this.callInitHooks();
 	}
 
 	callInitHooks() {


### PR DESCRIPTION
Moves the initialization logic for sub-classes extending `Class` into the constructor of `Class` itself. This allows classes that extend using the `extends` keyword (rather than `Class.extend()`) to perform initialization logic as well.

Implements parts of #8806.