### PR TITLE
Plugins: add maplibre-gl-leaflet

### DIFF
--- a/docs/_plugins/vector-tiles/leaflet-maplibre.md
+++ b/docs/_plugins/vector-tiles/leaflet-maplibre.md
@@ -1,0 +1,12 @@
+---
+name: maplibre-gl-leaflet
+category: vector-tiles
+repo: https://github.com/maplibre/maplibre-gl-leaflet
+author: MapLibre
+author-url: https://www.maplibre.org/
+demo:
+compatible-v0: false
+compatible-v1: true
+---
+
+Loads a [maplibre-gl-js](https://maplibre.org/projects/maplibre-gl-js/) map as a Leaflet layer


### PR DESCRIPTION
See https://github.com/maplibre/maplibre-gl-leaflet

I'm kinda surprised the MapLibre folks didn't ask for this plugin to be listed here already.