### PR TITLE
Lint files in `debug` directory

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@
 module.exports = {
 	ignorePatterns: [
 		'dist',
-		'debug',
 		'docs/docs/highlight',
 		'docs/examples/choropleth/us-states.js',
 		'docs/examples/geojson/sample-geojson.js',
@@ -65,6 +64,15 @@ module.exports = {
 			rules: {
 				'eol-last': 'off',
 				'no-unused-vars': 'off'
+			}
+		},
+		{
+			files: [
+				'*.html'
+			],
+			rules: {
+				'eol-last': 'off',
+				'no-new': 'off'
 			}
 		}
 	]


### PR DESCRIPTION
Since I've refactored all the examples for ESM support I have also taken some time to ensure the pass the linter in the same manner as other code. This means we can now remove the ignored directory from our linting config.