### PR TITLE
Mapbox tiles not loading 8960

### DIFF
--- a/docs/examples/layers-control/example.md
+++ b/docs/examples/layers-control/example.md
@@ -13,7 +13,7 @@ const osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 });
 
-const streets = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+const osmHOT = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
 });
@@ -26,7 +26,7 @@ const map = L.map('map', {
 
 const baseLayers = {
 	'OpenStreetMap': osm,
-	'Streets': streets
+	'OpenStreetMap.HOT': osmHOT
 };
 
 const overlays = {
@@ -40,10 +40,10 @@ const rubyHill = L.marker([39.68, -105.00]).bindPopup('This is Ruby Hill Park.')
 
 const parks = L.layerGroup([crownHill, rubyHill]);
 
-const satellite = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+const openTopoMap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
 });
-layerControl.addBaseLayer(satellite, 'Satellite');
+layerControl.addBaseLayer(openTopoMap, 'OpenTopoMap');
 layerControl.addOverlay(parks, 'Parks');
 </script>

--- a/docs/examples/layers-control/example.md
+++ b/docs/examples/layers-control/example.md
@@ -3,45 +3,47 @@ layout: tutorial_frame
 title: Layers Control Tutorial
 ---
 <script>
-	const cities = L.layerGroup();
+const cities = L.layerGroup();
+const mLittleton = L.marker([39.61, -105.02]).bindPopup('This is Littleton, CO.').addTo(cities);
+const mDenver = L.marker([39.74, -104.99]).bindPopup('This is Denver, CO.').addTo(cities);
+const mAurora = L.marker([39.73, -104.8]).bindPopup('This is Aurora, CO.').addTo(cities);
+const mGolden = L.marker([39.77, -105.23]).bindPopup('This is Golden, CO.').addTo(cities);
+const osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	maxZoom: 19,
+	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+});
 
-	const mLittleton = L.marker([39.61, -105.02]).bindPopup('This is Littleton, CO.').addTo(cities);
-	const mDenver = L.marker([39.74, -104.99]).bindPopup('This is Denver, CO.').addTo(cities);
-	const mAurora = L.marker([39.73, -104.8]).bindPopup('This is Aurora, CO.').addTo(cities);
-	const mGolden = L.marker([39.77, -105.23]).bindPopup('This is Golden, CO.').addTo(cities);
+const streets = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+	maxZoom: 19,
+	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
+});
 
-	const mbAttr = 'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>';
-	const mbUrl = 'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw';
- 
-	const streets = L.tileLayer(mbUrl, {id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mbAttr});
+const map = L.map('map', {
+	center: [39.73, -104.99],
+	zoom: 10,
+	layers: [osm, cities]
+});
 
-	const osm = L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-		maxZoom: 19,
-		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-	});
+const baseLayers = {
+	'OpenStreetMap': osm,
+	'Streets': streets
+};
 
-	const map = L.map('map', {
-		center: [39.73, -104.99],
-		zoom: 10,
-		layers: [osm, cities]
-	});
+const overlays = {
+	'Cities': cities
+};
 
-	const baseLayers = {
-		'OpenStreetMap': osm,
-		'Streets': streets
-	};
+const layerControl = L.control.layers(baseLayers, overlays).addTo(map);
 
-	const overlays = {
-		'Cities': cities
-	};
+const crownHill = L.marker([39.75, -105.09]).bindPopup('This is Crown Hill Park.');
+const rubyHill = L.marker([39.68, -105.00]).bindPopup('This is Ruby Hill Park.');
 
-	const layerControl = L.control.layers(baseLayers, overlays).addTo(map);
-	const crownHill = L.marker([39.75, -105.09]).bindPopup('This is Crown Hill Park.');
-	const rubyHill = L.marker([39.68, -105.00]).bindPopup('This is Ruby Hill Park.');
+const parks = L.layerGroup([crownHill, rubyHill]);
 
