### PR TITLE
Plugins: Add Leaflet.Gleo

### DIFF
--- a/docs/_plugins/dataviz/leaflet-gleo.md
+++ b/docs/_plugins/dataviz/leaflet-gleo.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.Gleo
+category: dataviz
+repo: https://gitlab.com/IvanSanchez/leaflet.gleo
+author: Iván Sánchez Ortega
+author-url: https://ivan.sanchezortega.es
+demo: https://ivansanchez.gitlab.io/leaflet.gleo/demo/sprites.html
+compatible-v0:
+compatible-v1: true
+---
+
+Embed a [Gleo](https://ivansanchez.gitlab.io/gleo/) renderer as a Leaflet layer. Gleo is a general-purpose object-oriented WebGL cartographic rendering library.


### PR DESCRIPTION
Finally, my [not-so-secret project](https://gitlab.com/IvanSanchez/gleo) to have a WebGL map library with a leaflet-like API now has a Leaflet connector. Conceptually, this plugin is similar to the D3SvgOverlay and PixiOverlay, so I've put it in the same category.

I'm stupidly proud of the ["one thousand moving markers repeating across the antimeridian" demo](https://ivansanchez.gitlab.io/leaflet.gleo/demo/sprites.html).