### PR TITLE
Allow auto merge to Dependabot PR if they pass CI

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,18 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  


### PR DESCRIPTION
This is a blatant copy of @HarelM's https://github.com/maplibre/maplibre-gl-js/pull/2345 . Should ease up maintenance a bit.