### PR TITLE
Guard for-in loops and enable guard-for-in lint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
 		'spaced-comment': 'error',
 		'strict': 'off',
 		'wrap-iife': 'off',
+		'guard-for-in': 'error',
 		// TODO: Re-enable the rules below and fix the linting issues.
 		'no-invalid-this': 'off',
 		'prefer-object-has-own': 'error',

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -83,10 +83,8 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 			detail: 2,
 			target: container
 		});
-		for (const prop in expectedProps) {
-			if (Object.hasOwn(expectedProps, prop)) {
-				expect(event[prop]).to.be(expectedProps[prop]);
-			}
+		for (const [prop, expectedValue] of Object.entries(expectedProps)) {
+			expect(event[prop]).to.be(expectedValue);
 		}
 		expect(event.isTrusted).not.to.be.ok();
 	});

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -84,7 +84,9 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 			target: container
 		});
 		for (const prop in expectedProps) {
-			expect(event[prop]).to.be(expectedProps[prop]);
+			if (Object.hasOwn(event, prop)) {
+				expect(event[prop]).to.be(expectedProps[prop]);
+			}
 		}
 		expect(event.isTrusted).not.to.be.ok();
 	});

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -84,7 +84,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 			target: container
 		});
 		for (const prop in expectedProps) {
-			if (Object.hasOwn(event, prop)) {
+			if (Object.hasOwn(expectedProps, prop)) {
 				expect(event[prop]).to.be(expectedProps[prop]);
 			}
 		}

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -79,9 +79,11 @@ describe('DomEvent.Pointer', () => {
 				}
 				let res;
 				for (const prop in props) {
-					res = true;
-					if (props[prop] !== evt[prop]) {
-						return false;
+					if (Object.hasOwn(props, prop)) {
+						res = true;
+						if (props[prop] !== evt[prop]) {
+							return false;
+						}
 					}
 				}
 				return res;

--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -356,7 +356,9 @@ describe('Polygon', () => {
 			polygon.setStyle(style);
 
 			for (const prop in style) {
-				expect(polygon.options[prop]).to.be(style[prop]);
+				if (Object.hasOwn(style, prop)) {
+					expect(polygon.options[prop]).to.be(style[prop]);
+				}
 			}
 		});
 	});

--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -355,10 +355,8 @@ describe('Polygon', () => {
 			polygon.addTo(map);
 			polygon.setStyle(style);
 
-			for (const prop in style) {
-				if (Object.hasOwn(style, prop)) {
-					expect(polygon.options[prop]).to.be(style[prop]);
-				}
+			for (const [prop, expectedValue] of Object.entries(style)) {
+				expect(polygon.options[prop]).to.be(expectedValue);
 			}
 		});
 	});

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -248,7 +248,9 @@ describe('Polyline', () => {
 			polyline.setStyle(style);
 
 			for (const prop in style) {
-				expect(polyline.options[prop]).to.be(style[prop]);
+				if (Object.hasOwn(style, prop)) {
+					expect(polyline.options[prop]).to.be(style[prop]);
+				}
 			}
 		});
 	});
@@ -264,7 +266,9 @@ describe('Polyline', () => {
 			polyline.setStyle(style);
 
 			for (const prop in style) {
-				expect(polyline.options[prop]).to.be(style[prop]);
+				if (Object.hasOwn(style, prop)) {
+					expect(polyline.options[prop]).to.be(style[prop]);
+				}
 			}
 		});
 	});

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -247,10 +247,8 @@ describe('Polyline', () => {
 			polyline.addTo(map);
 			polyline.setStyle(style);
 
-			for (const prop in style) {
-				if (Object.hasOwn(style, prop)) {
-					expect(polyline.options[prop]).to.be(style[prop]);
-				}
+			for (const [prop, expectedValue] of Object.entries(style)) {
+				expect(polyline.options[prop]).to.be(expectedValue);
 			}
 		});
 	});
