### PR TITLE
Update docs language for HTML and CSS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Weighing just about 42 KB of gzipped JS plus 4 KB of gzipped CSS code, it has al
 
 Leaflet is designed with *simplicity*, *performance* and *usability* in mind.
 It works efficiently across all major desktop and mobile platforms out of the box,
-taking advantage of HTML5 and CSS3 on modern browsers while being accessible on older ones too.
+taking advantage of modern browser features while being accessible on older ones too.
 It can be extended with a huge amount of [plugins][],
 has a beautiful, easy to use and [well-documented][] API
 and a simple, readable [source code][] that is a joy to [contribute][] to.

--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -28,7 +28,7 @@
 
 			const marker = new Marker(new LatLng(50.5, 30.505));
 			map.addLayer(marker);
-			marker.bindPopup('Leaflet is designed with simplicity, performance and usability in mind. It works efficiently across all major desktop and mobile platforms out of the box, taking advantage of HTML5 and CSS3 on modern browsers while still being accessible on older ones.').openPopup();
+			marker.bindPopup('Leaflet is designed with simplicity, performance and usability in mind. It works efficiently across all major desktop and mobile platforms out of the box, taking advantage of modern browser features while still being accessible on older ones.').openPopup();
 
 			const marker2 = new Marker(new LatLng(50.502, 30.515));
 			map.addLayer(marker2);

--- a/debug/tests/popup-offset.html
+++ b/debug/tests/popup-offset.html
@@ -24,7 +24,7 @@
 
 			new Marker(map.getCenter())
 				.addTo(map)
