### PR TITLE
Apply mix-blend-mode only on tile images

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -52,10 +52,11 @@
 	max-height: none !important;
 	width: auto;
 	padding: 0;
+	}
+.leaflet-container img.leaflet-tile {
 	/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */
 	mix-blend-mode: plus-lighter;
-
-	}
+}
 
 .leaflet-container.leaflet-touch-zoom {
 	touch-action: pan-x pan-y;
@@ -588,7 +589,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 
 /* Printing */
-	
+
 @media print {
 	/* Prevent printers from removing background-images of controls. */
 	.leaflet-control {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -56,7 +56,7 @@
 .leaflet-container img.leaflet-tile {
 	/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */
 	mix-blend-mode: plus-lighter;
-}
+	}
 
 .leaflet-container.leaflet-touch-zoom {
 	touch-action: pan-x pan-y;


### PR DESCRIPTION
Fix #8905, `mix-blend-mode` issue with custom svg-tiles. The bug was introduced in #8891.

Needs to be cherry-picked into `v1`