### PR TITLE
Use import maps to load Leaflet in the `debug` directory

### DIFF
--- a/debug/map/canvas.html
+++ b/debug/map/canvas.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {GridLayer, Map, LatLng} from '../../dist/leaflet-src.esm.js';
+			import {GridLayer, Map, LatLng} from 'leaflet';
 
 			const tiles = new GridLayer();
 

--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -15,7 +22,7 @@
 			}
 		</style>
 		<script type="module">
-			import {Map, TileLayer, Control, Circle, Polygon, GeoJSON} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Control, Circle, Polygon, GeoJSON} from 'leaflet';
 
 			const GrayscaleTileLayer = TileLayer.extend({
 				createTile(...args) {

--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker, LatLng, Control} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, Marker, LatLng, Control} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/geolocation.html
+++ b/debug/map/geolocation.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/grid.html
+++ b/debug/map/grid.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {GridLayer, Map} from '../../dist/leaflet-src.esm.js';
+			import {GridLayer, Map} from 'leaflet';
 
 			const grid = new GridLayer({
 				attribution: 'Grid Layer'

--- a/debug/map/iframe-map.html
+++ b/debug/map/iframe-map.html
@@ -7,12 +7,19 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<button id="populate">Populate with 10 markers</button>
 		<script type="module">
-			import {TileLayer, Map, FeatureGroup, LatLng, Marker, DomUtil} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, FeatureGroup, LatLng, Marker, DomUtil} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/iframe.html
+++ b/debug/map/iframe.html
@@ -4,6 +4,13 @@
 		<meta charset="utf-8" />
 		<title>Leaflet debug page - Iframe</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>

--- a/debug/map/image-overlay.html
+++ b/debug/map/image-overlay.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, LatLngBounds, ImageOverlay} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, LatLngBounds, ImageOverlay} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/layer-remove-add.html
+++ b/debug/map/layer-remove-add.html
@@ -6,12 +6,19 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<button id="removeAdd">Remove and Add Layer</button>
 		<script type="module">
-			import {Map, TileLayer, DomUtil} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, DomUtil} from 'leaflet';
 
 			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/debug/map/map-mobile.html
+++ b/debug/map/map-mobile.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, Marker} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/map-popup.html
+++ b/debug/map/map-popup.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker, Circle, Polygon, Popup} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, Marker, Circle, Polygon, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/map-scaled.html
+++ b/debug/map/map-scaled.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -32,7 +39,7 @@
 			<div id="map"></div>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, Marker, DomEvent} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, Marker, DomEvent} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';

--- a/debug/map/marker-autopan.html
+++ b/debug/map/marker-autopan.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon, TileLayer} from '../../dist/leaflet-src.esm.js';
+			import {Map, Marker, Polygon, TileLayer} from 'leaflet';
 
 			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 

--- a/debug/map/markers.html
+++ b/debug/map/markers.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon, TileLayer} from '../../dist/leaflet-src.esm.js';
+			import {Map, Marker, Polygon, TileLayer} from 'leaflet';
 
 			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 

--- a/debug/map/max-bounds-bouncy.html
+++ b/debug/map/max-bounds-bouncy.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<h1>Left: Bouncy maxBounds. Right: Not bouncy.</h1>
 		<div id="map1" style="float: left; width:45%; height: 80%;"></div>
 		<div id="map2" style="float: left; width:45%; height: 80%;"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm1 = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/max-bounds-infinite.html
+++ b/debug/map/max-bounds-infinite.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLngBounds, LatLng, Map} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/max-bounds.html
+++ b/debug/map/max-bounds.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/opacity.html
+++ b/debug/map/opacity.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -60,7 +67,7 @@
 			<div id="map6" class="map"></div>
 		</div>
 		<script type="module">
-			import {Map, TileLayer} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer} from 'leaflet';
 
 			const mapopts = {
 				center: [35, -122],

--- a/debug/map/popup-keep-in-view.html
+++ b/debug/map/popup-keep-in-view.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -17,7 +24,7 @@
 			<button id="movePopup">Move last popup</button>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, Popup} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, LatLng, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/popup.html