-	const parks = L.layerGroup([crownHill, rubyHill]);
-
-	const satellite = L.tileLayer(mbUrl, {id: 'mapbox/satellite-v9', tileSize: 512, zoomOffset: -1, attribution: mbAttr});
-	layerControl.addBaseLayer(satellite, 'Satellite');
-	layerControl.addOverlay(parks, 'Parks');
+const satellite = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+	maxZoom: 19,
+	attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+});
+layerControl.addBaseLayer(satellite, 'Satellite');
+layerControl.addOverlay(parks, 'Parks');
 </script>

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -28,7 +28,7 @@ Easy enough! Now you have a `cities` layer that combines your city markers into 
 
 Leaflet has a nice little control that allows your users to control which layers they see on your map. In addition to showing you how to use it, we'll also show you another handy use for layer groups.
 
-There are two types of layers: (1) base layers that are mutually exclusive (only one can be visible on your map at a time), e.g. tile layers, and (2) overlays, which are all the other stuff you put over the base layers. In this example, we want to have two base layers (a grayscale and a colored base map) to switch between, and an overlay to switch on and off: the city markers we created earlier.
+There are two types of layers: (1) base layers that are mutually exclusive (only one can be visible on your map at a time), e.g. tile layers, and (2) overlays, which are all the other stuff you put over the base layers. In this example, we want to have two base layers (OpenStreetMap 'osm' and Streets base map) to switch between, and an overlay to switch on and off: the city markers we created earlier.
 
 Now let's create those base layers and add the default ones to the map:
 
@@ -37,7 +37,9 @@ Now let's create those base layers and add the default ones to the map:
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 });
 
-var streets = L.tileLayer(mapboxUrl, {id: 'mapbox/streets-v11', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
+var streets = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+	maxZoom: 19,
+	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'});
 
 var map = L.map('map', {
 	center: [39.73, -104.99],
@@ -49,7 +51,7 @@ Next, we'll create two objects. One will contain our base layers and one will co
 
 <pre><code>var baseMaps = {
 	"OpenStreetMap": osm,
-	"Mapbox Streets": streets
+	"Streets": streets
 };
 
 var overlayMaps = {
@@ -67,10 +69,14 @@ Also note that when using multiple base layers, only one of them should be added
 You can also style the keys when you define the objects for the layers. For example, this code will make the label for the grayscale map gray:
 
 <pre><code>var baseMaps = {
-	"&lt;span style='color: gray'&gt;Grayscale&lt;/span&gt;": grayscale,
+	"&lt;span style='color: gray'&gt;OpenStreetMap&lt;/span&gt;": grayscale,
 	"Streets": streets
 };
 </code></pre>
+
+When adding stylings you need to reload the layerControl:
+
+<pre><code>var layerControl = L.control.layers(baseMaps, overlayMaps).addTo(map);</code></pre>
 
 Finally, you can add or remove base layers or overlays dynamically:
 
@@ -78,7 +84,10 @@ Finally, you can add or remove base layers or overlays dynamically:
     rubyHill = L.marker([39.68, -105.00]).bindPopup('This is Ruby Hill Park.');
     
 var parks = L.layerGroup([crownHill, rubyHill]);
-var satellite = L.tileLayer(mapboxUrl, {id: '<a href="https://mapbox.com">MapID</a>', tileSize: 512, zoomOffset: -1, attribution: mapboxAttribution});
+var satellite = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+	maxZoom: 19,
+	attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
+});
 
 layerControl.addBaseLayer(satellite, "Satellite");
 layerControl.addOverlay(parks, "Parks");

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -28,7 +28,7 @@ Easy enough! Now you have a `cities` layer that combines your city markers into 
 
 Leaflet has a nice little control that allows your users to control which layers they see on your map. In addition to showing you how to use it, we'll also show you another handy use for layer groups.
 
-There are two types of layers: (1) base layers that are mutually exclusive (only one can be visible on your map at a time), e.g. tile layers, and (2) overlays, which are all the other stuff you put over the base layers. In this example, we want to have two base layers (OpenStreetMap 'osm' and Streets base map) to switch between, and an overlay to switch on and off: the city markers we created earlier.
+There are two types of layers: (1) base layers that are mutually exclusive (only one can be visible on your map at a time), e.g. tile layers, and (2) overlays, which are all the other stuff you put over the base layers. In this example, we want to have two base layers (OpenStreetMap 'osm' and OpenStreetMap.Hot `osmHOT` base map) to switch between, and an overlay to switch on and off: the city markers we created earlier.
 
 Now let's create those base layers and add the default ones to the map:
 
@@ -37,7 +37,7 @@ Now let's create those base layers and add the default ones to the map:
 	attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 });
 
-var streets = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
+var osmHOT = L.tileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'});
 
@@ -47,11 +47,11 @@ var map = L.map('map', {
 	layers: [osm, cities]
 });</code></pre>
 
-Next, we'll create two objects. One will contain our base layers and one will contain our overlays. These are just simple objects with key/value pairs. The key sets the text for the layer in the control (e.g. "Streets"), while the corresponding value is a reference to the layer (e.g. `streets`).
+Next, we'll create two objects. One will contain our base layers and one will contain our overlays. These are just simple objects with key/value pairs. The key sets the text for the layer in the control (e.g. "OpenStreetMap"), while the corresponding value is a reference to the layer (e.g. `osm`).
 
 <pre><code>var baseMaps = {
 	"OpenStreetMap": osm,
-	"Streets": streets
+	"OpenStreetMap.HOT": osmHOT
 };
 
 var overlayMaps = {
@@ -62,21 +62,17 @@ Now, all that's left to do is to create a [Layers Control](/reference.html#contr
 
 <pre><code>var layerControl = L.control.layers(baseMaps, overlayMaps).addTo(map);</code></pre>
 
-Note that we added `osm` and `cities` layers to the map but didn't add `streets`. The layers control is smart enough to detect what layers we've already added and have corresponding checkboxes and radioboxes set.
+Note that we added `osm` and `cities` layers to the map but didn't add `osmHOT`. The layers control is smart enough to detect what layers we've already added and have corresponding checkboxes and radioboxes set.
 
 Also note that when using multiple base layers, only one of them should be added to the map at instantiation, but all of them should be present in the base layers object when creating the layers control.
 
-You can also style the keys when you define the objects for the layers. For example, this code will make the label for the grayscale map gray:
+You can also style the keys when you define the objects for the layers. For example, this code will make the label for the OpenStreetMap.HOT map red:
 
 <pre><code>var baseMaps = {
-	"&lt;span style='color: gray'&gt;OpenStreetMap&lt;/span&gt;": OpenStreetMap,
-	"Streets": streets
+	"OpenStreetMap": osm,
+	"&lt;span style='color: red'&gt;OpenStreetMap.HOT&lt;/span&gt;": osmHOT
 };
 </code></pre>
-
-When adding stylings you need to reload the layerControl:
-
-<pre><code>var layerControl = L.control.layers(baseMaps, overlayMaps).addTo(map);</code></pre>
 
 Finally, you can add or remove base layers or overlays dynamically:
 
@@ -84,12 +80,12 @@ Finally, you can add or remove base layers or overlays dynamically:
     rubyHill = L.marker([39.68, -105.00]).bindPopup('This is Ruby Hill Park.');
     
 var parks = L.layerGroup([crownHill, rubyHill]);
-var satellite = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+var openTopoMap = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
 	attribution: 'Map data: &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://viewfinderpanoramas.org">SRTM</a> | Map style: &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)'
 });
 