-				.bindPopup('A pretty CSS3 popup. <br> Easily customizable.', {
+				.bindPopup('A pretty CSS popup. <br> Easily customizable.', {
 					offset: [100, 200],
 				})
 				.openPopup();

--- a/docs/_plugins/fullscreen-controls/leaflet-fullscreen.md
+++ b/docs/_plugins/fullscreen-controls/leaflet-fullscreen.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Another fullscreen button control but for modern browsers, using HTML5 Fullscreen API.
+Another fullscreen button control but for modern browsers, using HTML Fullscreen API.

--- a/docs/_plugins/heatmaps/heatcanvas.md
+++ b/docs/_plugins/heatmaps/heatcanvas.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Simple heatmap api based on HTML5 canvas.
+Simple heatmap api based on HTML canvas.

--- a/docs/_plugins/heatmaps/heatmap-js.md
+++ b/docs/_plugins/heatmaps/heatmap-js.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-JavaScript Library for HTML5 canvas based heatmaps.			Its Leaflet layer implementation supports large datasets because it is tile based and uses a quadtree index to store the data.
+JavaScript Library for HTML canvas based heatmaps.			Its Leaflet layer implementation supports large datasets because it is tile based and uses a quadtree index to store the data.

--- a/docs/_plugins/heatmaps/leaflet-divheatmap.md
+++ b/docs/_plugins/heatmaps/leaflet-divheatmap.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Lightweight and versatile heatmap layer based on CSS3 and divIcons
+Lightweight and versatile heatmap layer based on CSS and divIcons

--- a/docs/_plugins/markers-renderers/leafleticonpulse.md
+++ b/docs/_plugins/markers-renderers/leafleticonpulse.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Renders pulsing icon using CSS3. It can be used for location marker.
+Renders pulsing icon using CSS. It can be used for location marker.

--- a/docs/_plugins/overlay-animations/leaflet-transitionedicon.md
+++ b/docs/_plugins/overlay-animations/leaflet-transitionedicon.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Transition in/out markers with CSS3 transitions. It supports jitter for staggering markers into view to prevent visual overload.
+Transition in/out markers with CSS transitions. It supports jitter for staggering markers into view to prevent visual overload.

--- a/docs/_plugins/overlay-data-formats/leaflet-filelayer.md
+++ b/docs/_plugins/overlay-data-formats/leaflet-filelayer.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Loads files (GeoJSON, GPX, KML) into the map using the HTML5 FileReader API (i.e. locally without server).
+Loads files (GeoJSON, GPX, KML) into the map using the HTML FileReader API (i.e. locally without server).

--- a/docs/_plugins/tile-image-display/tilelayer-boundarycanvas.md
+++ b/docs/_plugins/tile-image-display/tilelayer-boundarycanvas.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-Allows you to draw tile layers with arbitrary polygonal boundary. HTML5 Canvas is used for rendering.
+Allows you to draw tile layers with arbitrary polygonal boundary. HTML Canvas is used for rendering.

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@ L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 L.marker([51.5, -0.09]).addTo(map)
-    .bindPopup('A pretty CSS3 popup.&lt;br&gt; Easily customizable.')
+    .bindPopup('A pretty CSS popup.&lt;br&gt; Easily customizable.')
     .openPopup();</code></pre>
 
 <p>Learn more with the <a href="examples/quick-start/">quick start guide</a>, check out <a href="examples.html">other tutorials</a>,
@@ -110,7 +110,7 @@ If you have any questions, take a look at the <a href="https://github.com/Leafle
         <h3>Customization Features</h3>
 
         <ul>
-            <li>Pure CSS3 popups and controls <span class="quiet">for easy restyling</span></li>
+            <li>Pure CSS popups and controls <span class="quiet">for easy restyling</span></li>
             <li>Image- and HTML-based markers</li>
             <li><span class="quiet">A simple interface for</span> custom map layers and controls</li>
             <li>Custom map projections <span class="quiet">(with <code>EPSG:3857/4326/3395</code> out of the box)</span></li>
@@ -123,7 +123,7 @@ If you have any questions, take a look at the <a href="https://github.com/Leafle
 
         <ul>
             <li>Hardware acceleration on mobile <span class="quiet"> makes it feel as smooth as native apps</span></li>
-            <li>Utilizing CSS3 features <span class="quiet">to make panning and zooming really smooth</span></li>
+            <li>Utilizing CSS features <span class="quiet">to make panning and zooming really smooth</span></li>
             <li>Smart polyline/polygon rendering <span class="quiet">with dynamic clipping and simplification makes it very fast</span></li>
             <li>Modular build system<span class="quiet"> for leaving out features you don't need</span></li>
             <li>Tap delay elimination on mobile</li>
@@ -217,6 +217,6 @@ and spreading the word about Leaflet among your colleagues and friends.</p>
 
 	L.marker([51.504, -0.159])
 		.addTo(map)
-		.bindPopup('A pretty CSS3 popup.<br />Easily customizable.')
+		.bindPopup('A pretty CSS popup.<br />Easily customizable.')
 		.openPopup();
 </script>

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -7,7 +7,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  * @class PosAnimation
  * @aka L.PosAnimation
  * @inherits Evented
- * Used internally for panning animations, utilizing CSS3 Transitions for modern browsers and a timer fallback for IE6-9.
+ * Used internally for panning animations, utilizing CSS Transitions for modern browsers and a timer fallback for IE6-9.
  *
  * @example
  * ```js

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -10,7 +10,7 @@ import * as Util from '../core/Util.js';
  * Used to load and display a video player over specific bounds of the map. Extends `ImageOverlay`.
  *
  * A video overlay uses the [`<video>`](https://developer.mozilla.org/docs/Web/HTML/Element/video)
- * HTML5 element.
+ * HTML element.
  *
  * @example
  *

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -78,7 +78,7 @@ export const Map = Evented.extend({
 		// @section Animation Options
 		// @option zoomAnimation: Boolean = true
 		// Whether the map zoom animation is enabled. By default it's enabled
-		// in all browsers that support CSS3 Transitions except Android.
+		// in all browsers that support CSS Transitions except Android.
 		zoomAnimation: true,
 
 		// @option zoomAnimationThreshold: Number = 4
@@ -87,13 +87,13 @@ export const Map = Evented.extend({
 
 		// @option fadeAnimation: Boolean = true
 		// Whether the tile fade animation is enabled. By default it's enabled
-		// in all browsers that support CSS3 Transitions except Android.
+		// in all browsers that support CSS Transitions except Android.
 		fadeAnimation: true,
 
 		// @option markerZoomAnimation: Boolean = true
 		// Whether markers animate their zoom with the zoom animation, if disabled
 		// they will disappear for the length of the animation. By default it's
-		// enabled in all browsers that support CSS3 Transitions except Android.
+		// enabled in all browsers that support CSS Transitions except Android.
 		markerZoomAnimation: true,
 
 		// @option transform3DLimit: Number = 2^23


### PR DESCRIPTION
- Use HTML and CSS terminology instead of HTML5 and CSS3.

- Part of a larger cleanup to use evergreen language. Addresses first task of #8477.