+++ b/debug/map/popup.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, FeatureGroup, Marker, Polyline, Polygon, DomUtil, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, LatLng, FeatureGroup, Marker, Polyline, Polygon, DomUtil, CircleMarker} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/scroll.html
+++ b/debug/map/scroll.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div style="position: absolute; top: 100px; left: 100px; border: 1px solid green">
@@ -16,7 +23,7 @@
 			</div>
 		</div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Popup} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});

--- a/debug/map/simple-proj.html
+++ b/debug/map/simple-proj.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, CRS, Polygon, Marker, ImageOverlay, GridLayer, Circle} from '../../dist/leaflet-src.esm.js';
+			import {Map, CRS, Polygon, Marker, ImageOverlay, GridLayer, Circle} from 'leaflet';
 
 			const map = new Map('map', {
 				crs: CRS.Simple

--- a/debug/map/svg-overlay.html
+++ b/debug/map/svg-overlay.html
@@ -6,12 +6,19 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map" style='width:750px; height: 450px;'></div>
 		<svg id="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200"/><rect x="75" y="23" width="50" height="50" style="fill:red"/><rect x="75" y="123" width="50" height="50" style="fill:#0013ff"/></svg>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, SVGOverlay} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LatLngBounds, SVGOverlay} from 'leaflet';
 
 			const map = new Map('map');
 			

--- a/debug/map/tile-opacity.html
+++ b/debug/map/tile-opacity.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, LatLng} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LatLngBounds, LatLng} from 'leaflet';
 
 			const map = new Map('map');
 			const nexrad = new TileLayer.WMS('https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi', {

--- a/debug/map/tile.html
+++ b/debug/map/tile.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -147,7 +154,7 @@
 			<button id="reset">reset</button>
 		</div>
 		<script type="module">
-			import {Map, TileLayer, GridLayer, Point, DomUtil, Marker, ImageOverlay} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, GridLayer, Point, DomUtil, Marker, ImageOverlay} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];

--- a/debug/map/tooltip.html
+++ b/debug/map/tooltip.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style type="text/css">
@@ -19,7 +26,7 @@
 		</style>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Polygon, Marker, CircleMarker, DivIcon, FeatureGroup, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Polygon, Marker, CircleMarker, DivIcon, FeatureGroup, Polyline} from 'leaflet';
 
 			const center = [41.2058, 9.4307];
 			const map = new Map('map').setView(center, 13);

--- a/debug/map/video-overlay.html
+++ b/debug/map/video-overlay.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, VideoOverlay, Control, DomEvent, DomUtil} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LatLngBounds, VideoOverlay, Control, DomEvent, DomUtil} from 'leaflet';
 
 			const map = new Map('map');
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19}).addTo(map);

--- a/debug/map/wms.html
+++ b/debug/map/wms.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, LatLng, Control} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LatLngBounds, LatLng, Control} from 'leaflet';
 
 			const map = new Map('map');
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/debug/map/zoom-delta.html
+++ b/debug/map/zoom-delta.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -46,7 +53,7 @@
 			<span id="zoom2"></span>
 		</div>		
 		<script type="module">
-			import {TileLayer, LatLng, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map} from 'leaflet';
 
 			const sf = [37.77, -122.42];
 			const trd = [63.41, 10.41];

--- a/debug/map/zoom-levels.html
+++ b/debug/map/zoom-levels.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, LatLng, TileLayer, Control, Marker} from '../../dist/leaflet-src.esm.js';
+			import {Map, LatLng, TileLayer, Control, Marker} from 'leaflet';
 
 			// Test that changing between layers with differing zoomlevels also updates
 			// the zoomlevels in the map + also

--- a/debug/map/zoom-pan.html
+++ b/debug/map/zoom-pan.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -37,7 +44,7 @@
 			<tr><td>on grid load</td><td id='load'></td></tr>
 		</div>
 		<script type="module">
-			import {Map, TileLayer, Polyline, Marker, ImageOverlay} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Polyline, Marker, ImageOverlay} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];

--- a/debug/map/zoom-remain-centered.html
+++ b/debug/map/zoom-remain-centered.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Marker, Control} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, Marker, Control} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {minZoom: 14});

