### PR TITLE
Fix click events when latlng isn't initially set

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -399,11 +399,17 @@ export const Canvas = Renderer.extend({
 
 			if (candidateHoveredLayer) {
 				this._container.classList.add('leaflet-interactive'); // change cursor
+				if (!candidateHoveredLayer.getLatLng() && point) {
+					candidateHoveredLayer.setLatLng(this._map.unproject(point));
+				}
 				this._fireEvent([candidateHoveredLayer], e, 'mouseover');
 				this._hoveredLayer = candidateHoveredLayer;
 			}
 		}
 
+		if (this._hoveredLayer && !this._hoveredLayer.getLatLng() && point) {
+			this._hoveredLayer.setLatLng(this._map.unproject(point));
+		}
 		this._fireEvent(this._hoveredLayer ? [this._hoveredLayer] : false, e);
 
 		this._mouseHoverThrottled = true;


### PR DESCRIPTION
My use-case is this: I'm using latest Leaflet (1.9.3) alongside with [Leaflet.VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid/) (which is a bit outdated but anyway).

When I set up a VectorGrid layer, set `interactive: true` to its options, and add `myVectorGridLayer.on('click', ...)` event handling (also works with mousedown, per se), I have an error that says "latlng is not defined". This is probably caused by VectorGrid not using latlng by default, so I patched VectorGrid, but in the end I realized that "mouseover" also causes this "latlng is not defined" error right in the Canvas renderer.

So here is this patch.

I don't know Leaflet internals enough to see if this fix is the right one or if I should fix something upstream, so feel free to reject, but please send explanations if you do, so that we can learn more about internals 🙏

