### PR TITLE
Set `outlineStyle` instead of `outline` when preventing outline

### DIFF
--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -288,22 +288,23 @@ describe('DomUtil', () => {
 	describe('#preventOutline, #restoreOutline', () => {
 		it('prevent / restore outline for the element', () => {
 			const child = document.createElement('div');
-			el.appendChild(child);
+			const originalStyle = child.style.outlineStyle = 'dotted';
+
 			child.tabIndex = 0;
-			expect(child.style.outline).to.be.equal(child.style.outline);
-			L.DomUtil.preventOutline(child);
-			expect(child.style.outline).to.match(/(?:none)/);
+			el.appendChild(child);
 
-			//	Explicit #restoreOutline through direct call
-			expect(child.style.outline).to.match(/(?:none)/);
+			L.DomUtil.preventOutline(child);
+			expect(child.style.outlineStyle).to.equal('none');
+
+			// Explicit #restoreOutline through direct call
 			L.DomUtil.restoreOutline(child);
-			expect(child.style.outline).to.be.equal(child.style.outline);
+			expect(child.style.outlineStyle).to.be.equal(originalStyle);
 
-			//	Implicit #restoreOutline test through simulation
+			// Implicit #restoreOutline test through simulation
 			L.DomUtil.preventOutline(child);
-			expect(child.style.outline).to.match(/(?:none)/);
+			expect(child.style.outlineStyle).to.equal('none');
 			UIEventSimulator.fire('keydown', child);
-			expect(child.style.outline).to.be.equal(child.style.outline);
+			expect(child.style.outlineStyle).to.be.equal(originalStyle);
 		});
 	});
 });

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -134,8 +134,8 @@ export function preventOutline(element) {
 	if (!element.style) { return; }
 	restoreOutline();
 	_outlineElement = element;
-	_outlineStyle = element.style.outline;
-	element.style.outline = 'none';
+	_outlineStyle = element.style.outlineStyle;
+	element.style.outlineStyle = 'none';
 	DomEvent.on(window, 'keydown', restoreOutline);
 }
 
@@ -143,7 +143,7 @@ export function preventOutline(element) {
 // Cancels the effects of a previous [`L.DomUtil.preventOutline`](#domutil-preventoutline).
 export function restoreOutline() {
 	if (!_outlineElement) { return; }
-	_outlineElement.style.outline = _outlineStyle;
+	_outlineElement.style.outlineStyle = _outlineStyle;
 	_outlineElement = undefined;
 	_outlineStyle = undefined;
 	DomEvent.off(window, 'keydown', restoreOutline);


### PR DESCRIPTION
Changes the implementation of `preventOutline()` and `restoreOutline()` so that [`outline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style) is set rather than the whole [`outline`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline) property. This seems to prevent a regression introduced in Safari 16.4, and remains functional in other browsers.

Closes #8908