### PR TITLE
Alleviate tile gaps in chromium by using mix-blend-mode CSS

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -52,7 +52,9 @@
 	max-height: none !important;
 	width: auto;
 	padding: 0;
+	/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */
 	mix-blend-mode: plus-lighter;
+
 	}
 
 .leaflet-container.leaflet-touch-zoom {


### PR DESCRIPTION
This alleviates the dreaded tile gaps of #3575, in a clean way, with no downsides that I'm aware of.

The tile gaps are still visible if the page zoom is not 100%, however (see https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-1485077575).

Credit goes to @lapo-luchini (see https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-1484816250).