-layerControl.addBaseLayer(satellite, "Satellite");
+layerControl.addBaseLayer(openTopoMap, "OpenTopoMap");
 layerControl.addOverlay(parks, "Parks");
 </code></pre>
 

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -69,7 +69,7 @@ Also note that when using multiple base layers, only one of them should be added
 You can also style the keys when you define the objects for the layers. For example, this code will make the label for the grayscale map gray:
 
 <pre><code>var baseMaps = {
-	"&lt;span style='color: gray'&gt;OpenStreetMap&lt;/span&gt;": grayscale,
+	"&lt;span style='color: gray'&gt;OpenStreetMap&lt;/span&gt;": OpenStreetMap,
 	"Streets": streets
 };
 </code></pre>


### PR DESCRIPTION
Fix issue #8960.

Pull request to update the [Layer Control Tutorial Page](https://leafletjs.com/examples/layers-control/). 
Updated the Satellite and Street view of the examples with titles suggested by @Falke-Design .
Changed some verbiage on the index about using a gray scale map tile as it was not being used in the example.

There was additional issue of grayscaling the mapbox legend as the lint rules do not allow double quotations on the styling so it was left out of the example.md file.
![Screenshot 2023-05-23 at 1 27 54 PM](https://github.com/Leaflet/Leaflet/assets/18320363/ffee64b8-5c1b-4520-a5ff-52902f56fb8b)