--- a/debug/tests/add-remove-layers.html
+++ b/debug/tests/add-remove-layers.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -14,7 +21,7 @@
 			<button type="button" id="b2">Remove Layer</button>
 		</div>
 		<script type="module">
-			import {LayerGroup, Map, TileLayer, LatLngBounds, Circle, LatLng, Popup, DomUtil, DomEvent} from '../../dist/leaflet-src.esm.js';
+			import {LayerGroup, Map, TileLayer, LatLngBounds, Circle, LatLng, Popup, DomUtil, DomEvent} from 'leaflet';
 
 			const map = new Map('map');
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/debug/tests/canvas-loop.html
+++ b/debug/tests/canvas-loop.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LayerGroup, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LayerGroup, CircleMarker} from 'leaflet';
 
 			const map = new Map('map', {
 				center: [39.84, -96.591],

--- a/debug/tests/click-on-canvas.html
+++ b/debug/tests/click-on-canvas.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, FeatureGroup, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, FeatureGroup, Polyline} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const map = new Map('map', {

--- a/debug/tests/custom-panes.html
+++ b/debug/tests/custom-panes.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<style>
@@ -24,7 +31,7 @@
 			<div id="mapSvg"></div>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, Marker, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, Marker, CircleMarker} from 'leaflet';
 
 			function makeMap(container, options) {
 				const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});

--- a/debug/tests/detached-dom-memory-leak.html
+++ b/debug/tests/detached-dom-memory-leak.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<button id="once">Once</button>
 		<button id="start">Start</button>
 		<button id="stop">Stop</button>
 		<script type="module">
-			import {TileLayer, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map} from 'leaflet';
 
 			let map;
 			let mapDiv;

--- a/debug/tests/dragging-and-copyworldjump.html
+++ b/debug/tests/dragging-and-copyworldjump.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<p>
@@ -18,7 +25,7 @@
 		<div id="map1" style="height: 300px; width: 400px; float:left;"></div>
 		<div id="map2" style="height: 300px; width: 400px; float:left; margin-left: 10px;"></div>
 		<script type="module">
-			import {TileLayer, Marker, Map, LatLng} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Marker, Map, LatLng} from 'leaflet';
 
 			function addLayerAndMarker(map) {
 				new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/debug/tests/dragging-cursors.html
+++ b/debug/tests/dragging-cursors.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		This page tests if the cursors for dragging the map and the markers behave as expected. The left marker is draggable, the right one is not.
@@ -16,7 +23,7 @@
 		<div>Map dragging disabled:</div>
 		<div id="map2" style="height: 300px;width: 400px; float:left;"></div>
 		<script type="module">
-			import {TileLayer, Marker, Map, LatLng} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Marker, Map, LatLng} from 'leaflet';
 
 			function addLayerAndMarkers(map) {
 				new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/debug/tests/esm.html
+++ b/debug/tests/esm.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer} from 'leaflet';
 
 			const map = new Map('map', {
 				center: [39.84, -96.591],

--- a/debug/tests/event-perf-2.html
+++ b/debug/tests/event-perf-2.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, FeatureGroup, LatLng, Marker} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, FeatureGroup, LatLng, Marker} from 'leaflet';
 
 			/*
 			 * Can be used to profile performance of event system.

--- a/debug/tests/mousemove-on-polygons.html
+++ b/debug/tests/mousemove-on-polygons.html
@@ -37,6 +37,13 @@
 				}
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<table>
@@ -71,7 +78,7 @@
 		</table>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Polygon, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, Polygon, Marker} from 'leaflet';
 
 			const osm = new TileLayer(
 				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/debug/tests/opacity.html
+++ b/debug/tests/opacity.html
@@ -11,11 +11,18 @@
 				background-color: red;
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, DivIcon, Point, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Map, DivIcon, Point, Marker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const latlng = new LatLng(50.5, 30.51);

--- a/debug/tests/popup-context-menu-clicks.html
+++ b/debug/tests/popup-context-menu-clicks.html
@@ -6,12 +6,19 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<button id="populate">Populate with 10 markers</button>
 		<script type="module">
-			import {Map, TileLayer, GeoJSON, Marker} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, GeoJSON, Marker} from 'leaflet';
 
 			const map = new Map('map').setView([36.9, -95.4], 5);
 

--- a/debug/tests/popup-offset.html
+++ b/debug/tests/popup-offset.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, Marker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const map = new Map('map').setView([50.5, 30.51], 15).addLayer(osm);

--- a/debug/tests/remove-while-dragging.html
+++ b/debug/tests/remove-while-dragging.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker} from '../../dist/leaflet-src.esm.js';
+			import {Map, Marker} from 'leaflet';
 
 			const map = new Map('map').setView([50, 50], 10);
 			const marker = new Marker([50, 50], {draggable: true}).addTo(map);

--- a/debug/tests/reuse-popups.html
+++ b/debug/tests/reuse-popups.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, TileLayer, Popup} from '../../dist/leaflet-src.esm.js';
+			import {Map, Marker, TileLayer, Popup} from 'leaflet';
 
 			const map = new Map('map');
 

--- a/debug/tests/rtl.html
+++ b/debug/tests/rtl.html
@@ -11,12 +11,19 @@
 				direction: rtl;
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<p>Click the map to place a popup at the mouse location</p>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Popup} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Popup} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
 			const map = new Map('map')

--- a/debug/tests/rtl2.html
+++ b/debug/tests/rtl2.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Popup} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Popup} from 'leaflet';
 
 			const map = new Map('map').setView([51.505, -0.09], 13);
 

--- a/debug/tests/svg-clicks.html
+++ b/debug/tests/svg-clicks.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, LatLngBounds, Polyline} from 'leaflet';
 
 			const map = new Map('map');
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {minZoom: 1, maxZoom: 17});

--- a/debug/tests/text-selection.html
+++ b/debug/tests/text-selection.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<button id="disable" type="button">Disable text selection</button>
 		<button id="enable" type="button">Enable text selection</button>
 		<p>The quick brown fox jumps over the lazy dog.</p>
 		<script type="module">
-			import {DomUtil} from '../../dist/leaflet-src.esm.js';
+			import {DomUtil} from 'leaflet';
 
 			const disableBtn = document.getElementById('disable');
 			const enableBtn = document.getElementById('enable');

--- a/debug/tests/tile-bounds.html
+++ b/debug/tests/tile-bounds.html
@@ -13,6 +13,13 @@
 				overflow: visible
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		The CSS in this page makes the boundaries of the GridLayer tiles visible. Tiles which do not overlap the map bounds shall not be shown, even at fractional zoom levels.
@@ -20,7 +27,7 @@
 		<button id="zoomOut" type="button"> Zoom - 0.1 </button>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, GridLayer, Point} from '../../dist/leaflet-src.esm.js';
+			import {Map, GridLayer, Point} from 'leaflet';
 
 			const map = new Map('map', {
 				center: [35, -122],

--- a/debug/tests/tile-events.html
+++ b/debug/tests/tile-events.html
@@ -28,6 +28,13 @@
 				margin: 0;
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<p>
@@ -79,7 +86,7 @@
 		<div><button id="nul">NUL</button>(image overlay)</div>
 		<div><button id="stop">stop</button></div>
 		<script type="module">
-			import {Map, TileLayer, GridLayer, Point, DomUtil} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, GridLayer, Point, DomUtil} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, BlanketOverlay, Canvas, SVG, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, LatLng, BlanketOverlay, Canvas, SVG, CircleMarker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const map = new Map('map', {

--- a/debug/vector/bounds-extend.html
+++ b/debug/vector/bounds-extend.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<button type="button" id="extendBounds">Extend the bounds of the center rectangle with the upper right rectangle</button>
 		<button type="button" id="extendLatLng">Extend the bounds of the center rectangle with the lower left marker</button>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Marker} from 'leaflet';
 
 			const bounds1 = new LatLngBounds(
 				new LatLng(54.559322, -5.767822),

--- a/debug/vector/feature-group-bounds.html
+++ b/debug/vector/feature-group-bounds.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -13,7 +20,7 @@
 		<button id="featureGroupBounds" type="button">Show feature group bounds</button>
 		<script src="geojson-sample.js"></script>
 		<script type="module">
-			import {TileLayer, Map, GeoJSON, LatLng, Marker, Polyline, FeatureGroup, Rectangle} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, GeoJSON, LatLng, Marker, Polyline, FeatureGroup, Rectangle} from 'leaflet';
 			import geojsonSample from './geojson-sample.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});

--- a/debug/vector/geojson.html
+++ b/debug/vector/geojson.html
@@ -33,11 +33,18 @@
 				opacity: 0.7;
 			}
 		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Control, DomUtil, GeoJSON} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Control, DomUtil, GeoJSON} from 'leaflet';
 			import statesData from './us-states.js';
 
 			const map = new Map('map').setView([37.8, -96], 4);

--- a/debug/vector/inherit-dash-array.html
+++ b/debug/vector/inherit-dash-array.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Polygon, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Polygon, CircleMarker} from 'leaflet';
 
 			const map = new Map('map', {
 				center: [20, 20],

--- a/debug/vector/moving-canvas.html
+++ b/debug/vector/moving-canvas.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, CircleMarker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, CircleMarker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				maxZoom: 19,

--- a/debug/vector/rectangle.html
+++ b/debug/vector/rectangle.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -13,7 +20,7 @@
 			Set blue rectangle bounds as current map extent.
 		</button>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Rectangle, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLngBounds, LatLng, Rectangle, Map} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const bounds = new LatLngBounds(new LatLng(54.559322, -5.767822), new LatLng(56.1210604, -3.021240));

--- a/debug/vector/vector-bounds.html
+++ b/debug/vector/vector-bounds.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<button id="zoomToPath" type="button">Zoom to path</button>
 		<button id="zoomToPolygon" type="button">Zoom to polygon</button>
 		<script type="module">
-			import {TileLayer, Polyline, LatLng, Polygon, Map} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Polyline, LatLng, Polygon, Map} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 

--- a/debug/vector/vector-canvas.html
+++ b/debug/vector/vector-canvas.html
@@ -6,6 +6,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
@@ -13,7 +20,7 @@
 		<button id="removeCircle" type="button">Remove circle</button>
 		<button id="removeAll" type="button">Remove all layers</button>
 		<script type="module">
-			import {TileLayer, LatLng, Canvas, Polyline, Map, LayerGroup, LatLngBounds, Circle, CircleMarker, Polygon} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, LatLng, Canvas, Polyline, Map, LayerGroup, LatLngBounds, Circle, CircleMarker, Polygon} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});

--- a/debug/vector/vector-drift.html
+++ b/debug/vector/vector-drift.html
@@ -6,13 +6,20 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<button id="btn-1" type="button">A</button>
 		<button id="btn-2" type="button">B</button>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon} from '../../dist/leaflet-src.esm.js';
+			import {Map, Marker, Polygon} from 'leaflet';
 
 			const map = new Map('map', {
 				zoomAnimation: false,

--- a/debug/vector/vector-mobile.html
+++ b/debug/vector/vector-mobile.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, LatLngBounds, Marker, Polyline} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, LatLng, LatLngBounds, Marker, Polyline} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});

--- a/debug/vector/vector-simple.html
+++ b/debug/vector/vector-simple.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/mobile.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Marker, Circle, Polygon} from '../../dist/leaflet-src.esm.js';
+			import {Map, TileLayer, Marker, Circle, Polygon} from 'leaflet';
 
 			const map = new Map('map')
 				.setView([51.505, -0.09], 13);

--- a/debug/vector/vector.html
+++ b/debug/vector/vector.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, Polyline, LatLngBounds, Marker} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, Map, LatLng, Polyline, LatLngBounds, Marker} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});

--- a/debug/vector/vector2.html
+++ b/debug/vector/vector2.html
@@ -6,11 +6,18 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
 		<link rel="stylesheet" href="../../dist/leaflet.css" />
 		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
 	</head>
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, SVG, Map, Marker, Canvas, Polyline, Circle, CircleMarker, Control} from '../../dist/leaflet-src.esm.js';
+			import {TileLayer, SVG, Map, Marker, Canvas, Polyline, Circle, CircleMarker, Control} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});


### PR DESCRIPTION
Adds Leaflet to an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) for each of the examples in the `debug` directory. This allows Leaflet to be imported using `import {} from 'leaflet'`.