@@ -265,10 +263,8 @@ describe('Polyline', () => {
 			polyline.addTo(map);
 			polyline.setStyle(style);
 
-			for (const prop in style) {
-				if (Object.hasOwn(style, prop)) {
-					expect(polyline.options[prop]).to.be(style[prop]);
-				}
+			for (const [prop, expectedValue] of Object.entries(style)) {
+				expect(polyline.options[prop]).to.be(expectedValue);
 			}
 		});
 	});

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -165,7 +165,9 @@ describe('Map.TapHoldSpec.js', () => {
 			target: container
 		}, posStart);
 		for (const prop in expectedProps) {
-			expect(originalEvent[prop]).to.be(expectedProps[prop]);
+			if (Object.hasOwn(expectedProps, prop)) {
+				expect(originalEvent[prop]).to.be(expectedProps[prop]);
+			}
 		}
 	});
 });

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -164,10 +164,8 @@ describe('Map.TapHoldSpec.js', () => {
 			cancelable: true,
 			target: container
 		}, posStart);
-		for (const prop in expectedProps) {
-			if (Object.hasOwn(expectedProps, prop)) {
-				expect(originalEvent[prop]).to.be(expectedProps[prop]);
-			}
+		for (const [prop, expectedValue] of Object.entries(expectedProps)) {
+			expect(originalEvent[prop]).to.be(expectedValue);
 		}
 	});
 });

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -85,11 +85,15 @@ export const Layers = Control.extend({
 		this._handlingClick = false;
 
 		for (const i in baseLayers) {
-			this._addLayer(baseLayers[i], i);
+			if (Object.hasOwn(baseLayers, i)) {
+				this._addLayer(baseLayers[i], i);
+			}
 		}
 
 		for (const i in overlays) {
-			this._addLayer(overlays[i], i, true);
+			if (Object.hasOwn(overlays, i)) {
+				this._addLayer(overlays[i], i, true);
+			}
 		}
 	},
 

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -165,7 +165,9 @@ Map.include({
 
 	_clearControlPos() {
 		for (const i in this._controlCorners) {
-			this._controlCorners[i].remove();
+			if (Object.hasOwn(this._controlCorners, i)) {
+				this._controlCorners[i].remove();
+			}
 		}
 		this._controlContainer.remove();
 		delete this._controlCorners;

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -39,9 +39,11 @@ export const Events = {
 		// types can be a map of types/handlers
 		if (typeof types === 'object') {
 			for (const type in types) {
-				// we don't process space-separated events here for performance;
-				// it's a hot path since Layer uses the on(obj) syntax
-				this._on(type, types[type], fn);
+				if (Object.hasOwn(types, type)) {
+					// we don't process space-separated events here for performance;
+					// it's a hot path since Layer uses the on(obj) syntax
+					this._on(type, types[type], fn);
+				}
 			}
 
 		} else {
@@ -75,7 +77,9 @@ export const Events = {
 
 		} else if (typeof types === 'object') {
 			for (const type in types) {
-				this._off(type, types[type], fn);
+				if (Object.hasOwn(types, type)) {
+					this._off(type, types[type], fn);
+				}
 			}
 
 		} else {
@@ -272,9 +276,11 @@ export const Events = {
 		// types can be a map of types/handlers
 		if (typeof types === 'object') {
 			for (const type in types) {
-				// we don't process space-separated events here for performance;
-				// it's a hot path since Layer uses the on(obj) syntax
-				this._on(type, types[type], fn, true);
+				if (Object.hasOwn(types, type)) {
+					// we don't process space-separated events here for performance;
+					// it's a hot path since Layer uses the on(obj) syntax
+					this._on(type, types[type], fn, true);
+				}
 			}
 
 		} else {
@@ -308,10 +314,12 @@ export const Events = {
 
 	_propagateEvent(e) {
 		for (const id in this._eventParents) {
-			this._eventParents[id].fire(e.type, Util.extend({
-				layer: e.target,
-				propagatedFrom: e.target
-			}, e), true);
+			if (Object.hasOwn(this._eventParents, id)) {
+				this._eventParents[id].fire(e.type, Util.extend({
+					layer: e.target,
+					propagatedFrom: e.target
+				}, e), true);
+			}
 		}
 	}
 };

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -5,13 +5,16 @@
  */
 
 // @function extend(dest: Object, src?: Object): Object
-// Merges the properties of the `src` object (or multiple objects) into `dest` object and returns the latter. Has an `L.extend` shortcut.
+// Merges the properties (including properties inherited through the prototype chain)
+// of the `src` object (or multiple objects) into `dest` object and returns the latter.
+// Has an `L.extend` shortcut.
 export function extend(dest, ...args) {
-	let i, j, len, src;
+	let j, len, src;
 
 	for (j = 0, len = args.length; j < len; j++) {
 		src = args[j];
-		for (i in src) {
+		// eslint-disable-next-line guard-for-in
+		for (const i in src) {
 			dest[i] = src[i];
 		}
 	}
@@ -104,7 +107,9 @@ export function setOptions(obj, options) {
 		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
 	for (const i in options) {
-		obj.options[i] = options[i];
+		if (Object.hasOwn(options, i)) {
+			obj.options[i] = options[i];
+		}
 	}
 	return obj.options;
 }
@@ -117,7 +122,9 @@ export function setOptions(obj, options) {
 export function getParamString(obj, existingUrl, uppercase) {
 	const params = [];
 	for (const i in obj) {
-		params.push(`${encodeURIComponent(uppercase ? i.toUpperCase() : i)}=${encodeURIComponent(obj[i])}`);
+		if (Object.hasOwn(obj, i)) {
+			params.push(`${encodeURIComponent(uppercase ? i.toUpperCase() : i)}=${encodeURIComponent(obj[i])}`);
+		}
 	}
 	return ((!existingUrl || !existingUrl.includes('?')) ? '?' : '&') + params.join('&');
 }

--- a/src/dom/DomEvent.Pointer.js
+++ b/src/dom/DomEvent.Pointer.js
@@ -71,7 +71,9 @@ function _handlePointer(handler, e) {
 
 	e.touches = [];
 	for (const i in _pointers) {
-		e.touches.push(_pointers[i]);
+		if (Object.hasOwn(_pointers, i)) {
+			e.touches.push(_pointers[i]);
+		}
 	}
 	e.changedTouches = [e];
 

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -24,10 +24,8 @@ import {getScale} from './DomUtil.js';
 export function on(obj, types, fn, context) {
 
 	if (types && typeof types === 'object') {
-		for (const type in types) {
-			if (Object.hasOwn(types, type)) {
-				addOne(obj, type, types[type], fn);
-			}
+		for (const [type, listener] of Object.entries(types)) {
+			addOne(obj, type, listener, fn);
 		}
 	} else {
 		types = Util.splitWords(types);
@@ -65,10 +63,8 @@ export function off(obj, types, fn, context) {
 		delete obj[eventsKey];
 
 	} else if (types && typeof types === 'object') {
-		for (const type in types) {
-			if (Object.hasOwn(types, type)) {
-				removeOne(obj, type, types[type], fn);
-			}
+		for (const [type, listener] of Object.entries(types)) {
+			removeOne(obj, type, listener, fn);
 		}
 
 	} else {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -25,7 +25,9 @@ export function on(obj, types, fn, context) {
 
 	if (types && typeof types === 'object') {
 		for (const type in types) {
-			addOne(obj, type, types[type], fn);
+			if (Object.hasOwn(types, type)) {
+				addOne(obj, type, types[type], fn);
+			}
 		}
 	} else {
 		types = Util.splitWords(types);
@@ -64,7 +66,9 @@ export function off(obj, types, fn, context) {
 
 	} else if (types && typeof types === 'object') {
 		for (const type in types) {
-			removeOne(obj, type, types[type], fn);
+			if (Object.hasOwn(types, type)) {
+				removeOne(obj, type, types[type], fn);
+			}
 		}
 
 	} else {
@@ -84,9 +88,11 @@ export function off(obj, types, fn, context) {
 
 function batchRemove(obj, filterFn) {
 	for (const id in obj[eventsKey]) {
-		const type = id.split(/\d/)[0];
-		if (!filterFn || filterFn(type)) {
-			removeOne(obj, type, null, null, id);
+		if (Object.hasOwn(obj[eventsKey], id)) {
+			const type = id.split(/\d/)[0];
+			if (!filterFn || filterFn(type)) {
+				removeOne(obj, type, null, null, id);
+			}
 		}
 	}
 }

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -80,8 +80,10 @@ export const FeatureGroup = LayerGroup.extend({
 		const bounds = new LatLngBounds();
 
 		for (const id in this._layers) {
-			const layer = this._layers[id];
-			bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());
+			if (Object.hasOwn(this._layers, id)) {
+				const layer = this._layers[id];
+				bounds.extend(layer.getBounds ? layer.getBounds() : layer.getLatLng());
+			}
 		}
 		return bounds;
 	}

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -213,7 +213,9 @@ Map.include({
 	 */
 	eachLayer(method, context) {
 		for (const i in this._layers) {
-			method.call(context, this._layers[i]);
+			if (Object.hasOwn(this._layers, i)) {
+				method.call(context, this._layers[i]);
+			}
 		}
 		return this;
 	},
@@ -248,10 +250,12 @@ Map.include({
 		const oldZoomSpan = this._getZoomSpan();
 
 		for (const i in this._zoomBoundLayers) {
-			const options = this._zoomBoundLayers[i].options;
+			if (Object.hasOwn(this._zoomBoundLayers, i)) {
+				const options = this._zoomBoundLayers[i].options;
 
-			minZoom = options.minZoom === undefined ? minZoom : Math.min(minZoom, options.minZoom);
-			maxZoom = options.maxZoom === undefined ? maxZoom : Math.max(maxZoom, options.maxZoom);
+				minZoom = options.minZoom === undefined ? minZoom : Math.min(minZoom, options.minZoom);
+				maxZoom = options.maxZoom === undefined ? maxZoom : Math.max(maxZoom, options.maxZoom);
+			}
 		}
 
 		this._layersMaxZoom = maxZoom === -Infinity ? undefined : maxZoom;

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -91,10 +91,12 @@ export const LayerGroup = Layer.extend({
 		let i, layer;
 
 		for (i in this._layers) {
-			layer = this._layers[i];
+			if (Object.hasOwn(this._layers, i)) {
+				layer = this._layers[i];
 
-			if (layer[methodName]) {
-				layer[methodName].apply(layer, args);
+				if (layer[methodName]) {
+					layer[methodName].apply(layer, args);
+				}
 			}
 		}
 
@@ -118,7 +120,9 @@ export const LayerGroup = Layer.extend({
 	// ```
 	eachLayer(method, context) {
 		for (const i in this._layers) {
-			method.call(context, this._layers[i]);
+			if (Object.hasOwn(this._layers, i)) {
+				method.call(context, this._layers[i]);
+			}
 		}
 		return this;
 	},

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -317,6 +317,8 @@ export const GridLayer = Layer.extend({
 		    willPrune = false;
 
 		for (const key in this._tiles) {
+			if (!Object.hasOwn(this._tiles, key)) { continue; }
+
 			const tile = this._tiles[key];
 			if (!tile.current || !tile.loaded) { continue; }
 
@@ -366,6 +368,8 @@ export const GridLayer = Layer.extend({
 		if (zoom === undefined) { return undefined; }
 
 		for (let z in this._levels) {
+			if (!Object.hasOwn(this._levels, z)) { continue; }
+
 			z = Number(z);
 			if (this._levels[z].el.children.length || z === zoom) {
 				this._levels[z].el.style.zIndex = maxZoom - Math.abs(zoom - z);
@@ -424,11 +428,15 @@ export const GridLayer = Layer.extend({
 		}
 
 		for (key in this._tiles) {
-			tile = this._tiles[key];
-			tile.retain = tile.current;
+			if (Object.hasOwn(this._tiles, key)) {
+				tile = this._tiles[key];
+				tile.retain = tile.current;
+			}
 		}
 
 		for (key in this._tiles) {
+			if (!Object.hasOwn(this._tiles, key)) { continue; }
+
 			tile = this._tiles[key];
 			if (tile.current && !tile.active) {
 				const coords = tile.coords;
@@ -456,15 +464,19 @@ export const GridLayer = Layer.extend({
 
 	_removeAllTiles() {
 		for (const key in this._tiles) {
-			this._removeTile(key);
+			if (Object.hasOwn(this._tiles, key)) {
+				this._removeTile(key);
+			}
 		}
 	},
 
 	_invalidateAll() {
 		for (const z in this._levels) {
-			this._levels[z].el.remove();
-			this._onRemoveLevel(Number(z));
-			delete this._levels[z];
+			if (Object.hasOwn(this._levels, z)) {
+				this._levels[z].el.remove();
+				this._onRemoveLevel(Number(z));
+				delete this._levels[z];
+			}
 		}
 		this._removeAllTiles();
 
@@ -585,7 +597,9 @@ export const GridLayer = Layer.extend({
 
 	_setZoomTransforms(center, zoom) {
 		for (const i in this._levels) {
-			this._setZoomTransform(this._levels[i], center, zoom);
+			if (Object.hasOwn(this._levels, i)) {
+				this._setZoomTransform(this._levels[i], center, zoom);
+			}
 		}
 	},
 
@@ -658,9 +672,11 @@ export const GridLayer = Layer.extend({
 		      isFinite(tileRange.max.y))) { throw new Error('Attempted to load an infinite number of tiles'); }
 
 		for (const key in this._tiles) {
-			const c = this._tiles[key].coords;
-			if (c.z !== this._tileZoom || !noPruneRange.contains(new Point(c.x, c.y))) {
-				this._tiles[key].current = false;
+			if (Object.hasOwn(this._tiles, key)) {
+				const c = this._tiles[key].coords;
+				if (c.z !== this._tileZoom || !noPruneRange.contains(new Point(c.x, c.y))) {
+					this._tiles[key].current = false;
+				}
 			}
 		}
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -96,8 +96,10 @@ export const Canvas = Renderer.extend({
 		let layer;
 		this._redrawBounds = null;
 		for (const id in this._layers) {
-			layer = this._layers[id];
-			layer._update();
+			if (Object.hasOwn(this._layers, id)) {
+				layer = this._layers[id];
+				layer._update();
+			}
 		}
 		this._redraw();
 	},

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -47,19 +47,25 @@ export const Renderer = BlanketOverlay.extend({
 		// of paths are relative to the origin pixel and therefore need to
 		// be recalculated.
 		for (const id in this._layers) {
-			this._layers[id]._project();
+			if (Object.hasOwn(this._layers, id)) {
+				this._layers[id]._project();
+			}
 		}
 	},
 
 	_updatePaths() {
 		for (const id in this._layers) {
-			this._layers[id]._update();
+			if (Object.hasOwn(this._layers, id)) {
+				this._layers[id]._update();
+			}
 		}
 	},
 
 	_onViewReset() {
 		for (const id in this._layers) {
-			this._layers[id]._reset();
+			if (Object.hasOwn(this._layers, id)) {
+				this._layers[id]._reset();
+			}
 		}
 	},
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -781,10 +781,14 @@ export const Map = Evented.extend({
 
 		let i;
 		for (i in this._layers) {
-			this._layers[i].remove();
+			if (Object.hasOwn(this._layers, i)) {
+				this._layers[i].remove();
+			}
 		}
 		for (i in this._panes) {
-			this._panes[i].remove();
+			if (Object.hasOwn(this._panes, i)) {
+				this._panes[i].remove();
+			}
 		}
 
 		this._layers = [];


### PR DESCRIPTION
Closes #8843 

- Adds checks to for-in loops to ensure they are not looping over inherited properties.
- Enables [lint rule](https://eslint.org/docs/latest/rules/guard-for-in) to ensure these guards are enabled in future code.
- Does NOT add a guard to `Util.extend` as this code purposely copies properties from source objects.