### PR TITLE
Import Leaflet in tests using JavaScript modules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,7 +43,8 @@ module.exports = {
 		// TODO: Re-enable the rules below and fix the linting issues.
 		'no-invalid-this': 'off',
 		'prefer-object-has-own': 'error',
-		'prefer-spread': 'off'
+		'prefer-spread': 'off',
+		'no-new': 'off'
 	},
 	overrides: [
 		{
@@ -71,8 +72,7 @@ module.exports = {
 				'*.html'
 			],
 			rules: {
-				'eol-last': 'off',
-				'no-new': 'off'
+				'eol-last': 'off'
 			}
 		}
 	]

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -8,14 +8,10 @@ module.exports = {
 		mocha: true,
 	},
 	globals: {
-		L: true,
 		expect: false,
 		chai: false,
 		sinon: false,
 		UIEventSimulator: false,
 		Hand: false,
-		touchEventType: false, /* defined in SpecHelper.js */
-		createContainer: false, /* defined in SpecHelper.js */
-		removeMapContainer: false /* defined in SpecHelper.js */
 	}
 };

--- a/spec/after.js
+++ b/spec/after.js
@@ -1,1 +1,0 @@
-L.Icon.Default.imagePath = '/base/dist/images/';

--- a/spec/context.html
+++ b/spec/context.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!--
+This is the execution context.
+Loaded within the iframe.
+Reloaded before every execution run.
+-->
+<html>
+<head>
+  <title></title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <script type="importmap">
+    {
+      "imports": {
+        "leaflet": "/base/dist/leaflet-src.esm.js"
+      }
+    }
+  </script>
+</head>
+<body>
+  <!-- The scripts need to be in the body DOM element, as some test running frameworks need the body
+       to have already been created so they can insert their magic into it. For example, if loaded
+       before body, Angular Scenario test framework fails to find the body and crashes and burns in
+       an epic manner. -->
+  <script src="context.js"></script>
+  <script type="text/javascript">
+    // Configure our Karma and set up bindings
+    %CLIENT_CONFIG%
+    window.__karma__.setupContext(window);
+
+    // All served files with the latest timestamps
+    %MAPPINGS%
+  </script>
+  <!-- Dynamically replaced with <script> tags -->
+  %SCRIPTS%
+  <!-- Since %SCRIPTS% might include modules, the `loaded()` call needs to be in a module too.
+   This ensures all the tests will have been declared before karma tries to run them. -->
+  <script type="module">
+    window.__karma__.loaded();
+  </script>
+  <script nomodule>
+    window.__karma__.loaded();
+  </script>
+</body>
+</html>

--- a/spec/debug.html
+++ b/spec/debug.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<!--
+This file is almost the same as context.html - loads all source files,
+but its purpose is to be loaded in the main frame (not within an iframe),
+just for immediate execution, without reporting to Karma server.
+-->
+<html>
+<head>
+  %X_UA_COMPATIBLE%
+  <title>Karma DEBUG RUNNER</title>
+  <link href="favicon.ico" rel="icon" type="image/x-icon" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <script type="importmap">
+    {
+      "imports": {
+        "leaflet": "/base/dist/leaflet-src.esm.js"
+      }
+    }
+  </script>
+</head>
+<body>
+  <!-- The scripts need to be at the end of body, so that some test running frameworks
+   (Angular Scenario, for example) need the body to be loaded so that it can insert its magic
+   into it. If it is before body, then it fails to find the body and crashes and burns in an epic
+   manner. -->
+  <script src="context.js"></script>
+  <script src="debug.js"></script>
+  <script type="text/javascript">
+    // Configure our Karma
+    %CLIENT_CONFIG%
+
+    // All served files with the latest timestamps
+    %MAPPINGS%
+  </script>
+  <!-- Dynamically replaced with <script> tags -->
+  %SCRIPTS%
+  <!-- Since %SCRIPTS% might include modules, the `loaded()` call needs to be in a module too.
+   This ensures all the tests will have been declared before karma tries to run them. -->
+  <script type="module">
+    window.__karma__.loaded();
+  </script>
+  <script nomodule>
+    window.__karma__.loaded();
+  </script>
+</body>
+</html>

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -12,20 +12,17 @@ module.exports = function (/** @type {import('karma').Config} */ config) {
 			'karma-time-stats-reporter'
 		],
 		frameworks: ['mocha', 'sinon', 'chai'],
+		customContextFile: 'spec/context.html',
+		customDebugFile: 'spec/debug.html',
 		files: [
-			'spec/before.js',
-			{pattern: 'dist/leaflet-src.js'},
-			'spec/after.js',
 			'node_modules/ui-event-simulator/ui-event-simulator.js',
 			'node_modules/prosthetic-hand/dist/prosthetic-hand.js',
-			'spec/suites/SpecHelper.js',
-			'spec/suites/**/*.js',
-			'dist/*.css',
-			{pattern: 'dist/images/*.png', included: false, served: true}
+			{pattern: 'dist/**/*.js', included: false, served: true},
+			{pattern: 'dist/**/*.png', included: false, served: true},
+			{pattern: 'spec/setup.js', type: 'module'},
+			{pattern: 'spec/suites/**/*.js', type: 'module'},
+			{pattern: 'dist/*.css', type: 'css'},
 		],
-		proxies: {
-			'/base/dist/images/': 'dist/images/'
-		},
 		reporters: ['progress', 'time-stats'],
 		timeStatsReporter: {
 			reportTimeStats: false,

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,0 +1,3 @@
+import {Icon} from 'leaflet';
+
+Icon.Default.imagePath = '/base/dist/images/';

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -1,25 +1,28 @@
+import {point, latLng, Browser} from 'leaflet';
+
 chai.util.addMethod(chai.Assertion.prototype, 'near', function (expected, delta = 1) {
-	expected = L.point(expected);
+	expected = point(expected);
 
 	new chai.Assertion(this._obj.x).to.be.within(expected.x - delta, expected.x + delta);
 	new chai.Assertion(this._obj.y).to.be.within(expected.y - delta, expected.y + delta);
 });
 
 chai.util.addMethod(chai.Assertion.prototype, 'nearLatLng', function (expected, delta = 1e-4) {
-	expected = L.latLng(expected);
+	expected = latLng(expected);
 
 	new chai.Assertion(this._obj.lat).to.be.within(expected.lat - delta, expected.lat + delta);
 	new chai.Assertion(this._obj.lng).to.be.within(expected.lng - delta, expected.lng + delta);
 });
 
 // A couple of tests need the browser to be touch-capable
-it.skipIfNotTouch = L.Browser.touch ? it : it.skip;
+it.skipIfNotTouch = Browser.touch ? it : it.skip;
 
-const touchEventType = L.Browser.touchNative ? 'touch' : 'pointer'; // eslint-disable-line no-unused-vars
+export const touchEventType = Browser.touchNative ? 'touch' : 'pointer';
 // Note: this override is needed to workaround prosthetic-hand fail,
 //       see https://github.com/Leaflet/prosthetic-hand/issues/14
 
-function createContainer(width, height) { /* eslint-disable-line no-unused-vars */
+
+export function createContainer(width, height) {
 	width = width ? width : '400px';
 	height = height ? height : '400px';
 	const container = document.createElement('div');
@@ -34,7 +37,7 @@ function createContainer(width, height) { /* eslint-disable-line no-unused-vars 
 	return container;
 }
 
-function removeMapContainer(map, container) { /* eslint-disable-line no-unused-vars */
+export function removeMapContainer(map, container) {
 	if (map) {
 		map.remove();
 	}
@@ -43,5 +46,5 @@ function removeMapContainer(map, container) { /* eslint-disable-line no-unused-v
 	}
 }
 
-console.log('L.Browser.pointer', L.Browser.pointer);
-console.log('L.Browser.touchNative', L.Browser.touchNative);
+console.log('Browser.pointer', Browser.pointer);
+console.log('Browser.touchNative', Browser.touchNative);

--- a/spec/suites/control/Control.AttributionSpec.js
+++ b/spec/suites/control/Control.AttributionSpec.js
@@ -1,11 +1,14 @@
+import {Map, Control, Layer, control as lControl} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Control.Attribution', () => {
 	let map, control, container, controlContainer;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 
-		control = new L.Control.Attribution({
+		control = new Control.Attribution({
 			prefix: 'prefix'
 		}).addTo(map);
 		map.setView([0, 0], 1);
@@ -17,7 +20,7 @@ describe('Control.Attribution', () => {
 	});
 
 	function dummyLayer() {
-		const layer = new L.Layer();
+		const layer = new Layer();
 		layer.onAdd = function () { };
 		layer.onRemove = function () { };
 		return layer;
@@ -74,7 +77,7 @@ describe('Control.Attribution', () => {
 	describe('control.attribution factory', () => {
 		it('creates Control.Attribution instance', () => {
 			const options = {prefix: 'prefix'};
-			expect(L.control.attribution(options)).to.eql(new L.Control.Attribution(options));
+			expect(lControl.attribution(options)).to.eql(new Control.Attribution(options));
 		});
 	});
 

--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -1,9 +1,12 @@
+import {Map, TileLayer, Control, Marker, Util} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Control.Layers', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 
 		map.setView([0, 0], 14);
 	});
@@ -14,8 +17,8 @@ describe('Control.Layers', () => {
 
 	describe('baselayerchange event', () => {
 		it('is fired on input that changes the base layer', () => {
-			const baseLayers = {'Layer 1': L.tileLayer(''), 'Layer 2': L.tileLayer('')},
-			    layers = L.control.layers(baseLayers).addTo(map),
+			const baseLayers = {'Layer 1': new TileLayer(''), 'Layer 2': new TileLayer('')},
+			    layers = new Control.Layers(baseLayers).addTo(map),
 			    spy = sinon.spy();
 
 			map.on('baselayerchange', spy);
@@ -30,8 +33,8 @@ describe('Control.Layers', () => {
 		});
 
 		it('works after removing and readding the Control.Layers to the map', () => {
-			const baseLayers = {'Layer 1': L.tileLayer(''), 'Layer 2': L.tileLayer('')},
-			    layers = L.control.layers(baseLayers).addTo(map),
+			const baseLayers = {'Layer 1': new TileLayer(''), 'Layer 2': new TileLayer('')},
+			    layers = new Control.Layers(baseLayers).addTo(map),
 			    spy = sinon.spy();
 
 			map.on('baselayerchange', spy);
@@ -50,8 +53,8 @@ describe('Control.Layers', () => {
 		});
 
 		it('is not fired on input that doesn\'t change the base layer', () => {
-			const overlays = {'Marker 1': L.marker([0, 0]), 'Marker 2': L.marker([0, 0])},
-			    layers = L.control.layers({}, overlays).addTo(map),
+			const overlays = {'Marker 1': new Marker([0, 0]), 'Marker 2': new Marker([0, 0])},
+			    layers = new Control.Layers({}, overlays).addTo(map),
 			    spy = sinon.spy();
 
 			map.on('baselayerchange', spy);
@@ -63,9 +66,9 @@ describe('Control.Layers', () => {
 
 	describe('updates', () => {
 		it('when an included layer is added or removed from the map', () => {
-			const baseLayer = L.tileLayer(),
-			    overlay = L.marker([0, 0]),
-			    layers = L.control.layers({'Base': baseLayer}, {'Overlay': overlay}).addTo(map);
+			const baseLayer = new TileLayer(),
+			    overlay = new Marker([0, 0]),
+			    layers = new Control.Layers({'Base': baseLayer}, {'Overlay': overlay}).addTo(map);
 
 			const spy = sinon.spy(layers, '_update');
 
@@ -77,9 +80,9 @@ describe('Control.Layers', () => {
 		});
 
 		it('when an included layer is added or removed from the map, it\'s (un)checked', () => {
-			const baseLayer = L.tileLayer(),
-			    overlay = L.marker([0, 0]);
-			L.control.layers({'Baselayer': baseLayer}, {'Overlay': overlay}).addTo(map);
+			const baseLayer = new TileLayer(),
+			    overlay = new Marker([0, 0]);
+			new Control.Layers({'Baselayer': baseLayer}, {'Overlay': overlay}).addTo(map);
 
 			function isChecked() {
 				return !!(map._container.querySelector('.leaflet-control-layers-overlays input').checked);
@@ -93,9 +96,9 @@ describe('Control.Layers', () => {
 		});
 
 		it('not when a non-included layer is added or removed', () => {
-			const baseLayer = L.tileLayer(),
-			    overlay = L.marker([0, 0]),
-			    layers = L.control.layers({'Base': baseLayer}).addTo(map);
+			const baseLayer = new TileLayer(),
+			    overlay = new Marker([0, 0]),
+			    layers = new Control.Layers({'Base': baseLayer}).addTo(map);
 
 			const spy = sinon.spy(layers, '_update');
 
@@ -106,9 +109,9 @@ describe('Control.Layers', () => {
 		});
 
 		it('updates when an included layer is removed from the control', () => {
-			const baseLayer = L.tileLayer(),
-			    overlay = L.marker([0, 0]),
-			    layers = L.control.layers({'Base': baseLayer}, {'Overlay': overlay}).addTo(map);
+			const baseLayer = new TileLayer(),
+			    overlay = new Marker([0, 0]),
+			    layers = new Control.Layers({'Base': baseLayer}, {'Overlay': overlay}).addTo(map);
 
 			layers.removeLayer(overlay);
 			expect(map._container.querySelector('.leaflet-control-layers-overlays').children.length)
@@ -116,19 +119,19 @@ describe('Control.Layers', () => {
 		});
 
 		it('silently returns when trying to remove a non-existing layer from the control', () => {
-			const layers = L.control.layers({'base': L.tileLayer()}).addTo(map);
+			const layers = new Control.Layers({'base': new TileLayer()}).addTo(map);
 
 			expect(() => {
-				layers.removeLayer(L.marker([0, 0]));
+				layers.removeLayer(new Marker([0, 0]));
 			}).to.not.throw();
 
 			expect(layers._layers.length).to.be.equal(1);
 		});
 
 		it('having repeated layers works as expected', () => {
-			const layerA = L.tileLayer(''), layerB = L.tileLayer(''),
+			const layerA = new TileLayer(''), layerB = new TileLayer(''),
 			    baseLayers = {'Layer 1': layerA, 'Layer 2': layerB, 'Layer 3': layerA},
-			    layers = L.control.layers(baseLayers).addTo(map);
+			    layers = new Control.Layers(baseLayers).addTo(map);
 
 			function checkInputs(idx) {
 				const inputs = map._container.querySelectorAll('.leaflet-control-layers-base input');
@@ -139,23 +142,23 @@ describe('Control.Layers', () => {
 
 			UIEventSimulator.fire('click', layers._baseLayersList.getElementsByTagName('input')[1]);
 			checkInputs(1);
-			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(layerB);
-			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(undefined);
+			expect(map._layers[Util.stamp(layerB)]).to.be.equal(layerB);
+			expect(map._layers[Util.stamp(layerA)]).to.be.equal(undefined);
 			UIEventSimulator.fire('click', layers._baseLayersList.getElementsByTagName('input')[0]);
 			checkInputs(0);
-			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(layerA);
-			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(undefined);
+			expect(map._layers[Util.stamp(layerA)]).to.be.equal(layerA);
+			expect(map._layers[Util.stamp(layerB)]).to.be.equal(undefined);
 			UIEventSimulator.fire('click', layers._baseLayersList.getElementsByTagName('input')[2]);
 			checkInputs(2);
-			expect(map._layers[L.Util.stamp(layerA)]).to.be.equal(layerA);
-			expect(map._layers[L.Util.stamp(layerB)]).to.be.equal(undefined);
+			expect(map._layers[Util.stamp(layerA)]).to.be.equal(layerA);
+			expect(map._layers[Util.stamp(layerB)]).to.be.equal(undefined);
 		});
 	});
 
 	describe('is removed cleanly', () => {
 		it('and layers in the control can still be removed', () => {
-			const baseLayer = L.tileLayer('').addTo(map);
-			const layersCtrl = L.control.layers({'Base': baseLayer}).addTo(map);
+			const baseLayer = new TileLayer('').addTo(map);
+			const layersCtrl = new Control.Layers({'Base': baseLayer}).addTo(map);
 			map.removeControl(layersCtrl);
 
 			expect(() => {
@@ -164,8 +167,8 @@ describe('Control.Layers', () => {
 		});
 
 		it('and layers in the control can still be removed when added after removing control from map', () => {
-			const baseLayer = L.tileLayer('').addTo(map);
-			const layersCtrl = L.control.layers().addTo(map);
+			const baseLayer = new TileLayer('').addTo(map);
+			const layersCtrl = new Control.Layers().addTo(map);
 			map.removeControl(layersCtrl);
 			layersCtrl.addBaseLayer(baseLayer, 'Base');
 
@@ -177,52 +180,52 @@ describe('Control.Layers', () => {
 
 	describe('is created with an expand link', ()  => {
 		it('when collapsed', () => {
-			L.control.layers(null, null, {collapsed: true}).addTo(map);
+			new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			expect(map._container.querySelector('.leaflet-control-layers-toggle')).to.be.ok;
 		});
 
 		it('when not collapsed', () => {
-			L.control.layers(null, null, {collapsed: false}).addTo(map);
+			new Control.Layers(null, null, {collapsed: false}).addTo(map);
 			expect(map._container.querySelector('.leaflet-control-layers-toggle')).to.be.ok;
 		});
 	});
 
 	describe('collapse when collapsed: true', () => {
 		it('expands on "Enter" keydown when toggle is focused', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			const toggle = layersCtrl._container.querySelector('.leaflet-control-layers-toggle');
 			UIEventSimulator.fire('keydown', toggle, {code: 'Enter'});
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 		});
 
 		it('expands on click', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			const toggle = layersCtrl._container.querySelector('.leaflet-control-layers-toggle');
 			UIEventSimulator.fire('click', toggle);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 		});
 
 		it('does not expand on "Enter" keydown when toggle is not focused', () => {
-			L.control.layers(null, null, {collapsed: true}).addTo(map);
+			new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			UIEventSimulator.fire('keydown', document, {code:'Enter'});
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.null;
 		});
 
 		it('expands when mouse is over', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			UIEventSimulator.fire('mouseover', layersCtrl._container);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 		});
 
 		it('collapses when mouse is out', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			UIEventSimulator.fire('mouseover', layersCtrl._container);
 			UIEventSimulator.fire('mouseout', layersCtrl._container);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.null;
 		});
 
 		it('collapses when map is clicked', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: true}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: true}).addTo(map);
 			UIEventSimulator.fire('mouseover', layersCtrl._container);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 			UIEventSimulator.fire('click', map._container);
@@ -232,7 +235,7 @@ describe('Control.Layers', () => {
 
 	describe('does not collapse when collapsed: false', () => {
 		it('does not collapse when mouse enters or leaves', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: false}).addTo(map);
+			const layersCtrl = new Control.Layers(null, null, {collapsed: false}).addTo(map);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 			UIEventSimulator.fire('mouseover', layersCtrl._container);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
@@ -241,25 +244,25 @@ describe('Control.Layers', () => {
 		});
 
 		it('does not collapse when map is clicked', () => {
-			L.control.layers(null, null, {collapsed: false}).addTo(map);
+			new Control.Layers(null, null, {collapsed: false}).addTo(map);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 			UIEventSimulator.fire('click', map._container);
 			expect(map._container.querySelector('.leaflet-control-layers-expanded')).to.be.ok;
 		});
 
 		it('is scrollable if necessary when added on map', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: false});
+			const layersCtrl = new Control.Layers(null, null, {collapsed: false});
 			let i = 0;
 
 			// Need to create a DIV with specified height and insert it into DOM, so that the browser
 			// gives it an actual size.
 			map.remove();
 			container.style.height = container.style.width = '200px';
-			map = L.map(container);
+			map = new Map(container);
 
 			for (; i < 20; i += 1) {
 				// Default text size: 12px => 12 * 20 = 240px height (not even considering padding/margin).
-				layersCtrl.addOverlay(L.marker([0, 0]), i);
+				layersCtrl.addOverlay(new Marker([0, 0]), i);
 			}
 
 			layersCtrl.addTo(map);
@@ -270,21 +273,21 @@ describe('Control.Layers', () => {
 		});
 
 		it('becomes scrollable if necessary when too many layers are added while it is already on map', () => {
-			const layersCtrl = L.control.layers(null, null, {collapsed: false});
+			const layersCtrl = new Control.Layers(null, null, {collapsed: false});
 			let i = 0;
 
 			// Need to create a DIV with specified height and insert it into DOM, so that the browser
 			// gives it an actual size.
 			map.remove();
 			container.style.height = container.style.width = '200px';
-			map = L.map(container);
+			map = new Map(container);
 
 			layersCtrl.addTo(map);
 			expect(layersCtrl._section.classList.contains('leaflet-control-layers-scrollbar')).to.be.false;
 
 			for (; i < 20; i += 1) {
 				// Default text size: 12px => 12 * 20 = 240px height (not even considering padding/margin).
-				layersCtrl.addOverlay(L.marker([0, 0]), i);
+				layersCtrl.addOverlay(new Marker([0, 0]), i);
 			}
 
 			expect(container.clientHeight).to.be.greaterThan(layersCtrl._container.clientHeight);
@@ -294,13 +297,13 @@ describe('Control.Layers', () => {
 
 	describe('sortLayers', () => {
 		it('keeps original order by default', () => {
-			const baseLayerOne = L.tileLayer('').addTo(map);
-			const baseLayerTwo = L.tileLayer('').addTo(map);
-			const markerC = L.marker([0, 2]).addTo(map);
-			const markerB = L.marker([0, 1]).addTo(map);
-			const markerA = L.marker([0, 0]).addTo(map);
+			const baseLayerOne = new TileLayer('').addTo(map);
+			const baseLayerTwo = new TileLayer('').addTo(map);
+			const markerC = new Marker([0, 2]).addTo(map);
+			const markerB = new Marker([0, 1]).addTo(map);
+			const markerA = new Marker([0, 0]).addTo(map);
 
-			L.control.layers({
+			new Control.Layers({
 				'Base One': baseLayerOne,
 				'Base Two': baseLayerTwo
 			}, {
@@ -318,13 +321,13 @@ describe('Control.Layers', () => {
 		});
 
 		it('sorts alphabetically if no function is specified', () => {
-			const baseLayerOne = L.tileLayer('').addTo(map);
-			const baseLayerTwo = L.tileLayer('').addTo(map);
-			const markerA = L.marker([0, 0]).addTo(map);
-			const markerB = L.marker([0, 1]).addTo(map);
-			const markerC = L.marker([0, 2]).addTo(map);
+			const baseLayerOne = new TileLayer('').addTo(map);
+			const baseLayerTwo = new TileLayer('').addTo(map);
+			const markerA = new Marker([0, 0]).addTo(map);
+			const markerB = new Marker([0, 1]).addTo(map);
+			const markerC = new Marker([0, 2]).addTo(map);
 
-			L.control.layers({
+			new Control.Layers({
 				'Base Two': baseLayerTwo,
 				'Base One': baseLayerOne
 			}, {
@@ -344,13 +347,13 @@ describe('Control.Layers', () => {
 		});
 
 		it('uses the compare function to sort layers', () => {
-			const baseLayerOne = L.tileLayer('', {customOption: 999}).addTo(map);
-			const baseLayerTwo = L.tileLayer('', {customOption: 998}).addTo(map);
-			const markerA = L.marker([0, 0], {customOption: 102}).addTo(map);
-			const markerB = L.marker([0, 1], {customOption: 100}).addTo(map);
-			const markerC = L.marker([0, 2], {customOption: 101}).addTo(map);
+			const baseLayerOne = new TileLayer('', {customOption: 999}).addTo(map);
+			const baseLayerTwo = new TileLayer('', {customOption: 998}).addTo(map);
+			const markerA = new Marker([0, 0], {customOption: 102}).addTo(map);
+			const markerB = new Marker([0, 1], {customOption: 100}).addTo(map);
+			const markerC = new Marker([0, 2], {customOption: 101}).addTo(map);
 
-			L.control.layers({
+			new Control.Layers({
 				'Base One': baseLayerOne,
 				'Base Two': baseLayerTwo
 			}, {

--- a/spec/suites/control/Control.ScaleSpec.js
+++ b/spec/suites/control/Control.ScaleSpec.js
@@ -1,6 +1,8 @@
+import {Map, Control} from 'leaflet';
+
 describe('Control.Scale', () => {
 	it('can be added to an unloaded map', () => {
-		const map = L.map(document.createElement('div'));
-		new L.Control.Scale().addTo(map);
+		const map = new Map(document.createElement('div'));
+		new Control.Scale().addTo(map);
 	});
 });

--- a/spec/suites/control/ControlSpec.js
+++ b/spec/suites/control/ControlSpec.js
@@ -1,6 +1,9 @@
+import {DomUtil, Map, Control} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Control', () => {
 	function onAdd() {
-		return L.DomUtil.create('div', 'leaflet-test-control');
+		return DomUtil.create('div', 'leaflet-test-control');
 	}
 
 	let map,
@@ -9,10 +12,10 @@ describe('Control', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 
 		map.setView([0, 0], 1);
-		control = new L.Control();
+		control = new Control();
 		control.onAdd = onAdd;
 		control.addTo(map);
 	});
@@ -46,7 +49,7 @@ describe('Control', () => {
 		});
 
 		it('is a no-op if the control has not been added', () => {
-			const control = new L.Control();
+			const control = new Control();
 			expect(control.remove()).to.equal(control);
 		});
 	});

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -1,4 +1,5 @@
-/* eslint no-new: 0 */
+import {Class} from 'leaflet';
+
 describe('Class', () => {
 	describe('#extend', () => {
 		let Klass,
@@ -18,7 +19,7 @@ describe('Class', () => {
 				foo: 5,
 				bar: method
 			};
-			Klass = L.Class.extend(props);
+			Klass = Class.extend(props);
 		});
 
 		it('creates a class with the given constructor & properties', () => {
@@ -89,7 +90,7 @@ describe('Class', () => {
 		});
 
 		it('includes multiple mixins', () => {
-			const Klass2 = L.Class.extend({
+			const Klass2 = Class.extend({
 				includes: [{mixin: true}, {mixin2: true}]
 			});
 			const a = new Klass2();
@@ -106,7 +107,7 @@ describe('Class', () => {
 		});
 
 		it('merges options instead of replacing them', () => {
-			const KlassWithOptions1 = L.Class.extend({
+			const KlassWithOptions1 = Class.extend({
 				options: {
 					foo1: 1,
 					foo2: 2
@@ -126,13 +127,13 @@ describe('Class', () => {
 		});
 
 		it('gives new classes a distinct options object', () => {
-			const K1 = L.Class.extend({options: {}});
+			const K1 = Class.extend({options: {}});
 			const K2 = K1.extend({});
 			expect(K2.prototype.options).not.to.equal(K1.prototype.options);
 		});
 
 		it('inherits options prototypally', () => {
-			const K1 = L.Class.extend({options: {}});
+			const K1 = Class.extend({options: {}});
 			const K2 = K1.extend({options: {}});
 			K1.prototype.options.foo = 'bar';
 			expect(K2.prototype.options.foo).to.eql('bar');
@@ -140,13 +141,13 @@ describe('Class', () => {
 
 		it('does not reuse original props.options', () => {
 			const props = {options: {}};
-			const K = L.Class.extend(props);
+			const K = Class.extend(props);
 
 			expect(K.prototype.options).not.to.equal(props.options);
 		});
 
 		it('does not replace source props.options object', () => {
-			const K1 = L.Class.extend({options: {}});
+			const K1 = Class.extend({options: {}});
 			const opts = {};
 			const props = {options: opts};
 			K1.extend(props);
@@ -155,7 +156,7 @@ describe('Class', () => {
 		});
 
 		it('prevents change of prototype options', () => {
-			const Klass = L.Class.extend({options: {}});
+			const Klass = Class.extend({options: {}});
 			const instance = new Klass();
 			expect(Klass.prototype.options).to.not.equal(instance.options);
 		});
@@ -218,7 +219,7 @@ describe('Class', () => {
 		let Klass;
 
 		beforeEach(() => {
-			Klass = L.Class.extend({});
+			Klass = Class.extend({});
 		});
 
 		it('returns the class with the extra methods', () => {
@@ -239,7 +240,7 @@ describe('Class', () => {
 
 		it('keeps parent options', () => { // #6070
 
-			const Quux = L.Class.extend({
+			const Quux = Class.extend({
 				options: {foo: 'Foo!'}
 			});
 

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -1,7 +1,9 @@
+import {Evented, Class, Util, FeatureGroup, Marker} from 'leaflet';
+
 describe('Events', () => {
 	describe('#fireEvent', () => {
 		it('fires all listeners added through #addEventListener', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    spy3 = sinon.spy(),
@@ -34,9 +36,9 @@ describe('Events', () => {
 		});
 
 		it('fires all listeners in the order they are added', () => {
-			const obj = new L.Evented(),
-			    ctx1 = new L.Class(),
-			    ctx2 = new L.Class(),
+			const obj = new Evented(),
+			    ctx1 = new Class(),
+			    ctx2 = new Class(),
 			    count = {one: 0, two: 0, three: 0, four: 0};
 
 			function listener1() {
@@ -90,10 +92,10 @@ describe('Events', () => {
 		});
 
 		it('provides event object to listeners and executes them in the right context', () => {
-			const obj = new L.Evented(),
-			    obj2 = new L.Evented(),
-			    obj3 = new L.Evented(),
-			    obj4 = new L.Evented(),
+			const obj = new Evented(),
+			    obj2 = new Evented(),
+			    obj3 = new Evented(),
+			    obj4 = new Evented(),
 			    foo = {};
 
 			function listener1(e) {
@@ -136,7 +138,7 @@ describe('Events', () => {
 		});
 
 		it('calls no listeners removed through #removeEventListener', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    spy3 = sinon.spy(),
@@ -174,7 +176,7 @@ describe('Events', () => {
 		});
 
 		it('can handle calls to #removeEventListener on objects with no registered event listeners', () => {
-			const obj = new L.Evented();
+			const obj = new Evented();
 			const removeNonExistentListener = function () {
 				obj.removeEventListener('test');
 			};
@@ -183,12 +185,12 @@ describe('Events', () => {
 
 		// added due to context-sensitive removeListener optimization
 		it('fires multiple listeners with the same context with id', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    foo = {};
 
-			L.Util.stamp(foo);
+			Util.stamp(foo);
 
 			obj.addEventListener('test', spy1, foo);
 			obj.addEventListener('test', spy2, foo);
@@ -200,12 +202,12 @@ describe('Events', () => {
 		});
 
 		it('removes listeners with stamped contexts', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    foo = {};
 
-			L.Util.stamp(foo);
+			Util.stamp(foo);
 
 			obj.addEventListener('test', spy1, foo);
 			obj.addEventListener('test', spy2, foo);
@@ -219,13 +221,13 @@ describe('Events', () => {
 		});
 
 		it('removes listeners with a stamp originally added without one', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    foo = {};
 
 			obj.addEventListener('test', spy1, foo);
-			L.Util.stamp(foo);
+			Util.stamp(foo);
 			obj.addEventListener('test', spy2, foo);
 
 			obj.removeEventListener('test', spy1, foo);
@@ -238,14 +240,14 @@ describe('Events', () => {
 		});
 
 		it('removes listeners with context == this and a stamp originally added without one', () => {
-			const obj = new L.Evented(),
-			    obj2 = new L.Evented(),
+			const obj = new Evented(),
+			    obj2 = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    spy3 = sinon.spy();
 
 			obj.addEventListener('test', spy1, obj);
-			L.Util.stamp(obj);
+			Util.stamp(obj);
 			obj.addEventListener('test', spy2, obj);
 			obj.addEventListener('test', spy3, obj2); // So that there is a contextId based listener, otherwise removeEventListener will do correct behaviour anyway
 
@@ -261,14 +263,14 @@ describe('Events', () => {
 		});
 
 		it('doesnt lose track of listeners when removing non existent ones', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    foo = {},
 			    foo2 = {};
 
-			L.Util.stamp(foo);
-			L.Util.stamp(foo2);
+			Util.stamp(foo);
+			Util.stamp(foo2);
 
 			obj.addEventListener('test', spy, foo2);
 
@@ -283,7 +285,7 @@ describe('Events', () => {
 		});
 
 		it('correctly removes all listeners if given no fn', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    foo2 = {},
 			    foo3 = {};
@@ -309,7 +311,7 @@ describe('Events', () => {
 		});
 
 		it('makes sure an event is not triggered if a listener is removed during dispatch', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    spy2 = sinon.spy(),
 			    foo = {};
@@ -328,7 +330,7 @@ describe('Events', () => {
 		});
 
 		it('makes sure an event is not triggered if all listeners are removed during dispatch', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.addEventListener('test', () => { obj.removeEventListener('test'); });
@@ -339,7 +341,7 @@ describe('Events', () => {
 		});
 
 		it('handles reentrant event firing', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy();
 
@@ -359,7 +361,7 @@ describe('Events', () => {
 		});
 
 		it('can remove an event listener while firing', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			const removeSpy = function () {
@@ -379,8 +381,8 @@ describe('Events', () => {
 
 	describe('#on, #off & #fire', () => {
 		it('does not remove all listeners when any fn argument specified', () => {
-			const obj = new L.Evented();
-			obj.on('test', L.Util.falseFn);
+			const obj = new Evented();
+			obj.on('test', Util.falseFn);
 			obj.off('test', undefined);
 			obj.off({test: undefined});
 
@@ -388,7 +390,7 @@ describe('Events', () => {
 		});
 
 		it('ignores non-function listeners passed', () => {
-			const obj = new L.Evented();
+			const obj = new Evented();
 			const off = obj.off.bind(obj);
 			['string', {}, [], true, false, undefined].forEach((fn) => {
 				obj.on('test', fn);
@@ -398,20 +400,20 @@ describe('Events', () => {
 		});
 
 		it('throws with wrong types passed', () => {
-			const obj = new L.Evented();
+			const obj = new Evented();
 			const on = obj.on.bind(obj);
 			const off = obj.off.bind(obj);
 			// todo? make it throw  with []
 			[true, false, undefined, 1].forEach((type) => {
-				expect(() => on(type, L.Util.falseFn)).to.throw();
-				expect(() => off(type, L.Util.falseFn)).to.throw();
+				expect(() => on(type, Util.falseFn)).to.throw();
+				expect(() => off(type, Util.falseFn)).to.throw();
 			});
 
 			// todo? make `fire` and `listen` to throw with wrong type
 		});
 
 		it('works like #addEventListener && #removeEventListener', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.on('test', spy);
@@ -430,7 +432,7 @@ describe('Events', () => {
 			    spy2 = sinon.spy(),
 			    spy3 = sinon.spy();
 
-			const Klass = L.Evented.extend({
+			const Klass = Evented.extend({
 				on: spy1,
 				off: spy2,
 				fire: spy3
@@ -449,7 +451,7 @@ describe('Events', () => {
 		});
 
 		it('does not add twice the same function', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			/* register without context */
@@ -466,8 +468,8 @@ describe('Events', () => {
 	describe('#clearEventListeners', () => {
 		it('clears all registered listeners on an object', () => {
 			const spy = sinon.spy(),
-			    obj = new L.Evented(),
-			    otherObj = new L.Evented();
+			    obj = new Evented(),
+			    otherObj = new Evented();
 
 			obj.on('test', spy, obj);
 			obj.on('testTwo', spy);
@@ -482,7 +484,7 @@ describe('Events', () => {
 
 	describe('#once', () => {
 		it('removes event listeners after first trigger', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.once('test', spy, obj);
@@ -496,7 +498,7 @@ describe('Events', () => {
 		});
 
 		it('works with an object hash', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    otherSpy = sinon.spy();
 
@@ -519,7 +521,7 @@ describe('Events', () => {
 		});
 
 		it('doesn\'t call listeners to events that have been removed', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.once('test', spy, obj);
@@ -531,7 +533,7 @@ describe('Events', () => {
 		});
 
 		it('doesn\'t call once twice', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			spy = sinon.spy();
 			obj.once('test', () => {
 				spy();
@@ -545,7 +547,7 @@ describe('Events', () => {
 
 
 		it('works if called from a context that doesnt implement #Events', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy(),
 			    foo = {};
 
@@ -559,9 +561,9 @@ describe('Events', () => {
 
 	describe('addEventParent && removeEventParent', () => {
 		it('makes the object propagate events with to the given one if fired with propagate=true', () => {
-			const obj = new L.Evented(),
-			    parent1 = new L.Evented(),
-			    parent2 = new L.Evented(),
+			const obj = new Evented(),
+			    parent1 = new Evented(),
+			    parent2 = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy();
 
@@ -589,8 +591,8 @@ describe('Events', () => {
 		});
 
 		it('can fire event where child has no listeners', () => {
-			const obj = new L.Evented(),
-			    parent = new L.Evented(),
+			const obj = new Evented(),
+			    parent = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy();
 
@@ -608,8 +610,8 @@ describe('Events', () => {
 		});
 
 		it('sets target, sourceTarget and layer correctly', () => {
-			const obj = new L.Evented(),
-			    parent = new L.Evented(),
+			const obj = new Evented(),
+			    parent = new Evented(),
 			    spy1 = sinon.spy(),
 			    spy2 = sinon.spy();
 
@@ -641,13 +643,13 @@ describe('Events', () => {
 
 	describe('#listens', () => {
 		it('is false if there is no event handler', () => {
-			const obj = new L.Evented();
+			const obj = new Evented();
 
 			expect(obj.listens('test')).to.be.false;
 		});
 
 		it('is true if there is an event handler', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.on('test', spy);
@@ -655,7 +657,7 @@ describe('Events', () => {
 		});
 
 		it('is false if event handler has been removed', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.on('test', spy);
@@ -664,7 +666,7 @@ describe('Events', () => {
 		});
 
 		it('changes for a "once" handler', () => {
-			const obj = new L.Evented(),
+			const obj = new Evented(),
 			    spy = sinon.spy();
 
 			obj.once('test', spy);
@@ -675,8 +677,8 @@ describe('Events', () => {
 		});
 
 		it('returns true if event handler with specific function and context is existing', () => {
-			const obj = new L.Evented(),
-			differentContext = new L.Evented(),
+			const obj = new Evented(),
+			differentContext = new Evented(),
 			spy = sinon.spy(),
 			diffentFnc = sinon.spy();
 
@@ -697,8 +699,8 @@ describe('Events', () => {
 		});
 
 		it('is true if there is an event handler on parent', () => {
-			const fg = L.featureGroup(),
-			marker = L.marker([0, 0]).addTo(fg),
+			const fg = new FeatureGroup(),
+			marker = new Marker([0, 0]).addTo(fg),
 			spy = sinon.spy();
 
 			fg.on('test', spy);
@@ -707,9 +709,9 @@ describe('Events', () => {
 		});
 
 		it('is true if there is an event handler on parent parent', () => {
-			const fgP = L.featureGroup(),
-			fg = L.featureGroup().addTo(fgP),
-			marker = L.marker([0, 0]).addTo(fg),
+			const fgP = new FeatureGroup(),
+			fg = new FeatureGroup().addTo(fgP),
+			marker = new Marker([0, 0]).addTo(fg),
 			spy = sinon.spy();
 
 			fgP.on('test', spy);
@@ -718,8 +720,8 @@ describe('Events', () => {
 		});
 
 		it('is true if there is an event handler with specific function on parent', () => {
-			const fg = L.featureGroup(),
-			marker = L.marker([0, 0]).addTo(fg),
+			const fg = new FeatureGroup(),
+			marker = new Marker([0, 0]).addTo(fg),
 			spy = sinon.spy();
 
 			fg.on('test', spy);

--- a/spec/suites/core/GeneralSpec.js
+++ b/spec/suites/core/GeneralSpec.js
@@ -1,3 +1,6 @@
+/* global L */
+import 'leaflet';
+
 describe('General', () => {
 	it('namespace extension', () => {
 		L.Util.foo = 'bar';

--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -1,3 +1,5 @@
+import {Util} from 'leaflet';
+
 describe('Util', () => {
 	describe('#extend', () => {
 		let a;
@@ -10,7 +12,7 @@ describe('Util', () => {
 		});
 
 		it('extends the first argument with the properties of the second', () => {
-			L.Util.extend(a, {
+			Util.extend(a, {
 				bar: 7,
 				baz: 3
 			});
@@ -23,7 +25,7 @@ describe('Util', () => {
 		});
 
 		it('accepts more than 2 arguments', () => {
-			L.Util.extend(a, {bar: 7}, {baz: 3});
+			Util.extend(a, {bar: 7}, {baz: 3});
 
 			expect(a).to.eql({
 				foo: 5,
@@ -36,13 +38,13 @@ describe('Util', () => {
 	describe('#stamp', () => {
 		it('sets a unique id on the given object and returns it', () => {
 			const a = {},
-			    id = L.Util.stamp(a);
+			    id = Util.stamp(a);
 
 			expect(typeof id).to.eql('number');
-			expect(L.Util.stamp(a)).to.eql(id);
+			expect(Util.stamp(a)).to.eql(id);
 
 			const b = {},
-			    id2 = L.Util.stamp(b);
+			    id2 = Util.stamp(b);
 
 			expect(id2).not.to.eql(id);
 		});
@@ -50,17 +52,17 @@ describe('Util', () => {
 
 	describe('#falseFn', () => {
 		it('returns false', () => {
-			expect(L.Util.falseFn()).to.be.false;
+			expect(Util.falseFn()).to.be.false;
 		});
 	});
 
 	describe('#formatNum', () => {
 		it('formats numbers with a given precision', () => {
-			expect(L.Util.formatNum(13.12325555, 3)).to.eql(13.123);
-			expect(L.Util.formatNum(13.12325555)).to.eql(13.123256);
-			expect(L.Util.formatNum(13.12325555, 0)).to.eql(13);
-			expect(L.Util.formatNum(13.12325555, false)).to.eql(13.12325555);
-			expect(isNaN(L.Util.formatNum(-7.993322e-10))).to.eql(false);
+			expect(Util.formatNum(13.12325555, 3)).to.eql(13.123);
+			expect(Util.formatNum(13.12325555)).to.eql(13.123256);
+			expect(Util.formatNum(13.12325555, 0)).to.eql(13);
+			expect(Util.formatNum(13.12325555, false)).to.eql(13.12325555);
+			expect(isNaN(Util.formatNum(-7.993322e-10))).to.eql(false);
 		});
 	});
 
@@ -73,7 +75,7 @@ describe('Util', () => {
 				result: '?bar=7&baz=3'
 			};
 
-			expect(L.Util.getParamString(a.obj, a.url)).to.eql(a.result);
+			expect(Util.getParamString(a.obj, a.url)).to.eql(a.result);
 
 			const b = {
 				url: 'http://example.com/get?justone=qs',
@@ -81,7 +83,7 @@ describe('Util', () => {
 				result: '&bar=7&baz=3'
 			};
 
-			expect(L.Util.getParamString(b.obj, b.url)).to.eql(b.result);
+			expect(Util.getParamString(b.obj, b.url)).to.eql(b.result);
 
 			const c = {
 				url: undefined,
@@ -89,7 +91,7 @@ describe('Util', () => {
 				result: '?bar=7&baz=3'
 			};
 
-			expect(L.Util.getParamString(c.obj, c.url)).to.eql(c.result);
+			expect(Util.getParamString(c.obj, c.url)).to.eql(c.result);
 		});
 	});
 
@@ -98,14 +100,14 @@ describe('Util', () => {
 			const spy = sinon.spy(),
 			    foo = {};
 
-			L.Util.requestAnimFrame(spy);
+			Util.requestAnimFrame(spy);
 
-			L.Util.requestAnimFrame(function () {
+			Util.requestAnimFrame(function () {
 				expect(this).to.eql(foo);
 				done();
 			}, foo);
 
-			L.Util.cancelAnimFrame(spy);
+			Util.cancelAnimFrame(spy);
 		});
 	});
 
@@ -113,7 +115,7 @@ describe('Util', () => {
 		it('limits execution to not more often than specified time interval', (done) => {
 			const spy = sinon.spy();
 
-			const fn = L.Util.throttle(spy, 20);
+			const fn = Util.throttle(spy, 20);
 
 			fn();
 			fn();
@@ -130,47 +132,47 @@ describe('Util', () => {
 
 	describe('#splitWords', () => {
 		it('splits words into an array', () => {
-			expect(L.Util.splitWords('foo bar baz')).to.eql(['foo', 'bar', 'baz']);
+			expect(Util.splitWords('foo bar baz')).to.eql(['foo', 'bar', 'baz']);
 		});
 	});
 
 	describe('#setOptions', () => {
 		it('sets specified options on object', () => {
 			const o = {};
-			L.Util.setOptions(o, {foo: 'bar'});
+			Util.setOptions(o, {foo: 'bar'});
 			expect(o.options.foo).to.eql('bar');
 		});
 
 		it('returns options', () => {
 			const o = {};
-			const r = L.Util.setOptions(o, {foo: 'bar'});
+			const r = Util.setOptions(o, {foo: 'bar'});
 			expect(r).to.equal(o.options);
 		});
 
 		it('accepts undefined', () => {
 			const o = {};
-			L.Util.setOptions(o, undefined);
+			Util.setOptions(o, undefined);
 			expect(o.options).to.eql({});
 		});
 
 		it('creates a distinct options object', () => {
 			const opts = {},
 			    o = Object.create({options: opts});
-			L.Util.setOptions(o, {});
+			Util.setOptions(o, {});
 			expect(o.options).not.to.equal(opts);
 		});
 
 		it('doesn\'t create a distinct options object if object already has own options', () => {
 			const opts = {},
 			    o = {options: opts};
-			L.Util.setOptions(o, {});
+			Util.setOptions(o, {});
 			expect(o.options).to.equal(opts);
 		});
 
 		it('inherits options prototypally', () => {
 			const opts = {},
 			    o = Object.create({options: opts});
-			L.Util.setOptions(o, {});
+			Util.setOptions(o, {});
 			opts.foo = 'bar';
 			expect(o.options.foo).to.eql('bar');
 		});
@@ -180,7 +182,7 @@ describe('Util', () => {
 		it('evaluates templates with a given data object', () => {
 			const tpl = 'Hello {foo} and {bar}!';
 
-			const str = L.Util.template(tpl, {
+			const str = Util.template(tpl, {
 				foo: 'Vlad',
 				bar: 'Dave'
 			});
@@ -189,25 +191,25 @@ describe('Util', () => {
 		});
 
 		it('does not modify text without a token variable', () => {
-			expect(L.Util.template('foo', {})).to.eql('foo');
+			expect(Util.template('foo', {})).to.eql('foo');
 		});
 
 		it('supports templates with double quotes', () => {
-			expect(L.Util.template('He said: "{foo}"!', {
+			expect(Util.template('He said: "{foo}"!', {
 				foo: 'Hello'
 			})).to.eql('He said: "Hello"!');
 		});
 
 		it('throws when a template token is not given', () => {
 			expect(() => {
-				L.Util.template(undefined, {foo: 'bar'});
+				Util.template(undefined, {foo: 'bar'});
 			}).to.throw();
 		});
 
 		it('allows underscores, dashes and spaces in placeholders', () => {
-			expect(L.Util.template('{nice_stuff}', {'nice_stuff': 'foo'})).to.eql('foo');
-			expect(L.Util.template('{-y}', {'-y': 1})).to.eql('1');
-			expect(L.Util.template('{Day Of Month}', {'Day Of Month': 30})).to.eql('30');
+			expect(Util.template('{nice_stuff}', {'nice_stuff': 'foo'})).to.eql('foo');
+			expect(Util.template('{-y}', {'-y': 1})).to.eql('1');
+			expect(Util.template('{Day Of Month}', {'Day Of Month': 30})).to.eql('30');
 		});
 	});
 });

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -1,3 +1,6 @@
+import {DomEvent, Map, DomUtil, extend, Control} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('DomEvent.DoubleTapSpec.js', () => {
 	let container, clock, spy;
 
@@ -7,7 +10,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		clock = sinon.useFakeTimers();
 		clock.tick(1000);
 		spy = sinon.spy();
-		L.DomEvent.on(container, 'dblclick', spy);
+		DomEvent.on(container, 'dblclick', spy);
 	});
 
 	afterEach(() => {
@@ -44,7 +47,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 	});
 
 	it('does not fire dblclick after removeListener', () => {
-		L.DomEvent.off(container, 'dblclick', spy);
+		DomEvent.off(container, 'dblclick', spy);
 
 		UIEventSimulator.fire('click', container, {detail: 1});
 		clock.tick(100);
@@ -76,7 +79,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		UIEventSimulator.fire('click', container, click);
 
 		const event = spy.lastCall.args[0];
-		const expectedProps = L.extend(click, {
+		const expectedProps = extend(click, {
 			type: 'dblclick',
 			// bubbles: true,    // not important, as we do not actually dispatch the event
 			// cancelable: true, //
@@ -91,19 +94,19 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 
 	it('respects disableClickPropagation', () => {
 		const spyMap = sinon.spy();
-		const map = L.map(container).setView([51.505, -0.09], 13);
+		const map = new Map(container).setView([51.505, -0.09], 13);
 		map.on('dblclick', spyMap);
 
 		const spyCtrl = sinon.spy();
-		const ctrl = L.DomUtil.create('div');
-		L.DomEvent.disableClickPropagation(ctrl);
-		const MyControl = L.Control.extend({
+		const ctrl = DomUtil.create('div');
+		DomEvent.disableClickPropagation(ctrl);
+		const MyControl = Control.extend({
 			onAdd() {
 				return ctrl;
 			}
 		});
 		map.addControl(new MyControl());
-		L.DomEvent.on(ctrl, 'dblclick', spyCtrl);
+		DomEvent.on(ctrl, 'dblclick', spyCtrl);
 
 		UIEventSimulator.fire('click', ctrl, {detail: 1});
 		clock.tick(100);
@@ -115,13 +118,13 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 
 	it('doesn\'t fire double-click while clicking on a label with `for` attribute', () => {
 		const spyMap = sinon.spy();
-		const map = L.map(container).setView([51.505, -0.09], 13);
+		const map = new Map(container).setView([51.505, -0.09], 13);
 		map.on('dblclick', spyMap);
 
 		let div;
-		const MyControl = L.Control.extend({
+		const MyControl = Control.extend({
 			onAdd() {
-				div = L.DomUtil.create('div');
+				div = DomUtil.create('div');
 				div.innerHTML = '<input type="checkbox" id="input">' +
 					'<label for="input" style="background: #ffffff; width: 100px; height: 100px;display: block;">Click Me</label>';
 				return div;

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -1,3 +1,5 @@
+import {DomEvent, Browser, Util, extend} from 'leaflet';
+
 describe('DomEvent.Pointer', () => {
 	let el;
 	const listeners = {};
@@ -10,7 +12,7 @@ describe('DomEvent.Pointer', () => {
 		document.body.appendChild(el);
 		touchEvents.forEach((type) => {
 			listeners[type] = sinon.spy();
-			L.DomEvent.on(el, type, listeners[type]);
+			DomEvent.on(el, type, listeners[type]);
 		});
 	});
 
@@ -22,7 +24,7 @@ describe('DomEvent.Pointer', () => {
 
 	const skip = describe.skip;
 
-	const pointerToTouch = L.Browser.pointer && !L.Browser.touchNative;
+	const pointerToTouch = Browser.pointer && !Browser.touchNative;
 	(pointerToTouch ? describe : skip)('#Simulates touch based on pointer events', () => {
 		it('adds a listener and calls it on pointer event', () => {
 			pointerEvents.forEach((type) => {
@@ -36,7 +38,7 @@ describe('DomEvent.Pointer', () => {
 
 		it('does not call removed listener', () => {
 			touchEvents.forEach((type) => {
-				L.DomEvent.off(el, type, listeners[type]);
+				DomEvent.off(el, type, listeners[type]);
 			});
 			pointerEvents.forEach((type) => {
 				UIEventSimulator.fire(type, el);
@@ -65,8 +67,8 @@ describe('DomEvent.Pointer', () => {
 		});
 
 		it('does not throw on invalid event names', () => {
-			L.DomEvent.on(el, 'touchleave', L.Util.falseFn);
-			L.DomEvent.off(el, 'touchleave', L.Util.falseFn);
+			DomEvent.on(el, 'touchleave', Util.falseFn);
+			DomEvent.off(el, 'touchleave', Util.falseFn);
 		});
 
 		it('simulates touch events with correct properties', () => {
@@ -124,7 +126,7 @@ describe('DomEvent.Pointer', () => {
 			expect(containIn([pointer1, pointer2], evt.touches)).to.be.true;
 
 			// pointermove/touchmove (multitouch)
-			L.extend(pointer1, {clientX:11, clientY:11});
+			extend(pointer1, {clientX:11, clientY:11});
 			UIEventSimulator.fire('pointermove', el, pointer1);
 			evt = listeners.touchmove.lastCall.args[0];
 			expect(evt.type).to.equal('pointermove');
@@ -163,7 +165,7 @@ describe('DomEvent.Pointer', () => {
 		});
 	});
 
-	(L.Browser.pointer ? skip : describe)('#Does not intrude if pointer events are not available', () => {
+	(Browser.pointer ? skip : describe)('#Does not intrude if pointer events are not available', () => {
 		it('adds a listener and calls it on touch event', () => {
 			touchEvents.forEach((type) => {
 				UIEventSimulator.fire(type, el);

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -1,3 +1,5 @@
+import {DomEvent, Util, Map} from 'leaflet';
+
 describe('DomEvent', () => {
 	let el, listener;
 
@@ -13,179 +15,179 @@ describe('DomEvent', () => {
 
 	describe('#arguments check', () => {
 		it('throws when el is not HTMLElement', () => {
-			expect(() => L.DomEvent.on({}, 'click', L.Util.falseFn)).to.throw();
-			expect(() => L.DomEvent.disableScrollPropagation({})).to.throw();
-			expect(() => L.DomEvent.disableClickPropagation({})).to.throw();
-			expect(() => L.DomEvent.getMousePosition({clientX: 0, clientY: 0}, {})).to.throw();
+			expect(() => DomEvent.on({}, 'click', Util.falseFn)).to.throw();
+			expect(() => DomEvent.disableScrollPropagation({})).to.throw();
+			expect(() => DomEvent.disableClickPropagation({})).to.throw();
+			expect(() => DomEvent.getMousePosition({clientX: 0, clientY: 0}, {})).to.throw();
 			// .off and .isExternalTarget do not throw atm
 		});
 	});
 
 	describe('#on (addListener)', () => {
 		it('throws when type is undefined and context is falseFn', () => {
-			expect(() => L.DomEvent.on(el, undefined, L.Util.falseFn)).to.throw();
+			expect(() => DomEvent.on(el, undefined, Util.falseFn)).to.throw();
 		});
 
 		it('throws when type is null and context is falseFn', () => {
-			expect(() => L.DomEvent.on(el, null, L.Util.falseFn)).to.throw();
+			expect(() => DomEvent.on(el, null, Util.falseFn)).to.throw();
 		});
 
 		it('throws when type is false and context is falseFn', () => {
-			expect(() => L.DomEvent.on((el, false, L.Util.falseFn))).to.throw();
+			expect(() => DomEvent.on((el, false, Util.falseFn))).to.throw();
 		});
 
 		it('throws when type is "click" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'click', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'click', undefined)).to.throw();
 		});
 
 		it('throws when type is "click" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'click', null)).to.throw();
+			expect(() => DomEvent.on(el, 'click', null)).to.throw();
 		});
 
 		it('throws when type is "click" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'click', false)).to.throw();
+			expect(() => DomEvent.on(el, 'click', false)).to.throw();
 		});
 
 		it('throws when type is "click" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'click', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'click', undefined)).to.throw();
 		});
 
 		it('throws when type is "dblclick" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'dblclick', null)).to.throw();
+			expect(() => DomEvent.on(el, 'dblclick', null)).to.throw();
 		});
 
 		it('throws when type is "dblclick" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'dblclick', false)).to.throw();
+			expect(() => DomEvent.on(el, 'dblclick', false)).to.throw();
 		});
 
 		it('throws when type is "dblclick" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'dblclick', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'dblclick', undefined)).to.throw();
 		});
 
 		it('throws when type is "mousedown" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'mousedown', null)).to.throw();
+			expect(() => DomEvent.on(el, 'mousedown', null)).to.throw();
 		});
 
 		it('throws when type is "mousedown" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'mousedown', false)).to.throw();
+			expect(() => DomEvent.on(el, 'mousedown', false)).to.throw();
 		});
 
 		it('throws when type is "mousedown" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'mousedown', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'mousedown', undefined)).to.throw();
 		});
 
 		it('throws when type is "mouseup" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'mouseup', null)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseup', null)).to.throw();
 		});
 
 		it('throws when type is "mouseup" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'mouseup', false)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseup', false)).to.throw();
 		});
 
 		it('throws when type is "mouseup" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'mouseup', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseup', undefined)).to.throw();
 		});
 
 		it('throws when type is "mouseover" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'mouseover', null)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseover', null)).to.throw();
 		});
 
 		it('throws when type is "mouseover" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'mouseover', false)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseover', false)).to.throw();
 		});
 
 		it('throws when type is "mouseover" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'mouseover', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseover', undefined)).to.throw();
 		});
 
 		it('throws when type is "mouseout" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'mouseout', null)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseout', null)).to.throw();
 		});
 
 		it('throws when type is "mouseout" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'mouseout', false)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseout', false)).to.throw();
 		});
 
 		it('throws when type is "mouseout" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'mouseout', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'mouseout', undefined)).to.throw();
 		});
 
 		it('throws when type is "mousemove" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'mousemove', null)).to.throw();
+			expect(() => DomEvent.on(el, 'mousemove', null)).to.throw();
 		});
 
 		it('throws when type is "mousemove" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'mousemove', false)).to.throw();
+			expect(() => DomEvent.on(el, 'mousemove', false)).to.throw();
 		});
 
 		it('throws when type is "mousemove" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'mousemove', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'mousemove', undefined)).to.throw();
 		});
 
 		it('throws when type is "contextmenu" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'contextmenu', null)).to.throw();
+			expect(() => DomEvent.on(el, 'contextmenu', null)).to.throw();
 		});
 
 		it('throws when type is "contextmenu" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'contextmenu', false)).to.throw();
+			expect(() => DomEvent.on(el, 'contextmenu', false)).to.throw();
 		});
 
 		it('throws when type is "contextmenu" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'contextmenu', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'contextmenu', undefined)).to.throw();
 		});
 
 		it('throws when type is "keyup" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'keyup', null)).to.throw();
+			expect(() => DomEvent.on(el, 'keyup', null)).to.throw();
 		});
 
 		it('throws when type is "keyup" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'keyup', false)).to.throw();
+			expect(() => DomEvent.on(el, 'keyup', false)).to.throw();
 		});
 
 		it('throws when type is "keyup" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'keyup', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'keyup', undefined)).to.throw();
 		});
 
 		it('throws when type is "keypress" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'keypress', null)).to.throw();
+			expect(() => DomEvent.on(el, 'keypress', null)).to.throw();
 		});
 
 		it('throws when type is "keypress" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'keypress', false)).to.throw();
+			expect(() => DomEvent.on(el, 'keypress', false)).to.throw();
 		});
 
 		it('throws when type is "keypress" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'keypress', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'keypress', undefined)).to.throw();
 		});
 
 		it('throws when type is "keydown" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'keydown', null)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown', null)).to.throw();
 		});
 
 		it('throws when type is "keydown" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'keydown', false)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown', false)).to.throw();
 		});
 
 		it('throws when type is "keydown" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'keydown', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown', undefined)).to.throw();
 		});
 
 		it('throws when type is "keydown and click" and context is null', () => {
-			expect(() => L.DomEvent.on(el, 'keydown click', null)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown click', null)).to.throw();
 		});
 
 		it('throws when type is "keydown and click" and context is false', () => {
-			expect(() => L.DomEvent.on(el, 'keydown click', false)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown click', false)).to.throw();
 		});
 
 		it('throws when type is "keydown and click" and context is undefined', () => {
-			expect(() => L.DomEvent.on(el, 'keydown click', undefined)).to.throw();
+			expect(() => DomEvent.on(el, 'keydown click', undefined)).to.throw();
 		});
 
 		it('adds a listener and calls it on event with click', () => {
 			const listener2 = sinon.spy();
-			L.DomEvent.on(el, 'click', listener);
-			L.DomEvent.on(el, 'click', listener2);
+			DomEvent.on(el, 'click', listener);
+			DomEvent.on(el, 'click', listener2);
 
 			UIEventSimulator.fire('click', el);
 
@@ -195,8 +197,8 @@ describe('DomEvent', () => {
 
 		it('adds a listener and calls it on event with click and keypress', () => {
 			const listener2 = sinon.spy();
-			L.DomEvent.on(el, 'click keypress', listener);
-			L.DomEvent.on(el, 'click', listener2);
+			DomEvent.on(el, 'click keypress', listener);
+			DomEvent.on(el, 'click', listener2);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -208,7 +210,7 @@ describe('DomEvent', () => {
 		it('adds a listener when passed an event map', () => {
 			const listener = sinon.spy();
 
-			L.DomEvent.on(el, {click: listener});
+			DomEvent.on(el, {click: listener});
 
 			UIEventSimulator.fire('click', el);
 
@@ -218,7 +220,7 @@ describe('DomEvent', () => {
 		it('adds 2 listener when passed an event map with multiple events', () => {
 			const listener2 = sinon.spy();
 
-			L.DomEvent.on(el, {click: listener, keypress: listener2});
+			DomEvent.on(el, {click: listener, keypress: listener2});
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -229,7 +231,7 @@ describe('DomEvent', () => {
 
 		it('binds "this" to the given context', () => {
 			const obj = {foo: 'bar'};
-			L.DomEvent.on(el, 'click', listener, obj);
+			DomEvent.on(el, 'click', listener, obj);
 
 			UIEventSimulator.fire('click', el);
 
@@ -238,7 +240,7 @@ describe('DomEvent', () => {
 
 		it('binds "this" to the given context with multiple types', () => {
 			const obj = {foo: 'bar'};
-			L.DomEvent.on(el, 'click keypress', listener, obj);
+			DomEvent.on(el, 'click keypress', listener, obj);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -250,7 +252,7 @@ describe('DomEvent', () => {
 			const listener = sinon.spy(),
 			    ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, {click: listener}, ctx);
+			DomEvent.on(el, {click: listener}, ctx);
 
 			UIEventSimulator.fire('click', el);
 
@@ -261,7 +263,7 @@ describe('DomEvent', () => {
 			const listener2 = sinon.spy(),
 			    ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, {click: listener, keypress: listener2}, ctx);
+			DomEvent.on(el, {click: listener, keypress: listener2}, ctx);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -271,7 +273,7 @@ describe('DomEvent', () => {
 		});
 
 		it('passes an event object to the listener', () => {
-			L.DomEvent.on(el, 'click', listener);
+			DomEvent.on(el, 'click', listener);
 
 			UIEventSimulator.fire('click', el);
 
@@ -279,7 +281,7 @@ describe('DomEvent', () => {
 		});
 
 		it('passes two event objects to the listener', () => {
-			L.DomEvent.on(el, 'click keypress', listener);
+			DomEvent.on(el, 'click keypress', listener);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -289,20 +291,20 @@ describe('DomEvent', () => {
 		});
 
 		it('is chainable', () => {
-			const res = L.DomEvent.on(el, 'click', () => {});
+			const res = DomEvent.on(el, 'click', () => {});
 
-			expect(res).to.equal(L.DomEvent);
+			expect(res).to.equal(DomEvent);
 		});
 
 		it('is aliased to addListener ', () => {
-			expect(L.DomEvent.on).to.equal(L.DomEvent.addListener);
+			expect(DomEvent.on).to.equal(DomEvent.addListener);
 		});
 	});
 
 	describe('#off (removeListener)', () => {
 		it('removes a previously added listener', () => {
-			L.DomEvent.on(el, 'click', listener);
-			L.DomEvent.off(el, 'click', listener);
+			DomEvent.on(el, 'click', listener);
+			DomEvent.off(el, 'click', listener);
 
 			UIEventSimulator.fire('click', el);
 
@@ -310,8 +312,8 @@ describe('DomEvent', () => {
 		});
 
 		it('removes a previously added event', () => {
-			L.DomEvent.on(el, 'click keypress', listener);
-			L.DomEvent.off(el, 'click', listener);
+			DomEvent.on(el, 'click keypress', listener);
+			DomEvent.off(el, 'click', listener);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -323,9 +325,9 @@ describe('DomEvent', () => {
 			const listenerA = sinon.spy(),
 			listenerB = sinon.spy();
 
-			L.DomEvent.on(el, 'click', listenerA);
-			L.DomEvent.on(el, 'click', listenerB);
-			L.DomEvent.off(el, 'click', listenerA);
+			DomEvent.on(el, 'click', listenerA);
+			DomEvent.on(el, 'click', listenerB);
+			DomEvent.off(el, 'click', listenerA);
 
 			UIEventSimulator.fire('click', el);
 
@@ -337,8 +339,8 @@ describe('DomEvent', () => {
 			const listener = sinon.spy(),
 			    events = {click: listener};
 
-			L.DomEvent.on(el, events);
-			L.DomEvent.off(el, events);
+			DomEvent.on(el, events);
+			DomEvent.off(el, events);
 
 			UIEventSimulator.fire('click', el);
 
@@ -349,8 +351,8 @@ describe('DomEvent', () => {
 			const listener2 = sinon.spy(),
 			    events = {click: listener, keypress: listener2};
 
-			L.DomEvent.on(el, events);
-			L.DomEvent.off(el, events);
+			DomEvent.on(el, events);
+			DomEvent.off(el, events);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -364,8 +366,8 @@ describe('DomEvent', () => {
 			    events = {click: listener, keypress: listener2},
 			events2 = {click: listener};
 
-			L.DomEvent.on(el, events);
-			L.DomEvent.off(el, events2);
+			DomEvent.on(el, events);
+			DomEvent.off(el, events2);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -378,8 +380,8 @@ describe('DomEvent', () => {
 			const listener = sinon.spy(),
 			    ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, 'click', listener, ctx);
-			L.DomEvent.off(el, 'click', listener, ctx);
+			DomEvent.on(el, 'click', listener, ctx);
+			DomEvent.off(el, 'click', listener, ctx);
 
 			UIEventSimulator.fire('click', el);
 
@@ -391,8 +393,8 @@ describe('DomEvent', () => {
 			    events = {click: listener},
 			    ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, events, ctx);
-			L.DomEvent.off(el, events, ctx);
+			DomEvent.on(el, events, ctx);
+			DomEvent.off(el, events, ctx);
 
 			UIEventSimulator.fire('click', el);
 
@@ -405,8 +407,8 @@ describe('DomEvent', () => {
 			events2 = {click: listener},
 			    ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, events, ctx);
-			L.DomEvent.off(el, events2, ctx);
+			DomEvent.on(el, events, ctx);
+			DomEvent.off(el, events2, ctx);
 
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('keypress', el);
@@ -419,17 +421,17 @@ describe('DomEvent', () => {
 			let listener = sinon.spy();
 			const ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, 'click', listener);
-			L.DomEvent.off(el, 'click', listener, ctx);
+			DomEvent.on(el, 'click', listener);
+			DomEvent.off(el, 'click', listener, ctx);
 
 			UIEventSimulator.fire('click', el);
 
 			sinon.assert.called(listener);
 
 			listener = sinon.spy();
-			L.DomEvent.on(el, 'click', listener, ctx);
-			L.DomEvent.off(el, 'click', listener, {}); // wrong context
-			L.DomEvent.off(el, 'click', listener);
+			DomEvent.on(el, 'click', listener, ctx);
+			DomEvent.off(el, 'click', listener, {}); // wrong context
+			DomEvent.off(el, 'click', listener);
 
 			UIEventSimulator.fire('click', el);
 
@@ -441,8 +443,8 @@ describe('DomEvent', () => {
 			    events = {click: listener};
 			const ctx = {foo: 'bar'};
 
-			L.DomEvent.on(el, events);
-			L.DomEvent.off(el, events, ctx);
+			DomEvent.on(el, events);
+			DomEvent.off(el, events, ctx);
 
 			UIEventSimulator.fire('click', el);
 
@@ -451,9 +453,9 @@ describe('DomEvent', () => {
 			listener = sinon.spy();
 			   events = {click: listener};
 
-			L.DomEvent.on(el, events, ctx);
-			L.DomEvent.off(el, events);
-			L.DomEvent.off(el, events, {}); // wrong context
+			DomEvent.on(el, events, ctx);
+			DomEvent.off(el, events);
+			DomEvent.off(el, events, {}); // wrong context
 
 			UIEventSimulator.fire('click', el);
 
@@ -464,9 +466,9 @@ describe('DomEvent', () => {
 			const listenerA = sinon.spy(),
 			listenerB = sinon.spy();
 
-			L.DomEvent.on(el, 'click', listenerA);
-			L.DomEvent.on(el, 'click', listenerB, {});
-			L.DomEvent.off(el);
+			DomEvent.on(el, 'click', listenerA);
+			DomEvent.on(el, 'click', listenerB, {});
+			DomEvent.off(el);
 
 			UIEventSimulator.fire('click', el);
 
@@ -478,9 +480,9 @@ describe('DomEvent', () => {
 			const listenerClick = sinon.spy(),
 			listenerDblClick = sinon.spy();
 
-			L.DomEvent.on(el, 'click', listenerClick);
-			L.DomEvent.on(el, 'dblclick', listenerDblClick);
-			L.DomEvent.off(el, 'click');
+			DomEvent.on(el, 'click', listenerClick);
+			DomEvent.on(el, 'dblclick', listenerDblClick);
+			DomEvent.off(el, 'click');
 			UIEventSimulator.fire('click', el);
 			UIEventSimulator.fire('dblclick', el);
 
@@ -489,20 +491,20 @@ describe('DomEvent', () => {
 		});
 
 		it('throws when types/fn are undefined/null/false', () => {
-			expect(() => L.DomEvent.off(el, undefined)).to.throw();
-			expect(() => L.DomEvent.off(el, null)).to.throw();
-			expect(() => L.DomEvent.off(el, false)).to.throw();
+			expect(() => DomEvent.off(el, undefined)).to.throw();
+			expect(() => DomEvent.off(el, null)).to.throw();
+			expect(() => DomEvent.off(el, false)).to.throw();
 
-			expect(() => L.DomEvent.off(el, 'click', undefined)).to.throw();
-			expect(() => L.DomEvent.off(el, 'click', null)).to.throw();
-			expect(() => L.DomEvent.off(el, 'click', false)).to.throw();
+			expect(() => DomEvent.off(el, 'click', undefined)).to.throw();
+			expect(() => DomEvent.off(el, 'click', null)).to.throw();
+			expect(() => DomEvent.off(el, 'click', false)).to.throw();
 		});
 
 		it('removes listener when passed an event map', () => {
 			const listener = sinon.spy();
 
-			L.DomEvent.on(el, 'click', listener);
-			L.DomEvent.off(el, {'click': listener});
+			DomEvent.on(el, 'click', listener);
+			DomEvent.off(el, {'click': listener});
 
 			UIEventSimulator.fire('click', el);
 
@@ -510,13 +512,13 @@ describe('DomEvent', () => {
 		});
 
 		it('is chainable', () => {
-			const res = L.DomEvent.off(el, 'click', () => {});
+			const res = DomEvent.off(el, 'click', () => {});
 
-			expect(res).to.equal(L.DomEvent);
+			expect(res).to.equal(DomEvent);
 		});
 
 		it('is aliased to removeListener ', () => {
-			expect(L.DomEvent.off).to.equal(L.DomEvent.removeListener);
+			expect(DomEvent.off).to.equal(DomEvent.removeListener);
 		});
 	});
 
@@ -524,8 +526,8 @@ describe('DomEvent', () => {
 		it('stops propagation of the given event', () => {
 			const child = document.createElement('div');
 			el.appendChild(child);
-			L.DomEvent.on(child, 'click', L.DomEvent.stopPropagation);
-			L.DomEvent.on(el, 'click', listener);
+			DomEvent.on(child, 'click', DomEvent.stopPropagation);
+			DomEvent.on(el, 'click', listener);
 
 			UIEventSimulator.fire('click', child);
 
@@ -538,9 +540,9 @@ describe('DomEvent', () => {
 			const child = document.createElement('div');
 			el.appendChild(child);
 			const wheel = 'onwheel' in window ? 'wheel' : 'mousewheel';
-			L.DomEvent.on(el, wheel, listener);
+			DomEvent.on(el, wheel, listener);
 
-			L.DomEvent.disableScrollPropagation(child);
+			DomEvent.disableScrollPropagation(child);
 			UIEventSimulator.fire(wheel, child);
 
 			expect(listener.notCalled).to.be.true;
@@ -551,8 +553,8 @@ describe('DomEvent', () => {
 		it('stops click events from propagation to parent elements', () => { // except 'click'
 			const child = document.createElement('div');
 			el.appendChild(child);
-			L.DomEvent.disableClickPropagation(child);
-			L.DomEvent.on(el, 'dblclick contextmenu mousedown touchstart', listener);
+			DomEvent.disableClickPropagation(child);
+			DomEvent.on(el, 'dblclick contextmenu mousedown touchstart', listener);
 
 			UIEventSimulator.fire('dblclick', child);
 			UIEventSimulator.fire('contextmenu', child);
@@ -565,12 +567,12 @@ describe('DomEvent', () => {
 		it('prevents click event on map object, but propagates to DOM elements', () => { // to solve #301
 			const child = document.createElement('div');
 			el.appendChild(child);
-			L.DomEvent.disableClickPropagation(child);
-			L.DomEvent.on(el, 'click', listener);
+			DomEvent.disableClickPropagation(child);
+			DomEvent.on(el, 'click', listener);
 			const grandChild = document.createElement('div');
 			child.appendChild(grandChild);
 
-			const map = L.map(el).setView([0, 0], 0);
+			const map = new Map(el).setView([0, 0], 0);
 			const mapClickListener = sinon.spy();
 			const mapOtherListener = sinon.spy();
 			map.on('click', mapClickListener);          // control case
@@ -603,10 +605,10 @@ describe('DomEvent', () => {
 		}
 
 		it('prevents the default action of event', (done) => {
-			L.DomEvent.on(el, 'click', (e) => {
+			DomEvent.on(el, 'click', (e) => {
 				expect(isPrevented(e)).not.to.be.true; // control case
 
-				L.DomEvent.preventDefault(e);
+				DomEvent.preventDefault(e);
 
 				expect(isPrevented(e)).to.be.true;
 				done();

--- a/spec/suites/dom/DomUtilSpec.js
+++ b/spec/suites/dom/DomUtilSpec.js
@@ -1,3 +1,5 @@
+import {DomUtil, Point, point} from 'leaflet';
+
 describe('DomUtil', () => {
 	let el;
 
@@ -15,31 +17,31 @@ describe('DomUtil', () => {
 	describe('#get', () => {
 		it('gets element by id if the given argument is string', () => {
 			el.id = 'testId';
-			expect(L.DomUtil.get(el.id)).to.eql(el);
+			expect(DomUtil.get(el.id)).to.eql(el);
 		});
 
 		it('returns the element if it is given as an argument', () => {
-			expect(L.DomUtil.get(el)).to.eql(el);
+			expect(DomUtil.get(el)).to.eql(el);
 		});
 	});
 
 	describe('#create', () => {
 		it('creates an HTML element div without any class name', () => {
-			const e = L.DomUtil.create('div');
+			const e = DomUtil.create('div');
 			expect(e.className).to.eql('');
 			expect(e.tagName).to.eql('DIV');
 		});
 
 		it('creates an HTML element div with specified class name', () => {
-			const e = L.DomUtil.create('div', 'test');
+			const e = DomUtil.create('div', 'test');
 			expect(e.className).to.eql('test');
 			expect(e.tagName).to.eql('DIV');
 		});
 
 		it('creates an p element with a div as parent', () => {
-			const parent = L.DomUtil.create('div');
+			const parent = DomUtil.create('div');
 			expect(parent.children.length).to.equal(0);
-			const child = L.DomUtil.create('p', 'test', parent);
+			const child = DomUtil.create('p', 'test', parent);
 			expect(child.parentNode === parent).to.be.true;
 			expect(parent.children.length).to.equal(1);
 		});
@@ -47,53 +49,53 @@ describe('DomUtil', () => {
 
 	describe('#toFront', () => {
 		it('moves el to last child position parent element', () => {
-			const elm = L.DomUtil.create('div', 'childContainer', el);
-			L.DomUtil.create('div', 'test', el);
-			L.DomUtil.create('div', 'test1', el);
+			const elm = DomUtil.create('div', 'childContainer', el);
+			DomUtil.create('div', 'test', el);
+			DomUtil.create('div', 'test1', el);
 			expect(el.children.length).to.equal(3);
 			expect(Array.from(el.children).indexOf(elm)).to.equal(0);
-			L.DomUtil.toFront(elm);
+			DomUtil.toFront(elm);
 			expect(Array.from(el.children).indexOf(elm)).to.equal(2);
 		});
 
 		it('doesn\'t move an element if he\'s already in the front', () => {
-			L.DomUtil.create('div', 'test', el);
-			L.DomUtil.create('div', 'test1', el);
-			const e1 = L.DomUtil.create('div', 'test2', el);
+			DomUtil.create('div', 'test', el);
+			DomUtil.create('div', 'test1', el);
+			const e1 = DomUtil.create('div', 'test2', el);
 			expect(el.lastChild).to.eql(e1);
-			L.DomUtil.toFront(e1);
+			DomUtil.toFront(e1);
 			expect(el.lastChild).to.eql(e1);
 		});
 
 		it('doesn\'t crash if element doesn\'t have a parent', () => {
-			const e = L.DomUtil.create('div');
-			L.DomUtil.toFront(e);
+			const e = DomUtil.create('div');
+			DomUtil.toFront(e);
 		});
 	});
 
 	describe('#toBack', () => {
 		it('moves el to first child position parent element', () => {
-			L.DomUtil.create('div', 'test', el);
-			L.DomUtil.create('div', 'test1', el);
-			const elm = L.DomUtil.create('div', 'childContainer', el);
+			DomUtil.create('div', 'test', el);
+			DomUtil.create('div', 'test1', el);
+			const elm = DomUtil.create('div', 'childContainer', el);
 			expect(el.children.length).to.equal(3);
 			expect(Array.from(el.children).indexOf(elm)).to.equal(2);
-			L.DomUtil.toBack(elm);
+			DomUtil.toBack(elm);
 			expect(Array.from(el.children).indexOf(elm)).to.equal(0);
 		});
 
 		it('doesn\'t move an element if it is already in the back', () => {
-			const e1 = L.DomUtil.create('div', 'test', el);
-			L.DomUtil.create('div', 'test1', el);
-			L.DomUtil.create('div', 'test2', el);
+			const e1 = DomUtil.create('div', 'test', el);
+			DomUtil.create('div', 'test1', el);
+			DomUtil.create('div', 'test2', el);
 			expect(el.firstChild).to.equal(e1);
-			L.DomUtil.toBack(el);
+			DomUtil.toBack(el);
 			expect(el.firstChild).to.equal(e1);
 		});
 
 		it('doesn\'t crash if an element doesn\'t have a parent', () => {
-			const e = L.DomUtil.create('div');
-			L.DomUtil.toBack(e);
+			const e = DomUtil.create('div');
+			DomUtil.toBack(e);
 		});
 	});
 
@@ -101,35 +103,35 @@ describe('DomUtil', () => {
 		it('resets the transform style of an el.', () => {
 			expect(el.style.transform).to.be.equal('');
 
-			const offset = L.point(200, 200);
+			const offset = new Point(200, 200);
 			const scale = 10;
-			L.DomUtil.setTransform(el, offset, scale);
+			DomUtil.setTransform(el, offset, scale);
 			const transform = el.style.transform;
 			expect(el.style.transform).to.be.equal(transform);
 
 			const newScale = 20;
-			const newOffset = L.point(400, 400);
-			L.DomUtil.setTransform(el, newOffset, newScale);
+			const newOffset = new Point(400, 400);
+			DomUtil.setTransform(el, newOffset, newScale);
 			expect(el.style.transform).to.not.be.equal(transform);
 		});
 
 		it('reset the 3d CSS transform when offset and scale aren\'t specified', () => {
-			L.DomUtil.setTransform(el);
+			DomUtil.setTransform(el);
 			expect(el.style.transform).to.equal('translate3d(0px, 0px, 0px)');
 		});
 
 		it('set the 3d CSS transform with just the specified point if scale isn\'t specified', () => {
-			L.DomUtil.setTransform(el, new L.Point(1, 1));
+			DomUtil.setTransform(el, new Point(1, 1));
 			expect(el.style.transform).to.equal('translate3d(1px, 1px, 0px)');
 		});
 
 		it('set 3d CSS transform to translate3d(0px, 0px, 0) and add to it scale(${scalevalue}) if only scale is specified', () => {
-			L.DomUtil.setTransform(el, undefined, 5);
+			DomUtil.setTransform(el, undefined, 5);
 			expect(el.style.transform).to.equal('translate3d(0px, 0px, 0px) scale(5)');
 		});
 
 		it('set the 3d CSS transform with the specified point ant the corresponding scale', () => {
-			L.DomUtil.setTransform(el, new L.Point(1, 1), 5);
+			DomUtil.setTransform(el, new Point(1, 1), 5);
 			expect(el.style.transform).to.equal('translate3d(1px, 1px, 0px) scale(5)');
 		});
 	});
@@ -141,28 +143,28 @@ describe('DomUtil', () => {
 
 			const x = 50;
 			const y = 55;
-			const position = L.point(x, y);
-			L.DomUtil.setPosition(el, position);
-			expect(L.DomUtil.getPosition(el).equals(position)).to.be.true;
+			const position = point(x, y);
+			DomUtil.setPosition(el, position);
+			expect(DomUtil.getPosition(el).equals(position)).to.be.true;
 
 			const newX = 333;
 			const newY = 666;
-			const newPosition = L.point(newX, newY);
-			L.DomUtil.setPosition(el, newPosition);
-			expect(L.DomUtil.getPosition(el).equals(newPosition)).to.be.true;
+			const newPosition = point(newX, newY);
+			DomUtil.setPosition(el, newPosition);
+			expect(DomUtil.getPosition(el).equals(newPosition)).to.be.true;
 		});
 
 		it('returns position of an element positioned with setPosition.', () => {
 			const coordinates = {x: 333, y: 666};
-			const position = L.point(coordinates);
-			expect(L.DomUtil.getPosition(el).equals(position)).to.be.false;
-			L.DomUtil.setPosition(el, position);
-			expect(L.DomUtil.getPosition(el)).to.be.an('object');
-			expect(L.DomUtil.getPosition(el).equals(position)).to.be.true;
+			const position = point(coordinates);
+			expect(DomUtil.getPosition(el).equals(position)).to.be.false;
+			DomUtil.setPosition(el, position);
+			expect(DomUtil.getPosition(el)).to.be.an('object');
+			expect(DomUtil.getPosition(el).equals(position)).to.be.true;
 		});
 
 		it('returns [0, 0] point if the HTML element wasn\'t positioned before', () => {
-			expect(L.DomUtil.getPosition(el)).to.eql(new L.Point(0, 0));
+			expect(DomUtil.getPosition(el)).to.eql(new Point(0, 0));
 		});
 	});
 
@@ -173,12 +175,12 @@ describe('DomUtil', () => {
 			el.appendChild(child);
 			child.appendChild(grandChild);
 			child.style.width = child.style.height = '500px';
-			expect(L.DomUtil.getSizedParentNode(grandChild)).to.eql(child);
+			expect(DomUtil.getSizedParentNode(grandChild)).to.eql(child);
 		});
 
 		it('throws an error if the element hasn\'t a parent', () => {
 			expect(() => {
-				L.DomUtil.getSizedParentNode(document.createElement('div'));
+				DomUtil.getSizedParentNode(document.createElement('div'));
 			}).to.throw();
 		});
 	});
@@ -206,18 +208,18 @@ describe('DomUtil', () => {
 				}
 			};
 			// Not all browsers contain x y inside boundclientRect, always contains top, right, bottom and left properties
-			expect(L.DomUtil.getScale(childEl).boundingClientRect.top).to.be.equal(scale.boundingClientRect.top);
-			expect(L.DomUtil.getScale(childEl).boundingClientRect.right).to.be.equal(scale.boundingClientRect.right);
-			expect(L.DomUtil.getScale(childEl).boundingClientRect.bottom).to.be.equal(scale.boundingClientRect.bottom);
-			expect(L.DomUtil.getScale(childEl).boundingClientRect.left).to.be.equal(scale.boundingClientRect.left);
+			expect(DomUtil.getScale(childEl).boundingClientRect.top).to.be.equal(scale.boundingClientRect.top);
+			expect(DomUtil.getScale(childEl).boundingClientRect.right).to.be.equal(scale.boundingClientRect.right);
+			expect(DomUtil.getScale(childEl).boundingClientRect.bottom).to.be.equal(scale.boundingClientRect.bottom);
+			expect(DomUtil.getScale(childEl).boundingClientRect.left).to.be.equal(scale.boundingClientRect.left);
 
 			childEl.style.padding = '400px';
-			expect(L.DomUtil.getScale(childEl).boundingClientRect.bottom).to.not.be.equal(scale.boundingClientRect.bottom);
+			expect(DomUtil.getScale(childEl).boundingClientRect.bottom).to.not.be.equal(scale.boundingClientRect.bottom);
 		});
 
 		it('returns x and y to 1 with all boundingClientRect\'s values to 0 for empty element not added yet to the body', () => {
 			const newElement = document.createElement('div');
-			const scale = L.DomUtil.getScale(newElement);
+			const scale = DomUtil.getScale(newElement);
 			expect(scale.x).to.eql(1);
 			expect(scale.y).to.eql(1);
 			expect(scale.boundingClientRect.x).to.eql(0);
@@ -240,23 +242,23 @@ describe('DomUtil', () => {
 		afterEach(() => { documentStyle[userSelectProp] = ''; });
 
 		it('disables and enables text selection', () => {
-			L.DomUtil.disableTextSelection();
+			DomUtil.disableTextSelection();
 			expect(documentStyle[userSelectProp]).to.equal('none');
-			L.DomUtil.enableTextSelection();
+			DomUtil.enableTextSelection();
 			expect(documentStyle[userSelectProp]).to.equal('');
 		});
 
 		it('restores the text selection previously set', () => {
 			documentStyle[userSelectProp] = 'text';
-			L.DomUtil.disableTextSelection();
-			L.DomUtil.enableTextSelection();
+			DomUtil.disableTextSelection();
+			DomUtil.enableTextSelection();
 			expect(documentStyle[userSelectProp]).to.equal('text');
 		});
 
 		it('restores the text selection previously set when disabling multiple times', () => {
-			L.DomUtil.disableTextSelection();
-			L.DomUtil.disableTextSelection();
-			L.DomUtil.enableTextSelection();
+			DomUtil.disableTextSelection();
+			DomUtil.disableTextSelection();
+			DomUtil.enableTextSelection();
 			expect(documentStyle[userSelectProp]).to.equal('');
 		});
 	});
@@ -274,12 +276,12 @@ describe('DomUtil', () => {
 			const child = document.createElement('div');
 			el.appendChild(child);
 
-			L.DomUtil.disableImageDrag();
+			DomUtil.disableImageDrag();
 			window.addEventListener('dragstart', checkPrevented);
 			UIEventSimulator.fire('dragstart', child);
 			expect(selectionPrevented).to.be.true;
 
-			L.DomUtil.enableImageDrag();
+			DomUtil.enableImageDrag();
 			UIEventSimulator.fire('dragstart', child);
 			expect(selectionPrevented).to.be.false;
 		});
@@ -293,15 +295,15 @@ describe('DomUtil', () => {
 			child.tabIndex = 0;
 			el.appendChild(child);
 
-			L.DomUtil.preventOutline(child);
+			DomUtil.preventOutline(child);
 			expect(child.style.outlineStyle).to.equal('none');
 
 			// Explicit #restoreOutline through direct call
-			L.DomUtil.restoreOutline(child);
+			DomUtil.restoreOutline(child);
 			expect(child.style.outlineStyle).to.be.equal(originalStyle);
 
 			// Implicit #restoreOutline test through simulation
-			L.DomUtil.preventOutline(child);
+			DomUtil.preventOutline(child);
 			expect(child.style.outlineStyle).to.equal('none');
 			UIEventSimulator.fire('keydown', child);
 			expect(child.style.outlineStyle).to.be.equal(originalStyle);

--- a/spec/suites/geo/LatLngBoundsSpec.js
+++ b/spec/suites/geo/LatLngBoundsSpec.js
@@ -1,44 +1,47 @@
+import {LatLngBounds, latLngBounds, latLng} from 'leaflet';
+
 describe('LatLngBounds', () => {
 	let a, c;
 
 	beforeEach(() => {
-		a = L.latLngBounds(
-			L.latLng(14, 12),
-			L.latLng(30, 40));
-		c = L.latLngBounds();
+		a = latLngBounds(
+			latLng(14, 12),
+			latLng(30, 40)
+		);
+		c = latLngBounds();
 	});
 
 	describe('constructor', () => {
 		it('instantiates either passing two latlngs or an array of latlngs', () => {
-			const b = L.latLngBounds([
-				L.latLng(14, 12),
-				L.latLng(30, 40)
+			const b = latLngBounds([
+				latLng(14, 12),
+				latLng(30, 40)
 			]);
 			expect(b).to.eql(a);
-			expect(b.getNorthWest()).to.eql(L.latLng(30, 12));
+			expect(b.getNorthWest()).to.eql(latLng(30, 12));
 		});
 
 		it('returns an empty bounds when not argument is given', () => {
-			const bounds = L.latLngBounds();
-			expect(bounds instanceof L.LatLngBounds).to.be.true;
+			const bounds = latLngBounds();
+			expect(bounds instanceof LatLngBounds).to.be.true;
 		});
 
 		it('returns an empty bounds when not argument is given to factory', () => {
-			const bounds = L.latLngBounds();
-			expect(bounds instanceof L.LatLngBounds).to.be.true;
+			const bounds = latLngBounds();
+			expect(bounds instanceof LatLngBounds).to.be.true;
 		});
 
 	});
 
 	describe('#extend', () => {
 		it('extends the bounds by a given point', () => {
-			a.extend(L.latLng(20, 50));
-			expect(a.getNorthEast()).to.eql(L.latLng(30, 50));
+			a.extend(latLng(20, 50));
+			expect(a.getNorthEast()).to.eql(latLng(30, 50));
 		});
 
 		it('extends the bounds by given bounds', () => {
 			a.extend([[20, 50], [8, 40]]);
-			expect(a.getSouthEast()).to.eql(L.latLng(8, 50));
+			expect(a.getSouthEast()).to.eql(latLng(8, 50));
 		});
 
 		it('extends the bounds by undefined', () => {
@@ -47,17 +50,17 @@ describe('LatLngBounds', () => {
 
 		it('extends the bounds by raw object', () => {
 			a.extend({lat: 20, lng: 50});
-			expect(a.getNorthEast()).to.eql(L.latLng(30, 50));
+			expect(a.getNorthEast()).to.eql(latLng(30, 50));
 		});
 
 		it('extend the bounds by an empty bounds object', () => {
-			expect(a.extend(L.latLngBounds())).to.eql(a);
+			expect(a.extend(latLngBounds())).to.eql(a);
 		});
 	});
 
 	describe('#getCenter', () => {
 		it('returns the bounds center', () => {
-			expect(a.getCenter()).to.eql(L.latLng(22, 26));
+			expect(a.getCenter()).to.eql(latLng(22, 26));
 		});
 	});
 
@@ -65,7 +68,7 @@ describe('LatLngBounds', () => {
 		it('pads the bounds by a given ratio', () => {
 			const b = a.pad(0.5);
 
-			expect(b).to.eql(L.latLngBounds([[6, -2], [38, 54]]));
+			expect(b).to.eql(latLngBounds([[6, -2], [38, 54]]));
 		});
 	});
 
@@ -132,30 +135,30 @@ describe('LatLngBounds', () => {
 
 	describe('#getNorthWest', () => {
 		it('returns a proper north-west LatLng', () => {
-			expect(a.getNorthWest()).to.eql(L.latLng(a.getNorth(), a.getWest()));
+			expect(a.getNorthWest()).to.eql(latLng(a.getNorth(), a.getWest()));
 		});
 	});
 
 	describe('#getSouthEast', () => {
 		it('returns a proper south-east LatLng', () => {
-			expect(a.getSouthEast()).to.eql(L.latLng(a.getSouth(), a.getEast()));
+			expect(a.getSouthEast()).to.eql(latLng(a.getSouth(), a.getEast()));
 		});
 	});
 
 	describe('#contains', () => {
 		it('returns true if contains latlng point as array', () => {
 			expect(a.contains([16, 20])).to.eql(true);
-			expect(L.latLngBounds(a).contains([5, 20])).to.eql(false);
+			expect(latLngBounds(a).contains([5, 20])).to.eql(false);
 		});
 
 		it('returns true if contains latlng point as {lat:, lng:} object', () => {
 			expect(a.contains({lat: 16, lng: 20})).to.eql(true);
-			expect(L.latLngBounds(a).contains({lat: 5, lng: 20})).to.eql(false);
+			expect(latLngBounds(a).contains({lat: 5, lng: 20})).to.eql(false);
 		});
 
-		it('returns true if contains latlng point as L.LatLng instance', () => {
-			expect(a.contains(L.latLng([16, 20]))).to.eql(true);
-			expect(L.latLngBounds(a).contains(L.latLng([5, 20]))).to.eql(false);
+		it('returns true if contains latlng point as LatLng instance', () => {
+			expect(a.contains(latLng([16, 20]))).to.eql(true);
+			expect(latLngBounds(a).contains(latLng([5, 20]))).to.eql(false);
 		});
 
 		it('returns true if contains bounds', () => {

--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -1,57 +1,59 @@
+import {latLng} from 'leaflet';
+
 describe('LatLng', () => {
 	describe('constructor', () => {
 		it('sets lat and lng', () => {
-			const a = L.latLng(25, 74);
+			const a = latLng(25, 74);
 			expect(a.lat).to.eql(25);
 			expect(a.lng).to.eql(74);
 
-			const b = L.latLng(-25, -74);
+			const b = latLng(-25, -74);
 			expect(b.lat).to.eql(-25);
 			expect(b.lng).to.eql(-74);
 		});
 
 		it('throws an error if invalid lat or lng', () => {
 			expect(() => {
-				L.latLng(NaN, NaN);
+				latLng(NaN, NaN);
 			}).to.throw();
 		});
 
 		it('does not set altitude if undefined', () => {
-			const a = L.latLng(25, 74);
+			const a = latLng(25, 74);
 			expect(typeof a.alt).to.eql('undefined');
 		});
 
 		it('sets altitude', () => {
-			const a = L.latLng(25, 74, 50);
+			const a = latLng(25, 74, 50);
 			expect(a.alt).to.eql(50);
 
-			const b = L.latLng(-25, -74, -50);
+			const b = latLng(-25, -74, -50);
 			expect(b.alt).to.eql(-50);
 		});
 	});
 
 	describe('#equals', () => {
 		it('returns true if compared objects are equal within a certain margin', () => {
-			const a = L.latLng(10, 20);
-			const b = L.latLng(10 + 1.0E-10, 20 - 1.0E-10);
+			const a = latLng(10, 20);
+			const b = latLng(10 + 1.0E-10, 20 - 1.0E-10);
 			expect(a.equals(b)).to.eql(true);
 		});
 
 		it('returns false if compared objects are not equal within a certain margin', () => {
-			const a = L.latLng(10, 20);
-			const b = L.latLng(10, 23.3);
+			const a = latLng(10, 20);
+			const b = latLng(10, 23.3);
 			expect(a.equals(b)).to.eql(false);
 		});
 
 		it('returns false if passed non-valid object', () => {
-			const a = L.latLng(10, 20);
+			const a = latLng(10, 20);
 			expect(a.equals(null)).to.eql(false);
 		});
 	});
 
 	describe('#toString', () => {
 		it('formats a string', () => {
-			const a = L.latLng(10.333333333, 20.2222222);
+			const a = latLng(10.333333333, 20.2222222);
 			expect(a.toString(3)).to.eql('LatLng(10.333, 20.222)');
 			expect(a.toString()).to.eql('LatLng(10.333333, 20.222222)');
 		});
@@ -59,67 +61,67 @@ describe('LatLng', () => {
 
 	describe('#distanceTo', () => {
 		it('calculates distance in meters', () => {
-			const a = L.latLng(50.5, 30.5);
-			const b = L.latLng(50, 1);
+			const a = latLng(50.5, 30.5);
+			const b = latLng(50, 1);
 
 			expect(Math.abs(Math.round(a.distanceTo(b) / 1000) - 2084) < 5).to.eql(true);
 		});
 		it('does not return NaN if input points are equal', () => {
-			const a = L.latLng(50.5, 30.5);
-			const b = L.latLng(50.5, 30.5);
+			const a = latLng(50.5, 30.5);
+			const b = latLng(50.5, 30.5);
 
 			expect(a.distanceTo(b)).to.eql(0);
 		});
 	});
 
-	describe('L.latLng factory', () => {
+	describe('latLng factory', () => {
 		it('returns LatLng instance as is', () => {
-			const a = L.latLng(50, 30);
+			const a = latLng(50, 30);
 
-			expect(L.latLng(a)).to.eql(a);
+			expect(latLng(a)).to.eql(a);
 		});
 
 		it('accepts an array of coordinates', () => {
-			expect(L.latLng([])).to.eql(null);
-			expect(L.latLng([50])).to.eql(null);
-			expect(L.latLng([50, 30])).to.eql(L.latLng(50, 30));
-			expect(L.latLng([50, 30, 100])).to.eql(L.latLng(50, 30, 100));
+			expect(latLng([])).to.eql(null);
+			expect(latLng([50])).to.eql(null);
+			expect(latLng([50, 30])).to.eql(latLng(50, 30));
+			expect(latLng([50, 30, 100])).to.eql(latLng(50, 30, 100));
 		});
 
 		it('passes null or undefined as is', () => {
-			expect(L.latLng(undefined)).to.eql(undefined);
-			expect(L.latLng(null)).to.eql(null);
+			expect(latLng(undefined)).to.eql(undefined);
+			expect(latLng(null)).to.eql(null);
 		});
 
 		it('creates a LatLng object from two coordinates', () => {
-			expect(L.latLng(50, 30)).to.eql(L.latLng(50, 30));
+			expect(latLng(50, 30)).to.eql(latLng(50, 30));
 		});
 
 		it('accepts an object with lat/lng', () => {
-			expect(L.latLng({lat: 50, lng: 30})).to.eql(L.latLng(50, 30));
+			expect(latLng({lat: 50, lng: 30})).to.eql(latLng(50, 30));
 		});
 
 		it('accepts an object with lat/lon', () => {
-			expect(L.latLng({lat: 50, lon: 30})).to.eql(L.latLng(50, 30));
+			expect(latLng({lat: 50, lon: 30})).to.eql(latLng(50, 30));
 		});
 
 		it('returns null if lng not specified', () => {
-			expect(L.latLng(50)).to.equal(null);
+			expect(latLng(50)).to.equal(null);
 		});
 
 		it('accepts altitude as third parameter', () => {
-			expect(L.latLng(50, 30, 100)).to.eql(L.latLng(50, 30, 100));
+			expect(latLng(50, 30, 100)).to.eql(latLng(50, 30, 100));
 		});
 
 		it('accepts an object with alt', () => {
-			expect(L.latLng({lat: 50, lng: 30, alt: 100})).to.eql(L.latLng(50, 30, 100));
-			expect(L.latLng({lat: 50, lon: 30, alt: 100})).to.eql(L.latLng(50, 30, 100));
+			expect(latLng({lat: 50, lng: 30, alt: 100})).to.eql(latLng(50, 30, 100));
+			expect(latLng({lat: 50, lon: 30, alt: 100})).to.eql(latLng(50, 30, 100));
 		});
 	});
 
 	describe('#clone', () => {
 		it('should clone attributes', () => {
-			const a = L.latLng(50.5, 30.5, 100);
+			const a = latLng(50.5, 30.5, 100);
 			const b = a.clone();
 
 			expect(b.lat).to.equal(50.5);
@@ -128,7 +130,7 @@ describe('LatLng', () => {
 		});
 
 		it('should create another reference', () => {
-			const a = L.latLng(50.5, 30.5, 100);
+			const a = latLng(50.5, 30.5, 100);
 			const b = a.clone();
 
 			expect(a === b).to.be.false;

--- a/spec/suites/geo/crs/CRSSpec.js
+++ b/spec/suites/geo/crs/CRSSpec.js
@@ -1,39 +1,41 @@
+import {CRS, latLng, point, latLngBounds, Util, extend} from 'leaflet';
+
 describe('CRS.EPSG3857', () => {
-	const crs = L.CRS.EPSG3857;
+	const crs = CRS.EPSG3857;
 
 	describe('#latLngToPoint', () => {
 		it('projects a center point', () => {
-			expect(crs.latLngToPoint(L.latLng(0, 0), 0)).near([128, 128], 0.01);
+			expect(crs.latLngToPoint(latLng(0, 0), 0)).near([128, 128], 0.01);
 		});
 
 		it('projects the northeast corner of the world', () => {
-			expect(crs.latLngToPoint(L.latLng(85.0511287798, 180), 0)).near([256, 0]);
+			expect(crs.latLngToPoint(latLng(85.0511287798, 180), 0)).near([256, 0]);
 		});
 	});
 
 	describe('#pointToLatLng', () => {
 		it('reprojects a center point', () => {
-			expect(crs.pointToLatLng(L.point(128, 128), 0)).nearLatLng([0, 0], 0.01);
+			expect(crs.pointToLatLng(point(128, 128), 0)).nearLatLng([0, 0], 0.01);
 		});
 
 		it('reprojects the northeast corner of the world', () => {
-			expect(crs.pointToLatLng(L.point(256, 0), 0)).nearLatLng([85.0511287798, 180]);
+			expect(crs.pointToLatLng(point(256, 0), 0)).nearLatLng([85.0511287798, 180]);
 		});
 	});
 
 	describe('project', () => {
 		it('projects geo coords into meter coords correctly', () => {
-			expect(crs.project(L.latLng(50, 30))).near([3339584.7238, 6446275.84102]);
-			expect(crs.project(L.latLng(85.0511287798, 180))).near([20037508.34279, 20037508.34278]);
-			expect(crs.project(L.latLng(-85.0511287798, -180))).near([-20037508.34279, -20037508.34278]);
+			expect(crs.project(latLng(50, 30))).near([3339584.7238, 6446275.84102]);
+			expect(crs.project(latLng(85.0511287798, 180))).near([20037508.34279, 20037508.34278]);
+			expect(crs.project(latLng(-85.0511287798, -180))).near([-20037508.34279, -20037508.34278]);
 		});
 	});
 
 	describe('unproject', () => {
 		it('unprojects meter coords into geo coords correctly', () => {
-			expect(crs.unproject(L.point(3339584.7238, 6446275.84102))).nearLatLng([50, 30]);
-			expect(crs.unproject(L.point(20037508.34279, 20037508.34278))).nearLatLng([85.051129, 180]);
-			expect(crs.unproject(L.point(-20037508.34279, -20037508.34278))).nearLatLng([-85.051129, -180]);
+			expect(crs.unproject(point(3339584.7238, 6446275.84102))).nearLatLng([50, 30]);
+			expect(crs.unproject(point(20037508.34279, 20037508.34278))).nearLatLng([85.051129, 180]);
+			expect(crs.unproject(point(-20037508.34279, -20037508.34278))).nearLatLng([-85.051129, -180]);
 		});
 	});
 
@@ -53,31 +55,31 @@ describe('CRS.EPSG3857', () => {
 
 	describe('#wrapLatLng', () => {
 		it('wraps longitude to lie between -180 and 180 by default', () => {
-			expect(crs.wrapLatLng(L.latLng(0, 190)).lng).to.eql(-170);
-			expect(crs.wrapLatLng(L.latLng(0, 360)).lng).to.eql(0);
-			expect(crs.wrapLatLng(L.latLng(0, 380)).lng).to.eql(20);
-			expect(crs.wrapLatLng(L.latLng(0, -190)).lng).to.eql(170);
-			expect(crs.wrapLatLng(L.latLng(0, -360)).lng).to.eql(0);
-			expect(crs.wrapLatLng(L.latLng(0, -380)).lng).to.eql(-20);
-			expect(crs.wrapLatLng(L.latLng(0, 90)).lng).to.eql(90);
-			expect(crs.wrapLatLng(L.latLng(0, 180)).lng).to.eql(180);
+			expect(crs.wrapLatLng(latLng(0, 190)).lng).to.eql(-170);
+			expect(crs.wrapLatLng(latLng(0, 360)).lng).to.eql(0);
+			expect(crs.wrapLatLng(latLng(0, 380)).lng).to.eql(20);
+			expect(crs.wrapLatLng(latLng(0, -190)).lng).to.eql(170);
+			expect(crs.wrapLatLng(latLng(0, -360)).lng).to.eql(0);
+			expect(crs.wrapLatLng(latLng(0, -380)).lng).to.eql(-20);
+			expect(crs.wrapLatLng(latLng(0, 90)).lng).to.eql(90);
+			expect(crs.wrapLatLng(latLng(0, 180)).lng).to.eql(180);
 		});
 
 		it('does not drop altitude', () => {
-			expect(crs.wrapLatLng(L.latLng(0, 190, 1234)).lng).to.eql(-170);
-			expect(crs.wrapLatLng(L.latLng(0, 190, 1234)).alt).to.eql(1234);
+			expect(crs.wrapLatLng(latLng(0, 190, 1234)).lng).to.eql(-170);
+			expect(crs.wrapLatLng(latLng(0, 190, 1234)).alt).to.eql(1234);
 
-			expect(crs.wrapLatLng(L.latLng(0, 380, 1234)).lng).to.eql(20);
-			expect(crs.wrapLatLng(L.latLng(0, 380, 1234)).alt).to.eql(1234);
+			expect(crs.wrapLatLng(latLng(0, 380, 1234)).lng).to.eql(20);
+			expect(crs.wrapLatLng(latLng(0, 380, 1234)).alt).to.eql(1234);
 		});
 	});
 
 	describe('#wrapLatLngBounds', () => {
 		it('does not wrap bounds between -180 and 180 longitude', () => {
 
-			let bounds1 = L.latLngBounds([-10, -10], [10, 10]);
-			let bounds2 = L.latLngBounds([-80, -180], [-70, -170]);
-			let bounds3 = L.latLngBounds([70, 170], [80, 180]);
+			let bounds1 = latLngBounds([-10, -10], [10, 10]);
+			let bounds2 = latLngBounds([-80, -180], [-70, -170]);
+			let bounds3 = latLngBounds([70, 170], [80, 180]);
 
 			bounds1 = crs.wrapLatLngBounds(bounds1);
 			bounds2 = crs.wrapLatLngBounds(bounds2);
@@ -101,8 +103,8 @@ describe('CRS.EPSG3857', () => {
 		});
 
 		it('wraps bounds when center longitude is less than -180', () => {
-			let bounds1 = L.latLngBounds([0, -185], [10, -170]);
-			let bounds2 = L.latLngBounds([0, -190], [10, -175]);
+			let bounds1 = latLngBounds([0, -185], [10, -170]);
+			let bounds2 = latLngBounds([0, -190], [10, -175]);
 
 			bounds1 = crs.wrapLatLngBounds(bounds1);
 			bounds2 = crs.wrapLatLngBounds(bounds2);
@@ -119,8 +121,8 @@ describe('CRS.EPSG3857', () => {
 		});
 
 		it('wraps bounds when center longitude is larger than +180', () => {
-			let bounds1 = L.latLngBounds([0, 185], [10, 170]);
-			let bounds2 = L.latLngBounds([0, 190], [10, 175]);
+			let bounds1 = latLngBounds([0, 185], [10, 170]);
+			let bounds2 = latLngBounds([0, 190], [10, 175]);
 
 			bounds1 = crs.wrapLatLngBounds(bounds1);
 			bounds2 = crs.wrapLatLngBounds(bounds2);
@@ -141,7 +143,7 @@ describe('CRS.EPSG3857', () => {
 });
 
 describe('CRS.EPSG4326', () => {
-	const crs = L.CRS.EPSG4326;
+	const crs = CRS.EPSG4326;
 
 	describe('#getSize', () => {
 		it('gives correct size', () => {
@@ -160,45 +162,45 @@ describe('CRS.EPSG4326', () => {
 });
 
 describe('CRS.EPSG3395', () => {
-	const crs = L.CRS.EPSG3395;
+	const crs = CRS.EPSG3395;
 
 	describe('#latLngToPoint', () => {
 		it('projects a center point', () => {
-			expect(crs.latLngToPoint(L.latLng(0, 0), 0)).near([128, 128], 0.01);
+			expect(crs.latLngToPoint(latLng(0, 0), 0)).near([128, 128], 0.01);
 		});
 
 		it('projects the northeast corner of the world', () => {
-			expect(crs.latLngToPoint(L.latLng(85.0840591556, 180), 0)).near([256, 0]);
+			expect(crs.latLngToPoint(latLng(85.0840591556, 180), 0)).near([256, 0]);
 		});
 	});
 
 	describe('#pointToLatLng', () => {
 		it('reprojects a center point', () => {
-			expect(crs.pointToLatLng(L.point(128, 128), 0)).nearLatLng([0, 0], 0.01);
+			expect(crs.pointToLatLng(point(128, 128), 0)).nearLatLng([0, 0], 0.01);
 		});
 
 		it('reprojects the northeast corner of the world', () => {
-			expect(crs.pointToLatLng(L.point(256, 0), 0)).nearLatLng([85.0840591556, 180]);
+			expect(crs.pointToLatLng(point(256, 0), 0)).nearLatLng([85.0840591556, 180]);
 		});
 	});
 });
 
 describe('CRS.Simple', () => {
-	const crs = L.CRS.Simple;
+	const crs = CRS.Simple;
 
 	describe('#latLngToPoint', () => {
 		it('converts LatLng coords to pixels', () => {
-			expect(crs.latLngToPoint(L.latLng(0, 0), 0)).near([0, 0]);
-			expect(crs.latLngToPoint(L.latLng(700, 300), 0)).near([300, -700]);
-			expect(crs.latLngToPoint(L.latLng(-200, 1000), 1)).near([2000, 400]);
+			expect(crs.latLngToPoint(latLng(0, 0), 0)).near([0, 0]);
+			expect(crs.latLngToPoint(latLng(700, 300), 0)).near([300, -700]);
+			expect(crs.latLngToPoint(latLng(-200, 1000), 1)).near([2000, 400]);
 		});
 	});
 
 	describe('#pointToLatLng', () => {
 		it('converts pixels to LatLng coords', () => {
-			expect(crs.pointToLatLng(L.point(0, 0), 0)).nearLatLng([0, 0]);
-			expect(crs.pointToLatLng(L.point(300, -700), 0)).nearLatLng([700, 300]);
-			expect(crs.pointToLatLng(L.point(2000, 400), 1)).nearLatLng([-200, 1000]);
+			expect(crs.pointToLatLng(point(0, 0), 0)).nearLatLng([0, 0]);
+			expect(crs.pointToLatLng(point(300, -700), 0)).nearLatLng([700, 300]);
+			expect(crs.pointToLatLng(point(2000, 400), 1)).nearLatLng([-200, 1000]);
 		});
 	});
 
@@ -210,35 +212,35 @@ describe('CRS.Simple', () => {
 
 	describe('wrapLatLng', () => {
 		it('returns coords as is', () => {
-			expect(crs.wrapLatLng(L.latLng(270, 400)).equals(L.latLng(270, 400))).to.be.true;
+			expect(crs.wrapLatLng(latLng(270, 400)).equals(latLng(270, 400))).to.be.true;
 		});
 
 		it('wraps coords if configured', () => {
-			const crs = L.extend({}, L.CRS.Simple, {
+			const crs = extend({}, CRS.Simple, {
 				wrapLng: [-200, 200],
 				wrapLat: [-200, 200]
 			});
 
-			expect(crs.wrapLatLng(L.latLng(300, -250))).nearLatLng([-100, 150]);
+			expect(crs.wrapLatLng(latLng(300, -250))).nearLatLng([-100, 150]);
 		});
 	});
 });
 
 describe('CRS', () => {
-	const crs = L.CRS;
+	const crs = CRS;
 
 	describe('#zoom && #scale', () => {
 		it('convert zoom to scale and viceversa and return the same values', () => {
 			const zoom = 2.5;
 			const scale = crs.scale(zoom);
 			const zoom2 = crs.zoom(scale);
-			expect(L.Util.formatNum(zoom2)).to.eql(zoom);
+			expect(Util.formatNum(zoom2)).to.eql(zoom);
 		});
 	});
 });
 
 describe('CRS.ZoomNotPowerOfTwo', () => {
-	const crs = L.extend({}, L.CRS, {
+	const crs = extend({}, CRS, {
 		scale(zoom) {
 			return 256 * Math.pow(1.5, zoom);
 		},
@@ -271,8 +273,8 @@ describe('CRS.Earth', () => {
 		// we assume using mean earth radius (https://en.wikipedia.org/wiki/Earth_radius#Mean_radius)
 		// is correct, since that's what International Union of Geodesy and Geophysics recommends,
 		// and that sounds serious.
-		const p1 = L.latLng(36.12, -86.67);
-		const p2 = L.latLng(33.94, -118.40);
-		expect(L.CRS.Earth.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
+		const p1 = latLng(36.12, -86.67);
+		const p2 = latLng(33.94, -118.40);
+		expect(CRS.Earth.distance(p1, p2)).to.be.within(2886444.43, 2886444.45);
 	});
 });

--- a/spec/suites/geo/projection/ProjectionSpec.js
+++ b/spec/suites/geo/projection/ProjectionSpec.js
@@ -1,25 +1,27 @@
+import {Projection, latLng, point} from 'leaflet';
+
 describe('Projection.Mercator', () => {
-	const p = L.Projection.Mercator;
+	const p = Projection.Mercator;
 
 	describe('#project', () => {
 		it('projects a center point', () => {
 			// edge cases
-			expect(p.project(L.latLng(0, 0))).near([0, 0]);
+			expect(p.project(latLng(0, 0))).near([0, 0]);
 		});
 
 		it('projects the northeast corner of the world', () => {
-			expect(p.project(L.latLng(85.0840591556, 180))).near([20037508, 20037508]);
+			expect(p.project(latLng(85.0840591556, 180))).near([20037508, 20037508]);
 		});
 
 		it('projects the southwest corner of the world', () => {
-			expect(p.project(L.latLng(-85.0840591556, -180))).near([-20037508, -20037508]);
+			expect(p.project(latLng(-85.0840591556, -180))).near([-20037508, -20037508]);
 		});
 
 		it('projects other points', () => {
-			expect(p.project(L.latLng(50, 30))).near([3339584, 6413524]);
+			expect(p.project(latLng(50, 30))).near([3339584, 6413524]);
 
 			// from https://github.com/Leaflet/Leaflet/issues/1578
-			expect(p.project(L.latLng(51.9371170300465, 80.11230468750001)))
+			expect(p.project(latLng(51.9371170300465, 80.11230468750001)))
 			        .near([8918060.964088084, 6755099.410887127]);
 		});
 	});
@@ -30,45 +32,45 @@ describe('Projection.Mercator', () => {
 		}
 
 		it('unprojects a center point', () => {
-			expect(pr(L.point(0, 0))).near([0, 0]);
+			expect(pr(point(0, 0))).near([0, 0]);
 		});
 
 		it('unprojects pi points', () => {
-			expect(pr(L.point(-Math.PI, Math.PI))).near([-Math.PI, Math.PI]);
-			expect(pr(L.point(-Math.PI, -Math.PI))).near([-Math.PI, -Math.PI]);
+			expect(pr(point(-Math.PI, Math.PI))).near([-Math.PI, Math.PI]);
+			expect(pr(point(-Math.PI, -Math.PI))).near([-Math.PI, -Math.PI]);
 
-			expect(pr(L.point(0.523598775598, 1.010683188683))).near([0.523598775598, 1.010683188683]);
+			expect(pr(point(0.523598775598, 1.010683188683))).near([0.523598775598, 1.010683188683]);
 		});
 
 		it('unprojects other points', () => {
 			// from https://github.com/Leaflet/Leaflet/issues/1578
-			expect(pr(L.point(8918060.964088084, 6755099.410887127)));
+			expect(pr(point(8918060.964088084, 6755099.410887127)));
 		});
 	});
 });
 
 describe('Projection.SphericalMercator', () => {
-	const p = L.Projection.SphericalMercator;
+	const p = Projection.SphericalMercator;
 
 	describe('#project', () => {
 		it('projects a center point', () => {
 			// edge cases
-			expect(p.project(L.latLng(0, 0))).near([0, 0]);
+			expect(p.project(latLng(0, 0))).near([0, 0]);
 		});
 
 		it('projects the northeast corner of the world', () => {
-			expect(p.project(L.latLng(85.0511287798, 180))).near([20037508, 20037508]);
+			expect(p.project(latLng(85.0511287798, 180))).near([20037508, 20037508]);
 		});
 
 		it('projects the southwest corner of the world', () => {
-			expect(p.project(L.latLng(-85.0511287798, -180))).near([-20037508, -20037508]);
+			expect(p.project(latLng(-85.0511287798, -180))).near([-20037508, -20037508]);
 		});
 
 		it('projects other points', () => {
-			expect(p.project(L.latLng(50, 30))).near([3339584, 6446275]);
+			expect(p.project(latLng(50, 30))).near([3339584, 6446275]);
 
 			// from https://github.com/Leaflet/Leaflet/issues/1578
-			expect(p.project(L.latLng(51.9371170300465, 80.11230468750001)))
+			expect(p.project(latLng(51.9371170300465, 80.11230468750001)))
 				.near([8918060.96409, 6788763.38325]);
 		});
 	});
@@ -79,19 +81,19 @@ describe('Projection.SphericalMercator', () => {
 		}
 
 		it('unprojects a center point', () => {
-			expect(pr(L.point(0, 0))).near([0, 0]);
+			expect(pr(point(0, 0))).near([0, 0]);
 		});
 
 		it('unprojects pi points', () => {
-			expect(pr(L.point(-Math.PI, Math.PI))).near([-Math.PI, Math.PI]);
-			expect(pr(L.point(-Math.PI, -Math.PI))).near([-Math.PI, -Math.PI]);
+			expect(pr(point(-Math.PI, Math.PI))).near([-Math.PI, Math.PI]);
+			expect(pr(point(-Math.PI, -Math.PI))).near([-Math.PI, -Math.PI]);
 
-			expect(pr(L.point(0.523598775598, 1.010683188683))).near([0.523598775598, 1.010683188683]);
+			expect(pr(point(0.523598775598, 1.010683188683))).near([0.523598775598, 1.010683188683]);
 		});
 
 		it('unprojects other points', () => {
 			// from https://github.com/Leaflet/Leaflet/issues/1578
-			expect(pr(L.point(8918060.964088084, 6755099.410887127)));
+			expect(pr(point(8918060.964088084, 6755099.410887127)));
 		});
 	});
 });

--- a/spec/suites/geometry/BoundsSpec.js
+++ b/spec/suites/geometry/BoundsSpec.js
@@ -1,49 +1,51 @@
+import {bounds, Bounds, point} from 'leaflet';
+
 describe('Bounds', () => {
 	let a, b, c;
 
 	beforeEach(() => {
-		a = L.bounds(
+		a = bounds(
 			[14, 12], // left, top
 			[30, 40]); // right, bottom
-		b = L.bounds([
+		b = bounds([
 			[20, 12], // center, top
 			[14, 20], // left, middle
 			[30, 40] // right, bottom
 		]);
-		c = new L.Bounds();
+		c = new Bounds();
 	});
 
 	describe('constructor', () => {
 		it('creates bounds with proper min & max on (Point, Point)', () => {
-			expect(a.min).to.eql(L.point(14, 12));
-			expect(a.max).to.eql(L.point(30, 40));
+			expect(a.min).to.eql(point(14, 12));
+			expect(a.max).to.eql(point(30, 40));
 		});
 
 		it('creates bounds with proper min & max on (Point[])', () => {
-			expect(b.min).to.eql(L.point(14, 12));
-			expect(b.max).to.eql(L.point(30, 40));
+			expect(b.min).to.eql(point(14, 12));
+			expect(b.max).to.eql(point(30, 40));
 		});
 	});
 
 	describe('#extend', () => {
 		it('extends the bounds to contain the given point', () => {
 			a.extend([50, 20]);
-			expect(a.min).to.eql(L.point(14, 12));
-			expect(a.max).to.eql(L.point(50, 40));
+			expect(a.min).to.eql(point(14, 12));
+			expect(a.max).to.eql(point(50, 40));
 
 			b.extend([25, 50]);
-			expect(b.min).to.eql(L.point(14, 12));
-			expect(b.max).to.eql(L.point(30, 50));
+			expect(b.min).to.eql(point(14, 12));
+			expect(b.max).to.eql(point(30, 50));
 		});
 
 		it('extends the bounds by given bounds', () => {
 			a.extend([20, 50]);
-			expect(a.max).to.eql(L.point(30, 50));
+			expect(a.max).to.eql(point(30, 50));
 		});
 
 		it('extends the bounds by given bounds', () => {
 			a.extend([[20, 50], [8, 40]]);
-			expect(a.getBottomLeft()).to.eql(L.point(8, 50));
+			expect(a.getBottomLeft()).to.eql(point(8, 50));
 		});
 
 		it('extends the bounds by undefined', () => {
@@ -52,24 +54,23 @@ describe('Bounds', () => {
 
 		it('extends the bounds by raw object', () => {
 			a.extend({x: 20, y: 50});
-			expect(a.max).to.eql(L.point(30, 50));
+			expect(a.max).to.eql(point(30, 50));
 		});
 
 		it('extend the bounds by an empty bounds object', () => {
-			expect(a.extend(L.bounds())).to.eql(a);
+			expect(a.extend(bounds())).to.eql(a);
 		});
 	});
 
 	describe('#getCenter', () => {
 		it('returns the center point', () => {
-			expect(a.getCenter()).to.eql(L.point(22, 26));
+			expect(a.getCenter()).to.eql(point(22, 26));
 		});
 	});
 
 	describe('#pad', () => {
 		it('pads the bounds by a given ratio', () => {
-			const bounds = a.pad(0.5);
-			expect(bounds).to.eql(L.bounds([[6, -2], [38, 54]]));
+			expect(a.pad(0.5)).to.eql(bounds([[6, -2], [38, 54]]));
 		});
 	});
 
@@ -100,7 +101,7 @@ describe('Bounds', () => {
 
 	describe('#getSize', () => {
 		it('returns the size of the bounds as point', () => {
-			expect(a.getSize()).to.eql(L.point(16, 28));
+			expect(a.getSize()).to.eql(point(16, 28));
 		});
 	});
 
@@ -137,32 +138,31 @@ describe('Bounds', () => {
 
 	describe('#getBottomLeft', () => {
 		it('returns the proper bounds bottom-left value', () => {
-			expect(a.getBottomLeft()).to.eql(L.point(14, 40)); // left, bottom
+			expect(a.getBottomLeft()).to.eql(point(14, 40)); // left, bottom
 		});
 	});
 
 	describe('#getTopRight', () => {
 		it('returns the proper bounds top-right value', () => {
-			expect(a.getTopRight()).to.eql(L.point(30, 12)); // right, top
+			expect(a.getTopRight()).to.eql(point(30, 12)); // right, top
 		});
 	});
 
 	describe('#getTopLeft', () => {
 		it('returns the proper bounds top-left value', () => {
-			expect(a.getTopLeft()).to.eql(L.point(14, 12)); // left, top
+			expect(a.getTopLeft()).to.eql(point(14, 12)); // left, top
 		});
 	});
 
 	describe('#getBottomRight', () => {
 		it('returns the proper bounds bottom-right value', () => {
-			expect(a.getBottomRight()).to.eql(L.point(30, 40)); // left, bottom
+			expect(a.getBottomRight()).to.eql(point(30, 40)); // left, bottom
 		});
 	});
 
-	describe('L.bounds factory', () => {
+	describe('bounds factory', () => {
 		it('creates bounds from array of number arrays', () => {
-			const bounds = L.bounds([[14, 12], [30, 40]]);
-			expect(bounds).to.eql(a);
+			expect(bounds([[14, 12], [30, 40]])).to.eql(a);
 		});
 	});
 

--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -1,115 +1,117 @@
+import {Bounds, point, LineUtil, latLng, Map, polyline} from 'leaflet';
+
 describe('LineUtil', () => {
 	describe('#clipSegment', () => {
 		let bounds;
 
 		beforeEach(() => {
-			bounds = L.bounds([5, 0], [15, 10]);
+			bounds = new Bounds([5, 0], [15, 10]);
 		});
 
 		it('clips a segment by bounds', () => {
-			const a = L.point(0, 0);
-			const b = L.point(15, 15);
+			const a = point(0, 0);
+			const b = point(15, 15);
 
-			const segment = L.LineUtil.clipSegment(a, b, bounds);
+			const segment = LineUtil.clipSegment(a, b, bounds);
 
-			expect(segment[0]).to.eql(L.point(5, 5));
-			expect(segment[1]).to.eql(L.point(10, 10));
+			expect(segment[0]).to.eql(point(5, 5));
+			expect(segment[1]).to.eql(point(10, 10));
 
-			const c = L.point(5, -5);
-			const d = L.point(20, 10);
+			const c = point(5, -5);
+			const d = point(20, 10);
 
-			const segment2 = L.LineUtil.clipSegment(c, d, bounds);
+			const segment2 = LineUtil.clipSegment(c, d, bounds);
 
-			expect(segment2[0]).to.eql(L.point(10, 0));
-			expect(segment2[1]).to.eql(L.point(15, 5));
+			expect(segment2[0]).to.eql(point(10, 0));
+			expect(segment2[1]).to.eql(point(15, 5));
 		});
 
 		it('uses last bit code and reject segments out of bounds', () => {
-			const a = L.point(15, 15);
-			const b = L.point(25, 20);
-			const segment = L.LineUtil.clipSegment(a, b, bounds, true);
+			const a = point(15, 15);
+			const b = point(25, 20);
+			const segment = LineUtil.clipSegment(a, b, bounds, true);
 
 			expect(segment).to.be.false;
 		});
 
 		it('can round numbers in clipped bounds', () => {
-			const a = L.point(4, 5);
-			const b = L.point(8, 6);
+			const a = point(4, 5);
+			const b = point(8, 6);
 
-			const segment1 = L.LineUtil.clipSegment(a, b, bounds);
+			const segment1 = LineUtil.clipSegment(a, b, bounds);
 
-			expect(segment1[0]).to.eql(L.point(5, 5.25));
+			expect(segment1[0]).to.eql(point(5, 5.25));
 			expect(segment1[1]).to.eql(b);
 
-			const segment2 = L.LineUtil.clipSegment(a, b, bounds, false, true);
+			const segment2 = LineUtil.clipSegment(a, b, bounds, false, true);
 
-			expect(segment2[0]).to.eql(L.point(5, 5));
+			expect(segment2[0]).to.eql(point(5, 5));
 			expect(segment2[1]).to.eql(b);
 		});
 	});
 
 	describe('#pointToSegmentDistance & #closestPointOnSegment', () => {
-		const p1 = L.point(0, 10);
-		const p2 = L.point(10, 0);
-		const p = L.point(0, 0);
+		const p1 = point(0, 10);
+		const p2 = point(10, 0);
+		const p = point(0, 0);
 
 		it('calculates distance from point to segment', () => {
-			expect(L.LineUtil.pointToSegmentDistance(p, p1, p2)).to.eql(Math.sqrt(200) / 2);
+			expect(LineUtil.pointToSegmentDistance(p, p1, p2)).to.eql(Math.sqrt(200) / 2);
 		});
 
 		it('calculates point closest to segment', () => {
-			expect(L.LineUtil.closestPointOnSegment(p, p1, p2)).to.eql(L.point(5, 5));
+			expect(LineUtil.closestPointOnSegment(p, p1, p2)).to.eql(point(5, 5));
 		});
 	});
 
 	describe('#simplify', () => {
 		it('simplifies polylines according to tolerance', () => {
 			const points = [
-				L.point(0, 0),
-				L.point(0.01, 0),
-				L.point(0.5, 0.01),
-				L.point(0.7, 0),
-				L.point(1, 0),
-				L.point(1.999, 0.999),
-				L.point(2, 1)
+				point(0, 0),
+				point(0.01, 0),
+				point(0.5, 0.01),
+				point(0.7, 0),
+				point(1, 0),
+				point(1.999, 0.999),
+				point(2, 1)
 			];
 
-			const simplified = L.LineUtil.simplify(points, 0.1);
+			const simplified = LineUtil.simplify(points, 0.1);
 
 			expect(simplified).to.eql([
-				L.point(0, 0),
-				L.point(1, 0),
-				L.point(2, 1)
+				point(0, 0),
+				point(1, 0),
+				point(2, 1)
 			]);
 		});
 	});
 
 	describe('#isFlat', () => {
 		it('should return true for an array of LatLngs', () => {
-			expect(L.LineUtil.isFlat([L.latLng([0, 0])])).to.be.true;
+			expect(LineUtil.isFlat([latLng([0, 0])])).to.be.true;
 		});
 
 		it('should return true for an array of LatLngs arrays', () => {
-			expect(L.LineUtil.isFlat([[0, 0]])).to.be.true;
+			expect(LineUtil.isFlat([[0, 0]])).to.be.true;
 		});
 
 		it('should return true for an empty array', () => {
-			expect(L.LineUtil.isFlat([])).to.be.true;
+			expect(LineUtil.isFlat([])).to.be.true;
 		});
 
 		it('should return false for a nested array of LatLngs', () => {
-			expect(L.LineUtil.isFlat([[L.latLng([0, 0])]])).to.be.false;
+			expect(LineUtil.isFlat([[latLng([0, 0])]])).to.be.false;
 		});
 
 		it('should return false for a nested empty array', () => {
-			expect(L.LineUtil.isFlat([[]])).to.be.false;
+			expect(LineUtil.isFlat([[]])).to.be.false;
 		});
 	});
 
 	describe('#polylineCenter', () => {
 		let map, crs, zoom;
 		beforeEach(() => {
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
+			map = new Map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
 		});
 
@@ -121,38 +123,38 @@ describe('LineUtil', () => {
 
 		it('computes center of line', () => {
 			const latlngs = [[80, 0], [80, 90]];
-			const center = L.LineUtil.polylineCenter(latlngs, crs);
+			const center = LineUtil.polylineCenter(latlngs, crs);
 			expect(center).to.be.nearLatLng([80, 45]);
 		});
 
 		it('computes center of a small line', () => {
 			const latlngs = [[50.49898323576035, 30.509834789772036], [50.49998323576035, 30.509834789772036], [50.49998323576035, 30.509939789772037], [50.49898323576035, 30.509939789772037]];
-			const layer = L.polyline(latlngs).addTo(map);
+			const layer = polyline(latlngs).addTo(map);
 			expect(layer.getCenter()).to.be.nearLatLng([50.49998323576035, 30.50989603626345]);
 		});
 
 		it('throws error if latlngs not passed', () => {
 			expect(() => {
-				L.LineUtil.polylineCenter(null, crs);
+				LineUtil.polylineCenter(null, crs);
 			}).to.throw('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', () => {
 			expect(() => {
-				L.LineUtil.polylineCenter([], crs);
+				LineUtil.polylineCenter([], crs);
 			}).to.throw('latlngs not passed');
 		});
 
 
 		it('throws error if latlngs not passed', () => {
 			expect(() => {
-				L.LineUtil.polylineCenter(null, crs, zoom);
+				LineUtil.polylineCenter(null, crs, zoom);
 			}).to.throw('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', () => {
 			expect(() => {
-				L.LineUtil.polylineCenter([], crs, zoom);
+				LineUtil.polylineCenter([], crs, zoom);
 			}).to.throw('latlngs not passed');
 		});
 
@@ -161,7 +163,7 @@ describe('LineUtil', () => {
 				[[80, 0], [80, 90]]
 			];
 			const spy = sinon.spy(console, 'warn');
-			const center = L.LineUtil.polylineCenter(latlngs, crs);
+			const center = LineUtil.polylineCenter(latlngs, crs);
 			console.warn.restore();
 			expect(spy.calledOnce).to.be.true;
 			expect(center).to.be.nearLatLng([80, 45]);
@@ -173,7 +175,7 @@ describe('LineUtil', () => {
 			const latlngs = [
 				[[80, 0], [80, 90]]
 			];
-			const center = L.LineUtil.polylineCenter(latlngs, crs);
+			const center = LineUtil.polylineCenter(latlngs, crs);
 			expect(center).to.be.nearLatLng([80, 45]);
 		});
 	});

--- a/spec/suites/geometry/PointSpec.js
+++ b/spec/suites/geometry/PointSpec.js
@@ -1,13 +1,15 @@
+import {point} from 'leaflet';
+
 describe('Point', () => {
 	describe('constructor', () => {
 		it('creates a point with the given x and y', () => {
-			const p = L.point(1.5, 2.5);
+			const p = point(1.5, 2.5);
 			expect(p.x).to.eql(1.5);
 			expect(p.y).to.eql(2.5);
 		});
 
 		it('rounds the given x and y if the third argument is true', () => {
-			const p = L.point(1.3, 2.7, true);
+			const p = point(1.3, 2.7, true);
 			expect(p.x).to.eql(1);
 			expect(p.y).to.eql(3);
 		});
@@ -15,57 +17,57 @@ describe('Point', () => {
 
 	describe('#subtract', () => {
 		it('subtracts the given point from this one', () => {
-			const a = L.point(50, 30),
-			    b = L.point(20, 10);
-			expect(a.subtract(b)).to.eql(L.point(30, 20));
+			const a = point(50, 30),
+			    b = point(20, 10);
+			expect(a.subtract(b)).to.eql(point(30, 20));
 		});
 	});
 
 	describe('#add', () => {
 		it('adds given point to this one', () => {
-			expect(L.point(50, 30).add(L.point(20, 10))).to.eql(L.point(70, 40));
+			expect(point(50, 30).add(point(20, 10))).to.eql(point(70, 40));
 		});
 	});
 
 	describe('#divideBy', () => {
 		it('divides this point by the given amount', () => {
-			expect(L.point(50, 30).divideBy(5)).to.eql(L.point(10, 6));
+			expect(point(50, 30).divideBy(5)).to.eql(point(10, 6));
 		});
 	});
 
 	describe('#multiplyBy', () => {
 		it('multiplies this point by the given amount', () => {
-			expect(L.point(50, 30).multiplyBy(2)).to.eql(L.point(100, 60));
+			expect(point(50, 30).multiplyBy(2)).to.eql(point(100, 60));
 		});
 	});
 
 	describe('#floor', () => {
 		it('returns a new point with floored coordinates', () => {
-			expect(L.point(50.56, 30.123).floor()).to.eql(L.point(50, 30));
-			expect(L.point(-50.56, -30.123).floor()).to.eql(L.point(-51, -31));
+			expect(point(50.56, 30.123).floor()).to.eql(point(50, 30));
+			expect(point(-50.56, -30.123).floor()).to.eql(point(-51, -31));
 		});
 	});
 
 	describe('#trunc', () => {
 		it('returns a new point with truncated coordinates', () => {
-			expect(L.point(50.56, 30.123).trunc()).to.eql(L.point(50, 30));
-			expect(L.point(-50.56, -30.123).trunc()).to.eql(L.point(-50, -30));
+			expect(point(50.56, 30.123).trunc()).to.eql(point(50, 30));
+			expect(point(-50.56, -30.123).trunc()).to.eql(point(-50, -30));
 		});
 	});
 
 	describe('#distanceTo', () => {
 		it('calculates distance between two points', () => {
-			const p1 = L.point(0, 30);
-			const p2 = L.point(40, 0);
+			const p1 = point(0, 30);
+			const p2 = point(40, 0);
 			expect(p1.distanceTo(p2)).to.eql(50.0);
 		});
 	});
 
 	describe('#equals', () => {
 		it('returns true if points are equal', () => {
-			const p1 = L.point(20.4, 50.12);
-			const p2 = L.point(20.4, 50.12);
-			const p3 = L.point(20.5, 50.13);
+			const p1 = point(20.4, 50.12);
+			const p2 = point(20.4, 50.12);
+			const p3 = point(20.5, 50.13);
 
 			expect(p1.equals(p2)).to.be.true;
 			expect(p1.equals(p3)).to.be.false;
@@ -74,10 +76,10 @@ describe('Point', () => {
 
 	describe('#contains', () => {
 		it('returns true if the point is bigger in absolute dimensions than the passed one', () => {
-			const p1 = L.point(50, 30),
-			    p2 = L.point(-40, 20),
-			    p3 = L.point(60, -20),
-			    p4 = L.point(-40, -40);
+			const p1 = point(50, 30),
+			    p2 = point(-40, 20),
+			    p3 = point(60, -20),
+			    p4 = point(-40, -40);
 
 			expect(p1.contains(p2)).to.be.true;
 			expect(p1.contains(p3)).to.be.false;
@@ -87,32 +89,32 @@ describe('Point', () => {
 
 	describe('#toString', () => {
 		it('formats a string out of point coordinates', () => {
-			expect(`${L.point(50, 30)}`).to.eql('Point(50, 30)');
-			expect(`${L.point(50.1234567, 30.1234567)}`).to.eql('Point(50.123457, 30.123457)');
+			expect(`${point(50, 30)}`).to.eql('Point(50, 30)');
+			expect(`${point(50.1234567, 30.1234567)}`).to.eql('Point(50.123457, 30.123457)');
 		});
 	});
 
-	describe('L.point factory', () => {
-		it('leaves L.Point instances as is', () => {
-			const p = L.point(50, 30);
-			expect(L.point(p)).to.equal(p);
+	describe('point factory', () => {
+		it('leaves Point instances as is', () => {
+			const p = point(50, 30);
+			expect(point(p)).to.equal(p);
 		});
 
 		it('creates a point out of three arguments', () => {
-			expect(L.point(50.1, 30.1, true)).to.eql(L.point(50, 30));
+			expect(point(50.1, 30.1, true)).to.eql(point(50, 30));
 		});
 
 		it('creates a point from an array of coordinates', () => {
-			expect(L.point([50, 30])).to.eql(L.point(50, 30));
+			expect(point([50, 30])).to.eql(point(50, 30));
 		});
 
 		it('creates a point from an object with x and y properties', () => {
-			expect(L.point({x: 50, y: 30})).to.eql(L.point(50, 30));
+			expect(point({x: 50, y: 30})).to.eql(point(50, 30));
 		});
 
 		it('does not fail on invalid arguments', () => {
-			expect(L.point(undefined)).to.equal(undefined);
-			expect(L.point(null)).to.equal(null);
+			expect(point(undefined)).to.equal(undefined);
+			expect(point(null)).to.equal(null);
 		});
 	});
 });

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -1,40 +1,42 @@
+import {Bounds, Point, PolyUtil, Map, Polygon} from 'leaflet';
+
 describe('PolyUtil', () => {
 	describe('#clipPolygon', () => {
 		it('clips polygon by bounds', () => {
-			const bounds = L.bounds([0, 0], [10, 10]);
+			const bounds = new Bounds([0, 0], [10, 10]);
 
 			const points = [
-				L.point(5, 5),
-				L.point(15, 10),
-				L.point(10, 15)
+				new Point(5, 5),
+				new Point(15, 10),
+				new Point(10, 15)
 			];
 
 			// check clip without rounding
-			const clipped = L.PolyUtil.clipPolygon(points, bounds);
+			const clipped = PolyUtil.clipPolygon(points, bounds);
 
 			for (let i = 0, len = clipped.length; i < len; i++) {
 				delete clipped[i]._code;
 			}
 
 			expect(clipped).to.eql([
-				L.point(7.5, 10),
-				L.point(5, 5),
-				L.point(10, 7.5),
-				L.point(10, 10)
+				new Point(7.5, 10),
+				new Point(5, 5),
+				new Point(10, 7.5),
+				new Point(10, 10)
 			]);
 
 			// check clip with rounding
-			const clippedRounded = L.PolyUtil.clipPolygon(points, bounds, true);
+			const clippedRounded = PolyUtil.clipPolygon(points, bounds, true);
 
 			for (let i = 0, len = clippedRounded.length; i < len; i++) {
 				delete clippedRounded[i]._code;
 			}
 
 			expect(clippedRounded).to.eql([
-				L.point(8, 10),
-				L.point(5, 5),
-				L.point(10, 8),
-				L.point(10, 10)
+				new Point(8, 10),
+				new Point(5, 5),
+				new Point(10, 8),
+				new Point(10, 10)
 			]);
 		});
 	});
@@ -42,7 +44,7 @@ describe('PolyUtil', () => {
 	describe('#polygonCenter', () => {
 		let map, crs, zoom;
 		beforeEach(() => {
-			map = L.map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
+			map = new Map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
 			zoom = map.getZoom();
 		});
@@ -55,31 +57,31 @@ describe('PolyUtil', () => {
 
 		it('computes center of polygon', () => {
 			const latlngs = [[0, 0], [10, 0], [10, 10], [0, 10]];
-			const center = L.PolyUtil.polygonCenter(latlngs, crs, zoom);
+			const center = PolyUtil.polygonCenter(latlngs, crs, zoom);
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
 		});
 
 		it('computes center of a small polygon', () => {
 			const latlngs = [[42.87097909758862, -81.12594320566181], [42.87108302016597, -81.12594320566181], [42.87108302016597, -81.12576504805303], [42.87097909758862, -81.12576504805303]];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = new Polygon(latlngs).addTo(map);
 			expect(layer.getCenter()).to.be.nearLatLng([42.87103105887729, -81.12585412685742]);
 		});
 
 		it('computes center of a big polygon', () => {
 			const latlngs = [[90, -180], [90, 180], [-90, 180], [-90, -180]];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = new Polygon(latlngs).addTo(map);
 			expect(layer.getCenter()).to.be.nearLatLng([0, 0]);
 		});
 
 		it('throws error if latlngs not passed', () => {
 			expect(() => {
-				L.PolyUtil.polygonCenter(null,  crs);
+				PolyUtil.polygonCenter(null,  crs);
 			}).to.throw('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', () => {
 			expect(() => {
-				L.PolyUtil.polygonCenter([], crs);
+				PolyUtil.polygonCenter([], crs);
 			}).to.throw('latlngs not passed');
 		});
 
@@ -88,7 +90,7 @@ describe('PolyUtil', () => {
 				[[0, 0], [10, 0], [10, 10], [0, 10]]
 			];
 			const spy = sinon.spy(console, 'warn');
-			const center = L.PolyUtil.polygonCenter(latlngs, crs);
+			const center = PolyUtil.polygonCenter(latlngs, crs);
 			console.warn.restore();
 			expect(spy.calledOnce).to.be.true;
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
@@ -100,7 +102,7 @@ describe('PolyUtil', () => {
 			const latlngs = [
 				[[0, 0], [10, 0], [10, 10], [0, 10]]
 			];
-			const center = L.PolyUtil.polygonCenter(latlngs, crs);
+			const center = PolyUtil.polygonCenter(latlngs, crs);
 			expect(center).to.be.nearLatLng([5.019148099025293, 5]);
 		});
 	});

--- a/spec/suites/geometry/TransformationSpec.js
+++ b/spec/suites/geometry/TransformationSpec.js
@@ -1,20 +1,22 @@
+import {transformation, point} from 'leaflet';
+
 describe('Transformation', () => {
 	let t, p;
 
 	beforeEach(() => {
-		t = L.transformation(1, 2, 3, 4);
-		p = L.point(10, 20);
+		t = transformation(1, 2, 3, 4);
+		p = point(10, 20);
 	});
 
 	describe('#transform', () => {
 		it('performs a transformation', () => {
 			const p2 = t.transform(p, 2);
-			expect(p2).to.eql(L.point(24, 128));
+			expect(p2).to.eql(point(24, 128));
 		});
 
 		it('assumes a scale of 1 if not specified', () => {
 			const p2 = t.transform(p);
-			expect(p2).to.eql(L.point(12, 64));
+			expect(p2).to.eql(point(12, 64));
 		});
 	});
 
@@ -26,13 +28,13 @@ describe('Transformation', () => {
 		});
 
 		it('assumes a scale of 1 if not specified', () => {
-			expect(t.untransform(L.point(12, 64))).to.eql(L.point(10, 20));
+			expect(t.untransform(point(12, 64))).to.eql(point(10, 20));
 		});
 	});
 
 	describe('#constructor', () => {
 		it('allows an array property for a', () => {
-			const t2 = L.transformation([1, 2, 3, 4]);
+			const t2 = transformation([1, 2, 3, 4]);
 			expect(t._a).to.eql(t2._a);
 			expect(t._b).to.eql(t2._b);
 			expect(t._c).to.eql(t2._c);

--- a/spec/suites/layer/FeatureGroupSpec.js
+++ b/spec/suites/layer/FeatureGroupSpec.js
@@ -1,15 +1,17 @@
-﻿describe('FeatureGroup', () => {
+﻿import {Marker, featureGroup, layerGroup, stamp} from 'leaflet';
+
+describe('FeatureGroup', () => {
 	describe('#_propagateEvent', () => {
 		let marker;
 
 		beforeEach(() => {
-			marker = L.marker([0, 0]);
+			marker = new Marker([0, 0]);
 		});
 
 		describe('when a Marker is added to multiple FeatureGroups ', () => {
 			it('e.propagatedFrom should be the Marker', () => {
-				const fg1 = L.featureGroup(),
-				    fg2 = L.featureGroup();
+				const fg1 = featureGroup(),
+				    fg2 = featureGroup();
 
 				fg1.addLayer(marker);
 				fg2.addLayer(marker);
@@ -39,8 +41,8 @@
 
 	describe('addLayer', () => {
 		it('adds the layer', () => {
-			const fg = L.featureGroup(),
-			    marker = L.marker([0, 0]);
+			const fg = featureGroup(),
+			    marker = new Marker([0, 0]);
 
 			expect(fg.hasLayer(marker)).to.be.false;
 
@@ -50,8 +52,8 @@
 		});
 
 		it('supports non-evented layers', () => {
-			const fg = L.featureGroup(),
-			    g = L.layerGroup();
+			const fg = featureGroup(),
+			    g = layerGroup();
 
 			expect(fg.hasLayer(g)).to.be.false;
 
@@ -63,8 +65,8 @@
 
 	describe('removeLayer', () => {
 		it('removes the layer passed to it', () => {
-			const fg = L.featureGroup(),
-			    marker = L.marker([0, 0]);
+			const fg = featureGroup(),
+			    marker = new Marker([0, 0]);
 
 			fg.addLayer(marker);
 			expect(fg.hasLayer(marker)).to.be.true;
@@ -74,13 +76,13 @@
 		});
 
 		it('removes the layer passed to it by id', () => {
-			const fg = L.featureGroup(),
-			    marker = L.marker([0, 0]);
+			const fg = featureGroup(),
+			    marker = new Marker([0, 0]);
 
 			fg.addLayer(marker);
 			expect(fg.hasLayer(marker)).to.be.true;
 
-			fg.removeLayer(L.stamp(marker));
+			fg.removeLayer(stamp(marker));
 			expect(fg.hasLayer(marker)).to.be.false;
 		});
 	});

--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -1,4 +1,6 @@
-describe('L.GeoJSON', () => {
+import {GeoJSON, Marker, Circle, CircleMarker, Polyline, Polygon, LayerGroup, TileLayer, LatLng, FeatureGroup} from 'leaflet';
+
+describe('GeoJSON', () => {
 	describe('addData', () => {
 		const geojson = {
 			type: 'Feature',
@@ -14,19 +16,19 @@ describe('L.GeoJSON', () => {
 		};
 
 		it('sets feature property on member layers', () => {
-			const layer = L.geoJSON();
+			const layer = new GeoJSON();
 			layer.addData(geojson);
 			expect(layer.getLayers()[0].feature).to.eql(geojson);
 		});
 
 		it('normalizes a geometry to a Feature', () => {
-			const layer = L.geoJSON();
+			const layer = new GeoJSON();
 			layer.addData(geojson.geometry);
 			expect(layer.getLayers()[0].feature).to.eql(geojson);
 		});
 
 		it('accepts geojson with null geometry', () => {
-			const layer = L.geoJSON();
+			const layer = new GeoJSON();
 			layer.addData(geojsonEmpty);
 			expect(layer.getLayers().length).to.eql(0);
 		});
@@ -36,7 +38,7 @@ describe('L.GeoJSON', () => {
 			const options = {
 				customOption: 'My Custom Option'
 			};
-			const layer = L.geoJSON(null, options);
+			const layer = new GeoJSON(null, options);
 			layer.addData(geojson);
 			expect(layer.getLayers()[0].options.customOption).to.equal(undefined);
 
@@ -56,7 +58,7 @@ describe('L.GeoJSON', () => {
 					coordinates:[[-2.35, 51.38], [-2.38, 51.38]]
 				}
 			};
-			const geojson = L.geoJSON(feature, {weight: 7, color: 'chocolate'});
+			const geojson = new GeoJSON(feature, {weight: 7, color: 'chocolate'});
 			geojson.setStyle({weight: 22, color: 'coral'});
 			const layer = geojson.getLayers()[0];
 			expect(layer.options.weight).to.equal(22);
@@ -81,7 +83,7 @@ describe('L.GeoJSON', () => {
 					coordinates:[[-3.35, 50.38], [-3.38, 50.38]]
 				}
 			};
-			const geojson = L.geoJSON([feature, feature2], {weight: 7, color: 'chocolate'});
+			const geojson = new GeoJSON([feature, feature2], {weight: 7, color: 'chocolate'});
 			geojson.setStyle({weight: 22, color: 'coral'});
 			const layer = geojson.getLayers()[0];
 			expect(layer.options.weight).to.equal(22);
@@ -98,9 +100,9 @@ describe('L.GeoJSON', () => {
 	});
 });
 
-describe('L.Marker#toGeoJSON', () => {
+describe('Marker#toGeoJSON', () => {
 	it('returns a 2D Point object', () => {
-		const marker = L.marker([10, 20]);
+		const marker = new Marker([10, 20]);
 		expect(marker.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10]
@@ -108,7 +110,7 @@ describe('L.Marker#toGeoJSON', () => {
 	});
 
 	it('returns a 3D Point object', () => {
-		const marker = L.marker([10, 20, 30]);
+		const marker = new Marker([10, 20, 30]);
 		expect(marker.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10, 30]
@@ -116,7 +118,7 @@ describe('L.Marker#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const marker = L.marker([10.123456, 20.123456, 30.123456]);
+		const marker = new Marker([10.123456, 20.123456, 30.123456]);
 		expect(marker.toGeoJSON(3).geometry).to.eql({
 			type: 'Point',
 			coordinates: [20.123, 10.123, 30.123]
@@ -124,9 +126,9 @@ describe('L.Marker#toGeoJSON', () => {
 	});
 });
 
-describe('L.Circle#toGeoJSON', () => {
+describe('Circle#toGeoJSON', () => {
 	it('returns a 2D Point object', () => {
-		const circle = L.circle([10, 20], 100);
+		const circle = new Circle([10, 20], 100);
 		expect(circle.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10]
@@ -134,7 +136,7 @@ describe('L.Circle#toGeoJSON', () => {
 	});
 
 	it('returns a 3D Point object', () => {
-		const circle = L.circle([10, 20, 30], 100);
+		const circle = new Circle([10, 20, 30], 100);
 		expect(circle.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10, 30]
@@ -142,7 +144,7 @@ describe('L.Circle#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const circle = L.circle([10.1234, 20.1234, 30.1234], 100);
+		const circle = new Circle([10.1234, 20.1234, 30.1234], 100);
 		expect(circle.toGeoJSON(3).geometry).to.eql({
 			type: 'Point',
 			coordinates: [20.123, 10.123, 30.123]
@@ -150,9 +152,9 @@ describe('L.Circle#toGeoJSON', () => {
 	});
 });
 
-describe('L.CircleMarker#toGeoJSON', () => {
+describe('CircleMarker#toGeoJSON', () => {
 	it('returns a 2D Point object', () => {
-		const marker = L.circleMarker([10, 20]);
+		const marker = new CircleMarker([10, 20]);
 		expect(marker.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10]
@@ -160,7 +162,7 @@ describe('L.CircleMarker#toGeoJSON', () => {
 	});
 
 	it('returns a 3D Point object', () => {
-		const marker = L.circleMarker([10, 20, 30]);
+		const marker = new CircleMarker([10, 20, 30]);
 		expect(marker.toGeoJSON().geometry).to.eql({
 			type: 'Point',
 			coordinates: [20, 10, 30]
@@ -168,7 +170,7 @@ describe('L.CircleMarker#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const marker = L.circleMarker([10.1234, 20.1234]);
+		const marker = new CircleMarker([10.1234, 20.1234]);
 		expect(marker.toGeoJSON(3).geometry).to.eql({
 			type: 'Point',
 			coordinates: [20.123, 10.123]
@@ -176,9 +178,9 @@ describe('L.CircleMarker#toGeoJSON', () => {
 	});
 });
 
-describe('L.Polyline#toGeoJSON', () => {
+describe('Polyline#toGeoJSON', () => {
 	it('returns a 2D LineString object', () => {
-		const polyline = L.polyline([[10, 20], [2, 5]]);
+		const polyline = new Polyline([[10, 20], [2, 5]]);
 		expect(polyline.toGeoJSON().geometry).to.eql({
 			type: 'LineString',
 			coordinates: [[20, 10], [5, 2]]
@@ -186,7 +188,7 @@ describe('L.Polyline#toGeoJSON', () => {
 	});
 
 	it('returns a 3D LineString object', () => {
-		const polyline = L.polyline([[10, 20, 30], [2, 5, 10]]);
+		const polyline = new Polyline([[10, 20, 30], [2, 5, 10]]);
 		expect(polyline.toGeoJSON().geometry).to.eql({
 			type: 'LineString',
 			coordinates: [[20, 10, 30], [5, 2, 10]]
@@ -194,7 +196,7 @@ describe('L.Polyline#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const polyline = L.polyline([[10.1234, 20.1234, 30.1234], [2.1234, 5.1234, 10.1234]]);
+		const polyline = new Polyline([[10.1234, 20.1234, 30.1234], [2.1234, 5.1234, 10.1234]]);
 		expect(polyline.toGeoJSON(3).geometry).to.eql({
 			type: 'LineString',
 			coordinates: [[20.123, 10.123, 30.123], [5.123, 2.123, 10.123]]
@@ -202,9 +204,9 @@ describe('L.Polyline#toGeoJSON', () => {
 	});
 });
 
-describe('L.Polyline (multi) #toGeoJSON', () => {
+describe('Polyline (multi) #toGeoJSON', () => {
 	it('returns a 2D MultiLineString object', () => {
-		const multiPolyline = L.polyline([[[10, 20], [2, 5]], [[1, 2], [3, 4]]]);
+		const multiPolyline = new Polyline([[[10, 20], [2, 5]], [[1, 2], [3, 4]]]);
 		expect(multiPolyline.toGeoJSON().geometry).to.eql({
 			type: 'MultiLineString',
 			coordinates: [
@@ -215,7 +217,7 @@ describe('L.Polyline (multi) #toGeoJSON', () => {
 	});
 
 	it('returns a 3D MultiLineString object', () => {
-		const multiPolyline = L.polyline([[[10, 20, 30], [2, 5, 10]], [[1, 2, 3], [4, 5, 6]]]);
+		const multiPolyline = new Polyline([[[10, 20, 30], [2, 5, 10]], [[1, 2, 3], [4, 5, 6]]]);
 		expect(multiPolyline.toGeoJSON().geometry).to.eql({
 			type: 'MultiLineString',
 			coordinates: [
@@ -226,7 +228,7 @@ describe('L.Polyline (multi) #toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const multiPolyline = L.polyline([[[10.1234, 20.1234, 30.1234], [2.1234, 5.1234, 10.1234]], [[1.1234, 2.1234, 3.1234], [4.1234, 5.1234, 6.1234]]]);
+		const multiPolyline = new Polyline([[[10.1234, 20.1234, 30.1234], [2.1234, 5.1234, 10.1234]], [[1.1234, 2.1234, 3.1234], [4.1234, 5.1234, 6.1234]]]);
 		expect(multiPolyline.toGeoJSON(3).geometry).to.eql({
 			type: 'MultiLineString',
 			coordinates: [
@@ -237,9 +239,9 @@ describe('L.Polyline (multi) #toGeoJSON', () => {
 	});
 });
 
-describe('L.Polygon#toGeoJSON', () => {
+describe('Polygon#toGeoJSON', () => {
 	it('returns a 2D Polygon object (no holes) from a flat LatLngs array', () => {
-		const polygon = L.polygon([[1, 2], [3, 4], [5, 6]]);
+		const polygon = new Polygon([[1, 2], [3, 4], [5, 6]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [[[2, 1], [4, 3], [6, 5], [2, 1]]]
@@ -247,7 +249,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('returns a 3D Polygon object (no holes) from a flat LatLngs array', () => {
-		const polygon = L.polygon([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+		const polygon = new Polygon([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [[[2, 1, 3], [5, 4, 6], [8, 7, 9], [2, 1, 3]]]
@@ -255,7 +257,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('returns a 2D Polygon object from a simple GeoJSON like input', () => {
-		const multiPolygon = L.polygon([[[1, 2], [3, 4], [5, 6]]]);
+		const multiPolygon = new Polygon([[[1, 2], [3, 4], [5, 6]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [
@@ -265,7 +267,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('returns a 3D MultiPolygon object from a simple GeoJSON like input', () => {
-		const multiPolygon = L.polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
+		const multiPolygon = new Polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [
@@ -275,7 +277,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('returns a 2D Polygon object (with holes)', () => {
-		const polygon = L.polygon([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]);
+		const polygon = new Polygon([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [
@@ -286,7 +288,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('returns a 3D Polygon object (with holes)', () => {
-		const polygon = L.polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]]]);
+		const polygon = new Polygon([[[1, 2, 3], [4, 5, 6], [7, 8, 9]], [[10, 11, 12], [13, 14, 15], [16, 17, 18]]]);
 		expect(polygon.toGeoJSON().geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [
@@ -297,7 +299,7 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const polygon = L.polygon([[1.1234, 2.1234], [3.1234, 4.1234], [5.1234, 6.1234]]);
+		const polygon = new Polygon([[1.1234, 2.1234], [3.1234, 4.1234], [5.1234, 6.1234]]);
 		expect(polygon.toGeoJSON(3).geometry).to.eql({
 			type: 'Polygon',
 			coordinates: [[[2.123, 1.123], [4.123, 3.123], [6.123, 5.123], [2.123, 1.123]]]
@@ -305,9 +307,9 @@ describe('L.Polygon#toGeoJSON', () => {
 	});
 });
 
-describe('L.Polygon (multi) #toGeoJSON', () => {
+describe('Polygon (multi) #toGeoJSON', () => {
 	it('returns a 2D MultiPolygon object', () => {
-		const multiPolygon = L.polygon([[[[1, 2], [3, 4], [5, 6]]]]);
+		const multiPolygon = new Polygon([[[[1, 2], [3, 4], [5, 6]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -317,7 +319,7 @@ describe('L.Polygon (multi) #toGeoJSON', () => {
 	});
 
 	it('returns a 3D MultiPolygon object', () => {
-		const multiPolygon = L.polygon([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]]);
+		const multiPolygon = new Polygon([[[[1, 2, 3], [4, 5, 6], [7, 8, 9]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -327,7 +329,7 @@ describe('L.Polygon (multi) #toGeoJSON', () => {
 	});
 
 	it('returns a 2D MultiPolygon object with two polygons', () => {
-		const multiPolygon = L.polygon([[[[1, 2], [3, 4], [5, 6]]], [[[7, 8], [9, 10], [11, 12]]]]);
+		const multiPolygon = new Polygon([[[[1, 2], [3, 4], [5, 6]]], [[[7, 8], [9, 10], [11, 12]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -338,7 +340,7 @@ describe('L.Polygon (multi) #toGeoJSON', () => {
 	});
 
 	it('returns a 2D MultiPolygon object with polygon having a hole', () => {
-		const multiPolygon = L.polygon([[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]]);
+		const multiPolygon = new Polygon([[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]]);
 		expect(multiPolygon.toGeoJSON().geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -348,7 +350,7 @@ describe('L.Polygon (multi) #toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const multiPolygon = L.polygon([[[[1.1234, 2.1234], [3.1234, 4.1234], [5.1234, 6.1234]]]]);
+		const multiPolygon = new Polygon([[[[1.1234, 2.1234], [3.1234, 4.1234], [5.1234, 6.1234]]]]);
 		expect(multiPolygon.toGeoJSON(3).geometry).to.eql({
 			type: 'MultiPolygon',
 			coordinates: [
@@ -358,11 +360,11 @@ describe('L.Polygon (multi) #toGeoJSON', () => {
 	});
 });
 
-describe('L.LayerGroup#toGeoJSON', () => {
+describe('LayerGroup#toGeoJSON', () => {
 	it('returns a 2D FeatureCollection object', () => {
-		const marker = L.marker([10, 20]),
-		    polyline = L.polyline([[10, 20], [2, 5]]),
-		    layerGroup = L.layerGroup([marker, polyline]);
+		const marker = new Marker([10, 20]),
+		    polyline = new Polyline([[10, 20], [2, 5]]),
+		    layerGroup = new LayerGroup([marker, polyline]);
 		expect(layerGroup.toGeoJSON()).to.eql({
 			type: 'FeatureCollection',
 			features: [marker.toGeoJSON(), polyline.toGeoJSON()]
@@ -370,9 +372,9 @@ describe('L.LayerGroup#toGeoJSON', () => {
 	});
 
 	it('returns a 3D FeatureCollection object', () => {
-		const marker = L.marker([10, 20, 30]),
-		    polyline = L.polyline([[10, 20, 30], [2, 5, 10]]),
-		    layerGroup = L.layerGroup([marker, polyline]);
+		const marker = new Marker([10, 20, 30]),
+		    polyline = new Polyline([[10, 20, 30], [2, 5, 10]]),
+		    layerGroup = new LayerGroup([marker, polyline]);
 		expect(layerGroup.toGeoJSON()).to.eql({
 			type: 'FeatureCollection',
 			features: [marker.toGeoJSON(), polyline.toGeoJSON()]
@@ -380,8 +382,8 @@ describe('L.LayerGroup#toGeoJSON', () => {
 	});
 
 	it('ensures that every member is a Feature', () => {
-		const tileLayer = L.tileLayer(),
-		    layerGroup = L.layerGroup([tileLayer]);
+		const tileLayer = new TileLayer(),
+		    layerGroup = new LayerGroup([tileLayer]);
 
 		tileLayer.toGeoJSON = function () {
 			return {
@@ -446,7 +448,7 @@ describe('L.LayerGroup#toGeoJSON', () => {
 				}
 			}]
 		};
-		expect(L.geoJSON(json).toGeoJSON()).to.eql(expected);
+		expect(new GeoJSON(json).toGeoJSON()).to.eql(expected);
 	});
 
 	it('roundtrips MultiPoint features', () => {
@@ -477,12 +479,12 @@ describe('L.LayerGroup#toGeoJSON', () => {
 				}
 			}]
 		};
-		expect(L.geoJSON(json).toGeoJSON()).to.eql(expected);
+		expect(new GeoJSON(json).toGeoJSON()).to.eql(expected);
 	});
 
 	it('omits layers which do not implement toGeoJSON', () => {
-		const tileLayer = L.tileLayer(),
-		    layerGroup = L.layerGroup([tileLayer]);
+		const tileLayer = new TileLayer(),
+		    layerGroup = new LayerGroup([tileLayer]);
 		expect(layerGroup.toGeoJSON()).to.eql({
 			type: 'FeatureCollection',
 			features: []
@@ -490,9 +492,9 @@ describe('L.LayerGroup#toGeoJSON', () => {
 	});
 
 	it('should return only one FeatureCollection for nested LayerGroups', () => {
-		const layerGroup = L.layerGroup([
-			L.layerGroup([L.marker([-41.3330287, 173.2008273])]),
-			L.marker([-41.273356, 173.287278])
+		const layerGroup = new LayerGroup([
+			new LayerGroup([new Marker([-41.3330287, 173.2008273])]),
+			new Marker([-41.273356, 173.287278])
 		]);
 
 		const geoJSON = layerGroup.toGeoJSON();
@@ -503,9 +505,9 @@ describe('L.LayerGroup#toGeoJSON', () => {
 	});
 
 	it('should allow specific precisions', () => {
-		const marker = L.marker([10, 20]),
-		    polyline = L.polyline([[10, 20], [2, 5]]),
-		    layerGroup = L.layerGroup([marker, polyline]);
+		const marker = new Marker([10, 20]),
+		    polyline = new Polyline([[10, 20], [2, 5]]),
+		    layerGroup = new LayerGroup([marker, polyline]);
 		expect(layerGroup.toGeoJSON(3)).to.eql({
 			type: 'FeatureCollection',
 			features: [marker.toGeoJSON(3), polyline.toGeoJSON(3)]
@@ -513,7 +515,7 @@ describe('L.LayerGroup#toGeoJSON', () => {
 	});
 });
 
-describe('L.GeoJSON functions', () => {
+describe('GeoJSON functions', () => {
 	describe('#geometryToLayer', () => {
 		const point = {
 			type: 'Point',
@@ -585,29 +587,29 @@ describe('L.GeoJSON functions', () => {
 		};
 
 		function customPointToLayer(geojsonPoint, latLng) {
-			return L.circle(latLng, {
+			return new Circle(latLng, {
 				radius: geojsonPoint.properties.radius
 			});
 		}
 
 		function customCoordstoLatLng(coords) {
-			return L.latLng(coords[1] + 1, coords[0] + 1, coords[2] + 1);
+			return new LatLng(coords[1] + 1, coords[0] + 1, coords[2] + 1);
 		}
 
 		[
-			[point, L.Marker],
-			[line, L.Polyline],
-			[polygon, L.Polygon],
-			[multiPoint, L.FeatureGroup],
-			[multiLine, L.Polyline],
-			[multiPolygon, L.Polygon],
-			[geometryCollection, L.FeatureGroup],
-			[featureCollection, L.FeatureGroup]
+			[point, Marker],
+			[line, Polyline],
+			[polygon, Polygon],
+			[multiPoint, FeatureGroup],
+			[multiLine, Polyline],
+			[multiPolygon, Polygon],
+			[geometryCollection, FeatureGroup],
+			[featureCollection, FeatureGroup]
 		].forEach((item) => {
 			const geometry = item[0], expectedType = item[1];
 
 			it(`creates a Layer from a GeoJSON feature (type='${geometry.type}')`, () => {
-				const layer = L.GeoJSON.geometryToLayer({
+				const layer = GeoJSON.geometryToLayer({
 					type: 'Feature',
 					geometry
 				});
@@ -615,13 +617,13 @@ describe('L.GeoJSON functions', () => {
 			});
 
 			it(`creates a Layer from a GeoJSON geometry (type='${geometry.type}')`, () => {
-				const layer = L.GeoJSON.geometryToLayer(geometry);
+				const layer = GeoJSON.geometryToLayer(geometry);
 				expect(layer).to.be.instanceOf(expectedType);
 			});
 		});
 
 		it('throws an error if feature is an invalid GeoJSON object', () => {
-			expect(() => L.GeoJSON.geometryToLayer({
+			expect(() => GeoJSON.geometryToLayer({
 				type: 'Feature',
 				geometry: {
 					type: 'invalid',
@@ -631,24 +633,24 @@ describe('L.GeoJSON functions', () => {
 		});
 
 		it('returns nothing if feature does not have a geometry property', () => {
-			const ret = L.GeoJSON.geometryToLayer({type: 'Feature'});
+			const ret = GeoJSON.geometryToLayer({type: 'Feature'});
 			expect(ret).not.to.be.true;
 		});
 
 		it('creates a Layer using pointToLayer option (Point)', () => {
-			const layer = L.GeoJSON.geometryToLayer({
+			const layer = GeoJSON.geometryToLayer({
 				type: 'Feature',
 				geometry: point,
 				properties: {radius: 100}
 			}, {
 				pointToLayer: customPointToLayer
 			});
-			expect(layer).to.be.instanceOf(L.Circle);
+			expect(layer).to.be.instanceOf(Circle);
 			expect(layer.options.radius).to.equal(100);
 		});
 
 		it('creates a Layer using pointToLayer option (MultiPoint)', () => {
-			const layer = L.GeoJSON.geometryToLayer({
+			const layer = GeoJSON.geometryToLayer({
 				type: 'Feature',
 				geometry: multiPoint,
 				properties: {radius: 100}
@@ -656,13 +658,13 @@ describe('L.GeoJSON functions', () => {
 				pointToLayer: customPointToLayer
 			});
 			layer.eachLayer((lyr) => {
-				expect(lyr).to.be.instanceOf(L.Circle);
+				expect(lyr).to.be.instanceOf(Circle);
 				expect(lyr.options.radius).to.equal(100);
 			});
 		});
 
 		it('creates a Layer using coordsToLatLng option (Point)', () => {
-			const layer = L.GeoJSON.geometryToLayer({
+			const layer = GeoJSON.geometryToLayer({
 				type: 'Feature',
 				geometry: {
 					type: 'Point',
@@ -671,11 +673,11 @@ describe('L.GeoJSON functions', () => {
 			}, {
 				coordsToLatLng: customCoordstoLatLng
 			});
-			expect(layer.getLatLng().equals(L.latLng({lat: 3, lng: 2, alt: 4}))).to.be.true;
+			expect(layer.getLatLng().equals(new LatLng(3, 2, 4))).to.be.true;
 		});
 
 		it('creates a Layer using coordsToLatLng option (MultiPoint)', () => {
-			const layer = L.GeoJSON.geometryToLayer({
+			const layer = GeoJSON.geometryToLayer({
 				type: 'Feature',
 				geometry: {
 					type: 'MultiPoint',
@@ -687,68 +689,68 @@ describe('L.GeoJSON functions', () => {
 				coordsToLatLng: customCoordstoLatLng
 			});
 
-			expect(layer.getLayers()[0].getLatLng().equals(L.latLng({lat: 3, lng: 2, alt: 4}))).to.be.true;
-			expect(layer.getLayers()[1].getLatLng().equals(L.latLng({lat: 6, lng: 5, alt: 7}))).to.be.true;
+			expect(layer.getLayers()[0].getLatLng().equals(new LatLng(3, 2, 4))).to.be.true;
+			expect(layer.getLayers()[1].getLatLng().equals(new LatLng(6, 5, 7))).to.be.true;
 		});
 	});
 
 	describe('#coordsToLatLng', () => {
 		it('creates a LatLng object with given coordinates', () => {
-			const latLng = L.GeoJSON.coordsToLatLng([1, 2]);
-			const latLngWithAlt = L.GeoJSON.coordsToLatLng([3, 4, 5]);
-			expect(latLng).to.be.instanceOf(L.LatLng);
-			expect(latLngWithAlt).to.be.instanceOf(L.LatLng);
-			expect(latLng.equals(L.latLng({lng: 1, lat: 2}))).to.be.true;
-			expect(latLngWithAlt.equals(L.latLng({lng: 3, lat: 4, alt: 5})));
+			const latLng = GeoJSON.coordsToLatLng([1, 2]);
+			const latLngWithAlt = GeoJSON.coordsToLatLng([3, 4, 5]);
+			expect(latLng).to.be.instanceOf(LatLng);
+			expect(latLngWithAlt).to.be.instanceOf(LatLng);
+			expect(latLng.equals(new LatLng(2, 1))).to.be.true;
+			expect(latLngWithAlt.equals(new LatLng(4, 3, 5)));
 		});
 	});
 
 	describe('#coordsToLatLngs', () => {
 
 		function customCoordsToLatLng(coords) {
-			return L.latLng(coords[1] + 1, coords[0] + 1, coords[2] + 1);
+			return new LatLng(coords[1] + 1, coords[0] + 1, coords[2] + 1);
 		}
 
 		it('creates a multidimensional array of LatLngs', () => {
-			const latLngs = L.GeoJSON.coordsToLatLngs([[1, 2], [3, 4], [5, 6]]);
+			const latLngs = GeoJSON.coordsToLatLngs([[1, 2], [3, 4], [5, 6]]);
 
-			expect(latLngs[0].equals(L.latLng({lng: 1, lat: 2})));
-			expect(latLngs[1].equals(L.latLng({lng: 3, lat: 4})));
-			expect(latLngs[2].equals(L.latLng({lng: 5, lat: 6})));
+			expect(latLngs[0].equals(new LatLng(1, 2)));
+			expect(latLngs[1].equals(new LatLng(3, 4)));
+			expect(latLngs[2].equals(new LatLng(5, 6)));
 
 			latLngs.forEach((latLng) => {
-				expect(latLng).to.be.instanceOf(L.LatLng);
+				expect(latLng).to.be.instanceOf(LatLng);
 			});
 		});
 
 		it('creates a multidimensional array of LatLngs (levelsDeep=1)', () => {
-			const latLngs = L.GeoJSON.coordsToLatLngs([
+			const latLngs = GeoJSON.coordsToLatLngs([
 				[[1, 2], [3, 4], [5, 6]],
 				[[5, 6], [7, 8], [9, 10]]
 			], 1);
 
-			expect(latLngs[0][0].equals(L.latLng({lng: 1, lat: 2})));
-			expect(latLngs[0][1].equals(L.latLng({lng: 3, lat: 4})));
-			expect(latLngs[0][2].equals(L.latLng({lng: 5, lat: 6})));
+			expect(latLngs[0][0].equals(new LatLng(1, 2)));
+			expect(latLngs[0][1].equals(new LatLng(3, 4)));
+			expect(latLngs[0][2].equals(new LatLng(5, 6)));
 
-			expect(latLngs[1][0].equals(L.latLng({lng: 5, lat: 6})));
-			expect(latLngs[1][1].equals(L.latLng({lng: 7, lat: 8})));
-			expect(latLngs[1][2].equals(L.latLng({lng: 9, lat: 10})));
+			expect(latLngs[1][0].equals(new LatLng(5, 6)));
+			expect(latLngs[1][1].equals(new LatLng(7, 8)));
+			expect(latLngs[1][2].equals(new LatLng(9, 10)));
 
 			latLngs.forEach((arr) => {
 				arr.forEach((latlng) => {
-					expect(latlng).to.be.instanceOf(L.LatLng);
+					expect(latlng).to.be.instanceOf(LatLng);
 				});
 			});
 		});
 
 		it('creates a multidimensional array of LatLngs with custom coordsToLatLng', () => {
 			const coords = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
-			const latLngs = L.GeoJSON.coordsToLatLngs(coords, 0, customCoordsToLatLng);
+			const latLngs = GeoJSON.coordsToLatLngs(coords, 0, customCoordsToLatLng);
 
-			expect(latLngs[0].equals(L.latLng({lat: 3, lng: 2, alt: 4})));
-			expect(latLngs[1].equals(L.latLng({lat: 6, lng: 5, alt: 7})));
-			expect(latLngs[2].equals(L.latLng({lat: 9, lng: 8, alt: 10})));
+			expect(latLngs[0].equals(new LatLng(3, 2, 4)));
+			expect(latLngs[1].equals(new LatLng(6, 5, 7)));
+			expect(latLngs[2].equals(new LatLng(9, 8, 10)));
 		});
 
 		it('creates a multidimensional array of LatLngs with custom coordsToLatLng (levelDeep=1)', () => {
@@ -756,34 +758,34 @@ describe('L.GeoJSON functions', () => {
 				[[1, 2, 3], [4, 5, 6]],
 				[[12, 13, 14], [15, 16, 17]]
 			];
-			const latLngs = L.GeoJSON.coordsToLatLngs(coords, 1, customCoordsToLatLng);
+			const latLngs = GeoJSON.coordsToLatLngs(coords, 1, customCoordsToLatLng);
 
-			expect(latLngs[0][0].equals(L.latLng({lat: 3, lng: 2, alt: 4})));
-			expect(latLngs[0][1].equals(L.latLng({lat: 6, lng: 5, alt: 7})));
+			expect(latLngs[0][0].equals(new LatLng(3, 2, 4)));
+			expect(latLngs[0][1].equals(new LatLng(6, 5, 7)));
 
-			expect(latLngs[1][0].equals(L.latLng({lat: 14, lng: 13, alt: 15})));
-			expect(latLngs[1][1].equals(L.latLng({lat: 17, lng: 16, alt: 18})));
+			expect(latLngs[1][0].equals(new LatLng(14, 13, 15)));
+			expect(latLngs[1][1].equals(new LatLng(17, 16, 18)));
 		});
 	});
 
 	describe('#latLngToCoords', () => {
 		it('accepts latlng array', () => {
-			const coords = L.GeoJSON.latLngToCoords([2, 1, 3]);
+			const coords = GeoJSON.latLngToCoords([2, 1, 3]);
 			expect(coords).to.eql([1, 2, 3]);
 		});
 
 		it('returns an array of coordinates and altitude', () => {
-			const coords = L.GeoJSON.latLngToCoords(L.latLng(2, 1));
-			const coordsWithAlt = L.GeoJSON.latLngToCoords(L.latLng(2, 1, 3));
+			const coords = GeoJSON.latLngToCoords(new LatLng(2, 1));
+			const coordsWithAlt = GeoJSON.latLngToCoords(new LatLng(2, 1, 3));
 			expect(coords).to.eql([1, 2]);
 			expect(coordsWithAlt).to.eql([1, 2, 3]);
 		});
 
 		it('returns an array of coordinates with given precision', () => {
-			const coords = L.GeoJSON.latLngToCoords(L.latLng(
+			const coords = GeoJSON.latLngToCoords(new LatLng(
 				2.123456, 1.123456
 			), 3);
-			const coordsWithAlt = L.GeoJSON.latLngToCoords(L.latLng(
+			const coordsWithAlt = GeoJSON.latLngToCoords(new LatLng(
 				2.123456, 1.123456, 3.123456
 			), 3);
 			expect(coords).to.eql([1.123, 2.123]);
@@ -793,23 +795,23 @@ describe('L.GeoJSON functions', () => {
 
 	describe('#latLngsToCoords', () => {
 		it('accepts multidimensional latlng array', () => {
-			const coords = L.GeoJSON.latLngsToCoords([[2, 1, 3], [5, 4, 6]]);
+			const coords = GeoJSON.latLngsToCoords([[2, 1, 3], [5, 4, 6]]);
 			expect(coords).to.eql([[1, 2, 3], [4, 5, 6]]);
 		});
 
 		it('returns a multidimensional array of coordinates', () => {
-			const coords = L.GeoJSON.latLngsToCoords([L.latLng(2, 1), L.latLng(4, 3)]);
-			const coordWithAlt = L.GeoJSON.latLngsToCoords([L.latLng(2, 1, 3), L.latLng(5, 4, 6)]);
+			const coords = GeoJSON.latLngsToCoords([new LatLng(2, 1), new LatLng(4, 3)]);
+			const coordWithAlt = GeoJSON.latLngsToCoords([new LatLng(2, 1, 3), new LatLng(5, 4, 6)]);
 			expect(coords).to.eql([[1, 2], [3, 4]]);
 			expect(coordWithAlt).to.eql([[1, 2, 3], [4, 5, 6]]);
 		});
 
 		it('returns a multidimensional array of coordinates (levelDeep=1)', () => {
 			const latLngs = [
-				[L.latLng(2, 1), L.latLng(4, 3)],
-				[L.latLng(6, 5), L.latLng(8, 7)]
+				[new LatLng(2, 1), new LatLng(4, 3)],
+				[new LatLng(6, 5), new LatLng(8, 7)]
 			];
-			const coords = L.GeoJSON.latLngsToCoords(latLngs, 1);
+			const coords = GeoJSON.latLngsToCoords(latLngs, 1);
 			expect(coords).to.eql([
 				[[1, 2], [3, 4]],
 				[[5, 6], [7, 8]]
@@ -817,17 +819,17 @@ describe('L.GeoJSON functions', () => {
 		});
 
 		it('returns a multidimensional array of coordinates (closed=True)', () => {
-			const latLngs = [L.latLng(2, 1), L.latLng(4, 3), L.latLng(6, 5)];
-			const coords = L.GeoJSON.latLngsToCoords(latLngs, 0, true);
+			const latLngs = [new LatLng(2, 1), new LatLng(4, 3), new LatLng(6, 5)];
+			const coords = GeoJSON.latLngsToCoords(latLngs, 0, true);
 			expect(coords).to.eql([[1, 2], [3, 4], [5, 6], [1, 2]]);
 		});
 
 		it('returns a multidimensional array of coordinates (levelsDeep=1, closed=True)', () => {
 			const latLngs = [
-				[L.latLng(2, 1), L.latLng(4, 3), L.latLng(6, 5)],
-				[L.latLng(8, 7), L.latLng(10, 9), L.latLng(12, 11)]
+				[new LatLng(2, 1), new LatLng(4, 3), new LatLng(6, 5)],
+				[new LatLng(8, 7), new LatLng(10, 9), new LatLng(12, 11)]
 			];
-			const coords = L.GeoJSON.latLngsToCoords(latLngs, 1, true);
+			const coords = GeoJSON.latLngsToCoords(latLngs, 1, true);
 			expect(coords).to.eql([
 				[[1, 2], [3, 4], [5, 6], [1, 2]],
 				[[7, 8], [9, 10], [11, 12], [7, 8]]
@@ -835,13 +837,13 @@ describe('L.GeoJSON functions', () => {
 		});
 
 		it('returns a multidimensional array of coordinates with given precision', () => {
-			const latLngs = [L.latLng(2.123456, 1.123456), L.latLng(4.123456, 3.123456)];
-			const coords = L.GeoJSON.latLngsToCoords(latLngs, 0, false, 3);
+			const latLngs = [new LatLng(2.123456, 1.123456), new LatLng(4.123456, 3.123456)];
+			const coords = GeoJSON.latLngsToCoords(latLngs, 0, false, 3);
 			expect(coords).to.eql([[1.123, 2.123], [3.123, 4.123]]);
 		});
 
 		it('returns a valid geojson from an unbalanced multipolygon', () => {
-			const poly = L.polygon([
+			const poly = new Polygon([
 				[
 					[
 						[51.509, -0.08],
@@ -886,13 +888,13 @@ describe('L.GeoJSON functions', () => {
 			});
 		});
 		it('has no reference between first and last coordinates', () => {
-			const coords = L.GeoJSON.latLngsToCoords([[2, 1, 3], [5, 4, 6]], null, true);
+			const coords = GeoJSON.latLngsToCoords([[2, 1, 3], [5, 4, 6]], null, true);
 			expect(coords).to.eql([[1, 2, 3], [4, 5, 6], [1, 2, 3]]);
 			expect(coords[0] === coords[2]).to.be.false;
 		});
 		it('still works if no values in coords array', () => {
 			expect(() => {
-				L.GeoJSON.latLngsToCoords([[]], 1, true);
+				GeoJSON.latLngsToCoords([[]], 1, true);
 			}).to.not.throw();
 		});
 	});
@@ -929,7 +931,7 @@ describe('L.GeoJSON functions', () => {
 		};
 
 		it('given a bare geometry returns a GeoJSON-like feature', () => {
-			const ret = L.GeoJSON.asFeature(geometry1);
+			const ret = GeoJSON.asFeature(geometry1);
 			expect(ret).to.eql({
 				type: 'Feature',
 				properties: {},
@@ -938,12 +940,12 @@ describe('L.GeoJSON functions', () => {
 		});
 
 		it('given a GeoJSON feature directly returns it', () => {
-			const ret = L.GeoJSON.asFeature(feature1);
+			const ret = GeoJSON.asFeature(feature1);
 			expect(ret).to.eql(feature1);
 		});
 
 		it('given a GeoJSON feature collection directly returns it', () => {
-			const ret = L.GeoJSON.asFeature(featureCollection);
+			const ret = GeoJSON.asFeature(featureCollection);
 			expect(ret).to.eql(featureCollection);
 		});
 	});

--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -1,10 +1,13 @@
+import {Map, imageOverlay, LatLngBounds} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('ImageOverlay', () => {
 	let container, map;
 	const imageBounds = [[40.712216, -74.22655], [40.773941, -74.12544]];
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView([55.8, 37.6], 6);	// view needs to be set so when layer is added it is initilized
 	});
 
@@ -14,18 +17,18 @@ describe('ImageOverlay', () => {
 
 	describe('#setStyle', () => {
 		it('sets opacity', () => {
-			const overlay = L.imageOverlay().setStyle({opacity: 0.5});
+			const overlay = imageOverlay().setStyle({opacity: 0.5});
 			expect(overlay.options.opacity).to.equal(0.5);
 		});
 	});
 
 	describe('#setBounds', () => {
 		it('sets bounds', () => {
-			const bounds = L.latLngBounds(
+			const bounds = new LatLngBounds(
 				[14, 12],
 				[30, 40]
 			);
-			const overlay = L.imageOverlay().setBounds(bounds);
+			const overlay = imageOverlay().setBounds(bounds);
 			expect(overlay._bounds).to.equal(bounds);
 		});
 	});
@@ -39,13 +42,13 @@ describe('ImageOverlay', () => {
 
 		// Create overlay for each test
 		beforeEach(() => {
-			overlay = L.imageOverlay(blankUrl, imageBounds, {
+			overlay = imageOverlay(blankUrl, imageBounds, {
 				errorOverlayUrl: errorUrl,
 				className: 'my-custom-image-class'
 			});
 			map.addLayer(overlay);
 
-			const bounds = L.latLngBounds(
+			const bounds = new LatLngBounds(
 				[14, 12],
 				[30, 40]
 			);
@@ -97,13 +100,13 @@ describe('ImageOverlay', () => {
 
 	describe('#setZIndex', () => {
 		it('sets the z-index of the image', () => {
-			const overlay = L.imageOverlay();
+			const overlay = imageOverlay();
 			overlay.setZIndex(10);
 			expect(overlay.options.zIndex).to.equal(10);
 		});
 
 		it('should update the z-index of the image if it has allready been added to the map', () => {
-			const overlay = L.imageOverlay('', imageBounds);
+			const overlay = imageOverlay('', imageBounds);
 			overlay.addTo(map);
 			expect(overlay._image.style.zIndex).to.eql('1'); // Number type in IE
 
@@ -112,31 +115,31 @@ describe('ImageOverlay', () => {
 		});
 
 		it('should set the z-index of the image when it is added to the map', () => {
-			const overlay = L.imageOverlay('', imageBounds);
+			const overlay = imageOverlay('', imageBounds);
 			overlay.setZIndex('10');
 			overlay.addTo(map);
 			expect(overlay._image.style.zIndex).to.eql('10'); // Number type in IE
 		});
 
 		it('should use the z-index specified in options', () => {
-			const overlay = L.imageOverlay('', imageBounds, {zIndex: 20});
+			const overlay = imageOverlay('', imageBounds, {zIndex: 20});
 			overlay.addTo(map);
 			expect(overlay._image.style.zIndex).to.eql('20'); // Number type in IE
 		});
 
 		it('should be fluent', () => {
-			const overlay = L.imageOverlay();
+			const overlay = imageOverlay();
 			expect(overlay.setZIndex()).to.equal(overlay);
 		});
 	});
 
 	describe('#getCenter', () => {
 		it('should return the correct center', () => {
-			const overlay = L.imageOverlay('', imageBounds).addTo(map);
+			const overlay = imageOverlay('', imageBounds).addTo(map);
 			expect(overlay.getCenter()).to.be.nearLatLng([40.743078, -74.175995]);
 		});
 		it('should open popup at the center', () => {
-			const overlay = L.imageOverlay('', imageBounds).addTo(map);
+			const overlay = imageOverlay('', imageBounds).addTo(map);
 			overlay.bindPopup('Center').openPopup();
 			expect(overlay.getPopup().getLatLng()).to.be.nearLatLng([40.743078, -74.175995]);
 		});
@@ -155,7 +158,7 @@ describe('ImageOverlay', () => {
 
 		function testCrossOriginValue(crossOrigin, expectedValue) {
 			it(`uses crossOrigin option value ${crossOrigin}`, () => {
-				overlay = L.imageOverlay(blankUrl, imageBounds, {
+				overlay = imageOverlay(blankUrl, imageBounds, {
 					crossOrigin
 				});
 				map.addLayer(overlay);

--- a/spec/suites/layer/LayerGroupSpec.js
+++ b/spec/suites/layer/LayerGroupSpec.js
@@ -1,9 +1,11 @@
-﻿describe('LayerGroup', () => {
+﻿import {layerGroup, Layer, Marker, GeoJSON} from 'leaflet';
+
+describe('LayerGroup', () => {
 	describe('#hasLayer', () => {
 		it('throws when called without proper argument', () => {
-			const lg = L.layerGroup();
+			const lg = layerGroup();
 			const hasLayer = lg.hasLayer.bind(lg);
-			expect(() => hasLayer(new L.Layer())).to.not.throw(); // control case
+			expect(() => hasLayer(new Layer())).to.not.throw(); // control case
 
 			expect(() => hasLayer(undefined)).to.throw();
 			expect(() => hasLayer(null)).to.throw();
@@ -14,8 +16,8 @@
 
 	describe('#addLayer', () => {
 		it('adds a layer', () => {
-			const lg = L.layerGroup(),
-			    marker = L.marker([0, 0]);
+			const lg = layerGroup(),
+			    marker = new Marker([0, 0]);
 
 			expect(lg.addLayer(marker)).to.eql(lg);
 
@@ -25,8 +27,8 @@
 
 	describe('#removeLayer', () => {
 		it('removes a layer', () => {
-			const lg = L.layerGroup(),
-			    marker = L.marker([0, 0]);
+			const lg = layerGroup(),
+			    marker = new Marker([0, 0]);
 
 			lg.addLayer(marker);
 			expect(lg.removeLayer(marker)).to.eql(lg);
@@ -37,8 +39,8 @@
 
 	describe('#clearLayers', () => {
 		it('removes all layers', () => {
-			const lg = L.layerGroup(),
-			    marker = L.marker([0, 0]);
+			const lg = layerGroup(),
+			    marker = new Marker([0, 0]);
 
 			lg.addLayer(marker);
 			expect(lg.clearLayers()).to.eql(lg);
@@ -49,8 +51,8 @@
 
 	describe('#getLayers', () => {
 		it('gets all layers', () => {
-			const lg = L.layerGroup(),
-			    marker = L.marker([0, 0]);
+			const lg = layerGroup(),
+			    marker = new Marker([0, 0]);
 
 			lg.addLayer(marker);
 
@@ -60,8 +62,8 @@
 
 	describe('#eachLayer', () => {
 		it('iterates over all layers', () => {
-			const lg = L.layerGroup(),
-			    marker = L.marker([0, 0]),
+			const lg = layerGroup(),
+			    marker = new Marker([0, 0]),
 			    ctx = {foo: 'bar'};
 
 			lg.addLayer(marker);
@@ -89,21 +91,21 @@
 				]
 			};
 
-			const layerGroup = L.layerGroup();
-			const layer = L.geoJSON(geoJSON);
-			layerGroup.addLayer(layer);
+			const lg = layerGroup();
+			const layer = new GeoJSON(geoJSON);
+			lg.addLayer(layer);
 
-			L.geoJson(layerGroup.toGeoJSON());
+			new GeoJSON(lg.toGeoJSON());
 		});
 	});
 
 	describe('#invoke', () => {
 		it('should invoke `setOpacity` method on every layer', () => {
 			const layers = [
-				L.marker([0, 0]),
-				L.marker([1, 1])
+				new Marker([0, 0]),
+				new Marker([1, 1])
 			];
-			const lg = L.layerGroup(layers);
+			const lg = layerGroup(layers);
 			const opacity = 0.5;
 
 			expect(layers[0].options.opacity).to.not.eql(opacity);

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -1,10 +1,13 @@
+import {Map, Popup, Marker, FeatureGroup, Point, Icon, DivIcon, DomUtil, Polygon} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Popup', () => {
 	let container, map;
 	const center = [55.8, 37.6];
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView(center, 6);
 	});
 
@@ -16,7 +19,7 @@ describe('Popup', () => {
 	it('closes on map click when map has closePopupOnClick option', () => {
 		map.options.closePopupOnClick = true;
 
-		const popup = L.popup()
+		const popup = new Popup()
 			.setLatLng(center)
 			.openOn(map);
 
@@ -28,7 +31,7 @@ describe('Popup', () => {
 	it('closes on map click when popup has closeOnClick option', () => {
 		map.options.closePopupOnClick = false;
 
-		const popup = L.popup({closeOnClick: true})
+		const popup = new Popup({closeOnClick: true})
 			.setLatLng(center)
 			.openOn(map);
 
@@ -40,7 +43,7 @@ describe('Popup', () => {
 	it('does not close on map click when popup has closeOnClick: false option', () => {
 		map.options.closePopupOnClick = true;
 
-		const popup = L.popup({closeOnClick: false})
+		const popup = new Popup({closeOnClick: false})
 			.setLatLng(center)
 			.openOn(map);
 
@@ -50,7 +53,7 @@ describe('Popup', () => {
 	});
 
 	it('sets the default \'closeButtonLabel\' on the close button', () => {
-		const popup = L.popup()
+		const popup = new Popup()
 			.setLatLng(center)
 			.openOn(map);
 
@@ -59,7 +62,7 @@ describe('Popup', () => {
 
 	it('sets a custom \'closeButtonLabel\' on the close button', () => {
 		const closeButtonLabel = 'TestLabel';
-		const popup = L.popup({closeButtonLabel})
+		const popup = new Popup({closeButtonLabel})
 			.setLatLng(center)
 			.openOn(map);
 
@@ -67,7 +70,7 @@ describe('Popup', () => {
 	});
 
 	it('toggles its visibility when marker is clicked', () => {
-		const marker = L.marker(center);
+		const marker = new Marker(center);
 		map.addLayer(marker);
 
 		marker.bindPopup('Popup1');
@@ -83,9 +86,9 @@ describe('Popup', () => {
 	});
 
 	it('it should use a popup with a function as content with a FeatureGroup', () => {
-		const marker1 = L.marker(center);
-		const marker2 = L.marker([54.6, 38.2]);
-		const group = L.featureGroup([marker1, marker2]).addTo(map);
+		const marker1 = new Marker(center);
+		const marker2 = new Marker([54.6, 38.2]);
+		const group = new FeatureGroup([marker1, marker2]).addTo(map);
 
 		marker1.description = 'I\'m marker 1.';
 		marker2.description = 'I\'m marker 2.';
@@ -111,9 +114,9 @@ describe('Popup', () => {
 	});
 
 	it('it should function for popup content after bindPopup is called', () => {
-		const marker1 = L.marker(center);
-		const marker2 = L.marker([54.6, 38.2]);
-		const group = L.featureGroup([marker1]).addTo(map);
+		const marker1 = new Marker(center);
+		const marker2 = new Marker([54.6, 38.2]);
+		const group = new FeatureGroup([marker1]).addTo(map);
 
 		marker1.description = 'I\'m marker 1.';
 		marker2.description = 'I\'m marker 2.';
@@ -141,8 +144,8 @@ describe('Popup', () => {
 	});
 
 	it('should use a function for popup content when a source is passed to Popup', () => {
-		const marker = L.marker(center).addTo(map);
-		L.popup({}, marker);
+		const marker = new Marker(center).addTo(map);
+		new Popup({}, marker);
 
 		marker.description = 'I am a marker.';
 
@@ -157,8 +160,8 @@ describe('Popup', () => {
 	});
 
 	it('triggers popupopen on marker when popup opens', () => {
-		const marker1 = L.marker(center);
-		const marker2 = L.marker([57.123076977278, 44.861962891635]);
+		const marker1 = new Marker(center);
+		const marker2 = new Marker([57.123076977278, 44.861962891635]);
 
 		map.addLayer(marker1);
 		map.addLayer(marker2);
@@ -179,12 +182,12 @@ describe('Popup', () => {
 
 	// Related to #8558
 	it('references the correct targets in popupopen event with multiple markers bound to same popup', () => {
-		const marker1 = L.marker(center, {testId: 'markerA'});
-		const marker2 = L.marker([57.123076977278, 44.861962891635], {testId: 'markerB'});
+		const marker1 = new Marker(center, {testId: 'markerA'});
+		const marker2 = new Marker([57.123076977278, 44.861962891635], {testId: 'markerB'});
 		map.addLayer(marker1);
 		map.addLayer(marker2);
 
-		const popup = L.popup().setContent('test');
+		const popup = new Popup().setContent('test');
 
 		marker2.bindPopup(popup);
 		marker1.bindPopup(popup);
@@ -211,8 +214,8 @@ describe('Popup', () => {
 	});
 
 	it('triggers popupclose on marker when popup closes', () => {
-		const marker1 = L.marker(center);
-		const marker2 = L.marker([57.123076977278, 44.861962891635]);
+		const marker1 = new Marker(center);
+		const marker2 = new Marker([57.123076977278, 44.861962891635]);
 
 		map.addLayer(marker1);
 		map.addLayer(marker2);
@@ -238,48 +241,48 @@ describe('Popup', () => {
 
 	it('should take into account icon popupAnchor option', () => {
 		const latlng = center;
-		const offset = L.point(20, 30);
+		const offset = new Point(20, 30);
 
-		const autoPanBefore = L.Popup.prototype.options.autoPan;
-		L.Popup.prototype.options.autoPan = false;
-		const popupAnchorBefore = L.Icon.Default.prototype.options.popupAnchor;
-		L.Icon.Default.prototype.options.popupAnchor = [0, 0];
+		const autoPanBefore = Popup.prototype.options.autoPan;
+		Popup.prototype.options.autoPan = false;
+		const popupAnchorBefore = Icon.Default.prototype.options.popupAnchor;
+		Icon.Default.prototype.options.popupAnchor = [0, 0];
 
-		const icon = L.divIcon({popupAnchor: offset});
-		const marker1 = L.marker(latlng);
-		const marker2 = L.marker(latlng, {icon});
+		const icon = new DivIcon({popupAnchor: offset});
+		const marker1 = new Marker(latlng);
+		const marker2 = new Marker(latlng, {icon});
 
 		marker1.bindPopup('Popup').addTo(map);
 		marker1.openPopup();
-		const defaultLeft = L.DomUtil.getPosition(marker1._popup._container).x;
-		const defaultTop = L.DomUtil.getPosition(marker1._popup._container).y;
+		const defaultLeft = DomUtil.getPosition(marker1._popup._container).x;
+		const defaultTop = DomUtil.getPosition(marker1._popup._container).y;
 		marker2.bindPopup('Popup').addTo(map);
 		marker2.openPopup();
-		let offsetLeft = L.DomUtil.getPosition(marker2._popup._container).x;
-		let offsetTop = L.DomUtil.getPosition(marker2._popup._container).y;
+		let offsetLeft = DomUtil.getPosition(marker2._popup._container).x;
+		let offsetTop = DomUtil.getPosition(marker2._popup._container).y;
 		expect(offsetLeft - offset.x).to.eql(defaultLeft);
 		expect(offsetTop - offset.y).to.eql(defaultTop);
 
 		// Now retry passing a popup instance to bindPopup
-		marker2.bindPopup(L.popup());
+		marker2.bindPopup(new Popup());
 		marker2.openPopup();
-		offsetLeft = L.DomUtil.getPosition(marker2._popup._container).x;
-		offsetTop = L.DomUtil.getPosition(marker2._popup._container).y;
+		offsetLeft = DomUtil.getPosition(marker2._popup._container).x;
+		offsetTop = DomUtil.getPosition(marker2._popup._container).y;
 		expect(offsetLeft - offset.x).to.eql(defaultLeft);
 		expect(offsetTop - offset.y).to.eql(defaultTop);
 
-		L.Popup.prototype.options.autoPan = autoPanBefore;
-		L.Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
+		Popup.prototype.options.autoPan = autoPanBefore;
+		Icon.Default.prototype.options.popupAnchor = popupAnchorBefore;
 	});
 
 	it('prevents an underlying map click for Layer', () => {
-		const layer = L.polygon([center, [55.9, 37.7], [56.0, 37.8]]).addTo(map);
+		const layer = new Polygon([center, [55.9, 37.7], [56.0, 37.8]]).addTo(map);
 		layer.bindPopup('layer popup');
 
 		let mapClicked = false;
 		map.on('click', (e) => {
 			mapClicked = true;
-			L.popup()
+			new Popup()
 				.setLatLng(e.latlng)
 				.setContent('map popup')
 				.openOn(map);
@@ -293,7 +296,7 @@ describe('Popup', () => {
 
 
 	it('can open a popup with enter keypress when marker has focus', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		layer.bindPopup('layer popup');
 
 		UIEventSimulator.fire('keypress', layer._icon, {
@@ -330,7 +333,7 @@ describe('Popup', () => {
 			});
 			map.openPopup('<div style="height: 400px;"></div>', [58.4, 37.6], {
 				autoPan: true,
-				autoPanPadding: L.point(10, 10)
+				autoPanPadding: new Point(10, 10)
 			});
 		});
 
@@ -348,62 +351,62 @@ describe('Popup', () => {
 
 			map.openPopup('<div style="height: 400px;"></div>', [58.4, 37.6], {
 				autoPan: true,
-				autoPanPadding: L.point(10, 10)
+				autoPanPadding: new Point(10, 10)
 			});
 		});
 	});
 
 	it('opens popup with passed latlng position while initializing', () => {
-		const popup = new L.Popup(center)
+		const popup = new Popup(center)
 			.openOn(map);
 		expect(map.hasLayer(popup)).to.be.true;
 	});
 
 	it('opens popup with passed latlng and options position while initializing', () => {
-		const popup = new L.Popup(center, {className: 'testClass'})
+		const popup = new Popup(center, {className: 'testClass'})
 			.addTo(map);
 		expect(map.hasLayer(popup)).to.be.true;
 		expect(popup.getElement().classList.contains('testClass')).to.be.true;
 	});
 
 	it('adds popup with passed content in options while initializing', () => {
-		const popup = new L.Popup(center, {content: 'Test'})
+		const popup = new Popup(center, {content: 'Test'})
 			.addTo(map);
 		expect(map.hasLayer(popup)).to.be.true;
 		expect(popup.getContent()).to.equal('Test');
 	});
 
-	describe('L.Map#openPopup', () => {
+	describe('Map#openPopup', () => {
 		it('adds the popup layer to the map', () => {
-			const popup = L.popup()
+			const popup = new Popup()
 				.setLatLng(center);
 			map.openPopup(popup);
 			expect(map.hasLayer(popup)).to.be.true;
 		});
 
 		it('sets popup location', () => {
-			const popup = L.popup();
+			const popup = new Popup();
 			map.openPopup(popup, center);
 			expect(popup.getLatLng()).to.be.nearLatLng([55.8, 37.6]);
 		});
 
 		it('creates a popup from content', () => {
 			map.openPopup('<h2>Hello World</h2>', center);
-			expect(map._popup).to.be.instanceOf(L.Popup);
+			expect(map._popup).to.be.instanceOf(Popup);
 			expect(map._popup.getContent()).to.eql('<h2>Hello World</h2>');
 		});
 
 		it('closes existing popup', () => {
-			const p1 = L.popup().setLatLng(center);
-			const p2 = L.popup().setLatLng(center);
+			const p1 = new Popup().setLatLng(center);
+			const p2 = new Popup().setLatLng(center);
 			map.openPopup(p1);
 			map.openPopup(p2);
 			expect(map.hasLayer(p1)).to.be.false;
 		});
 
 		it('does not close existing popup with autoClose: false option', () => {
-			const p1 = L.popup({autoClose: false}).setLatLng(center);
-			const p2 = L.popup().setLatLng(center);
+			const p1 = new Popup({autoClose: false}).setLatLng(center);
+			const p2 = new Popup().setLatLng(center);
 			map.openPopup(p1);
 			map.openPopup(p2);
 			expect(map.hasLayer(p1)).to.be.true;
@@ -418,7 +421,7 @@ describe('Popup', () => {
 
 			const coords = map._container.getBoundingClientRect();
 			const spy = sinon.spy();
-			const p = L.popup().setLatLng(center);
+			const p = new Popup().setLatLng(center);
 			map.openPopup(p);
 			expect(map.hasLayer(p)).to.be.true;
 			map.on('drag', spy);
@@ -447,7 +450,7 @@ describe('Popup', () => {
 			map.on('autopanstart', spy);
 
 			// Short hop to the edge of the map (at time of writing, will trigger an animated pan)
-			const p = L.popup({keepInView: true}).setContent('Popup').setLatLng(map.getBounds()._northEast);
+			const p = new Popup({keepInView: true}).setContent('Popup').setLatLng(map.getBounds()._northEast);
 			map.once('moveend', () => {
 				expect(spy.callCount).to.equal(1);
 				expect(map.getBounds().contains(p.getLatLng())).to.be.true;
@@ -469,7 +472,7 @@ describe('Popup', () => {
 			map.on('autopanstart', spy);
 
 			// Long hop (at time of writing, will trigger a view reset)
-			const p = L.popup({keepInView: true}).setContent('Popup').setLatLng([center[0], center[1] + 50]);
+			const p = new Popup({keepInView: true}).setContent('Popup').setLatLng([center[0], center[1] + 50]);
 			map.once('moveend', () => {
 				expect(spy.callCount).to.equal(1);
 				expect(map.getBounds().contains(p.getLatLng())).to.be.true;
@@ -479,7 +482,7 @@ describe('Popup', () => {
 		});
 
 		it('moves on setLatLng after initial autopan', (done) => {
-			const p = L.popup().setContent('Popup').setLatLng(map.getBounds().getNorthEast());
+			const p = new Popup().setContent('Popup').setLatLng(map.getBounds().getNorthEast());
 
 			map.once('moveend', () => {
 				map.once('moveend', () => {
@@ -494,9 +497,9 @@ describe('Popup', () => {
 		});
 
 		it('shows the popup at the correct location when multiple markers are registered', () => {
-			const popup = L.popup();
-			const marker1 = L.marker([86, 32]).bindPopup(popup).addTo(map);
-			const marker2 = L.marker([26.3, 83.9]).bindPopup(popup).addTo(map);
+			const popup = new Popup();
+			const marker1 = new Marker([86, 32]).bindPopup(popup).addTo(map);
+			const marker2 = new Marker([26.3, 83.9]).bindPopup(popup).addTo(map);
 
 			expect(popup.getLatLng()).to.equal(undefined);
 
@@ -508,11 +511,11 @@ describe('Popup', () => {
 		});
 	});
 
-	describe('L.Layer#_popup', () => {
+	describe('Layer#_popup', () => {
 		let marker;
 
 		beforeEach(() => {
-			marker = L.marker([55.8, 37.6]).addTo(map);
+			marker = new Marker([55.8, 37.6]).addTo(map);
 		});
 
 		it('only adds a popup to the map when opened', () => {
@@ -574,7 +577,7 @@ describe('Popup', () => {
 			container.style.position = 'absolute';
 			container.style.top = '0';
 			container.style.left = '0';
-			const popup = L.popup().setLatLng(map.getCenter())
+			const popup = new Popup().setLatLng(map.getCenter())
 				.openOn(map);
 
 			const point = map.latLngToContainerPoint(map.getCenter());
@@ -590,8 +593,8 @@ describe('Popup', () => {
 		});
 
 		it('does not open for empty FeatureGroup', () => {
-			const popup = L.popup();
-			L.featureGroup([])
+			const popup = new Popup();
+			new FeatureGroup([])
 			  .addTo(map)
 			  .bindPopup(popup)
 			  .openPopup();
@@ -600,11 +603,11 @@ describe('Popup', () => {
 		});
 
 		it('uses only visible layers of FeatureGroup for popup content source', () => {
-			const marker1 = L.marker([1, 1]);
-			const marker2 = L.marker([2, 2]);
-			const marker3 = L.marker([3, 3]);
-			const popup = L.popup();
-			const group = L.featureGroup([marker1, marker2, marker3])
+			const marker1 = new Marker([1, 1]);
+			const marker2 = new Marker([2, 2]);
+			const marker3 = new Marker([3, 3]);
+			const popup = new Popup();
+			const group = new FeatureGroup([marker1, marker2, marker3])
 			  .bindPopup(popup)
 			  .addTo(map);
 

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -1,10 +1,13 @@
+import {CircleMarker, FeatureGroup, LayerGroup, Map, Marker, Polygon, Polyline, Rectangle, Tooltip} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Tooltip', () => {
 	let container, map;
 	const center = [55.8, 37.6];
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView(center, 6);
 	});
 
@@ -13,7 +16,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on marker mouseover and close on mouseout', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 
@@ -26,7 +29,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on marker focus and closes on blur', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 
@@ -41,7 +44,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on marker focus and closes on blur when first bound, then added to map', () => {
-		const layer = L.marker(center);
+		const layer = new Marker(center);
 
 		layer.bindTooltip('Tooltip').addTo(map);
 
@@ -56,9 +59,9 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on marker focus and closes on blur in layer group', () => {
-		const marker1 = L.marker([41.18, 9.45], {description: 'Marker 1'});
-		const marker2 = L.marker([41.18, 9.46], {description: 'Marker 2'});
-		const group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+		const marker1 = new Marker([41.18, 9.45], {description: 'Marker 1'});
+		const marker2 = new Marker([41.18, 9.46], {description: 'Marker 2'});
+		const group = new FeatureGroup([marker1, marker2]).addTo(map);
 		group.bindTooltip(layer => `Group tooltip: ${layer.options.description}`);
 
 		const element1 = marker1.getElement();
@@ -82,9 +85,9 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on marker focus and ignore layers without getElement function', () => {
-		const marker1 = L.marker([41.18, 9.45]);
-		const someLayerWithoutGetElement = L.layerGroup();
-		const group = new L.FeatureGroup([marker1, someLayerWithoutGetElement]).addTo(map);
+		const marker1 = new Marker([41.18, 9.45]);
+		const someLayerWithoutGetElement = new LayerGroup();
+		const group = new FeatureGroup([marker1, someLayerWithoutGetElement]).addTo(map);
 		group.bindTooltip('Tooltip');
 		expect(() => {
 			UIEventSimulator.fire('focus', marker1.getElement());
@@ -93,7 +96,7 @@ describe('Tooltip', () => {
 
 
 	it('is mentioned in aria-describedby of a bound layer', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 		const element = layer.getElement();
@@ -105,9 +108,9 @@ describe('Tooltip', () => {
 	});
 
 	it('is mentioned in aria-describedby of a bound layer group', () => {
-		const marker1 = L.marker([41.18, 9.45], {description: 'Marker 1'});
-		const marker2 = L.marker([41.18, 9.46], {description: 'Marker 2'});
-		const group = new L.FeatureGroup([marker1, marker2]).addTo(map);
+		const marker1 = new Marker([41.18, 9.45], {description: 'Marker 1'});
+		const marker2 = new Marker([41.18, 9.46], {description: 'Marker 2'});
+		const group = new FeatureGroup([marker1, marker2]).addTo(map);
 		group.bindTooltip(layer => `Group tooltip: ${layer.options.description}`);
 
 		const element = marker2.getElement();
@@ -120,14 +123,14 @@ describe('Tooltip', () => {
 	});
 
 	it('stays open on marker when permanent', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.true;
 	});
 
 	it('can be added with bindTooltip before added to the map', () => {
-		const layer = L.marker(center);
+		const layer = new Marker(center);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.false;
@@ -136,7 +139,7 @@ describe('Tooltip', () => {
 	});
 
 	it('is removed when removing marker', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.true;
@@ -145,7 +148,7 @@ describe('Tooltip', () => {
 	});
 
 	it('is not interactive by default', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 
 		layer.bindTooltip('Tooltip', {permanent: true});
@@ -155,7 +158,7 @@ describe('Tooltip', () => {
 	});
 
 	it('can be made interactive', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 
 		layer.bindTooltip('Tooltip', {permanent: true, interactive: true});
@@ -165,7 +168,7 @@ describe('Tooltip', () => {
 	});
 
 	it('events are propagated to bound layer', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -175,19 +178,19 @@ describe('Tooltip', () => {
 	});
 
 	it('has class leaflet-interactive', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true, interactive: true});
 		expect(layer._tooltip._container.classList.contains('leaflet-interactive')).to.be.true;
 	});
 
 	it('has not class leaflet-interactive', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(layer._tooltip._container.classList.contains('leaflet-interactive')).to.be.false;
 	});
 
 	it('can be forced on left direction', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -198,7 +201,7 @@ describe('Tooltip', () => {
 	});
 
 	it('honours offset on left direction', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -211,7 +214,7 @@ describe('Tooltip', () => {
 	});
 
 	it('can be forced on top direction', () => {
-		const layer = L.circleMarker(center).addTo(map);
+		const layer = new CircleMarker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -222,7 +225,7 @@ describe('Tooltip', () => {
 	});
 
 	it('honours offset on top direction', () => {
-		const layer = L.circleMarker(center).addTo(map);
+		const layer = new CircleMarker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -234,7 +237,7 @@ describe('Tooltip', () => {
 	});
 
 	it('can be forced on bottom direction', () => {
-		const layer = L.circleMarker(center).addTo(map);
+		const layer = new CircleMarker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -245,7 +248,7 @@ describe('Tooltip', () => {
 	});
 
 	it('honours offset on bottom direction', () => {
-		const layer = L.circleMarker(center).addTo(map);
+		const layer = new CircleMarker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -258,7 +261,7 @@ describe('Tooltip', () => {
 	});
 
 	it('can be forced on center', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const spy = sinon.spy();
 		layer.on('click', spy);
 
@@ -269,13 +272,13 @@ describe('Tooltip', () => {
 	});
 
 	it('honours opacity option', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true, opacity: 0.57});
 		expect(layer._tooltip._container.style.opacity).to.eql('0.57');
 	});
 
 	it('can change opacity with setOpacity', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(layer._tooltip._container.style.opacity).to.eql('0.9');
 		layer._tooltip.setOpacity(0.57);
@@ -283,9 +286,9 @@ describe('Tooltip', () => {
 	});
 
 	it('it should use a tooltip with a function as content with a FeatureGroup', () => {
-		const marker1 = L.marker([55.8, 37.6], {description: 'I\'m marker 1.'});
-		const marker2 = L.marker([54.6, 38.2], {description: 'I\'m marker 2.'});
-		const group = L.featureGroup([marker1, marker2]).addTo(map);
+		const marker1 = new Marker([55.8, 37.6], {description: 'I\'m marker 1.'});
+		const marker2 = new Marker([54.6, 38.2], {description: 'I\'m marker 2.'});
+		const group = new FeatureGroup([marker1, marker2]).addTo(map);
 
 		group.bindTooltip(layer => layer.options.description);
 
@@ -301,7 +304,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on polygon mouseover and close on mouseout', () => {
-		const layer = L.polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
+		const layer = new Polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 
@@ -314,14 +317,14 @@ describe('Tooltip', () => {
 	});
 
 	it('stays open on polygon when permanent', () => {
-		const layer = L.polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
+		const layer = new Polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.true;
 	});
 
 	it('can be added on polygon with bindTooltip before beind added to the map', () => {
-		const layer = L.polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
+		const layer = new Polygon([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.false;
@@ -334,7 +337,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens on polyline mouseover and close on mouseout', () => {
-		const layer = L.polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
+		const layer = new Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 
@@ -347,14 +350,14 @@ describe('Tooltip', () => {
 	});
 
 	it('stays open on polyline when permanent', () => {
-		const layer = L.polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
+		const layer = new Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]).addTo(map);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.true;
 	});
 
 	it('can be added on polyline with bindTooltip before added to the map', () => {
-		const layer = L.polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
+		const layer = new Polyline([[55.8, 37.6], [55.9, 37.6], [55.8, 37.5]]);
 
 		layer.bindTooltip('Tooltip', {permanent: true});
 		expect(map.hasLayer(layer._tooltip)).to.be.false;
@@ -367,7 +370,7 @@ describe('Tooltip', () => {
 	});
 
 	it.skipIfNotTouch('is opened when tapping on touch', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 		expect(map.hasLayer(layer._tooltip)).to.be.false;
@@ -376,7 +379,7 @@ describe('Tooltip', () => {
 	});
 
 	it.skipIfNotTouch('is closed if not permanent when clicking on the map elsewhere on touch', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 
 		layer.bindTooltip('Tooltip');
 		UIEventSimulator.fire('click', layer._icon);
@@ -396,7 +399,7 @@ describe('Tooltip', () => {
 
 	it('map.openTooltip considers interactive option', () => {
 		const spy = sinon.spy();
-		const tooltip = L.tooltip({interactive: true, permanent: true})
+		const tooltip = new Tooltip({interactive: true, permanent: true})
 		  .setContent('Tooltip')
 		  .on('click', spy);
 		map.openTooltip(tooltip, center);
@@ -406,13 +409,13 @@ describe('Tooltip', () => {
 	});
 
 	it('can call closeTooltip while not on the map', () => {
-		const layer = L.marker(center);
+		const layer = new Marker(center);
 		layer.bindTooltip('Tooltip', {interactive: true});
 		layer.closeTooltip();
 	});
 
 	it('opens a tooltip and follow the mouse (sticky)', () => {
-		const layer = L.rectangle([[58, 39.7], [54, 35.3]]).addTo(map);
+		const layer = new Rectangle([[58, 39.7], [54, 35.3]]).addTo(map);
 		layer.bindTooltip('Sticky', {sticky: true}).openTooltip();
 		const tooltip = layer.getTooltip();
 		expect(tooltip.getLatLng().equals(layer.getCenter())).to.be.true;
@@ -423,7 +426,7 @@ describe('Tooltip', () => {
 	});
 
 	it('opens a permanent tooltip and follow the mouse (sticky)', (done) => {
-		const layer = L.rectangle([[58, 39.7], [54, 35.3]]).addTo(map);
+		const layer = new Rectangle([[58, 39.7], [54, 35.3]]).addTo(map);
 		layer.bindTooltip('Sticky', {sticky: true, permanent: true}).openTooltip();
 		const tooltip = layer.getTooltip();
 		expect(tooltip.getLatLng().equals(layer.getCenter())).to.be.true;
@@ -441,7 +444,7 @@ describe('Tooltip', () => {
 	});
 
 	it('closes existent tooltip on new bindTooltip call', () => {
-		const layer = L.marker(center).addTo(map);
+		const layer = new Marker(center).addTo(map);
 		const eventSpy = sinon.spy(layer, 'unbindTooltip');
 		layer.bindTooltip('Tooltip1', {permanent: true});
 		const tooltip1 = layer.getTooltip();
@@ -454,7 +457,7 @@ describe('Tooltip', () => {
 	it('don\'t opens the tooltip on marker mouseover while dragging map', () => {
 		// Sometimes the mouse is moving faster then the map while dragging and then the marker can be hover and
 		// the tooltip opened / closed.
-		const layer = L.marker(center).addTo(map).bindTooltip('Tooltip');
+		const layer = new Marker(center).addTo(map).bindTooltip('Tooltip');
 		const tooltip = layer.getTooltip();
 
 		// simulate map dragging
@@ -474,7 +477,7 @@ describe('Tooltip', () => {
 	it('closes the tooltip on marker mouseout while dragging map and don\'t open it again', () => {
 		// Sometimes the mouse is moving faster then the map while dragging and then the marker can be hover and
 		// the tooltip opened / closed.
-		const layer = L.marker(center).addTo(map).bindTooltip('Tooltip');
+		const layer = new Marker(center).addTo(map).bindTooltip('Tooltip');
 		const tooltip = layer.getTooltip();
 
 		// open tooltip before "dragging map"
@@ -497,7 +500,7 @@ describe('Tooltip', () => {
 
 		// If tooltips are dynamically loaded while the map is dragging, they need
 		// to be loaded when the dragging stops.
-		const layer = L.marker(center).bindTooltip('Tooltip', {permanent: true});
+		const layer = new Marker(center).bindTooltip('Tooltip', {permanent: true});
 		map.addLayer(layer);
 
 		// simulate map not dragging anymore
@@ -513,20 +516,20 @@ describe('Tooltip', () => {
 	});
 
 	it('opens tooltip with passed latlng position while initializing', () => {
-		const tooltip = new L.Tooltip(center)
+		const tooltip = new Tooltip(center)
 			.addTo(map);
 		expect(map.hasLayer(tooltip)).to.be.true;
 	});
 
 	it('opens tooltip with passed latlng and options position while initializing', () => {
-		const tooltip = new L.Tooltip(center, {className: 'testClass'})
+		const tooltip = new Tooltip(center, {className: 'testClass'})
 			.addTo(map);
 		expect(map.hasLayer(tooltip)).to.be.true;
 		expect(tooltip.getElement().classList.contains('testClass')).to.be.true;
 	});
 
 	it('adds tooltip with passed content in options while initializing', () => {
-		const tooltip = new L.Tooltip(center, {content: 'Test'})
+		const tooltip = new Tooltip(center, {content: 'Test'})
 			.addTo(map);
 		expect(map.hasLayer(tooltip)).to.be.true;
 		expect(tooltip.getContent()).to.equal('Test');
@@ -534,12 +537,12 @@ describe('Tooltip', () => {
 
 	// Related to #8558
 	it('references the correct targets in tooltipopen event with multiple markers bound to same tooltip', () => {
-		const marker1 = L.marker(center, {testId: 'markerA'});
-		const marker2 = L.marker([57.123076977278, 44.861962891635], {testId: 'markerB'});
+		const marker1 = new Marker(center, {testId: 'markerA'});
+		const marker2 = new Marker([57.123076977278, 44.861962891635], {testId: 'markerB'});
 		map.addLayer(marker1);
 		map.addLayer(marker2);
 
-		const tooltip = L.tooltip().setContent('test');
+		const tooltip = new Tooltip().setContent('test');
 
 		const layer1 = marker1.bindTooltip(tooltip);
 		const layer2 = marker2.bindTooltip(tooltip);

--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -1,10 +1,13 @@
+import {LatLngBounds, Map, VideoOverlay} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('VideoOverlay', () => {
 	let container, map;
-	const videoBounds = L.latLngBounds([[32, -130], [13, -100]]);
+	const videoBounds = new LatLngBounds([[32, -130], [13, -100]]);
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView([55.8, 37.6], 6);	// view needs to be set so when layer is added it is initilized
 	});
 
@@ -21,7 +24,7 @@ describe('VideoOverlay', () => {
 			'https://www.mapbox.com/bites/00188/patricia_nasa.mp4'
 		];
 
-		const videoOverlay = L.videoOverlay(videoUrls, videoBounds).addTo(map);
+		const videoOverlay = new VideoOverlay(videoUrls, videoBounds).addTo(map);
 
 		expect(map.hasLayer(videoOverlay)).to.be.true;
 	});

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -1,12 +1,15 @@
+import {Map, Marker, Icon} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Icon.Default', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 
 		map.setView([0, 0], 0);
-		L.marker([0, 0]).addTo(map);
+		new Marker([0, 0]).addTo(map);
 	});
 
 	afterEach(() => {
@@ -14,17 +17,17 @@ describe('Icon.Default', () => {
 	});
 
 	it('detect icon images path', () => {
-		const origPath = L.Icon.Default.imagePath; // set in after.js
+		const origPath = Icon.Default.imagePath; // set in after.js
 		expect(origPath).to.be.ok;
-		delete L.Icon.Default.imagePath;
-		const marker = L.marker([0, 0]);
+		delete Icon.Default.imagePath;
+		const marker = new Marker([0, 0]);
 
-		expect(L.Icon.Default.imagePath).to.be.undefined;
+		expect(Icon.Default.imagePath).to.be.undefined;
 		marker.addTo(map);
 
-		expect(L.Icon.Default.imagePath).to.equal(location.origin + origPath);
+		expect(Icon.Default.imagePath).to.equal(location.origin + origPath);
 
-		const stripUrl = L.Icon.Default.prototype._stripUrl;
+		const stripUrl = Icon.Default.prototype._stripUrl;
 		const properPath = 'http://localhost:8000/base/dist/images/';
 		[ // valid
 			'url("http://localhost:8000/base/dist/images/marker-icon.png")',  // Firefox

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -1,10 +1,13 @@
+import {Map, Marker, DomUtil, Point} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Marker.Drag', () => {
 	let map,
 	    container;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		container.style.width = '600px';
 		container.style.height = '600px';
 		map.setView([0, 0], 0);
@@ -14,9 +17,9 @@ describe('Marker.Drag', () => {
 		removeMapContainer(map, container);
 	});
 
-	const MyMarker = L.Marker.extend({
+	const MyMarker = Marker.extend({
 		_getPosition() {
-			return L.DomUtil.getPosition(this.dragging._draggable._element);
+			return DomUtil.getPosition(this.dragging._draggable._element);
 		},
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
@@ -29,8 +32,8 @@ describe('Marker.Drag', () => {
 		it('drags a marker with mouse', (done) => {
 			const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 
-			const start = L.point(300, 280);
-			const offset = L.point(256, 32);
+			const start = new Point(300, 280);
+			const offset = new Point(256, 32);
 			const finish = start.add(offset);
 
 			const hand = new Hand({
@@ -51,7 +54,7 @@ describe('Marker.Drag', () => {
 		});
 
 		describe('in CSS scaled container', () => {
-			const scale = L.point(2, 1.5);
+			const scale = new Point(2, 1.5);
 
 			beforeEach(() => {
 				container.style.webkitTransformOrigin = 'top left';
@@ -61,8 +64,8 @@ describe('Marker.Drag', () => {
 			it('drags a marker with mouse, compensating for CSS scale', (done) => {
 				const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 
-				const start = L.point(300, 280);
-				const offset = L.point(256, 32);
+				const start = new Point(300, 280);
+				const offset = new Point(256, 32);
 				const finish = start.add(offset);
 
 				const hand = new Hand({
@@ -91,8 +94,8 @@ describe('Marker.Drag', () => {
 				autoPan: true
 			}).addTo(map);
 
-			const start = L.point(300, 280);
-			const offset = L.point(290, 32);
+			const start = new Point(300, 280);
+			const offset = new Point(290, 32);
 			const finish = start.add(offset);
 
 			const hand = new Hand({

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -1,3 +1,6 @@
+import {Map, Icon, Marker, Point, DivIcon, Browser, LatLng} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Marker', () => {
 	let map,
 	    container,
@@ -6,11 +9,11 @@ describe('Marker', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 
 		map.setView([0, 0], 0);
-		icon1 = new L.Icon.Default();
-		icon2 = new L.Icon.Default({
+		icon1 = new Icon.Default();
+		icon2 = new Icon.Default({
 			iconUrl: `${icon1.options.iconUrl}?2`,
 			shadowUrl: `${icon1.options.shadowUrl}?2`
 		});
@@ -25,12 +28,12 @@ describe('Marker', () => {
 		it('set the correct x and y size attributes', () => {
 			const expectedX = 96;
 			const expectedY = 100;
-			const sizedIcon = new L.Icon.Default({
+			const sizedIcon = new Icon.Default({
 				iconUrl: `${icon1.options.iconUrl}?3`,
 				iconSize: [expectedX, expectedY]
 			});
 
-			const marker = L.marker([0, 0], {icon: sizedIcon});
+			const marker = new Marker([0, 0], {icon: sizedIcon});
 			map.addLayer(marker);
 
 			const icon = marker._icon;
@@ -41,12 +44,12 @@ describe('Marker', () => {
 
 		it('set the correct x and y size attributes passing only one value', () => {
 			const expectedXY = 96;
-			const sizedIcon = new L.Icon.Default({
+			const sizedIcon = new Icon.Default({
 				iconUrl: `${icon1.options.iconUrl}?3`,
 				iconSize: expectedXY
 			});
 
-			const marker = L.marker([0, 0], {icon: sizedIcon});
+			const marker = new Marker([0, 0], {icon: sizedIcon});
 			map.addLayer(marker);
 
 			const icon = marker._icon;
@@ -55,14 +58,14 @@ describe('Marker', () => {
 			expect(icon.style.height).to.equal(`${expectedXY}px`);
 		});
 
-		it('set the correct x and y size attributes passing a L.Point instance', () => {
+		it('set the correct x and y size attributes passing a Point instance', () => {
 			const expectedXY = 96;
-			const sizedIcon = new L.Icon.Default({
+			const sizedIcon = new Icon.Default({
 				iconUrl: `${icon1.options.iconUrl}?3`,
-				iconSize: L.point(expectedXY, expectedXY)
+				iconSize: new Point(expectedXY, expectedXY)
 			});
 
-			const marker = L.marker([0, 0], {icon: sizedIcon});
+			const marker = new Marker([0, 0], {icon: sizedIcon});
 			map.addLayer(marker);
 
 			const icon = marker._icon;
@@ -72,7 +75,7 @@ describe('Marker', () => {
 		});
 
 		it('changes the icon to another image while re-using the IMG element', () => {
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 
 			const beforeIcon = marker._icon;
@@ -84,7 +87,7 @@ describe('Marker', () => {
 		});
 
 		it('preserves draggability', () => {
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 
 			marker.dragging.disable();
@@ -121,11 +124,11 @@ describe('Marker', () => {
 		});
 
 		it('changes the DivIcon to another DivIcon, while re-using the DIV element', () => {
-			const marker = L.marker([0, 0], {icon: L.divIcon({html: 'Inner1Text'})});
+			const marker = new Marker([0, 0], {icon: new DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);
 
 			const beforeIcon = marker._icon;
-			marker.setIcon(L.divIcon({html: 'Inner2Text'}));
+			marker.setIcon(new DivIcon({html: 'Inner2Text'}));
 			const afterIcon = marker._icon;
 
 			expect(beforeIcon).to.equal(afterIcon); // Check that the <DIV> element is re-used
@@ -133,16 +136,16 @@ describe('Marker', () => {
 		});
 
 		it('removes text when changing to a blank DivIcon', () => {
-			const marker = L.marker([0, 0], {icon: L.divIcon({html: 'Inner1Text'})});
+			const marker = new Marker([0, 0], {icon: new DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);
 
-			marker.setIcon(L.divIcon());
+			marker.setIcon(new DivIcon());
 
 			expect(marker._icon.innerHTML).to.not.contain('Inner1Text');
 		});
 
 		it('changes a DivIcon to an image', () => {
-			const marker = L.marker([0, 0], {icon: L.divIcon({html: 'Inner1Text'})});
+			const marker = new Marker([0, 0], {icon: new DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);
 			const oldIcon = marker._icon;
 
@@ -151,7 +154,7 @@ describe('Marker', () => {
 			expect(oldIcon).to.not.equal(marker._icon); // Check that the _icon is NOT re-used
 			expect(oldIcon.parentNode).to.equal(null);
 
-			if (L.Browser.retina) {
+			if (Browser.retina) {
 				expect(marker._icon.src).to.contain('marker-icon-2x.png');
 			} else {
 				expect(marker._icon.src).to.contain('marker-icon.png');
@@ -160,11 +163,11 @@ describe('Marker', () => {
 		});
 
 		it('changes an image to a DivIcon', () => {
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 			const oldIcon = marker._icon;
 
-			marker.setIcon(L.divIcon({html: 'Inner1Text'}));
+			marker.setIcon(new DivIcon({html: 'Inner1Text'}));
 
 			expect(oldIcon).to.not.equal(marker._icon); // Check that the _icon is NOT re-used
 			expect(oldIcon.parentNode).to.equal(null);
@@ -174,7 +177,7 @@ describe('Marker', () => {
 		});
 
 		it('reuses the icon/shadow when changing icon', () => {
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 			const oldIcon = marker._icon;
 			const oldShadow = marker._shadow;
@@ -189,7 +192,7 @@ describe('Marker', () => {
 		});
 
 		it('sets the alt attribute to a default value when no alt text is passed', () => {
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 			const icon = marker._icon;
 			expect(icon.hasAttribute('alt')).to.be.true;
@@ -197,14 +200,14 @@ describe('Marker', () => {
 		});
 
 		it('doesn\'t set the alt attribute for DivIcons', () => {
-			const marker = L.marker([0, 0], {icon: L.divIcon(), alt: 'test'});
+			const marker = new Marker([0, 0], {icon: new DivIcon(), alt: 'test'});
 			map.addLayer(marker);
 			const icon = marker._icon;
 			expect(icon.hasAttribute('alt')).to.be.false;
 		});
 
 		it('pan map to focus marker', () => {
-			const marker = L.marker([70, 0], {icon: L.divIcon()});
+			const marker = new Marker([70, 0], {icon: new DivIcon()});
 			map.addLayer(marker);
 
 			expect(() => {
@@ -213,7 +216,7 @@ describe('Marker', () => {
 		});
 
 		it('pan map to focus marker with no iconSize', () => {
-			const marker = L.marker([70, 0], {icon: L.divIcon({iconSize: null})});
+			const marker = new Marker([70, 0], {icon: new DivIcon({iconSize: null})});
 			map.addLayer(marker);
 
 			expect(() => {
@@ -225,11 +228,11 @@ describe('Marker', () => {
 	describe('#setLatLng', () => {
 		it('fires a move event', () => {
 
-			const marker = L.marker([0, 0], {icon: icon1});
+			const marker = new Marker([0, 0], {icon: icon1});
 			map.addLayer(marker);
 
 			const beforeLatLng = marker._latlng;
-			const afterLatLng = new L.LatLng(1, 2);
+			const afterLatLng = new LatLng(1, 2);
 
 			let eventArgs = null;
 			marker.on('move', (e) => {
@@ -249,7 +252,7 @@ describe('Marker', () => {
 		it('fires click event when clicked', () => {
 			const spy = sinon.spy();
 
-			const marker = L.marker([0, 0]).addTo(map);
+			const marker = new Marker([0, 0]).addTo(map);
 
 			marker.on('click', spy);
 			UIEventSimulator.fire('click', marker._icon);
@@ -260,7 +263,7 @@ describe('Marker', () => {
 		it('fires click event when clicked with DivIcon', () => {
 			const spy = sinon.spy();
 
-			const marker = L.marker([0, 0], {icon: L.divIcon()}).addTo(map);
+			const marker = new Marker([0, 0], {icon: new DivIcon()}).addTo(map);
 
 			marker.on('click', spy);
 			UIEventSimulator.fire('click', marker._icon);
@@ -271,7 +274,7 @@ describe('Marker', () => {
 		it('fires click event when clicked on DivIcon child element', () => {
 			const spy = sinon.spy();
 
-			const marker = L.marker([0, 0], {icon: L.divIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'})}).addTo(map);
+			const marker = new Marker([0, 0], {icon: new DivIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'})}).addTo(map);
 
 			marker.on('click', spy);
 
@@ -285,8 +288,8 @@ describe('Marker', () => {
 		it('fires click event when clicked on DivIcon child element set using setIcon', () => {
 			const spy = sinon.spy();
 
-			const marker = L.marker([0, 0]).addTo(map);
-			marker.setIcon(L.divIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'}));
+			const marker = new Marker([0, 0]).addTo(map);
+			marker.setIcon(new DivIcon({html: '<img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" />'}));
 
 			marker.on('click', spy);
 
@@ -301,7 +304,7 @@ describe('Marker', () => {
 			const spy = sinon.spy();
 			const spy2 = sinon.spy();
 			const mapSpy = sinon.spy();
-			const marker = L.marker([55.8, 37.6]);
+			const marker = new Marker([55.8, 37.6]);
 			map.addLayer(marker);
 			marker.on('click', spy);
 			marker.on('click', spy2);
@@ -316,7 +319,7 @@ describe('Marker', () => {
 			const spy = sinon.spy();
 			const spy2 = sinon.spy();
 			const mapSpy = sinon.spy();
-			const marker = L.marker([55.8, 37.6]);
+			const marker = new Marker([55.8, 37.6]);
 			map.addLayer(marker);
 			marker.on('dblclick', spy);
 			marker.on('dblclick', spy2);
@@ -328,7 +331,7 @@ describe('Marker', () => {
 		});
 
 		it('do not catch event if it does not listen to it', (done) => {
-			const marker = L.marker([55, 37]);
+			const marker = new Marker([55, 37]);
 			map.addLayer(marker);
 			marker.once('mousemove', (e) => {
 				// It should be the marker coordinates

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -1,9 +1,12 @@
+import {Map, GridLayer, DomUtil, Point, Util} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('GridLayer', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		container.style.width = '800px';
 		container.style.height = '600px';
 	});
@@ -14,22 +17,22 @@ describe('GridLayer', () => {
 
 	describe('#redraw', () => {
 		it('can be called before map.setView', () => {
-			const grid = L.gridLayer().addTo(map);
+			const grid = new GridLayer().addTo(map);
 			expect(grid.redraw()).to.equal(grid);
 		});
 	});
 
 	describe('#setOpacity', () => {
 		it('can be called before map.setView', () => {
-			const grid = L.gridLayer().addTo(map);
+			const grid = new GridLayer().addTo(map);
 			expect(grid.setOpacity(0.5)).to.equal(grid);
 		});
 
 		it('works when map has fadeAnimated=false (IE8 is exempt)', (done) => {
 			map.remove();
-			map = L.map(container, {fadeAnimation: false}).setView([0, 0], 0);
+			map = new Map(container, {fadeAnimation: false}).setView([0, 0], 0);
 
-			const grid = L.gridLayer().setOpacity(0.5).addTo(map);
+			const grid = new GridLayer().setOpacity(0.5).addTo(map);
 			grid.on('load', () => {
 				expect(grid._container.style.opacity).to.equal('0.5');
 				done();
@@ -42,7 +45,7 @@ describe('GridLayer', () => {
 
 		const tiles = [];
 
-		const grid = L.gridLayer();
+		const grid = new GridLayer();
 		grid.createTile = function (coords) {
 			const tile = document.createElement('div');
 			tiles.push({coords, tile});
@@ -55,7 +58,7 @@ describe('GridLayer', () => {
 
 		for (let i = 0; i < tiles.length; i++) {
 			const coords = tiles[i].coords,
-			    pos = L.DomUtil.getPosition(tiles[i].tile);
+			    pos = DomUtil.getPosition(tiles[i].tile);
 
 			loaded[`${pos.x}:${pos.y}`] = [coords.x, coords.y];
 		}
@@ -85,10 +88,10 @@ describe('GridLayer', () => {
 
 		it('removes tiles for unused zoom levels', (done) => {
 			map.remove();
-			map = L.map(container, {fadeAnimation: false});
+			map = new Map(container, {fadeAnimation: false});
 			map.setView([0, 0], 1);
 
-			const grid = L.gridLayer();
+			const grid = new GridLayer();
 			const tiles = {};
 
 			grid.createTile = function (coords) {
@@ -124,7 +127,7 @@ describe('GridLayer', () => {
 
 			map.setView([0, 0], 10);
 
-			grid = L.gridLayer();
+			grid = new GridLayer();
 		});
 
 		it('only creates tiles for visible area on zoom in', (done) => {
@@ -205,7 +208,7 @@ describe('GridLayer', () => {
 
 	describe('#onAdd', () => {
 		it('is called after zoomend on first map load', () => {
-			const layer = L.gridLayer().addTo(map);
+			const layer = new GridLayer().addTo(map);
 
 			const onAdd = layer.onAdd,
 			    onAddSpy = sinon.spy();
@@ -232,7 +235,7 @@ describe('GridLayer', () => {
 				const maxZoom = 10,
 				    minZoom = 5;
 
-				L.gridLayer({
+				new GridLayer({
 					maxZoom,
 					minZoom
 				}).addTo(map);
@@ -244,27 +247,27 @@ describe('GridLayer', () => {
 
 		describe('accessing a gridlayer\'s properties', () => {
 			it('provides a container', () => {
-				const layer = L.gridLayer().addTo(map);
+				const layer = new GridLayer().addTo(map);
 				expect(layer.getContainer()).to.be.ok;
 			});
 		});
 
 		describe('when a gridlayer is added to a map that already has a gridlayer', () => {
 			it('has its zoomlevels updated to fit the new layer', () => {
-				L.gridLayer({minZoom: 10, maxZoom: 15}).addTo(map);
+				new GridLayer({minZoom: 10, maxZoom: 15}).addTo(map);
 				expect(map.getMinZoom()).to.equal(10);
 				expect(map.getMaxZoom()).to.equal(15);
 
-				L.gridLayer({minZoom: 5, maxZoom: 10}).addTo(map);
+				new GridLayer({minZoom: 5, maxZoom: 10}).addTo(map);
 				expect(map.getMinZoom()).to.equal(5);  // changed
 				expect(map.getMaxZoom()).to.equal(15); // unchanged
 
-				L.gridLayer({minZoom: 10, maxZoom: 20}).addTo(map);
+				new GridLayer({minZoom: 10, maxZoom: 20}).addTo(map);
 				expect(map.getMinZoom()).to.equal(5);  // unchanged
 				expect(map.getMaxZoom()).to.equal(20); // changed
 
 
-				L.gridLayer({minZoom: 0, maxZoom: 25}).addTo(map);
+				new GridLayer({minZoom: 0, maxZoom: 25}).addTo(map);
 				expect(map.getMinZoom()).to.equal(0); // changed
 				expect(map.getMaxZoom()).to.equal(25); // changed
 			});
@@ -273,10 +276,10 @@ describe('GridLayer', () => {
 		describe('when a gridlayer is removed from a map', () => {
 			it('has its zoomlevels updated to only fit the layers it currently has', () => {
 				const tiles = [
-					L.gridLayer({minZoom: 10, maxZoom: 15}).addTo(map),
-					L.gridLayer({minZoom: 5, maxZoom: 10}).addTo(map),
-					L.gridLayer({minZoom: 10, maxZoom: 20}).addTo(map),
-					L.gridLayer({minZoom: 0, maxZoom: 25}).addTo(map)
+					new GridLayer({minZoom: 10, maxZoom: 15}).addTo(map),
+					new GridLayer({minZoom: 5, maxZoom: 10}).addTo(map),
+					new GridLayer({minZoom: 10, maxZoom: 20}).addTo(map),
+					new GridLayer({minZoom: 0, maxZoom: 25}).addTo(map)
 				];
 				expect(map.getMinZoom()).to.equal(0);
 				expect(map.getMaxZoom()).to.equal(25);
@@ -304,7 +307,7 @@ describe('GridLayer', () => {
 		it('calls createTile() with maxNativeZoom when map zoom is larger', (done) => {
 			map.setView([0, 0], 10);
 
-			const grid = L.gridLayer({
+			const grid = new GridLayer({
 				maxNativeZoom: 5
 			});
 			let tileCount = 0;
@@ -328,7 +331,7 @@ describe('GridLayer', () => {
 		it('calls createTile() with minNativeZoom when map zoom is smaller', (done) => {
 			map.setView([0, 0], 3);
 
-			const grid = L.gridLayer({
+			const grid = new GridLayer({
 				minNativeZoom: 5
 			});
 			let tileCount = 0;
@@ -353,7 +356,7 @@ describe('GridLayer', () => {
 			const initialZoom = 12;
 			map.setView([0, 0], initialZoom);
 
-			const grid = L.gridLayer().addTo(map);
+			const grid = new GridLayer().addTo(map);
 			expect(grid._tileZoom).to.equal(initialZoom);
 
 			grid.options.maxNativeZoom = 11;
@@ -368,9 +371,9 @@ describe('GridLayer', () => {
 		beforeEach(() => {
 			clock = sinon.useFakeTimers();
 
-			grid = L.gridLayer({
+			grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256)
+				tileSize: new Point(256, 256)
 			});
 
 			grid.createTile = function (coords) {
@@ -519,9 +522,9 @@ describe('GridLayer', () => {
 		beforeEach(() => {
 			clock = sinon.useFakeTimers();
 
-			grid = L.gridLayer({
+			grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256)
+				tileSize: new Point(256, 256)
 			});
 
 			grid.createTile = function (coords) {
@@ -571,10 +574,10 @@ describe('GridLayer', () => {
 				return function () {
 					clock.tick(40); // 40msec/frame ~= 25fps
 					map.fire('_frame');
-					L.Util.requestAnimFrame(_runFrames(n - 1));
+					Util.requestAnimFrame(_runFrames(n - 1));
 				};
 			} else {
-				return L.Util.falseFn;
+				return Util.falseFn;
 			}
 		}
 
@@ -593,7 +596,7 @@ describe('GridLayer', () => {
 				expect(counts.tileunload).to.equal(0);
 
 				// Wait for a frame to let _updateOpacity starting.
-				L.Util.requestAnimFrame(() => {
+				Util.requestAnimFrame(() => {
 					// Wait > 250msec for the tile fade-in animation to complete,
 					// which triggers the tile pruning
 					clock.tick(300);
@@ -630,7 +633,7 @@ describe('GridLayer', () => {
 						// so the remaining 4 tiles from z10 can then be pruned.
 						// However we have skipped any pruning from _updateOpacity,
 						// so we will have to rely on the setTimeout from _tileReady.
-						L.Util.requestAnimFrame(() => {
+						Util.requestAnimFrame(() => {
 							// Wait > 250msec for the tile fade-in animation to complete,
 							// which triggers the tile pruning
 							clock.tick(300);
@@ -644,7 +647,7 @@ describe('GridLayer', () => {
 
 					map.setZoom(11, {animate: true});
 					// Animation (and new tiles loading) starts after 1 frame.
-					L.Util.requestAnimFrame(() => {
+					Util.requestAnimFrame(() => {
 						// 16 extra tiles from z11 being loaded. Total 16 + 16 = 32.
 						expect(counts.tileloadstart).to.equal(32);
 					});
@@ -670,7 +673,7 @@ describe('GridLayer', () => {
 
 					// In this particular scenario, the tile unloads happen in the
 					// next render frame after the grid's 'load' event.
-					L.Util.requestAnimFrame(() => {
+					Util.requestAnimFrame(() => {
 						expect(counts.tileloadstart).to.equal(32);
 						expect(counts.tileload).to.equal(32);
 						expect(counts.tileunload).to.equal(16);
@@ -698,7 +701,7 @@ describe('GridLayer', () => {
 				expect(counts.tileunload).to.equal(0);
 
 				// Wait for a frame to let _updateOpacity starting.
-				L.Util.requestAnimFrame(() => {
+				Util.requestAnimFrame(() => {
 					// Wait > 250msec for the tile fade-in animation to complete,
 					// which triggers the tile pruning
 					clock.tick(300);
@@ -735,7 +738,7 @@ describe('GridLayer', () => {
 							// Wait for a frame for next _updateOpacity to prune
 							// all 16 tiles from z11 which are now covered by the
 							// 4 central active tiles of z10.
-							L.Util.requestAnimFrame(() => {
+							Util.requestAnimFrame(() => {
 								expect(counts.tileunload).to.equal(16);
 								done();
 							});
@@ -745,7 +748,7 @@ describe('GridLayer', () => {
 
 				map.setZoom(10, {animate: true});
 				// Animation (and new tiles loading) starts after 1 frame.
-				L.Util.requestAnimFrame(() => {
+				Util.requestAnimFrame(() => {
 					// We're one frame into the zoom animation, there are
 					// 16 tiles for z11 plus 4 tiles for z10 covering the
 					// bounds at the *beginning* of the zoom-*out* anim
@@ -770,7 +773,7 @@ describe('GridLayer', () => {
 
 					// In this particular scenario, the tile unloads happen in the
 					// next render frame after the grid's 'load' event.
-					L.Util.requestAnimFrame(() => {
+					Util.requestAnimFrame(() => {
 						expect(counts.tileloadstart).to.equal(32);
 						expect(counts.tileload).to.equal(32);
 						expect(counts.tileunload).to.equal(16);
@@ -828,9 +831,9 @@ describe('GridLayer', () => {
 		beforeEach(() => {
 			clock = sinon.useFakeTimers();
 
-			grid = L.gridLayer({
+			grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256)
+				tileSize: new Point(256, 256)
 			});
 
 			grid.createTile = function (coords) {
@@ -877,7 +880,7 @@ describe('GridLayer', () => {
 				expect(counts.tileunload).to.equal(0);
 
 				// Wait for a frame to let _updateOpacity starting.
-				L.Util.requestAnimFrame(() => {
+				Util.requestAnimFrame(() => {
 
 					// Wait > 250msec for the tile fade-in animation to complete,
 					// which triggers the tile pruning
@@ -894,7 +897,7 @@ describe('GridLayer', () => {
 
 						// Wait for a frame to let _updateOpacity starting
 						// It will prune the 12 tiles outside the new bounds.
-						L.Util.requestAnimFrame(() => {
+						Util.requestAnimFrame(() => {
 							expect(counts.tileunload).to.equal(12);
 							done();
 						});
@@ -933,7 +936,7 @@ describe('GridLayer', () => {
 
 					// Wait for a frame to let _updateOpacity starting
 					// It will prune the 12 tiles outside the new bounds.
-					L.Util.requestAnimFrame(() => {
+					Util.requestAnimFrame(() => {
 						expect(counts.tileunload).to.equal(12);
 
 						grid.once('load', () => {
@@ -941,7 +944,7 @@ describe('GridLayer', () => {
 							expect(counts.tileload).to.equal(40);
 
 							// Wait an extra frame for the tile pruning to happen.
-							L.Util.requestAnimFrame(() => {
+							Util.requestAnimFrame(() => {
 								expect(counts.tileunload).to.equal(24);
 								done();
 							});
@@ -997,9 +1000,9 @@ describe('GridLayer', () => {
 
 	describe('nowrap option', () => {
 		it('When false, uses same coords at zoom 0 for all tiles', (done) => {
-			const grid = L.gridLayer({
+			const grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256),
+				tileSize: new Point(256, 256),
 				noWrap: false
 			});
 			const loadedTileKeys = [];
@@ -1018,9 +1021,9 @@ describe('GridLayer', () => {
 		});
 
 		it('When true, uses different coords at zoom level 0 for all tiles', (done) => {
-			const grid = L.gridLayer({
+			const grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256),
+				tileSize: new Point(256, 256),
 				noWrap: true
 			});
 			const loadedTileKeys = [];
@@ -1039,9 +1042,9 @@ describe('GridLayer', () => {
 		});
 
 		it('When true and with bounds, loads just one tile at zoom level 0', (done) => {
-			const grid = L.gridLayer({
+			const grid = new GridLayer({
 				attribution: 'Grid Layer',
-				tileSize: L.point(256, 256),
+				tileSize: new Point(256, 256),
 				bounds: [[-90, -180], [90, 180]],
 				noWrap: true
 			});
@@ -1065,21 +1068,21 @@ describe('GridLayer', () => {
 		it('Throws error on map center at plus Infinity longitude', () => {
 			expect(() => {
 				map.panTo([Infinity, Infinity]);
-				L.gridLayer().addTo(map);
+				new GridLayer().addTo(map);
 			}).to.throw('Attempted to load an infinite number of tiles');
 		});
 
 		it('Throws error on map center at minus Infinity longitude', () => {
 			expect(() => {
 				map.panTo([-Infinity, -Infinity]);
-				L.gridLayer().addTo(map);
+				new GridLayer().addTo(map);
 			}).to.throw('Attempted to load an infinite number of tiles');
 		});
 	});
 
 	it('doesn\'t call map\'s getZoomScale method with null after _invalidateAll method was called', () => {
 		map.setView([0, 0], 0);
-		const grid = L.gridLayer().addTo(map);
+		const grid = new GridLayer().addTo(map);
 		const wrapped = sinon.spy(map, 'getZoomScale');
 		grid._invalidateAll();
 		grid.redraw();

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -1,3 +1,6 @@
+import {Map, TileLayer, Util, CRS, DomUtil, Browser} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('TileLayer', () => {
 	let container, map;
 
@@ -160,7 +163,7 @@ describe('TileLayer', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		container.style.width = '800px';
 		container.style.height = '600px';
 	});
@@ -170,7 +173,7 @@ describe('TileLayer', () => {
 	});
 
 	function kittenLayerFactory(options) {
-		return L.tileLayer(placeKitten, options || {});
+		return new TileLayer(placeKitten, options || {});
 	}
 
 	function eachImg(layer, callback) {
@@ -195,10 +198,10 @@ describe('TileLayer', () => {
 				return function () {
 					clock.tick(40); // 40msec/frame ~= 25fps
 					map.fire('_frame');
-					L.Util.requestAnimFrame(_runFrames(n - 1));
+					Util.requestAnimFrame(_runFrames(n - 1));
 				};
 			} else {
-				return L.Util.falseFn;
+				return Util.falseFn;
 			}
 		}
 
@@ -291,7 +294,7 @@ describe('TileLayer', () => {
 		});
 
 		it('replaces {y} with y coordinate', () => {
-			const layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png').addTo(map);
+			const layer = new TileLayer('http://example.com/{z}/{y}/{x}.png').addTo(map);
 
 			const urls = [
 				'http://example.com/2/1/1.png',
@@ -308,7 +311,7 @@ describe('TileLayer', () => {
 		});
 
 		it('replaces {-y} with inverse y coordinate', () => {
-			const layer = L.tileLayer('http://example.com/{z}/{-y}/{x}.png').addTo(map);
+			const layer = new TileLayer('http://example.com/{z}/{-y}/{x}.png').addTo(map);
 			const urls = [
 				'http://example.com/2/2/1.png',
 				'http://example.com/2/2/2.png',
@@ -329,10 +332,10 @@ describe('TileLayer', () => {
 			simplediv.style.visibility = 'hidden';
 
 			document.body.appendChild(simplediv);
-			const simpleMap = L.map(simplediv, {
-				crs: L.CRS.Simple
+			const simpleMap = new Map(simplediv, {
+				crs: CRS.Simple
 			}).setView([0, 0], 5);
-			const layer = L.tileLayer('http://example.com/{z}/{-y}/{x}.png');
+			const layer = new TileLayer('http://example.com/{z}/{-y}/{x}.png');
 
 			expect(() => {
 				layer.addTo(simpleMap);
@@ -343,7 +346,7 @@ describe('TileLayer', () => {
 		});
 
 		it('replaces {s} with [abc] by default', () => {
-			const layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png').addTo(map);
+			const layer = new TileLayer('http://{s}.example.com/{z}/{-y}/{x}.png').addTo(map);
 
 			eachImg(layer, (img) => {
 				expect(['a', 'b', 'c'].includes(img.src[7])).to.eql(true);
@@ -351,7 +354,7 @@ describe('TileLayer', () => {
 		});
 
 		it('replaces {s} with specified prefixes', () => {
-			const layer = L.tileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
+			const layer = new TileLayer('http://{s}.example.com/{z}/{-y}/{x}.png', {
 				subdomains: 'qrs'
 			}).addTo(map);
 
@@ -362,7 +365,7 @@ describe('TileLayer', () => {
 
 		it('uses zoomOffset option', () => {
 			// Map view is set at zoom 2 in beforeEach.
-			const layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+			const layer = new TileLayer('http://example.com/{z}/{y}/{x}.png', {
 				zoomOffset: 1 // => zoom 2 + zoomOffset 1 => z 3 in URL.
 			}).addTo(map);
 
@@ -382,7 +385,7 @@ describe('TileLayer', () => {
 
 		it('uses negative zoomOffset option', () => {
 			// Map view is set at zoom 2 in beforeEach.
-			const layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+			const layer = new TileLayer('http://example.com/{z}/{y}/{x}.png', {
 				zoomOffset: -3 // => zoom 2 + zoomOffset -3 => z -1 in URL.
 			}).addTo(map);
 
@@ -402,7 +405,7 @@ describe('TileLayer', () => {
 
 	});
 
-	const _describe = 'crossOrigin' in L.DomUtil.create('img') ? describe : describe.skip; // skip in IE<11
+	const _describe = 'crossOrigin' in DomUtil.create('img') ? describe : describe.skip; // skip in IE<11
 	_describe('crossOrigin option', () => {
 		beforeEach(() => {
 			map.setView([0, 0], 2);
@@ -417,7 +420,7 @@ describe('TileLayer', () => {
 
 		function testCrossOriginValue(crossOrigin, expectedValue) {
 			it(`uses crossOrigin value ${crossOrigin}`, () => {
-				const layer = L.tileLayer('http://example.com/{z}/{y}/{x}.png', {
+				const layer = new TileLayer('http://example.com/{z}/{y}/{x}.png', {
 					crossOrigin
 				}).addTo(map);
 
@@ -432,8 +435,8 @@ describe('TileLayer', () => {
 			const minZoom = 1;
 
 			// override retina to load extra tiles
-			const originalRetina = L.Browser.retina;
-			L.Browser.retina = true;
+			const originalRetina = Browser.retina;
+			Browser.retina = true;
 
 			const kittenLayer = kittenLayerFactory({
 				maxZoom,
@@ -446,7 +449,7 @@ describe('TileLayer', () => {
 				expect(kittenLayer.options.minZoom).to.equal(minZoom);
 
 				// reset retina value
-				L.Browser.retina = originalRetina;
+				Browser.retina = originalRetina;
 
 				done();
 			});
@@ -456,8 +459,8 @@ describe('TileLayer', () => {
 
 		it('resets invalid min/maxZoom to allow for tiles to be loaded without detectRetina', (done) => {
 			// override retina to load extra tiles
-			const originalRetina = L.Browser.retina;
-			L.Browser.retina = false;
+			const originalRetina = Browser.retina;
+			Browser.retina = false;
 
 			const kittenLayer = kittenLayerFactory({
 				// invalid min/maxZoom
@@ -471,7 +474,7 @@ describe('TileLayer', () => {
 				expect(kittenLayer.options.maxZoom).to.equal(kittenLayer.options.minZoom);
 
 				// reset retina value
-				L.Browser.retina = originalRetina;
+				Browser.retina = originalRetina;
 
 				done();
 			});
@@ -482,7 +485,7 @@ describe('TileLayer', () => {
 
 	describe('#setUrl', () => {
 		it('fires only one load event', (done) => {
-			const layer = L.tileLayer(placeKitten).addTo(map);
+			const layer = new TileLayer(placeKitten).addTo(map);
 			const counts = {
 				load: 0,
 				tileload: 0

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -1,3 +1,6 @@
+import {Map, Polygon, DomEvent, Marker, Circle, SVG, stamp, Util, Polyline, LayerGroup, Canvas} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Canvas', () => {
 	let container, map, latLngs;
 
@@ -7,7 +10,7 @@ describe('Canvas', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {preferCanvas: true, zoomControl: false});
+		map = new Map(container, {preferCanvas: true, zoomControl: false});
 		map.setView([0, 0], 6);
 		latLngs = [p2ll(0, 0), p2ll(0, 100), p2ll(100, 100), p2ll(100, 0)];
 	});
@@ -20,7 +23,7 @@ describe('Canvas', () => {
 		let layer;
 
 		beforeEach(() => {
-			layer = L.polygon(latLngs).addTo(map);
+			layer = new Polygon(latLngs).addTo(map);
 		});
 
 		it('should fire event when layer contains mouse', () => {
@@ -43,7 +46,7 @@ describe('Canvas', () => {
 			const mapSpy = sinon.spy();
 			const layerSpy = sinon.spy();
 			map.on('click', mapSpy);
-			layer.on('click', L.DomEvent.stopPropagation).on('click', layerSpy);
+			layer.on('click', DomEvent.stopPropagation).on('click', layerSpy);
 			UIEventSimulator.fireAt('click', 50, 50);
 			expect(layerSpy.callCount).to.eql(1);
 			expect(mapSpy.callCount).to.eql(0);
@@ -51,18 +54,18 @@ describe('Canvas', () => {
 
 		it('DOM events fired on canvas polygon are propagated only once to the map even when two layers contains the event', () => {
 			const spy = sinon.spy();
-			L.polygon(latLngs).addTo(map); // layer 2
+			new Polygon(latLngs).addTo(map); // layer 2
 			map.on('click', spy);
 			UIEventSimulator.fireAt('click', 50, 50);
 			expect(spy.callCount).to.eql(1);
 		});
 
 		it('should be transparent for DOM events going to non-canvas features', () => {
-			const marker = L.marker(map.layerPointToLatLng([150, 150]))
+			const marker = new Marker(map.layerPointToLatLng([150, 150]))
 				.addTo(map);
-			const circle = L.circle(map.layerPointToLatLng([200, 200]), {
+			const circle = new Circle(map.layerPointToLatLng([200, 200]), {
 				radius: 20000,
-				renderer: L.svg()
+				renderer: new SVG()
 			}).addTo(map);
 
 			const spyPolygon = sinon.spy();
@@ -128,8 +131,7 @@ describe('Canvas', () => {
 			});
 			const mouse = hand.growFinger('mouse');
 
-			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
+			// We move 5 pixels first to overcome the 3-pixel threshold of Draggable.
 			mouse.moveTo(50, 50, 0)
 				.down().moveBy(20, 10, 200).up();
 		});
@@ -138,7 +140,7 @@ describe('Canvas', () => {
 			const spy = sinon.spy();
 			const center = p2ll(300, 300);
 			const radius = p2ll(200, 200).distanceTo(center);
-			const circle = L.circle(center, {radius}).addTo(map);
+			const circle = new Circle(center, {radius}).addTo(map);
 			circle.on('mousedown', spy);
 
 			const hand = new Hand({
@@ -159,7 +161,7 @@ describe('Canvas', () => {
 
 	describe('#events(interactive=false)', () => {
 		it('should not fire click when not interactive', () => {
-			const layer = L.polygon(latLngs, {interactive: false}).addTo(map);
+			const layer = new Polygon(latLngs, {interactive: false}).addTo(map);
 			const spy = sinon.spy();
 			layer.on('click', spy);
 			UIEventSimulator.fireAt('click', 50, 50);  // Click on the layer.
@@ -171,13 +173,13 @@ describe('Canvas', () => {
 
 	describe('#dashArray', () => {
 		it('can add polyline with dashArray', () => {
-			L.polygon(latLngs, {
+			new Polygon(latLngs, {
 				dashArray: '5,5'
 			}).addTo(map);
 		});
 
 		it('can setStyle with dashArray', () => {
-			const layer = L.polygon(latLngs).addTo(map);
+			const layer = new Polygon(latLngs).addTo(map);
 			layer.setStyle({
 				dashArray: '5,5'
 			});
@@ -185,23 +187,23 @@ describe('Canvas', () => {
 	});
 
 	it('removes vector on next animation frame', function (done) {
-		const layer = L.circle([0, 0]).addTo(map),
-		    layerId = L.stamp(layer),
+		const layer = new Circle([0, 0]).addTo(map),
+		    layerId = stamp(layer),
 		    canvas = map.getRenderer(layer);
 
 		expect(canvas._layers).to.have.property(layerId);
 
 		map.removeLayer(layer);
 		// Defer check due to how Canvas renderer manages layer removal.
-		L.Util.requestAnimFrame(() => {
+		Util.requestAnimFrame(() => {
 			expect(canvas._layers).to.not.have.property(layerId);
 			done();
 		}, this);
 	});
 
 	it('adds vectors even if they have been removed just before', function (done) {
-		const layer = L.circle([0, 0]).addTo(map),
-		    layerId = L.stamp(layer),
+		const layer = new Circle([0, 0]).addTo(map),
+		    layerId = stamp(layer),
 		    canvas = map.getRenderer(layer);
 
 		expect(canvas._layers).to.have.property(layerId);
@@ -210,7 +212,7 @@ describe('Canvas', () => {
 		map.addLayer(layer);
 		expect(canvas._layers).to.have.property(layerId);
 		// Re-perform a deferred check due to how Canvas renderer manages layer removal.
-		L.Util.requestAnimFrame(() => {
+		Util.requestAnimFrame(() => {
 			expect(canvas._layers).to.have.property(layerId);
 			done();
 		}, this);
@@ -218,13 +220,13 @@ describe('Canvas', () => {
 
 	describe('#bringToBack', () => {
 		it('is a no-op for layers not on a map', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			expect(path.bringToBack()).to.equal(path);
 		});
 
 		it('is a no-op for layers no longer in a LayerGroup', () => {
-			const group = L.layerGroup().addTo(map);
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
+			const group = new LayerGroup().addTo(map);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
 
 			group.clearLayers();
 
@@ -234,13 +236,13 @@ describe('Canvas', () => {
 
 	describe('#bringToFront', () => {
 		it('is a no-op for layers not on a map', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			expect(path.bringToFront()).to.equal(path);
 		});
 
 		it('is a no-op for layers no longer in a LayerGroup', () => {
-			const group = L.layerGroup().addTo(map);
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
+			const group = new LayerGroup().addTo(map);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
 
 			group.clearLayers();
 
@@ -250,24 +252,24 @@ describe('Canvas', () => {
 
 	describe('Canvas #remove', () => {
 		it('can remove the map without errors', (done) => {
-			L.polygon(latLngs).addTo(map);
+			new Polygon(latLngs).addTo(map);
 			map.remove();
 			map = null;
-			L.Util.requestAnimFrame(() => { done(); });
+			Util.requestAnimFrame(() => { done(); });
 		});
 
 		it('can remove renderer without errors', (done) => {
 			map.remove();
 
-			const canvas = L.canvas();
-			map = L.map(container, {renderer: canvas});
+			const canvas = new Canvas();
+			map = new Map(container, {renderer: canvas});
 			map.setView([0, 0], 6);
-			L.polygon(latLngs).addTo(map);
+			new Polygon(latLngs).addTo(map);
 
 			canvas.remove();
 			map.remove();
 			map = null;
-			L.Util.requestAnimFrame(() => { done(); });
+			Util.requestAnimFrame(() => { done(); });
 		});
 	});
 });

--- a/spec/suites/layer/vector/CircleMarkerSpec.js
+++ b/spec/suites/layer/vector/CircleMarkerSpec.js
@@ -1,9 +1,12 @@
-﻿describe('CircleMarker', () => {
+﻿import {Map, CircleMarker, LatLng, Point} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
+describe('CircleMarker', () => {
 	let map, container;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView([0, 0], 1);
 	});
 
@@ -15,7 +18,7 @@
 		describe('when a CircleMarker is added to the map ', () => {
 			describe('with a radius set as an option', () => {
 				it('takes that radius', () => {
-					const marker = L.circleMarker([0, 0], {radius: 20}).addTo(map);
+					const marker = new CircleMarker([0, 0], {radius: 20}).addTo(map);
 
 					expect(marker._radius).to.equal(20);
 				});
@@ -23,7 +26,7 @@
 
 			describe('and radius is set before adding it', () => {
 				it('takes that radius', () => {
-					const marker = L.circleMarker([0, 0], {radius: 20});
+					const marker = new CircleMarker([0, 0], {radius: 20});
 					marker.setRadius(15);
 					marker.addTo(map);
 					expect(marker._radius).to.equal(15);
@@ -32,7 +35,7 @@
 
 			describe('and radius is set after adding it', () => {
 				it('takes that radius', () => {
-					const marker = L.circleMarker([0, 0], {radius: 20});
+					const marker = new CircleMarker([0, 0], {radius: 20});
 					marker.addTo(map);
 					marker.setRadius(15);
 					expect(marker._radius).to.equal(15);
@@ -41,7 +44,7 @@
 
 			describe('and setStyle is used to change the radius after adding', () => {
 				it('takes the given radius', () => {
-					const marker = L.circleMarker([0, 0], {radius: 20});
+					const marker = new CircleMarker([0, 0], {radius: 20});
 					marker.addTo(map);
 					marker.setStyle({radius: 15});
 					expect(marker._radius).to.equal(15);
@@ -50,7 +53,7 @@
 
 			describe('and setStyle is used to change the radius before adding', () => {
 				it('takes the given radius', () => {
-					const marker = L.circleMarker([0, 0], {radius: 20});
+					const marker = new CircleMarker([0, 0], {radius: 20});
 					marker.setStyle({radius: 15});
 					marker.addTo(map);
 					expect(marker._radius).to.equal(15);
@@ -61,11 +64,11 @@
 
 	describe('#setLatLng', () => {
 		it('fires a move event', () => {
-			const marker = L.circleMarker([0, 0]);
+			const marker = new CircleMarker([0, 0]);
 			map.addLayer(marker);
 
 			const beforeLatLng = marker._latlng;
-			const afterLatLng = L.latLng(1, 2);
+			const afterLatLng = new LatLng(1, 2);
 
 			let eventArgs = null;
 			marker.on('move', (e) => {
@@ -83,9 +86,9 @@
 
 	describe('#_containsPoint', () => {
 		it('checks if a point is contained', () => {
-			const point1 = L.point(200, 200);
-			const point2 = L.point(10, 10);
-			const circlemarker = L.circleMarker([10, 10], {radius: 20});
+			const point1 = new Point(200, 200);
+			const point2 = new Point(10, 10);
+			const circlemarker = new CircleMarker([10, 10], {radius: 20});
 
 			circlemarker.addTo(map);
 

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -1,11 +1,14 @@
+import {Map, Circle} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Circle', () => {
 	let map, container, circle;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView([0, 0], 4);
-		circle = L.circle([50, 30], {radius: 200}).addTo(map);
+		circle = new Circle([50, 30], {radius: 200}).addTo(map);
 	});
 
 	afterEach(() => {
@@ -14,13 +17,13 @@ describe('Circle', () => {
 
 	describe('#init', () => {
 		it('uses default radius if not given', () => {
-			const circle = L.circle([0, 0]);
+			const circle = new Circle([0, 0]);
 			expect(circle.getRadius()).to.eql(10);
 		});
 
 		it('throws error if radius is NaN', () => {
 			expect(() => {
-				L.circle([0, 0], NaN);
+				new Circle([0, 0], NaN);
 			}).to.throw('Circle radius cannot be NaN');
 		});
 

--- a/spec/suites/layer/vector/PathSpec.js
+++ b/spec/suites/layer/vector/PathSpec.js
@@ -1,9 +1,12 @@
+import {Map, Polyline, LayerGroup, Polygon} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Path', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 		map.setView([0, 0], 0);
 	});
 
@@ -12,16 +15,16 @@ describe('Path', () => {
 	});
 
 	// The following two tests are skipped, as the ES6-ifycation of Leaflet
-	// means that L.Path is no longer visible.
+	// means that Path is no longer visible.
 	describe('#bringToBack', () => {
 		it('is a no-op for layers not on a map', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			expect(path.bringToBack()).to.equal(path);
 		});
 
 		it('is a no-op for layers no longer in a LayerGroup', () => {
-			const group = L.layerGroup().addTo(map);
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
+			const group = new LayerGroup().addTo(map);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
 
 			group.clearLayers();
 
@@ -31,13 +34,13 @@ describe('Path', () => {
 
 	describe('#bringToFront', () => {
 		it('is a no-op for layers not on a map', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			expect(path.bringToFront()).to.equal(path);
 		});
 
 		it('is a no-op for layers no longer in a LayerGroup', () => {
-			const group = L.layerGroup().addTo(map);
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
+			const group = new LayerGroup().addTo(map);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]).addTo(group);
 
 			group.clearLayers();
 
@@ -48,7 +51,7 @@ describe('Path', () => {
 	describe('#events', () => {
 		it('fires click event', () => {
 			const spy = sinon.spy();
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
 			layer.on('click', spy);
 			UIEventSimulator.fire('click', layer._path);
 			expect(spy.called).to.be.true;
@@ -58,7 +61,7 @@ describe('Path', () => {
 			const spy = sinon.spy();
 			const spy2 = sinon.spy();
 			const mapSpy = sinon.spy();
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
 			layer.on('click', spy);
 			layer.on('click', spy2);
 			map.on('click', mapSpy);
@@ -69,13 +72,13 @@ describe('Path', () => {
 		});
 
 		it('can add a layer while being inside a moveend handler', () => {
-			const zoneLayer = L.layerGroup();
+			const zoneLayer = new LayerGroup();
 			let polygon;
 			map.addLayer(zoneLayer);
 
 			map.on('moveend', () => {
 				zoneLayer.clearLayers();
-				polygon = L.polygon([[1, 2], [3, 4], [5, 6]]);
+				polygon = new Polygon([[1, 2], [3, 4], [5, 6]]);
 				zoneLayer.addLayer(polygon);
 			});
 
@@ -90,13 +93,13 @@ describe('Path', () => {
 		});
 
 		it('it should return tolerance with stroke', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			path.addTo(map);
 			expect(path._clickTolerance()).to.equal(path.options.weight / 2);
 		});
 
 		it('it should return zero tolerance without stroke', () => {
-			const path = L.polyline([[1, 2], [3, 4], [5, 6]]);
+			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);
 			path.addTo(map);
 			path.options.stroke = false;
 			expect(path._clickTolerance()).to.equal(0);

--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -1,9 +1,12 @@
+import {Map, polygon, LineUtil, latLng} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Polygon', () => {
 	let map, container;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {
@@ -14,10 +17,10 @@ describe('Polygon', () => {
 		it('should never be flat', () => {
 			const latLngs = [[1, 2], [3, 4]];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			expect(L.LineUtil.isFlat(polygon._latlngs)).to.be.false;
-			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
+			expect(LineUtil.isFlat(poly._latlngs)).to.be.false;
+			expect(poly.getLatLngs()).to.eql(poly._latlngs);
 		});
 
 		it('doesn\'t overwrite the given latlng array', () => {
@@ -27,16 +30,16 @@ describe('Polygon', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const polygon = L.polygon(sourceLatLngs);
+			const poly = polygon(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
-			expect(polygon._latlngs).to.not.eql(sourceLatLngs);
+			expect(poly._latlngs).to.not.eql(sourceLatLngs);
 		});
 
 		it('can be called with an empty array', () => {
-			const polygon = L.polygon([]);
-			expect(polygon._latlngs).to.eql([[]]);
-			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
+			const poly = polygon([]);
+			expect(poly._latlngs).to.eql([[]]);
+			expect(poly.getLatLngs()).to.eql(poly._latlngs);
 		});
 
 		it('can be initialized with holes', () => {
@@ -45,13 +48,13 @@ describe('Polygon', () => {
 				[[2, 3], [2, 4], [3, 4]] // hole
 			];
 
-			const polygon = L.polygon(originalLatLngs);
+			const poly = polygon(originalLatLngs);
 
-			expect(polygon._latlngs).to.eql([
-				[L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])],
-				[L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]
+			expect(poly._latlngs).to.eql([
+				[latLng([0, 10]), latLng([10, 10]), latLng([10, 0])],
+				[latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]
 			]);
-			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
+			expect(poly.getLatLngs()).to.eql(poly._latlngs);
 		});
 
 		it('can be initialized with multi including hole', () => {
@@ -60,18 +63,18 @@ describe('Polygon', () => {
 				[[[0, 10], [10, 10], [10, 0]], [[2, 3], [2, 4], [3, 4]]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			expect(polygon._latlngs).to.eql([
-				[[L.latLng([10, 20]), L.latLng([30, 40]), L.latLng([50, 60])]],
-				[[L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])], [L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]]
+			expect(poly._latlngs).to.eql([
+				[[latLng([10, 20]), latLng([30, 40]), latLng([50, 60])]],
+				[[latLng([0, 10]), latLng([10, 10]), latLng([10, 0])], [latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]]
 			]);
-			expect(polygon.getLatLngs()).to.eql(polygon._latlngs);
+			expect(poly.getLatLngs()).to.eql(poly._latlngs);
 		});
 
 		it('can be added to the map when empty', () => {
-			const polygon = L.polygon([]).addTo(map);
-			const isAdded = map.hasLayer(polygon);
+			const poly = polygon([]).addTo(map);
+			const isAdded = map.hasLayer(poly);
 			expect(isAdded).to.be.true;
 		});
 
@@ -80,13 +83,13 @@ describe('Polygon', () => {
 	describe('#isEmpty', () => {
 
 		it('should return true for a polygon with no latlngs', () => {
-			const layer = L.polygon([]);
+			const layer = polygon([]);
 			expect(layer.isEmpty()).to.be.true;
 		});
 
 		it('should return false for simple polygon', () => {
 			const latLngs = [[1, 2], [3, 4], [5, 6]];
-			const layer = L.polygon(latLngs);
+			const layer = polygon(latLngs);
 			expect(layer.isEmpty()).to.be.false;
 		});
 
@@ -95,7 +98,7 @@ describe('Polygon', () => {
 				[[[10, 20], [30, 40], [50, 60]]],
 				[[[0, 10], [10, 10], [10, 0]], [[2, 3], [2, 4], [3, 4]]]
 			];
-			const layer = L.polygon(latLngs);
+			const layer = polygon(latLngs);
 			expect(layer.isEmpty()).to.be.false;
 		});
 
@@ -109,9 +112,9 @@ describe('Polygon', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const polygon = L.polygon(sourceLatLngs);
+			const poly = polygon(sourceLatLngs);
 
-			polygon.setLatLngs(sourceLatLngs);
+			poly.setLatLngs(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
 		});
@@ -122,12 +125,12 @@ describe('Polygon', () => {
 				[[2, 3], [2, 4], [3, 4]] // hole
 			];
 
-			const polygon = L.polygon([]);
-			polygon.setLatLngs(latLngs);
+			const poly = polygon([]);
+			poly.setLatLngs(latLngs);
 
-			expect(polygon.getLatLngs()).to.eql([
-				[L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])],
-				[L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]
+			expect(poly.getLatLngs()).to.eql([
+				[latLng([0, 10]), latLng([10, 10]), latLng([10, 0])],
+				[latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]
 			]);
 		});
 
@@ -137,12 +140,12 @@ describe('Polygon', () => {
 				[[[0, 10], [10, 10], [10, 0]], [[2, 3], [2, 4], [3, 4]]]
 			];
 
-			const polygon = L.polygon([]);
-			polygon.setLatLngs(latLngs);
+			const poly = polygon([]);
+			poly.setLatLngs(latLngs);
 
-			expect(polygon.getLatLngs()).to.eql([
-				[[L.latLng([10, 20]), L.latLng([30, 40]), L.latLng([50, 60])]],
-				[[L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])], [L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]]
+			expect(poly.getLatLngs()).to.eql([
+				[[latLng([10, 20]), latLng([30, 40]), latLng([50, 60])]],
+				[[latLng([0, 10]), latLng([10, 10]), latLng([10, 0])], [latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]]
 			]);
 		});
 
@@ -153,7 +156,7 @@ describe('Polygon', () => {
 			const latlngs = [
 				[[0, 0], [10, 0], [10, 10], [0, 10]]
 			];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = polygon(latlngs).addTo(map);
 			expect(layer.getCenter()).to.be.nearLatLng([5.019148099025293, 5]);
 		});
 
@@ -161,7 +164,7 @@ describe('Polygon', () => {
 			const latlngs = [
 				[[0, 0], [0.010, 0], [0.010, 0.010], [0, 0.010]]
 			];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = polygon(latlngs).addTo(map);
 			map.setZoom(0);  // Make the polygon disappear in screen.
 			expect(layer.getCenter()).to.be.nearLatLng([0.005, 0.005]);
 		});
@@ -171,7 +174,7 @@ describe('Polygon', () => {
 				const latlngs = [
 					[[0, 0], [10, 0], [10, 10], [0, 10]]
 				];
-				const layer = L.polygon(latlngs);
+				const layer = polygon(latlngs);
 				layer.getCenter();
 			}).to.throw('Must add layer to map before using getCenter()');
 		});
@@ -180,7 +183,7 @@ describe('Polygon', () => {
 			const latlngs = [
 				[[0, 0], [0.010, 0], [0.010, 0.010], [0, 0.010]]
 			];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = polygon(latlngs).addTo(map);
 			map.setZoom(0);
 			const center = layer.getCenter();
 			map.setZoom(18);
@@ -192,7 +195,7 @@ describe('Polygon', () => {
 				[[[10, 20], [30, 40], [50, 60]]],
 				[[[0, 10], [10, 10], [10, 0]], [[2, 3], [2, 4], [3, 4]]]
 			];
-			const layer = L.polygon(latlngs).addTo(map);
+			const layer = polygon(latlngs).addTo(map);
 			expect(layer.getCenter()).to.be.nearLatLng([31.436532296911807, 39.99999999999979]);
 		});
 	});
@@ -200,47 +203,47 @@ describe('Polygon', () => {
 	describe('#_defaultShape', () => {
 		it('should return latlngs on a simple polygon', () => {
 			const latlngs = [
-				L.latLng([1, 2]),
-				L.latLng([3, 4])
+				latLng([1, 2]),
+				latLng([3, 4])
 			];
 
-			const polygon = L.polygon(latlngs);
+			const poly = polygon(latlngs);
 
-			expect(polygon._defaultShape()).to.eql(latlngs);
+			expect(poly._defaultShape()).to.eql(latlngs);
 		});
 
 		it('should return first latlngs on a polygon with hole', () => {
 			const latlngs = [
-				[L.latLng([0, 12]), L.latLng([13, 14]), L.latLng([15, 16])],
-				[L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]
+				[latLng([0, 12]), latLng([13, 14]), latLng([15, 16])],
+				[latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]
 			];
 
-			const polygon = L.polygon(latlngs);
+			const poly = polygon(latlngs);
 
-			expect(polygon._defaultShape()).to.eql(latlngs[0]);
+			expect(poly._defaultShape()).to.eql(latlngs[0]);
 		});
 
 		it('should return first latlngs on a multipolygon', () => {
 			const latlngs = [
-				[[L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]],
-				[[L.latLng([11, 12]), L.latLng([13, 14]), L.latLng([15, 16])]]
+				[[latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]],
+				[[latLng([11, 12]), latLng([13, 14]), latLng([15, 16])]]
 			];
 
-			const polygon = L.polygon(latlngs);
+			const poly = polygon(latlngs);
 
-			expect(polygon._defaultShape()).to.eql(latlngs[0][0]);
+			expect(poly._defaultShape()).to.eql(latlngs[0][0]);
 		});
 
 		it('should return first latlngs on a multipolygon with hole', () => {
 			const latlngs = [
-				[[L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])],
-				 [L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]],
-				[[L.latLng([10, 20]), L.latLng([30, 40]), L.latLng([50, 60])]]
+				[[latLng([0, 10]), latLng([10, 10]), latLng([10, 0])],
+				 [latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]],
+				[[latLng([10, 20]), latLng([30, 40]), latLng([50, 60])]]
 			];
 
-			const polygon = L.polygon(latlngs);
+			const poly = polygon(latlngs);
 
-			expect(polygon._defaultShape()).to.eql(latlngs[0][0]);
+			expect(poly._defaultShape()).to.eql(latlngs[0][0]);
 		});
 	});
 
@@ -251,11 +254,11 @@ describe('Polygon', () => {
 				[3, 4]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([5, 6]);
+			poly.addLatLng([5, 6]);
 
-			expect(polygon._latlngs).to.eql([[L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]]);
+			expect(poly._latlngs).to.eql([[latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]]);
 		});
 
 		it('should add latlng to first latlngs on a polygon with hole', () => {
@@ -264,12 +267,12 @@ describe('Polygon', () => {
 				[[1, 2], [3, 4], [5, 6]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([17, 0]);
+			poly.addLatLng([17, 0]);
 
-			expect(polygon._latlngs[0]).to.eql([L.latLng([0, 12]), L.latLng([13, 14]), L.latLng([15, 16]), L.latLng([17, 0])]);
-			expect(polygon._latlngs[1]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
+			expect(poly._latlngs[0]).to.eql([latLng([0, 12]), latLng([13, 14]), latLng([15, 16]), latLng([17, 0])]);
+			expect(poly._latlngs[1]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
 		});
 
 		it('should add latlng by reference on a polygon with hole', () => {
@@ -278,12 +281,12 @@ describe('Polygon', () => {
 				[[1, 2], [3, 4], [5, 6]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([7, 8], polygon._latlngs[1]);
+			poly.addLatLng([7, 8], poly._latlngs[1]);
 
-			expect(polygon._latlngs[0]).to.eql([L.latLng([0, 12]), L.latLng([13, 14]), L.latLng([15, 16])]);
-			expect(polygon._latlngs[1]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6]), L.latLng([7, 8])]);
+			expect(poly._latlngs[0]).to.eql([latLng([0, 12]), latLng([13, 14]), latLng([15, 16])]);
+			expect(poly._latlngs[1]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6]), latLng([7, 8])]);
 		});
 
 		it('should add latlng to first latlngs on a multi', () => {
@@ -292,12 +295,12 @@ describe('Polygon', () => {
 				[[[11, 12], [13, 14], [15, 16]]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([5, 6]);
+			poly.addLatLng([5, 6]);
 
-			expect(polygon._latlngs[0]).to.eql([[L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]]);
-			expect(polygon._latlngs[1]).to.eql([[L.latLng([11, 12]), L.latLng([13, 14]), L.latLng([15, 16])]]);
+			expect(poly._latlngs[0]).to.eql([[latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]]);
+			expect(poly._latlngs[1]).to.eql([[latLng([11, 12]), latLng([13, 14]), latLng([15, 16])]]);
 		});
 
 		it('should add latlng to latlngs by reference on a multi', () => {
@@ -306,12 +309,12 @@ describe('Polygon', () => {
 				[[[1, 2], [3, 4]]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([5, 6], polygon._latlngs[1][0]);
+			poly.addLatLng([5, 6], poly._latlngs[1][0]);
 
-			expect(polygon._latlngs[1]).to.eql([[L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]]);
-			expect(polygon._latlngs[0]).to.eql([[L.latLng([11, 12]), L.latLng([13, 14]), L.latLng([15, 16])]]);
+			expect(poly._latlngs[1]).to.eql([[latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]]);
+			expect(poly._latlngs[0]).to.eql([[latLng([11, 12]), latLng([13, 14]), latLng([15, 16])]]);
 		});
 
 		it('should add latlng on first latlngs by default on a multipolygon with hole', () => {
@@ -320,13 +323,13 @@ describe('Polygon', () => {
 				[[[10, 20], [30, 40], [50, 60]]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([-10, -10]);
+			poly.addLatLng([-10, -10]);
 
-			expect(polygon._latlngs[0][0]).to.eql([L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0]), L.latLng([-10, -10])]);
-			expect(polygon._latlngs[0][1]).to.eql([L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4])]);
-			expect(polygon._latlngs[1][0]).to.eql([L.latLng([10, 20]), L.latLng([30, 40]), L.latLng([50, 60])]);
+			expect(poly._latlngs[0][0]).to.eql([latLng([0, 10]), latLng([10, 10]), latLng([10, 0]), latLng([-10, -10])]);
+			expect(poly._latlngs[0][1]).to.eql([latLng([2, 3]), latLng([2, 4]), latLng([3, 4])]);
+			expect(poly._latlngs[1][0]).to.eql([latLng([10, 20]), latLng([30, 40]), latLng([50, 60])]);
 		});
 
 		it('should add latlng by reference on a multipolygon with hole', () => {
@@ -335,13 +338,13 @@ describe('Polygon', () => {
 				[[[0, 10], [10, 10], [10, 0]], [[2, 3], [2, 4], [3, 4]]]
 			];
 
-			const polygon = L.polygon(latLngs);
+			const poly = polygon(latLngs);
 
-			polygon.addLatLng([2, 2], polygon._latlngs[1][1]);
+			poly.addLatLng([2, 2], poly._latlngs[1][1]);
 
-			expect(polygon._latlngs[0][0]).to.eql([L.latLng([10, 20]), L.latLng([30, 40]), L.latLng([50, 60])]);
-			expect(polygon._latlngs[1][0]).to.eql([L.latLng([0, 10]), L.latLng([10, 10]), L.latLng([10, 0])]);
-			expect(polygon._latlngs[1][1]).to.eql([L.latLng([2, 3]), L.latLng([2, 4]), L.latLng([3, 4]), L.latLng([2, 2])]);
+			expect(poly._latlngs[0][0]).to.eql([latLng([10, 20]), latLng([30, 40]), latLng([50, 60])]);
+			expect(poly._latlngs[1][0]).to.eql([latLng([0, 10]), latLng([10, 10]), latLng([10, 0])]);
+			expect(poly._latlngs[1][1]).to.eql([latLng([2, 3]), latLng([2, 4]), latLng([3, 4]), latLng([2, 2])]);
 		});
 	});
 
@@ -350,13 +353,13 @@ describe('Polygon', () => {
 			const style = {
 				weight: 3
 			};
-			const polygon = L.polygon([]);
+			const poly = polygon([]);
 
-			polygon.addTo(map);
-			polygon.setStyle(style);
+			poly.addTo(map);
+			poly.setStyle(style);
 
 			for (const [prop, expectedValue] of Object.entries(style)) {
-				expect(polygon.options[prop]).to.equal(expectedValue);
+				expect(poly.options[prop]).to.equal(expectedValue);
 			}
 		});
 	});

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -1,9 +1,12 @@
+import {Map, polyline, latLng} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Polyline', () => {
 	let map, container;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {
@@ -18,11 +21,11 @@ describe('Polyline', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const polyline = L.polyline(sourceLatLngs);
+			const polyln = polyline(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
-			expect(polyline._latlngs).to.not.eql(sourceLatLngs);
-			expect(polyline.getLatLngs()).to.eql(polyline._latlngs);
+			expect(polyln._latlngs).to.not.eql(sourceLatLngs);
+			expect(polyln.getLatLngs()).to.eql(polyln._latlngs);
 		});
 
 		it('should accept a multi', () => {
@@ -31,37 +34,37 @@ describe('Polyline', () => {
 				[[11, 12], [13, 14], [15, 16]]
 			];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			expect(polyline._latlngs[0]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
-			expect(polyline._latlngs[1]).to.eql([L.latLng([11, 12]), L.latLng([13, 14]), L.latLng([15, 16])]);
-			expect(polyline.getLatLngs()).to.eql(polyline._latlngs);
+			expect(polyln._latlngs[0]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
+			expect(polyln._latlngs[1]).to.eql([latLng([11, 12]), latLng([13, 14]), latLng([15, 16])]);
+			expect(polyln.getLatLngs()).to.eql(polyln._latlngs);
 		});
 
 		it('should accept an empty array', () => {
-			const polyline = L.polyline([]);
+			const polyln = polyline([]);
 
-			expect(polyline._latlngs).to.eql([]);
-			expect(polyline.getLatLngs()).to.eql(polyline._latlngs);
+			expect(polyln._latlngs).to.eql([]);
+			expect(polyln.getLatLngs()).to.eql(polyln._latlngs);
 		});
 
 		it('can be added to the map when empty', () => {
-			const polyline = L.polyline([]).addTo(map);
-			expect(map.hasLayer(polyline)).to.be.true;
+			const polyln = polyline([]).addTo(map);
+			expect(map.hasLayer(polyln)).to.be.true;
 		});
 
 	});
 
 	describe('#isEmpty', () => {
 		it('should return true for a polyline with no latlngs', () => {
-			const polyline = L.polyline([]);
-			expect(polyline.isEmpty()).to.be.true;
+			const polyln = polyline([]);
+			expect(polyln.isEmpty()).to.be.true;
 		});
 
 		it('should return false for simple polyline', () => {
 			const latLngs = [[1, 2], [3, 4]];
-			const polyline = L.polyline(latLngs);
-			expect(polyline.isEmpty()).to.be.false;
+			const polyln = polyline(latLngs);
+			expect(polyln.isEmpty()).to.be.false;
 		});
 
 		it('should return false for multi-polyline', () => {
@@ -69,8 +72,8 @@ describe('Polyline', () => {
 				[[1, 2], [3, 4]],
 				[[11, 12], [13, 14]]
 			];
-			const polyline = L.polyline(latLngs);
-			expect(polyline.isEmpty()).to.be.false;
+			const polyln = polyline(latLngs);
+			expect(polyln.isEmpty()).to.be.false;
 		});
 
 	});
@@ -83,9 +86,9 @@ describe('Polyline', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const polyline = L.polyline(sourceLatLngs);
+			const polyln = polyline(sourceLatLngs);
 
-			polyline.setLatLngs(sourceLatLngs);
+			polyln.setLatLngs(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
 		});
@@ -96,61 +99,61 @@ describe('Polyline', () => {
 				[[11, 12], [13, 14], [15, 16]]
 			];
 
-			const polyline = L.polyline([]);
-			polyline.setLatLngs(latLngs);
+			const polyln = polyline([]);
+			polyln.setLatLngs(latLngs);
 
-			expect(polyline._latlngs[0]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
-			expect(polyline._latlngs[1]).to.eql([L.latLng([11, 12]), L.latLng([13, 14]), L.latLng([15, 16])]);
+			expect(polyln._latlngs[0]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
+			expect(polyln._latlngs[1]).to.eql([latLng([11, 12]), latLng([13, 14]), latLng([15, 16])]);
 		});
 	});
 
 	describe('#getCenter', () => {
 		it('should compute center of a big flat line on equator', () => {
-			const polyline = L.polyline([[0, 0], [0, 90]]).addTo(map);
-			expect(polyline.getCenter()).to.eql(L.latLng([0, 45]));
+			const polyln = polyline([[0, 0], [0, 90]]).addTo(map);
+			expect(polyln.getCenter()).to.eql(latLng([0, 45]));
 		});
 
 		it('should compute center of a big flat line on equator with maxZoom', () => {
 			map.setMaxZoom(18);
-			const polyline = L.polyline([[0, 0], [0, 90]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([0, 45]);
+			const polyln = polyline([[0, 0], [0, 90]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([0, 45]);
 		});
 
 		it('should compute center of a big flat line close to the pole', () => {
-			const polyline = L.polyline([[80, 0], [80, 90]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([80, 45], 1e-2);
+			const polyln = polyline([[80, 0], [80, 90]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([80, 45], 1e-2);
 		});
 
 		it('should compute center of a big diagonal line', () => {
-			const polyline = L.polyline([[0, 0], [80, 80]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([57.04516467328689, 40], 1);
+			const polyln = polyline([[0, 0], [80, 80]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([57.04516467328689, 40], 1);
 		});
 
 		it('should compute center of a diagonal line close to the pole', () => {
-			const polyline = L.polyline([[70, 70], [84, 84]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([79.01810060159328, 77], 1);
+			const polyln = polyline([[70, 70], [84, 84]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([79.01810060159328, 77], 1);
 		});
 
 		it('should compute center of a big multiline', () => {
-			const polyline = L.polyline([[10, -80], [0, 0], [0, 10], [10, 90]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([0, 5], 1);
+			const polyln = polyline([[10, -80], [0, 0], [0, 10], [10, 90]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([0, 5], 1);
 		});
 
 		it('should compute center of a small flat line', () => {
-			const polyline = L.polyline([[0, 0], [0, 0.090]]).addTo(map);
+			const polyln = polyline([[0, 0], [0, 0.090]]).addTo(map);
 			map.setZoom(0);  // Make the line disappear in screen;
-			expect(polyline.getCenter()).to.be.nearLatLng([0, 0.045]);
+			expect(polyln.getCenter()).to.be.nearLatLng([0, 0.045]);
 		});
 
 		it('throws error if not yet added to map', () => {
 			expect(() => {
-				const polyline = L.polyline([[0, 0], [0, 0.090]]);
-				polyline.getCenter();
+				const poly = polyline([[0, 0], [0, 0.090]]);
+				poly.getCenter();
 			}).to.throw('Must add layer to map before using getCenter()');
 		});
 
 		it('should compute same center for low and high zoom', () => {
-			const layer = L.polyline([[10, -80], [0, 0], [0, 10], [10, 90]]).addTo(map);
+			const layer = polyline([[10, -80], [0, 0], [0, 10], [10, 90]]).addTo(map);
 			map.setZoom(0);
 			const center = layer.getCenter();
 			map.setZoom(18);
@@ -158,30 +161,30 @@ describe('Polyline', () => {
 		});
 
 		it('should compute center of a zick-zack line', () => {
-			const polyline = L.polyline([[0, 0], [50, 50], [30, 30], [35, 35]]).addTo(map);
-			expect(polyline.getCenter()).to.be.nearLatLng([40.551864181628666, 38.36684065813897]);
+			const polyln = polyline([[0, 0], [50, 50], [30, 30], [35, 35]]).addTo(map);
+			expect(polyln.getCenter()).to.be.nearLatLng([40.551864181628666, 38.36684065813897]);
 		});
 
 	});
 
 	describe('#_defaultShape', () => {
 		it('should return latlngs when flat', () => {
-			const latLngs = [L.latLng([1, 2]), L.latLng([3, 4])];
+			const latLngs = [latLng([1, 2]), latLng([3, 4])];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			expect(polyline._defaultShape()).to.eql(latLngs);
+			expect(polyln._defaultShape()).to.eql(latLngs);
 		});
 
 		it('should return first latlngs on a multi', () => {
 			const latLngs = [
-				[L.latLng([1, 2]), L.latLng([3, 4])],
-				[L.latLng([11, 12]), L.latLng([13, 14])]
+				[latLng([1, 2]), latLng([3, 4])],
+				[latLng([11, 12]), latLng([13, 14])]
 			];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			expect(polyline._defaultShape()).to.eql(latLngs[0]);
+			expect(polyln._defaultShape()).to.eql(latLngs[0]);
 		});
 
 	});
@@ -193,11 +196,11 @@ describe('Polyline', () => {
 				[3, 4]
 			];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			polyline.addLatLng([5, 6]);
+			polyln.addLatLng([5, 6]);
 
-			expect(polyline._latlngs).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
+			expect(polyln._latlngs).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
 		});
 
 		it('should add latlng to first latlngs on a multi', () => {
@@ -206,12 +209,12 @@ describe('Polyline', () => {
 				[[11, 12], [13, 14]]
 			];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			polyline.addLatLng([5, 6]);
+			polyln.addLatLng([5, 6]);
 
-			expect(polyline._latlngs[0]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
-			expect(polyline._latlngs[1]).to.eql([L.latLng([11, 12]), L.latLng([13, 14])]);
+			expect(polyln._latlngs[0]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
+			expect(polyln._latlngs[1]).to.eql([latLng([11, 12]), latLng([13, 14])]);
 		});
 
 		it('should add latlng to latlngs by reference', () => {
@@ -220,20 +223,20 @@ describe('Polyline', () => {
 				[[1, 2], [3, 4]]
 			];
 
-			const polyline = L.polyline(latLngs);
+			const polyln = polyline(latLngs);
 
-			polyline.addLatLng([5, 6], polyline._latlngs[1]);
+			polyln.addLatLng([5, 6], polyln._latlngs[1]);
 
-			expect(polyline._latlngs[1]).to.eql([L.latLng([1, 2]), L.latLng([3, 4]), L.latLng([5, 6])]);
-			expect(polyline._latlngs[0]).to.eql([L.latLng([11, 12]), L.latLng([13, 14])]);
+			expect(polyln._latlngs[1]).to.eql([latLng([1, 2]), latLng([3, 4]), latLng([5, 6])]);
+			expect(polyln._latlngs[0]).to.eql([latLng([11, 12]), latLng([13, 14])]);
 		});
 
 		it('should add latlng on empty polyline', () => {
-			const polyline = L.polyline([]);
+			const polyln = polyline([]);
 
-			polyline.addLatLng([1, 2]);
+			polyln.addLatLng([1, 2]);
 
-			expect(polyline._latlngs).to.eql([L.latLng([1, 2])]);
+			expect(polyln._latlngs).to.eql([latLng([1, 2])]);
 		});
 	});
 
@@ -242,13 +245,13 @@ describe('Polyline', () => {
 			const style = {
 				weight: 3
 			};
-			const polyline = L.polyline([]);
+			const polyln = polyline([]);
 
-			polyline.addTo(map);
-			polyline.setStyle(style);
+			polyln.addTo(map);
+			polyln.setStyle(style);
 
 			for (const [prop, expectedValue] of Object.entries(style)) {
-				expect(polyline.options[prop]).to.equal(expectedValue);
+				expect(polyln.options[prop]).to.equal(expectedValue);
 			}
 		});
 	});
@@ -258,13 +261,13 @@ describe('Polyline', () => {
 			const style = {
 				weight: 3
 			};
-			const polyline = L.polyline([]);
+			const polyln = polyline([]);
 
-			polyline.addTo(map);
-			polyline.setStyle(style);
+			polyln.addTo(map);
+			polyln.setStyle(style);
 
 			for (const [prop, expectedValue] of Object.entries(style)) {
-				expect(polyline.options[prop]).to.equal(expectedValue);
+				expect(polyln.options[prop]).to.equal(expectedValue);
 			}
 		});
 	});
@@ -274,21 +277,21 @@ describe('Polyline', () => {
 			const p1 = map.latLngToLayerPoint([55.8, 37.6]);
 			const p2 = map.latLngToLayerPoint([57.123076977278, 44.861962891635]);
 			const latlngs = [[56.485503424111, 35.545556640339], [55.972522915346, 36.116845702918], [55.502459116923, 34.930322265253], [55.31534617509, 38.973291015816]]
-				.map(ll => L.latLng(ll[0], ll[1]));
-			const polyline = L.polyline([], {
+				.map(ll => latLng(ll[0], ll[1]));
+			const polyln = polyline([], {
 				'noClip': true
 			});
-			map.addLayer(polyline);
+			map.addLayer(polyln);
 
-			expect(polyline.closestLayerPoint(p1)).to.equal(null);
+			expect(polyln.closestLayerPoint(p1)).to.equal(null);
 
-			polyline.setLatLngs(latlngs);
-			const point = polyline.closestLayerPoint(p1);
+			polyln.setLatLngs(latlngs);
+			const point = polyln.closestLayerPoint(p1);
 			expect(point).not.to.equal(null);
 			expect(point.distance).to.not.equal(Infinity);
 			expect(point.distance).to.not.equal(NaN);
 
-			const point2 = polyline.closestLayerPoint(p2);
+			const point2 = polyln.closestLayerPoint(p2);
 
 			expect(point.distance).to.be.lessThan(point2.distance);
 		});

--- a/spec/suites/layer/vector/RectangleSpec.js
+++ b/spec/suites/layer/vector/RectangleSpec.js
@@ -1,9 +1,12 @@
+import {Map, rectangle, LineUtil, latLng, Canvas, Polygon} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Rectangle', () => {
 	let map, container;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {
@@ -14,10 +17,10 @@ describe('Rectangle', () => {
 		it('should never be flat', () => {
 			const latLngs = [[1, 2], [3, 4]];
 
-			const rectangle = L.rectangle(latLngs);
+			const rect = rectangle(latLngs);
 
-			expect(L.LineUtil.isFlat(rectangle._latlngs)).to.be.false;
-			expect(rectangle.getLatLngs()).to.eql(rectangle._latlngs);
+			expect(LineUtil.isFlat(rect._latlngs)).to.be.false;
+			expect(rect.getLatLngs()).to.eql(rect._latlngs);
 		});
 
 		it('doesn\'t overwrite the given latlng array', () => {
@@ -27,16 +30,16 @@ describe('Rectangle', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const rectangle = L.rectangle(sourceLatLngs);
+			const rect = rectangle(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
-			expect(rectangle._latlngs).to.not.eql(sourceLatLngs);
+			expect(rect._latlngs).to.not.eql(sourceLatLngs);
 		});
 
 		it('cannot be called with an empty array', () => {
 			// Throws error due to undefined lat
 			expect(() => {
-				L.rectangle([]);
+				rectangle([]);
 			}).to.throw();
 		});
 
@@ -46,12 +49,12 @@ describe('Rectangle', () => {
 				[40, 50], [60, 70] // extended bounds
 			];
 
-			const rectangle = L.rectangle(originalLatLngs);
+			const rect = rectangle(originalLatLngs);
 
-			expect(rectangle._latlngs).to.eql([
-				[L.latLng([0, 10]), L.latLng([60, 10]), L.latLng([60, 70]), L.latLng([0, 70])]
+			expect(rect._latlngs).to.eql([
+				[latLng([0, 10]), latLng([60, 10]), latLng([60, 70]), latLng([0, 70])]
 			]);
-			expect(rectangle.getLatLngs()).to.eql(rectangle._latlngs);
+			expect(rect.getLatLngs()).to.eql(rect._latlngs);
 		});
 	});
 
@@ -63,9 +66,9 @@ describe('Rectangle', () => {
 			];
 			const sourceLatLngs = originalLatLngs.slice();
 
-			const rectangle = L.rectangle(sourceLatLngs);
+			const rect = rectangle(sourceLatLngs);
 
-			rectangle.setBounds(sourceLatLngs);
+			rect.setBounds(sourceLatLngs);
 
 			expect(sourceLatLngs).to.eql(originalLatLngs);
 		});
@@ -81,14 +84,14 @@ describe('Rectangle', () => {
 				[7, 8]
 			];
 
-			const rectangle = L.rectangle(originalLatLngs);
-			rectangle.setBounds(newLatLngs);
+			const rect = rectangle(originalLatLngs);
+			rect.setBounds(newLatLngs);
 
-			expect(rectangle._latlngs).to.eql([
-				[L.latLng([5, 6]), L.latLng([7, 6]), L.latLng([7, 8]), L.latLng([5, 8])]
+			expect(rect._latlngs).to.eql([
+				[latLng([5, 6]), latLng([7, 6]), latLng([7, 8]), latLng([5, 8])]
 			]);
 
-			expect(rectangle.getLatLngs()).to.eql(rectangle._latlngs);
+			expect(rect.getLatLngs()).to.eql(rect._latlngs);
 		});
 
 		it('can be set with extending bounds', () => {
@@ -101,13 +104,13 @@ describe('Rectangle', () => {
 				[40, 50], [60, 70] // extending bounds
 			];
 
-			const rectangle = L.rectangle(originalLatLngs);
-			rectangle.setBounds(newLatLngs);
+			const rect = rectangle(originalLatLngs);
+			rect.setBounds(newLatLngs);
 
-			expect(rectangle._latlngs).to.eql([
-				[L.latLng([0, 10]), L.latLng([60, 10]), L.latLng([60, 70]), L.latLng([0, 70])]
+			expect(rect._latlngs).to.eql([
+				[latLng([0, 10]), latLng([60, 10]), latLng([60, 70]), latLng([0, 70])]
 			]);
-			expect(rectangle.getLatLngs()).to.eql(rectangle._latlngs);
+			expect(rect.getLatLngs()).to.eql(rect._latlngs);
 		});
 	});
 
@@ -115,10 +118,10 @@ describe('Rectangle', () => {
 		it('doesn\'t apply `focus` listener if element is undefined', () => {
 			map.remove();
 
-			map = L.map(container, {renderer: L.canvas()});
+			map = new Map(container, {renderer: new Canvas()});
 			map.setView([0, 0], 6);
 			expect(() => {
-				L.polygon([[[2, 3], [4, 5]]]).addTo(map).bindTooltip('test');
+				new Polygon([[[2, 3], [4, 5]]]).addTo(map).bindTooltip('test');
 			}).to.not.throw();
 		});
 	});

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1,10 +1,13 @@
+import {Map, latLng, Point, LatLngBounds, TileLayer, Handler, DomEvent, Bounds, Layer, control as lControl, GridLayer, Util, Marker, Polygon, DivIcon, CircleMarker, Canvas} from 'leaflet';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
 describe('Map', () => {
 	let container,
 	    map;
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = L.map(container);
+		map = new Map(container);
 	});
 
 	afterEach(() => {
@@ -35,12 +38,12 @@ describe('Map', () => {
 
 		describe('corner case checking', () => {
 			it('throws an exception upon reinitialization', () => {
-				expect(() => L.map(container))
+				expect(() => new Map(container))
 				  .to.throw('Map container is already initialized.');
 			});
 
 			it('throws an exception if a container is not found', () => {
-				expect(() => L.map('nonexistentdivelement'))
+				expect(() => new Map('nonexistentdivelement'))
 				  .to.throw('Map container not found.');
 			});
 		});
@@ -88,7 +91,7 @@ describe('Map', () => {
 
 		it('throws error if container is reused by other instance', () => {
 			map.remove();
-			const map2 = L.map(container);
+			const map2 = new Map(container);
 
 			expect(() => {
 				map.remove();
@@ -107,14 +110,14 @@ describe('Map', () => {
 		});
 
 		it('returns a precise center when zoomed in after being set (#426)', () => {
-			const center = L.latLng(10, 10);
+			const center = latLng(10, 10);
 			map.setView(center, 1);
 			map.setZoom(19);
 			expect(map.getCenter()).to.eql(center);
 		});
 
 		it('returns correct center after invalidateSize (#1919)', () => {
-			const center = L.latLng(10, 10);
+			const center = latLng(10, 10);
 			map.setView(center, 1);
 			map.invalidateSize();
 			expect(map.getCenter()).not.to.eql(center);
@@ -124,7 +127,7 @@ describe('Map', () => {
 			map.setView([10, 10], 1);
 			const center = map.getCenter();
 			center.lat += 10;
-			expect(map.getCenter()).to.eql(L.latLng(10, 10));
+			expect(map.getCenter()).to.eql(latLng(10, 10));
 		});
 	});
 
@@ -174,14 +177,14 @@ describe('Map', () => {
 		});
 
 		it('defaults to zoom passed as map option', () => {
-			const map = L.map(document.createElement('div'), {zoom: 13});
+			const map = new Map(document.createElement('div'), {zoom: 13});
 			const zoom = map.setView([51.605, -0.11]).getZoom();
 			map.remove(); // clean up
 			expect(zoom).to.equal(13);
 		});
 
 		it('passes duration option to panBy', () => {
-			const map = L.map(document.createElement('div'), {zoom: 13, center: [0, 0]});
+			const map = new Map(document.createElement('div'), {zoom: 13, center: [0, 0]});
 			map.panBy = sinon.spy();
 			map.setView([51.605, -0.11], 13, {animate: true, duration: 13});
 			map.remove(); // clean up
@@ -215,7 +218,7 @@ describe('Map', () => {
 			});
 
 			it('overwrites zoom passed as map option', () => {
-				const map2 = L.map(document.createElement('div'), {zoom: 13});
+				const map2 = new Map(document.createElement('div'), {zoom: 13});
 				map2.setZoom(15);
 				const zoom = map2.getZoom();
 
@@ -237,7 +240,7 @@ describe('Map', () => {
 			});
 
 			it('does not overwrite zoom passed as map option', () => {
-				const map2 = L.map(document.createElement('div'), {zoom: 13});
+				const map2 = new Map(document.createElement('div'), {zoom: 13});
 				map2.setView([0, 0]);
 				map2.setZoom(15);
 				const zoom = map2.getZoom();
@@ -306,14 +309,14 @@ describe('Map', () => {
 		});
 
 		it('pass Point and change pixel in view', () => {
-			const point = L.point(5, 5);
+			const point = new Point(5, 5);
 			map.setZoomAround(point, 5);
 
 			expect(map.getBounds().contains(map.options.crs.pointToLatLng(point, 5))).to.be.false;
 		});
 
 		it('pass Point and change pixel in view at high zoom', () => {
-			const point = L.point(5, 5);
+			const point = new Point(5, 5);
 			map.setZoomAround(point, 18);
 
 			expect(map.getBounds().contains(map.options.crs.pointToLatLng(point, 18))).to.be.false;
@@ -332,7 +335,7 @@ describe('Map', () => {
 		});
 
 		it('throws if map is not loaded', () => {
-			const unloadedMap = L.map(document.createElement('div'));
+			const unloadedMap = new Map(document.createElement('div'));
 
 			expect(() => unloadedMap.setZoomAround([5, 5], 4)).to.throw();
 		});
@@ -359,7 +362,7 @@ describe('Map', () => {
 
 	describe('#getBounds', () => {
 		it('is safe to call from within a moveend callback during initial load (#1027)', () => {
-			const map = L.map(document.createElement('div'));
+			const map = new Map(document.createElement('div'));
 			map.on('moveend', () => {
 				map.getBounds();
 			});
@@ -394,10 +397,10 @@ describe('Map', () => {
 			container.style.height = '';
 			container.style.width = '';
 			map.setZoom(16);
-			const bounds = L.latLngBounds(
+			const bounds = new LatLngBounds(
 				[62.18475569507688, 6.926335173954951],
 				[62.140483526511694, 6.923933370740089]);
-			const padding = L.point(-50, -50);
+			const padding = new Point(-50, -50);
 
 			// control case: default crs
 			let boundsZoom = map.getBoundsZoom(bounds, false, padding);
@@ -408,10 +411,10 @@ describe('Map', () => {
 			const crsMock = sinon.mock(map.options.crs);
 			crsMock.expects('latLngToPoint')
 				.withExactArgs(bounds.getNorthWest(), 16)
-				.returns(L.point(7800503.059925064, 6440062.353052008));
+				.returns(new Point(7800503.059925064, 6440062.353052008));
 			crsMock.expects('latLngToPoint')
 				.withExactArgs(bounds.getSouthEast(), 16)
-				.returns(L.point(7801987.203481699, 6425186.447901004));
+				.returns(new Point(7801987.203481699, 6425186.447901004));
 			boundsZoom = map.getBoundsZoom(bounds, false, padding);
 			crsMock.restore();
 
@@ -432,10 +435,10 @@ describe('Map', () => {
 			// large view, cannot fit within maxBounds
 			container.style.width = container.style.height = '1000px';
 			// maxBounds
-			const bounds = L.latLngBounds([51.5, -0.05], [51.55, 0.05]);
+			const bounds = new LatLngBounds([51.5, -0.05], [51.55, 0.05]);
 			map.setMaxBounds(bounds, {animate: false});
 			// set view outside
-			map.setView(L.latLng([53.0, 0.15]), 12, {animate: false});
+			map.setView(latLng([53.0, 0.15]), 12, {animate: false});
 			// get center of bounds in pixels
 			const boundsCenter = map.project(bounds.getCenter()).round();
 			expect(map.project(map.getCenter()).round()).to.eql(boundsCenter);
@@ -445,12 +448,12 @@ describe('Map', () => {
 			// small view, can fit within maxBounds
 			container.style.width = container.style.height = '200px';
 			// maxBounds
-			const bounds = L.latLngBounds([51, -0.2], [52, 0.2]);
+			const bounds = new LatLngBounds([51, -0.2], [52, 0.2]);
 			map.setMaxBounds(bounds, {animate: false});
 			// set view outside maxBounds on one direction only
 			// leaves untouched the other coordinate (that is not already centered)
 			const initCenter = [53.0, 0.1];
-			map.setView(L.latLng(initCenter), 16, {animate: false});
+			map.setView(latLng(initCenter), 16, {animate: false});
 			// one pixel coordinate hasn't changed, the other has
 			const pixelCenter = map.project(map.getCenter()).round();
 			const pixelInit = map.project(initCenter).round();
@@ -461,13 +464,13 @@ describe('Map', () => {
 		});
 
 		it('remove listeners when called without arguments', (done) => {
-			L.tileLayer('', {minZoom: 0, maxZoom: 20}).addTo(map);
+			new TileLayer('', {minZoom: 0, maxZoom: 20}).addTo(map);
 			container.style.width = container.style.height = '500px';
-			const bounds = L.latLngBounds([51.5, -0.05], [51.55, 0.05]);
+			const bounds = new LatLngBounds([51.5, -0.05], [51.55, 0.05]);
 			map.setMaxBounds(bounds, {animate: false});
 			map.setMaxBounds();
 			// set view outside
-			const center = L.latLng([0, 0]);
+			const center = latLng([0, 0]);
 			map.once('moveend', () => {
 				expect(center.equals(map.getCenter())).to.be.true;
 				done();
@@ -476,9 +479,9 @@ describe('Map', () => {
 		});
 
 		it('does not try to remove listeners if it wasn\'t set before', () => {
-			L.tileLayer('', {minZoom: 0, maxZoom: 20}).addTo(map);
+			new TileLayer('', {minZoom: 0, maxZoom: 20}).addTo(map);
 			container.style.width = container.style.height = '500px';
-			const bounds = L.latLngBounds([51.5, -0.05], [51.55, 0.05]);
+			const bounds = new LatLngBounds([51.5, -0.05], [51.55, 0.05]);
 			map.off = sinon.spy();
 			map.setMaxBounds(bounds, {animate: false});
 			expect(map.off.called).not.to.be.true;
@@ -599,11 +602,11 @@ describe('Map', () => {
 		it('minZoom and maxZoom options overrides any minZoom and maxZoom set on layers', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {minZoom: 2, maxZoom: 20});
+			map = new Map(container, {minZoom: 2, maxZoom: 20});
 
-			L.tileLayer('', {minZoom: 4, maxZoom: 10}).addTo(map);
-			L.tileLayer('', {minZoom: 6, maxZoom: 17}).addTo(map);
-			L.tileLayer('', {minZoom: 0, maxZoom: 22}).addTo(map);
+			new TileLayer('', {minZoom: 4, maxZoom: 10}).addTo(map);
+			new TileLayer('', {minZoom: 6, maxZoom: 17}).addTo(map);
+			new TileLayer('', {minZoom: 0, maxZoom: 22}).addTo(map);
 
 			expect(map.getMinZoom()).to.equal(2);
 			expect(map.getMaxZoom()).to.equal(20);
@@ -612,9 +615,9 @@ describe('Map', () => {
 		it('layer minZoom overrides map zoom if map has no minZoom set and layer minZoom is bigger than map zoom', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {zoom: 10});
+			map = new Map(container, {zoom: 10});
 
-			L.tileLayer('', {minZoom: 15}).addTo(map);
+			new TileLayer('', {minZoom: 15}).addTo(map);
 
 			expect(map.getMinZoom()).to.equal(15);
 		});
@@ -622,9 +625,9 @@ describe('Map', () => {
 		it('layer maxZoom overrides map zoom if map has no maxZoom set and layer maxZoom is smaller than map zoom', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {zoom: 20});
+			map = new Map(container, {zoom: 20});
 
-			L.tileLayer('', {maxZoom: 15}).addTo(map);
+			new TileLayer('', {maxZoom: 15}).addTo(map);
 
 			expect(map.getMaxZoom()).to.equal(15);
 		});
@@ -632,9 +635,9 @@ describe('Map', () => {
 		it('map\'s zoom is adjusted to layer\'s minZoom even if initialized with smaller value', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {zoom: 10});
+			map = new Map(container, {zoom: 10});
 
-			L.tileLayer('', {minZoom: 15}).addTo(map);
+			new TileLayer('', {minZoom: 15}).addTo(map);
 
 			expect(map.getZoom()).to.equal(15);
 		});
@@ -642,9 +645,9 @@ describe('Map', () => {
 		it('map\'s zoom is adjusted to layer\'s maxZoom even if initialized with larger value', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {zoom: 20});
+			map = new Map(container, {zoom: 20});
 
-			L.tileLayer('', {maxZoom: 15}).addTo(map);
+			new TileLayer('', {maxZoom: 15}).addTo(map);
 
 			expect(map.getZoom()).to.equal(15);
 		});
@@ -652,13 +655,13 @@ describe('Map', () => {
 
 	describe('#addHandler', () => {
 		function getHandler(callback = () => {}) {
-			return L.Handler.extend({
+			return Handler.extend({
 				addHooks() {
-					L.DomEvent.on(window, 'click', this.handleClick, this);
+					DomEvent.on(window, 'click', this.handleClick, this);
 				},
 
 				removeHooks() {
-					L.DomEvent.off(window, 'click', this.handleClick, this);
+					DomEvent.off(window, 'click', this.handleClick, this);
 				},
 
 				handleClick: callback
@@ -666,8 +669,7 @@ describe('Map', () => {
 		}
 
 		it('checking enabled method', () => {
-			L.ClickHandler = getHandler();
-			map.addHandler('clickHandler', L.ClickHandler);
+			map.addHandler('clickHandler', getHandler());
 
 			expect(map.clickHandler.enabled()).to.eql(false);
 
@@ -680,18 +682,16 @@ describe('Map', () => {
 
 		it('automatically enabled, when has a property named the same as the handler', () => {
 			map.remove();
-			map = L.map(container, {clickHandler: true});
+			map = new Map(container, {clickHandler: true});
 
-			L.ClickHandler = getHandler();
-			map.addHandler('clickHandler', L.ClickHandler);
+			map.addHandler('clickHandler', getHandler());
 
 			expect(map.clickHandler.enabled()).to.eql(true);
 		});
 
 		it('checking handling events when enabled/disabled', () => {
 			const spy = sinon.spy();
-			L.ClickHandler = getHandler(spy);
-			map.addHandler('clickHandler', L.ClickHandler);
+			map.addHandler('clickHandler', getHandler(spy));
 
 			UIEventSimulator.fire('click', window);
 			UIEventSimulator.fire('click', window);
@@ -764,7 +764,7 @@ describe('Map', () => {
 		});
 
 		it('return empty pane when map deleted', () => {
-			const map2 = L.map(document.createElement('div'));
+			const map2 = new Map(document.createElement('div'));
 			map2.remove();
 
 			expect(map2.getPanes()).to.eql({});
@@ -778,7 +778,7 @@ describe('Map', () => {
 
 		it('return undefined on empty container id', () => {
 			const container2 = createContainer();
-			const map2 = L.map(container2);
+			const map2 = new Map(container2);
 			map2.remove(); // clean up
 
 			expect(map2.getContainer()._leaflet_id).to.eql(undefined);
@@ -787,13 +787,13 @@ describe('Map', () => {
 
 	describe('#getSize', () => {
 		it('return map size in pixels', () => {
-			expect(map.getSize()).to.eql(L.point([400, 400]));
+			expect(map.getSize()).to.eql(new Point(400, 400));
 		});
 
 		it('return map size if not specified', () => {
-			const map2 = L.map(document.createElement('div'));
+			const map2 = new Map(document.createElement('div'));
 
-			expect(map2.getSize()).to.eql(L.point([0, 0]));
+			expect(map2.getSize()).to.eql(new Point(0, 0));
 
 			map2.remove(); // clean up
 		});
@@ -802,13 +802,13 @@ describe('Map', () => {
 			container.style.width = '0px';
 			container.style.height = '0px';
 
-			expect(map.getSize()).to.eql(L.point([0, 0]));
+			expect(map.getSize()).to.eql(new Point(0, 0));
 		});
 
 		it('return new pixels on change', () => {
 			container.style.width = '300px';
 
-			expect(map.getSize()).to.eql(L.point([300, 400]));
+			expect(map.getSize()).to.eql(new Point(300, 400));
 		});
 
 		it('return clone of size object from map', () => {
@@ -817,11 +817,11 @@ describe('Map', () => {
 
 		it('return previous size on empty map', () => {
 			const container2 = createContainer();
-			const map2 = L.map(container2);
+			const map2 = new Map(container2);
 
 			map2.remove(); // clean up
 
-			expect(map2.getSize()).to.eql(L.point([400, 400]));
+			expect(map2.getSize()).to.eql(new Point(400, 400));
 		});
 	});
 
@@ -831,24 +831,24 @@ describe('Map', () => {
 		});
 
 		it('return map bounds in pixels', () => {
-			expect(map.getPixelBounds()).to.eql(L.bounds([-72, -72], [328, 328]));
+			expect(map.getPixelBounds()).to.eql(new Bounds([-72, -72], [328, 328]));
 		});
 
 		it('return changed map bounds if really zoomed in', () => {
 			map.setZoom(20);
 
-			expect(map.getPixelBounds()).to.eql(L.bounds([134217528, 134217528], [134217928, 134217928]));
+			expect(map.getPixelBounds()).to.eql(new Bounds([134217528, 134217528], [134217928, 134217928]));
 		});
 
 		it('return new pixels on view change', () => {
 			map.setView([50, 50], 5);
 
-			expect(map.getPixelBounds()).to.eql(L.bounds([5034, 2578], [5434, 2978]));
+			expect(map.getPixelBounds()).to.eql(new Bounds([5034, 2578], [5434, 2978]));
 		});
 
 		it('throw error if center and zoom were not set / map not loaded', () => {
 			const container2 = createContainer();
-			const map2 = L.map(container2);
+			const map2 = new Map(container2);
 
 			expect(map2.getPixelBounds).to.throw();
 
@@ -862,24 +862,24 @@ describe('Map', () => {
 		});
 
 		it('return pixel origin', () => {
-			expect(map.getPixelOrigin()).to.eql(L.point([-72, -72]));
+			expect(map.getPixelOrigin()).to.eql(new Point(-72, -72));
 		});
 
 		it('return new pixels on view change', () => {
 			map.setView([50, 50], 5);
 
-			expect(map.getPixelOrigin()).to.eql(L.point([5034, 2578]));
+			expect(map.getPixelOrigin()).to.eql(new Point(5034, 2578));
 		});
 
 		it('return changed map bounds if really zoomed in', () => {
 			map.setZoom(20);
 
-			expect(map.getPixelOrigin()).to.eql(L.point([134217528, 134217528]));
+			expect(map.getPixelOrigin()).to.eql(new Point(134217528, 134217528));
 		});
 
 		it('throw error if center and zoom were not set / map not loaded', () => {
 			const container2 = createContainer();
-			const map2 = L.map(container2);
+			const map2 = new Map(container2);
 
 			expect(map2.getPixelOrigin).to.throw();
 
@@ -889,34 +889,34 @@ describe('Map', () => {
 
 	describe('#getPixelWorldBounds', () => {
 		it('return map bounds in pixels', () => {
-			expect(map.getPixelWorldBounds()).to.eql(L.bounds(
+			expect(map.getPixelWorldBounds()).to.eql(new Bounds(
 				[5.551115123125783e-17, 5.551115123125783e-17], [1, 1]));
 		});
 
 		it('return changed map bounds if really zoomed in', () => {
 			map.setZoom(20);
 
-			expect(map.getPixelWorldBounds()).to.eql(L.bounds(
+			expect(map.getPixelWorldBounds()).to.eql(new Bounds(
 				[1.4901161193847656e-8, 1.4901161193847656e-8], [268435456, 268435456]));
 		});
 
 		it('return new pixels on zoom change', () => {
 			map.setZoom(5);
 
-			expect(map.getPixelWorldBounds()).to.eql(L.bounds(
+			expect(map.getPixelWorldBounds()).to.eql(new Bounds(
 				[4.547473508864641e-13, 4.547473508864641e-13], [8192, 8192]));
 
 			map.setView([0, 0]);
 
 			// view does not change pixel world bounds
-			expect(map.getPixelWorldBounds()).to.eql(L.bounds(
+			expect(map.getPixelWorldBounds()).to.eql(new Bounds(
 				[4.547473508864641e-13, 4.547473508864641e-13], [8192, 8192]));
 		});
 
 		it('return infinity bounds on infinity zoom', () => {
 			map.setZoom(Infinity);
 
-			expect(map.getPixelWorldBounds()).to.eql(L.bounds(
+			expect(map.getPixelWorldBounds()).to.eql(new Bounds(
 				[Infinity, Infinity], [Infinity, Infinity]));
 		});
 	});
@@ -924,7 +924,7 @@ describe('Map', () => {
 	describe('#hasLayer', () => {
 		it('throws when called without proper argument', () => {
 			const hasLayer = map.hasLayer.bind(map);
-			expect(() => hasLayer(new L.Layer())).to.not.throw(); // control case
+			expect(() => hasLayer(new Layer())).to.not.throw(); // control case
 
 			expect(() => hasLayer(undefined)).to.throw();
 			expect(() => hasLayer(null)).to.throw();
@@ -934,7 +934,7 @@ describe('Map', () => {
 	});
 
 	function layerSpy() {
-		const layer = new L.Layer();
+		const layer = new Layer();
 		layer.onAdd = sinon.spy();
 		layer.onRemove = sinon.spy();
 		return layer;
@@ -1004,7 +1004,7 @@ describe('Map', () => {
 		});
 
 		it('throws if adding something which is not a layer', () => {
-			const control = L.control.layers();
+			const control = lControl.layers();
 			expect(() => {
 				map.addLayer(control);
 			}).to.throw();
@@ -1015,7 +1015,7 @@ describe('Map', () => {
 				const spy = sinon.spy();
 				map.on('zoomlevelschange', spy);
 				expect(spy.called).not.to.be.true;
-				L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 				expect(spy.called).to.be.true;
 			});
 		});
@@ -1023,10 +1023,10 @@ describe('Map', () => {
 		describe('when a new layer with greater zoomlevel coverage than the current layer is added to a map', () => {
 			it('fires a zoomlevelschange event', () => {
 				const spy = sinon.spy();
-				L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 				map.on('zoomlevelschange', spy);
 				expect(spy.called).not.to.be.true;
-				L.tileLayer('', {minZoom: 0, maxZoom: 15}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 15}).addTo(map);
 				expect(spy.called).to.be.true;
 			});
 		});
@@ -1034,12 +1034,12 @@ describe('Map', () => {
 		describe('when a new layer with the same or lower zoomlevel coverage as the current layer is added to a map', () => {
 			it('fires no zoomlevelschange event', () => {
 				const spy = sinon.spy();
-				L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 				map.on('zoomlevelschange', spy);
 				expect(spy.called).not.to.be.true;
-				L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 				expect(spy.called).not.to.be.true;
-				L.tileLayer('', {minZoom: 0, maxZoom: 5}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 5}).addTo(map);
 				expect(spy.called).not.to.be.true;
 			});
 		});
@@ -1108,14 +1108,14 @@ describe('Map', () => {
 		});
 
 		it('supports adding and removing a tile layer without initializing the map', () => {
-			const layer = L.tileLayer('');
+			const layer = new TileLayer('');
 			map.addLayer(layer);
 			map.removeLayer(layer);
 		});
 
 		it('supports adding and removing a tile layer without initializing the map', () => {
 			map.setView([0, 0], 18);
-			const layer = L.gridLayer();
+			const layer = new GridLayer();
 			map.addLayer(layer);
 			map.removeLayer(layer);
 		});
@@ -1124,7 +1124,7 @@ describe('Map', () => {
 			it('fires a zoomlevelschange event', () => {
 				map.setView([0, 0], 0);
 				const spy = sinon.spy();
-				const tl = L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				const tl = new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 
 				map.on('zoomlevelschange', spy);
 				expect(spy.called).not.to.be.true;
@@ -1136,9 +1136,9 @@ describe('Map', () => {
 		describe('when a tile layer is removed from a map and it had greater zoom level coverage than the remainding layer', () => {
 			it('fires a zoomlevelschange event', () => {
 				map.setView([0, 0], 0);
-				L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
+				new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map);
 				const spy = sinon.spy(),
-				    t2 = L.tileLayer('', {minZoom: 0, maxZoom: 15}).addTo(map);
+				    t2 = new TileLayer('', {minZoom: 0, maxZoom: 15}).addTo(map);
 
 				map.on('zoomlevelschange', spy);
 				expect(spy.called).to.be.false;
@@ -1151,9 +1151,9 @@ describe('Map', () => {
 			it('fires no zoomlevelschange event', () => {
 				map.setView([0, 0], 0);
 				const spy = sinon.spy(),
-				    t1 = L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map),
-				    t2 = L.tileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map),
-				    t3 = L.tileLayer('', {minZoom: 0, maxZoom: 5}).addTo(map);
+				    t1 = new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map),
+				    t2 = new TileLayer('', {minZoom: 0, maxZoom: 10}).addTo(map),
+				    t3 = new TileLayer('', {minZoom: 0, maxZoom: 5}).addTo(map);
 
 				map.on('zoomlevelschange', spy);
 				map.removeLayer(t2);
@@ -1168,12 +1168,12 @@ describe('Map', () => {
 
 	describe('#eachLayer', () => {
 		it('returns self', () => {
-			expect(map.eachLayer(L.Util.falseFn)).to.equal(map);
+			expect(map.eachLayer(Util.falseFn)).to.equal(map);
 		});
 
 		it('calls the provided function for each layer', () => {
-			const t1 = L.tileLayer('').addTo(map),
-			    t2 = L.tileLayer('').addTo(map),
+			const t1 = new TileLayer('').addTo(map),
+			    t2 = new TileLayer('').addTo(map),
 			    spy = sinon.spy();
 
 			map.eachLayer(spy);
@@ -1185,7 +1185,7 @@ describe('Map', () => {
 
 		it('calls the provided function with the provided context', () => {
 			const spy = sinon.spy();
-			L.tileLayer('').addTo(map);
+			new TileLayer('').addTo(map);
 
 			map.eachLayer(spy, map);
 
@@ -1297,7 +1297,7 @@ describe('Map', () => {
 			const center = [0, 0];
 
 			// The edge case is only if view is set directly during map initialization
-			map = L.map(container, {
+			map = new Map(container, {
 				center,
 				zoom: 0
 			});
@@ -1341,7 +1341,7 @@ describe('Map', () => {
 			const center = [0, 0];
 
 			// The edge case is only if view is set directly during map initialization
-			map = L.map(container, {
+			map = new Map(container, {
 				center,
 				zoom: 0,
 				trackResize: false
@@ -1375,7 +1375,7 @@ describe('Map', () => {
 				expect(spy.called).to.be.false;
 
 				// make sure afterEach works correctly
-				map = L.map(container);
+				map = new Map(container);
 				done();
 				// we need the 10 ms to be sure that the ResizeObserver is not triggered
 			}, 10);
@@ -1392,7 +1392,7 @@ describe('Map', () => {
 		it('move to requested center and zoom, and call zoomend once', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
-			const newCenter = L.latLng(10, 11),
+			const newCenter = latLng(10, 11),
 			    newZoom = 12;
 			const callback = function () {
 				expect(map.getCenter()).to.eql(newCenter);
@@ -1406,7 +1406,7 @@ describe('Map', () => {
 		it('flyTo start latlng == end latlng', function (done) {
 			this.timeout(10000); // This test takes longer than usual due to frames
 
-			const dc = L.latLng(38.91, -77.04);
+			const dc = latLng(38.91, -77.04);
 			map.setView(dc, 14);
 
 			map.on('zoomend', () => {
@@ -1420,7 +1420,7 @@ describe('Map', () => {
 	});
 
 	describe('#zoomIn and #zoomOut', () => {
-		const center = L.latLng(22, 33);
+		const center = latLng(22, 33);
 		beforeEach(() => {
 			map.setView(center, 10);
 		});
@@ -1491,7 +1491,7 @@ describe('Map', () => {
 	});
 
 	describe('#_getBoundsCenterZoom', () => {
-		const center = L.latLng(50.5, 30.51);
+		const center = latLng(50.5, 30.51);
 
 		it('Returns valid center on empty bounds in unitialized map', () => {
 			// Edge case from #5153
@@ -1502,8 +1502,8 @@ describe('Map', () => {
 	});
 
 	describe('#fitBounds', () => {
-		const center = L.latLng(50.5, 30.51);
-		let bounds = L.latLngBounds(L.latLng(1, 102), L.latLng(11, 122)),
+		const center = latLng(50.5, 30.51);
+		let bounds = new LatLngBounds(latLng(1, 102), latLng(11, 122)),
 		    boundsCenter = bounds.getCenter();
 
 		beforeEach(() => {
@@ -1570,7 +1570,7 @@ describe('Map', () => {
 				map.fitBounds(bounds);
 			});
 
-			bounds = L.latLngBounds([57.73, 11.93], [57.75, 11.95]);
+			bounds = new LatLngBounds([57.73, 11.93], [57.75, 11.95]);
 			boundsCenter = bounds.getCenter();
 			map.setZoom(0);
 		});
@@ -1585,15 +1585,15 @@ describe('Map', () => {
 				map.fitBounds(bounds);
 			});
 
-			bounds = L.latLngBounds([90, -180], [-90, 180]);
+			bounds = new LatLngBounds([90, -180], [-90, 180]);
 			boundsCenter = bounds.getCenter();
 			map.setZoom(22);
 		});
 	});
 
 	describe('#fitBounds after layers set', () => {
-		const center = L.latLng(22, 33),
-		    bounds = L.latLngBounds(L.latLng(1, 102), L.latLng(11, 122));
+		const center = latLng(22, 33),
+		    bounds = new LatLngBounds(latLng(1, 102), latLng(11, 122));
 
 		beforeEach(() => {
 			// fitBounds needs a map container with non-null area
@@ -1601,14 +1601,14 @@ describe('Map', () => {
 		});
 
 		it('Snaps to a number after adding tile layer', () => {
-			map.addLayer(L.tileLayer(''));
+			map.addLayer(new TileLayer(''));
 			expect(map.getZoom()).to.equal(undefined);
 			map.fitBounds(bounds);
 			expect(map.getZoom()).to.equal(2);
 		});
 
 		it('Snaps to a number after adding marker', () => {
-			map.addLayer(L.marker(center));
+			map.addLayer(new Marker(center));
 			expect(map.getZoom()).to.equal(undefined);
 			map.fitBounds(bounds);
 			expect(map.getZoom()).to.equal(2);
@@ -1617,7 +1617,7 @@ describe('Map', () => {
 	});
 
 	describe('#fitWorld', () => {
-		const bounds = L.latLngBounds([90, -180], [-90, 180]),
+		const bounds = new LatLngBounds([90, -180], [-90, 180]),
 		boundsCenter = bounds.getCenter();
 
 
@@ -1642,7 +1642,7 @@ describe('Map', () => {
 
 		beforeEach(() => {
 			container.style.height = container.style.width = '500px';
-			map.setView(L.latLng([53.0, 0.15]), 12, {animate: false});
+			map.setView(latLng([53.0, 0.15]), 12, {animate: false});
 			center = map.getCenter().clone();
 			tl = map.getBounds().getNorthWest();
 			tlPix = map.getPixelBounds().min;
@@ -1659,25 +1659,25 @@ describe('Map', () => {
 			    distanceMoved;
 			map.panInside(map.unproject(p), {padding, animate: false});
 			distanceMoved = map.getPixelBounds().min.subtract(tlPix);
-			expect(distanceMoved.equals(L.point([-10, -20]))).to.eql(true);
+			expect(distanceMoved.equals(new Point(-10, -20))).to.eql(true);
 
 			tlPix = map.getPixelBounds().min;
 			p = [map.getPixelBounds().max.x - 10, map.getPixelBounds().min.y];	// Top-right
 			map.panInside(map.unproject(p), {padding, animate: false});
 			distanceMoved = map.getPixelBounds().min.subtract(tlPix);
-			expect(distanceMoved.equals(L.point([30, -20]))).to.eql(true);
+			expect(distanceMoved.equals(new Point(30, -20))).to.eql(true);
 
 			tlPix = map.getPixelBounds().min;
 			p = [map.getPixelBounds().min.x + 35, map.getPixelBounds().max.y];	// Bottom-left
 			map.panInside(map.unproject(p), {padding, animate: false});
 			distanceMoved = map.getPixelBounds().min.subtract(tlPix);
-			expect(distanceMoved.equals(L.point([-5, 20]))).to.eql(true);
+			expect(distanceMoved.equals(new Point(-5, 20))).to.eql(true);
 
 			tlPix = map.getPixelBounds().min;
 			p = [map.getPixelBounds().max.x - 15, map.getPixelBounds().max.y]; // Bottom-right
 			map.panInside(map.unproject(p), {padding, animate: false});
 			distanceMoved = map.getPixelBounds().min.subtract(tlPix);
-			expect(distanceMoved.equals(L.point([25, 20]))).to.eql(true);
+			expect(distanceMoved.equals(new Point(25, 20))).to.eql(true);
 		});
 
 		it('supports different padding values for each border', () => {
@@ -1687,7 +1687,7 @@ describe('Map', () => {
 			expect(center).to.eql(map.getCenter());
 
 			const br = map.getPixelBounds().max;	// Bottom-Right
-			map.panInside(map.unproject(L.point(br.x + 20, br.y)), opts);
+			map.panInside(map.unproject(new Point(br.x + 20, br.y)), opts);
 			expect(center).to.not.eql(map.getCenter());
 		});
 
@@ -1700,7 +1700,7 @@ describe('Map', () => {
 		});
 
 		it('pans only on the Y axis when the target\'s X coord is within bounds but the Y is not', () => {
-			const p = L.latLng(tl.lat + 5, tl.lng);
+			const p = latLng(tl.lat + 5, tl.lng);
 			map.panInside(p, {animate: false});
 			expect(map.getBounds().contains(p)).to.be.true;
 			const dx = Math.abs(map.getCenter().lng - center.lng);
@@ -1709,7 +1709,7 @@ describe('Map', () => {
 		});
 
 		it('pans only on the X axis when the target\'s Y coord is within bounds but the X is not', () => {
-			const p = L.latLng(tl.lat, tl.lng - 5);
+			const p = latLng(tl.lat, tl.lng - 5);
 			map.panInside(p, 0, {animate: false});
 			expect(map.getBounds().contains(p)).to.be.true;
 			expect(map.getCenter().lng).to.not.eql(center.lng);
@@ -1719,15 +1719,15 @@ describe('Map', () => {
 
 		it('pans correctly when padding takes up more than half the display bounds', () => {
 			const oldCenter = map.project(center);
-			const targetOffset = L.point(0, -5); // arbitrary point above center
+			const targetOffset = new Point(0, -5); // arbitrary point above center
 			const target = oldCenter.add(targetOffset);
-			const paddingOffset = L.point(0, 15);
+			const paddingOffset = new Point(0, 15);
 			const padding = map.getSize().divideBy(2) // half size
 			  .add(paddingOffset); // padding more than half the display bounds (replicates issue #7445)
 			map.panInside(map.unproject(target), {paddingBottomRight: [0, padding.y], animate: false});
 			const offset = map.project(map.getCenter()).subtract(oldCenter); // distance moved during the pan
 			const result = paddingOffset.add(targetOffset).subtract(offset);
-			expect(result.trunc().equals(L.point(0, 0))).to.be.true;
+			expect(result.trunc().equals(new Point(0, 0))).to.be.true;
 		});
 	});
 
@@ -1739,7 +1739,7 @@ describe('Map', () => {
 		it('DOM events propagate from polygon to map', () => {
 			const spy = sinon.spy();
 			map.on('mousemove', spy);
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
 			UIEventSimulator.fire('mousemove', layer._path);
 			expect(spy.calledOnce).to.be.true;
 		});
@@ -1747,7 +1747,7 @@ describe('Map', () => {
 		it('DOM events propagate from marker to map', () => {
 			const spy = sinon.spy();
 			map.on('mousemove', spy);
-			const layer = L.marker([1, 2]).addTo(map);
+			const layer = new Marker([1, 2]).addTo(map);
 			UIEventSimulator.fire('mousemove', layer._icon);
 			expect(spy.calledOnce).to.be.true;
 		});
@@ -1756,8 +1756,8 @@ describe('Map', () => {
 			const mapSpy = sinon.spy();
 			const layerSpy = sinon.spy();
 			map.on('mousemove', mapSpy);
-			const layer = L.marker([1, 2]).addTo(map);
-			layer.on('mousemove', L.DomEvent.stopPropagation).on('mousemove', layerSpy);
+			const layer = new Marker([1, 2]).addTo(map);
+			layer.on('mousemove', DomEvent.stopPropagation).on('mousemove', layerSpy);
 			UIEventSimulator.fire('mousemove', layer._icon);
 			expect(layerSpy.calledOnce).to.be.true;
 			expect(mapSpy.called).not.to.be.true;
@@ -1767,8 +1767,8 @@ describe('Map', () => {
 			const mapSpy = sinon.spy();
 			const layerSpy = sinon.spy();
 			map.on('mousemove', mapSpy);
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
-			layer.on('mousemove', L.DomEvent.stopPropagation).on('mousemove', layerSpy);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			layer.on('mousemove', DomEvent.stopPropagation).on('mousemove', layerSpy);
 			UIEventSimulator.fire('mousemove', layer._path);
 			expect(layerSpy.calledOnce).to.be.true;
 			expect(mapSpy.called).not.to.be.true;
@@ -1778,8 +1778,8 @@ describe('Map', () => {
 			const mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
 			    otherSpy = sinon.spy();
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
-			const other = L.polygon([[10, 20], [30, 40], [50, 60]]).addTo(map);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			const other = new Polygon([[10, 20], [30, 40], [50, 60]]).addTo(map);
 			map.on('mouseout', mapSpy);
 			layer.on('mouseout', layerSpy);
 			other.on('mouseout', otherSpy);
@@ -1790,13 +1790,13 @@ describe('Map', () => {
 		});
 
 		it('mouseout is forwarded when using a DivIcon', () => {
-			const icon = L.divIcon({
+			const icon = new DivIcon({
 				html: '<p>this is text in a child element</p>',
 				iconSize: [100, 100]
 			});
 			const mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
-			    layer = L.marker([1, 2], {icon}).addTo(map);
+			    layer = new Marker([1, 2], {icon}).addTo(map);
 			map.on('mouseout', mapSpy);
 			layer.on('mouseout', layerSpy);
 			UIEventSimulator.fire('mouseout', layer._icon, {relatedTarget: container});
@@ -1805,13 +1805,13 @@ describe('Map', () => {
 		});
 
 		it('mouseout is not forwarded if relatedTarget is a target\'s child', () => {
-			const icon = L.divIcon({
+			const icon = new DivIcon({
 				html: '<p>this is text in a child element</p>',
 				iconSize: [100, 100]
 			});
 			const mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
-			    layer = L.marker([1, 2], {icon}).addTo(map),
+			    layer = new Marker([1, 2], {icon}).addTo(map),
 			    child = layer._icon.querySelector('p');
 			map.on('mouseout', mapSpy);
 			layer.on('mouseout', layerSpy);
@@ -1821,13 +1821,13 @@ describe('Map', () => {
 		});
 
 		it('mouseout is not forwarded if fired on target\'s child', () => {
-			const icon = L.divIcon({
+			const icon = new DivIcon({
 				html: '<p>this is text in a child element</p>',
 				iconSize: [100, 100]
 			});
 			const mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
-			    layer = L.marker([1, 2], {icon}).addTo(map),
+			    layer = new Marker([1, 2], {icon}).addTo(map),
 			    child = layer._icon.querySelector('p');
 			map.on('mouseout', mapSpy);
 			layer.on('mouseout', layerSpy);
@@ -1840,8 +1840,8 @@ describe('Map', () => {
 			const mapSpy = sinon.spy(),
 			    layerSpy = sinon.spy(),
 			    otherSpy = sinon.spy();
-			const layer = L.polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
-			const other = L.polygon([[10, 20], [30, 40], [50, 60]]).addTo(map);
+			const layer = new Polygon([[1, 2], [3, 4], [5, 6]]).addTo(map);
+			const other = new Polygon([[10, 20], [30, 40], [50, 60]]).addTo(map);
 			map.on('mouseout', mapSpy);
 			layer.on('mouseout', layerSpy);
 			other.on('mouseout', otherSpy);
@@ -1853,7 +1853,7 @@ describe('Map', () => {
 
 		it('preclick is fired before click on marker and map', () => {
 			let called = 0;
-			const layer = L.marker([1, 2], {bubblingMouseEvents: true}).addTo(map);
+			const layer = new Marker([1, 2], {bubblingMouseEvents: true}).addTo(map);
 			layer.on('preclick', (e) => {
 				expect(called++).to.eql(0);
 				expect(e.latlng).to.be.ok;
@@ -1877,20 +1877,20 @@ describe('Map', () => {
 		it('prevents default action of contextmenu if there is any listener', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = L.map(container, {
-				renderer: L.canvas(),
+			map = new Map(container, {
+				renderer: new Canvas(),
 				center: [0, 0],
 				zoom: 0
 			});
 
 			container.style.width = container.style.height = '300px';
 
-			map.setView(L.latLng([0, 0]), 12);
+			map.setView(latLng([0, 0]), 12);
 			const spy = sinon.spy();
 			map.on('contextmenu', (e) => {
 				spy(e.originalEvent.defaultPrevented);
 			});
-			const marker = L.circleMarker([0, 0]).addTo(map);
+			const marker = new CircleMarker([0, 0]).addTo(map);
 
 			UIEventSimulator.fireAt('contextmenu', 0, 0); // first
 
@@ -1926,7 +1926,7 @@ describe('Map', () => {
 		});
 
 		it('returns undefined if map not initialized but layers added', () => {
-			map.addLayer(L.tileLayer(''));
+			map.addLayer(new TileLayer(''));
 			expect(map.getZoom()).to.equal(undefined);
 		});
 	});
@@ -1958,7 +1958,7 @@ describe('Map', () => {
 			const child = document.createElement('div');
 			parent.appendChild(child);
 			container.appendChild(parent);
-			L.DomEvent.on(child, 'click', () => {
+			DomEvent.on(child, 'click', () => {
 				parent.remove();
 			});
 			expect(() => {
@@ -1969,22 +1969,22 @@ describe('Map', () => {
 
 	describe('#distance', () => {
 		it('measure distance in meters', () => {
-			const LA = L.latLng(34.0485672098387, -118.217781922035);
-			const columbus = L.latLng(39.95715687063701, -83.00205705857633);
+			const LA = latLng(34.0485672098387, -118.217781922035);
+			const columbus = latLng(39.95715687063701, -83.00205705857633);
 
 			expect(map.distance(LA, columbus)).to.be.within(3173910, 3173915);
 		});
 
 		it('accurately measure in small distances', () => {
-			const p1 = L.latLng(40.160857881285416, -83.00841851162649);
-			const p2 = L.latLng(40.16246493902907, -83.008622359483);
+			const p1 = latLng(40.160857881285416, -83.00841851162649);
+			const p2 = latLng(40.16246493902907, -83.008622359483);
 
 			expect(map.distance(p1, p2)).to.be.within(175, 185);
 		});
 
 		it('accurately measure in long distances', () => {
-			const canada = L.latLng(60.01810635103154, -112.19675246283015);
-			const newZeland = L.latLng(-42.36275164460971, 172.39309066597883);
+			const canada = latLng(60.01810635103154, -112.19675246283015);
+			const newZeland = latLng(-42.36275164460971, 172.39309066597883);
 
 			expect(map.distance(canada, newZeland)).to.be.within(13274700, 13274800);
 		});
@@ -2002,7 +2002,7 @@ describe('Map', () => {
 		});
 
 		it('return 0 with 2 same latLng', () => {
-			const p = L.latLng(20, 50);
+			const p = latLng(20, 50);
 
 			expect(map.distance(p, p)).to.eql(0);
 		});
@@ -2010,14 +2010,14 @@ describe('Map', () => {
 
 	describe('#containerPointToLayerPoint', () => {
 		it('return same point of LayerPoint is 0, 0', () => {
-			expect(map.containerPointToLayerPoint(L.point(25, 25))).to.eql(L.point(25, 25));
+			expect(map.containerPointToLayerPoint(new Point(25, 25))).to.eql(new Point(25, 25));
 		});
 
 		it('return point relative to LayerPoint', (done) => {
 			map.setView([20, 20], 2);
 
 			map.once('moveend', () => {
-				expect(map.containerPointToLayerPoint(L.point(30, 30))).to.eql(L.point(80, 80));
+				expect(map.containerPointToLayerPoint(new Point(30, 30))).to.eql(new Point(80, 80));
 				done();
 			});
 
@@ -2027,14 +2027,14 @@ describe('Map', () => {
 
 	describe('#layerPointToContainerPoint', () => {
 		it('return same point of ContainerPoint is 0, 0', () => {
-			expect(map.layerPointToContainerPoint(L.point(25, 25))).to.eql(L.point(25, 25));
+			expect(map.layerPointToContainerPoint(new Point(25, 25))).to.eql(new Point(25, 25));
 		});
 
 		it('return point relative to ContainerPoint', (done) => {
 			map.setView([20, 20], 2);
 
 			map.once('moveend', () => {
-				expect(map.layerPointToContainerPoint(L.point(30, 30))).to.eql(L.point(-20, -20));
+				expect(map.layerPointToContainerPoint(new Point(30, 30))).to.eql(new Point(-20, -20));
 				done();
 			});
 
@@ -2044,59 +2044,59 @@ describe('Map', () => {
 
 	describe('_addZoomLimit', () => {
 		it('update zoom levels when min zoom is a number in a layer that is added to map', () => {
-			map._addZoomLimit(L.tileLayer('', {minZoom: 4}));
+			map._addZoomLimit(new TileLayer('', {minZoom: 4}));
 			expect(map._layersMinZoom).to.equal(4);
 		});
 
 		it('update zoom levels when max zoom is a number in a layer that is added to map', () => {
-			map._addZoomLimit(L.tileLayer('', {maxZoom: 10}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: 10}));
 			expect(map._layersMaxZoom).to.equal(10);
 		});
 
 		it('update zoom levels when min zoom is a number in two layers that are added to map', () => {
-			map._addZoomLimit(L.tileLayer('', {minZoom: 6}));
-			map._addZoomLimit(L.tileLayer('', {minZoom: 4}));
+			map._addZoomLimit(new TileLayer('', {minZoom: 6}));
+			map._addZoomLimit(new TileLayer('', {minZoom: 4}));
 			expect(map._layersMinZoom).to.equal(4);
 		});
 
 		it('update zoom levels when max zoom is a number in two layers that are added to map', () => {
-			map._addZoomLimit(L.tileLayer('', {maxZoom: 10}));
-			map._addZoomLimit(L.tileLayer('', {maxZoom: 8}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: 10}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: 8}));
 			expect(map._layersMaxZoom).to.equal(10);
 		});
 
 		// This test shows the NaN usage - it's not clear if NaN is a wanted "feature"
 		it('update zoom levels when min zoom is NaN in a layer that is added to map, so that min zoom becomes NaN,', () => {
-			map._addZoomLimit(L.tileLayer('', {minZoom: NaN}));
+			map._addZoomLimit(new TileLayer('', {minZoom: NaN}));
 			expect(isNaN(map._layersMinZoom)).to.be.true;
 		});
 
 		// This test shows the NaN usage - it's not clear if NaN is a wanted "feature"
 		it('update zoom levels when max zoom is NaN in a layer that is added to map, so that max zoom becomes NaN', () => {
-			map._addZoomLimit(L.tileLayer('', {maxZoom: NaN}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: NaN}));
 			expect(isNaN(map._layersMaxZoom)).to.be.true;
 		});
 
 		// This test shows the NaN usage - it's not clear if NaN is a wanted "feature"
 		// Test is clearly wrong, but kept for future fixes
 		// it("update zoom levels when min zoom is NaN in at least one of many layers that are added to map, so that min zoom becomes NaN", function () {
-		// 	map._addZoomLimit(L.tileLayer("", {minZoom: 6}));
-		// 	map._addZoomLimit(L.tileLayer("", {minZoom: NaN})); --> Results in maxZoom = NaN --> _updateZoomLevels is not called.
+		// 	map._addZoomLimit(new TileLayer("", {minZoom: 6}));
+		// 	map._addZoomLimit(new TileLayer("", {minZoom: NaN})); --> Results in maxZoom = NaN --> _updateZoomLevels is not called.
 		// 	Not same logic as for maxZoom.
-		// 	map._addZoomLimit(L.tileLayer("", {minZoom: 4}));
+		// 	map._addZoomLimit(new TileLayer("", {minZoom: 4}));
 		// 	expect(isNaN(map._layersMinZoom)).to.be.true;
 		// });
 
 		// This test shows the NaN usage - it's not clear if NaN is a wanted "feature"
 		it('update zoom levels when max zoom is NaN in at least one of many layers that are added to map, so that max zoom becomes NaN', () => {
-			map._addZoomLimit(L.tileLayer('', {maxZoom: 10}));
-			map._addZoomLimit(L.tileLayer('', {maxZoom: 8}));
-			map._addZoomLimit(L.tileLayer('', {maxZoom: NaN}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: 10}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: 8}));
+			map._addZoomLimit(new TileLayer('', {maxZoom: NaN}));
 			expect(isNaN(map._layersMaxZoom)).to.be.true;
 		});
 
 		it('doesn\'t update zoom levels when min and max zoom are both NaN in a layer that is added to map', () => {
-			map._addZoomLimit(L.tileLayer('', {minZoom: NaN, maxZoom: NaN}));
+			map._addZoomLimit(new TileLayer('', {minZoom: NaN, maxZoom: NaN}));
 			expect(map._layersMinZoom === undefined && map._layersMaxZoom === undefined).to.be.true;
 		});
 	});
@@ -2110,9 +2110,9 @@ describe('Map', () => {
 		});
 
 		it('returns geographical coordinate for point relative to map container', () => {
-			const center = L.latLng(10, 10);
+			const center = latLng(10, 10);
 			map.setView(center, 50);
-			const p = map.containerPointToLatLng(L.point(200, 200));
+			const p = map.containerPointToLatLng(new Point(200, 200));
 			expect(p.lat).to.be.within(10.0000000, 10.0000001);
 			expect(p.lng).to.be.within(10.0000000, 10.0000001);
 		});
@@ -2128,7 +2128,7 @@ describe('Map', () => {
 		});
 
 		it('returns point relative to map container for geographical coordinate', () => {
-			const center = L.latLng(10, 10);
+			const center = latLng(10, 10);
 			map.setView(center);
 			const p = map.latLngToContainerPoint(center);
 			expect(p.x).to.be.equal(200);
@@ -2145,7 +2145,7 @@ describe('Map', () => {
 		});
 
 		it('pans the map to accurate location', () => {
-			const center = L.latLng([50, 30]);
+			const center = latLng([50, 30]);
 			expect(map.panTo(center)).to.equal(map);
 			expect(map.getCenter().distanceTo(center)).to.be.lessThan(5);
 		});
@@ -2167,15 +2167,15 @@ describe('Map', () => {
 
 		it('doesn\'t pan if already in bounds', () => {
 			map.setView([0, 0]);
-			const bounds = L.latLngBounds([[-1, -1], [1, 1]]);
-			const expectedCenter = L.latLng([0, 0]);
+			const bounds = new LatLngBounds([[-1, -1], [1, 1]]);
+			const expectedCenter = latLng([0, 0]);
 			expect(map.panInsideBounds(bounds)).to.equal(map);
 			expect(map.getCenter()).to.be.nearLatLng(expectedCenter);
 		});
 
 		it('pans to closest view in bounds', () => {
-			const bounds = L.latLngBounds([[41.8, -87.6], [40.7, -74]]);
-			const expectedCenter = L.latLng([41.59452223189, -74.2738647460]);
+			const bounds = new LatLngBounds([[41.8, -87.6], [40.7, -74]]);
+			const expectedCenter = latLng([41.59452223189, -74.2738647460]);
 			map.setView([50.5, 30.5], 10);
 			expect(map.panInsideBounds(bounds)).to.equal(map);
 			expect(map.getCenter()).to.be.nearLatLng(expectedCenter);
@@ -2191,7 +2191,7 @@ describe('Map', () => {
 		});
 
 		it('returns the corresponding pixel coordinate relative to the origin pixel', () => {
-			const center = L.latLng([10, 10]);
+			const center = latLng([10, 10]);
 			map.setView(center, 0);
 			const p = map.latLngToLayerPoint(center);
 			expect(p.x).to.be.equal(200);
@@ -2208,9 +2208,9 @@ describe('Map', () => {
 		});
 
 		it('returns the corresponding geographical coordinate for a pixel coordinate relative to the origin pixel', () => {
-			const center = L.latLng(10, 10);
+			const center = latLng(10, 10);
 			map.setView(center, 10);
-			const point = L.point(200, 200);
+			const point = new Point(200, 200);
 			const latlng = map.layerPointToLatLng(point);
 			expect(latlng).to.be.nearLatLng([9.9999579356371, 10.000305175781252]);
 		});
@@ -2446,7 +2446,7 @@ describe('Map', () => {
 	});
 
 	describe('#panBy', () => {
-		const offset = L.point(1000, 1000);
+		const offset = new Point(1000, 1000);
 
 		it('throws if map is not set before', () => {
 			expect(() => {
@@ -2455,7 +2455,7 @@ describe('Map', () => {
 		});
 
 		it('pans the map by given offset', () => {
-			const center = L.latLng([0, 0]);
+			const center = latLng([0, 0]);
 			map.setView(center, 7);
 			const offsetCenterPoint = map.options.crs.latLngToPoint(center, 7).add(offset);
 			const target = map.options.crs.pointToLatLng(offsetCenterPoint, 7);
@@ -2470,16 +2470,16 @@ describe('Map', () => {
 
 		it('returns the latitude and langitude with given point', () => {
 			map.setView([0, 0], 6);
-			const expectedOutput = L.latLng(82.7432022836318, -175.60546875000003);
-			const offset = L.point(200, 1000);
+			const expectedOutput = latLng(82.7432022836318, -175.60546875000003);
+			const offset = new Point(200, 1000);
 			const output = map.unproject(offset);
 			expect(output).to.be.nearLatLng(expectedOutput);
 		});
 
 		it('return the latitude and langitude with different zoom and points', () => {
 			map.setView([0, 0], 10);
-			const expectedOutput = L.latLng(85.03926769025156, -179.98626708984378);
-			const offset = L.point(10, 100);
+			const expectedOutput = latLng(85.03926769025156, -179.98626708984378);
+			const offset = new Point(10, 100);
 			const output = map.unproject(offset);
 			expect(output).to.be.nearLatLng(expectedOutput);
 

--- a/spec/suites/map/handler/Map.BoxZoom.js
+++ b/spec/suites/map/handler/Map.BoxZoom.js
@@ -1,9 +1,12 @@
+import {Map} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Map.BoxZoom', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			center: [0, 0],
 			zoom: 3
 		});

--- a/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
+++ b/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
@@ -1,9 +1,12 @@
+import {Map} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Map.DoubleClickZoom', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			center: [0, 0],
 			zoom: 3,
 			zoomAnimation: false

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -1,3 +1,6 @@
+import {Map, DomUtil, Point, LatLng, Marker} from 'leaflet';
+import {createContainer, removeMapContainer, touchEventType} from '../../SpecHelper.js';
+
 describe('Map.Drag', () => {
 	let container, map;
 
@@ -12,7 +15,7 @@ describe('Map.Drag', () => {
 
 	describe('#addHook', () => {
 		it('calls the map with dragging enabled', () => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true
 			});
 
@@ -22,7 +25,7 @@ describe('Map.Drag', () => {
 		});
 
 		it('calls the map with dragging and worldCopyJump enabled', () => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				worldCopyJump: true
 			});
@@ -34,7 +37,7 @@ describe('Map.Drag', () => {
 
 		it('calls the map with dragging disabled and worldCopyJump enabled; ' +
 			'enables dragging after setting center and zoom', () => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: false,
 				worldCopyJump: true
 			});
@@ -46,9 +49,9 @@ describe('Map.Drag', () => {
 		});
 	});
 
-	const MyMap = L.Map.extend({
+	const MyMap = Map.extend({
 		_getPosition() {
-			return L.DomUtil.getPosition(this.dragging._draggable._element);
+			return DomUtil.getPosition(this.dragging._draggable._element);
 		},
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
@@ -65,8 +68,8 @@ describe('Map.Drag', () => {
 			});
 			map.setView([0, 0], 1);
 
-			const start = L.point(200, 200);
-			const offset = L.point(256, 32);
+			const start = new Point(200, 200);
+			const offset = new Point(256, 32);
 			const finish = start.add(offset);
 
 			const hand = new Hand({
@@ -87,7 +90,7 @@ describe('Map.Drag', () => {
 		});
 
 		describe('in CSS scaled container', () => {
-			const scale = L.point(2, 1.5);
+			const scale = new Point(2, 1.5);
 
 			beforeEach(() => {
 				container.style.webkitTransformOrigin = 'top left';
@@ -101,8 +104,8 @@ describe('Map.Drag', () => {
 				});
 				map.setView([0, 0], 1);
 
-				const start = L.point(200, 200);
-				const offset = L.point(256, 32);
+				const start = new Point(200, 200);
+				const offset = new Point(256, 32);
 				const finish = start.add(offset);
 
 				const hand = new Hand({
@@ -126,12 +129,12 @@ describe('Map.Drag', () => {
 		});
 
 		it('does not change the center of the map when mouse is moved less than the drag threshold', (done) => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
 
-			const originalCenter = L.latLng(0, 0);
+			const originalCenter = new LatLng(0, 0);
 			map.setView(originalCenter.clone(), 1);
 
 			const spy = sinon.spy();
@@ -151,13 +154,13 @@ describe('Map.Drag', () => {
 			const mouse = hand.growFinger('mouse');
 
 			// We move 2 pixels to stay below the default 3-pixel threshold of
-			// L.Draggable. This should result in a click and not a drag.
+			// Draggable. This should result in a click and not a drag.
 			mouse.moveTo(200, 200, 0)
 				.down().moveBy(1, 0, 20).moveBy(1, 0, 200).up();
 		});
 
 		it('does not trigger preclick nor click', (done) => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -189,12 +192,12 @@ describe('Map.Drag', () => {
 
 		it('does not trigger preclick nor click when dragging on top of a static marker', (done) => {
 			container.style.width = container.style.height = '600px';
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
 			map.setView([0, 0], 1);
-			const marker = L.marker(map.getCenter()).addTo(map);
+			const marker = new Marker(map.getCenter()).addTo(map);
 			const clickSpy = sinon.spy();
 			const preclickSpy = sinon.spy();
 			const markerDragSpy = sinon.spy();
@@ -222,19 +225,19 @@ describe('Map.Drag', () => {
 			const mouse = hand.growFinger('mouse');
 
 			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
+			// Draggable.
 			mouse.moveTo(300, 280, 0)
 				.down().moveBy(5, 0, 20).moveBy(20, 20, 100).up();
 		});
 
 		it('does not trigger preclick nor click when dragging a marker', (done) => {
 			container.style.width = container.style.height = '600px';
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
 			map.setView([0, 0], 1);
-			const marker = L.marker(map.getCenter(), {draggable: true}).addTo(map);
+			const marker = new Marker(map.getCenter(), {draggable: true}).addTo(map);
 			const clickSpy = sinon.spy();
 			const preclickSpy = sinon.spy();
 			const markerDragSpy = sinon.spy();
@@ -262,17 +265,17 @@ describe('Map.Drag', () => {
 			const mouse = hand.growFinger('mouse');
 
 			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
+			// Draggable.
 			mouse.moveTo(300, 280, 0)
 				.down().moveBy(5, 0, 20).moveBy(50, 50, 100).up();
 		});
 
 		it('does not change the center of the map when drag is disabled on click', (done) => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
-			const originalCenter = L.latLng(0, 0);
+			const originalCenter = new LatLng(0, 0);
 			map.setView(originalCenter.clone(), 1);
 
 			map.on('mousedown', () => {
@@ -295,7 +298,7 @@ describe('Map.Drag', () => {
 			const mouse = hand.growFinger('mouse');
 
 			// We move 5 pixels first to overcome the 3-pixel threshold of
-			// L.Draggable.
+			// Draggable.
 			mouse.moveTo(200, 200, 0)
 				.down().moveBy(5, 0, 20).moveBy(256, 32, 200).up();
 		});
@@ -309,8 +312,8 @@ describe('Map.Drag', () => {
 			});
 			map.setView([0, 0], 1);
 
-			const start = L.point(200, 200);
-			const offset = L.point(256, 32);
+			const start = new Point(200, 200);
+			const offset = new Point(256, 32);
 			const finish = start.add(offset);
 
 			const hand = new Hand({
@@ -331,12 +334,12 @@ describe('Map.Drag', () => {
 		});
 
 		it.skipIfNotTouch('does not change the center of the map when finger is moved less than the drag threshold', (done) => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false
 			});
 
-			const originalCenter = L.latLng(0, 0);
+			const originalCenter = new LatLng(0, 0);
 			map.setView(originalCenter, 1);
 
 			const spy = sinon.spy();
@@ -357,13 +360,13 @@ describe('Map.Drag', () => {
 			const toucher = hand.growFinger(touchEventType);
 
 			// We move 2 pixels to stay below the default 3-pixel threshold of
-			// L.Draggable. This should result in a click and not a drag.
+			// Draggable. This should result in a click and not a drag.
 			toucher.moveTo(200, 200, 0)
 				.down().moveBy(1, 0, 20).moveBy(1, 0, 200).up();
 		});
 
 		it.skipIfNotTouch('reset itself after touchend', (done) => {
-			map = L.map(container, {
+			map = new Map(container, {
 				dragging: true,
 				inertia: false,
 				zoomAnimation: false	// If true, the test has to wait extra 250msec

--- a/spec/suites/map/handler/Map.KeyboardSpec.js
+++ b/spec/suites/map/handler/Map.KeyboardSpec.js
@@ -1,3 +1,6 @@
+import {Map, Popup} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Map.Keyboard', () => {
 	const KEYCODE_LOWERCASE_A = 'KeyA';
 	const KEYCODE_ARROW_LEFT = 'ArrowLeft';
@@ -12,12 +15,12 @@ describe('Map.Keyboard', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			zoomAnimation: false	// If true, the test has to wait extra 250msec
 		});
 
 		// make keyboard-caused panning instant to cut down on test running time
-		map.panBy = function (offset) { return L.Map.prototype.panBy.call(this, offset, {animate: false}); };
+		map.panBy = function (offset) { return Map.prototype.panBy.call(this, offset, {animate: false}); };
 
 		map.setView([0, 0], 5);
 
@@ -122,7 +125,7 @@ describe('Map.Keyboard', () => {
 	describe('popup closing', () => {
 		it('closes a popup when pressing escape', () => {
 
-			const popup = L.popup().setLatLng([0, 0]).setContent('Null Island');
+			const popup = new Popup().setLatLng([0, 0]).setContent('Null Island');
 			map.openPopup(popup);
 
 			expect(popup.isOpen()).to.be.true;
@@ -137,7 +140,7 @@ describe('Map.Keyboard', () => {
 	describe('popup closing disabled', () => {
 		it('close of popup when pressing escape disabled via options', () => {
 
-			const popup = L.popup({closeOnEscapeKey: false}).setLatLng([0, 0]).setContent('Null Island');
+			const popup = new Popup({closeOnEscapeKey: false}).setLatLng([0, 0]).setContent('Null Island');
 			map.openPopup(popup);
 
 			expect(popup.isOpen()).to.be.true;

--- a/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
+++ b/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
@@ -1,3 +1,6 @@
+import {Map, DomEvent} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Map.ScrollWheelZoom', () => {
 	let container, map;
 	const wheel = 'onwheel' in window ? 'wheel' : 'mousewheel';
@@ -12,7 +15,7 @@ describe('Map.ScrollWheelZoom', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			center: [0, 0],
 			zoom: 3,
 			zoomAnimation: false
@@ -101,7 +104,7 @@ describe('Map.ScrollWheelZoom', () => {
 			map.setZoom(zoom, {animate: false});
 			expect(map.getZoom()).to.equal(zoom);
 
-			map.options.wheelPxPerZoomLevel = 30 / L.DomEvent.getWheelPxFactor();
+			map.options.wheelPxPerZoomLevel = 30 / DomEvent.getWheelPxFactor();
 			UIEventSimulator.fire(wheel, container, scrollIn);
 
 			map.once('zoomend', () => {

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -1,3 +1,6 @@
+import {Map, Browser, extend, Point} from 'leaflet';
+import {createContainer, removeMapContainer} from '../../SpecHelper.js';
+
 describe('Map.TapHoldSpec.js', () => {
 	let container, clock, spy, map;
 
@@ -7,7 +10,7 @@ describe('Map.TapHoldSpec.js', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			center: [51.505, -0.09],
 			zoom: 13,
 			tapHold: true
@@ -77,7 +80,7 @@ describe('Map.TapHoldSpec.js', () => {
 		expect(spy.notCalled).to.be.true;
 	});
 
-	(L.Browser.pointer ? it : it.skip)('ignores events from mouse', () => {
+	(Browser.pointer ? it : it.skip)('ignores events from mouse', () => {
 		UIEventSimulator.fire('pointerdown', container, {pointerId:0, pointerType:'mouse', ...posStart});
 		clock.tick(650);
 
@@ -132,7 +135,7 @@ describe('Map.TapHoldSpec.js', () => {
 	});
 
 	it('ignores long movements', () => {
-		expect(L.point(posStart.clientX, posStart.clientY).distanceTo([posFar.clientX, posFar.clientY]))
+		expect(new Point(posStart.clientX, posStart.clientY).distanceTo([posFar.clientX, posFar.clientY]))
 		  .to.be.above(map.options.tapTolerance);
 
 		UIEventSimulator.fire('touchstart', container, {touches: [posStart]});
@@ -148,7 +151,7 @@ describe('Map.TapHoldSpec.js', () => {
 	});
 
 	it('.originalEvent has expected properties', () => {
-		L.extend(posStart, {
+		extend(posStart, {
 			screenX: 2,
 			screenY: 2,
 		});
@@ -158,7 +161,7 @@ describe('Map.TapHoldSpec.js', () => {
 		clock.tick(650);
 
 		const originalEvent = spy.lastCall.args[0].originalEvent;
-		const expectedProps = L.extend({
+		const expectedProps = extend({
 			type: 'contextmenu',
 			bubbles: true,
 			cancelable: true,

--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -1,9 +1,12 @@
+import {LatLng, Map, Polygon, Rectangle} from 'leaflet';
+import {createContainer, removeMapContainer, touchEventType} from '../../SpecHelper.js';
+
 describe('Map.TouchZoom', () => {
 	let container, map;
 
 	beforeEach(() => {
 		container = createContainer();
-		map = L.map(container, {
+		map = new Map(container, {
 			touchZoom: true,
 			inertia: false,
 			zoomAnimation: false	// If true, the test has to wait extra 250msec
@@ -18,7 +21,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('Increases zoom when pinching out', (done) => {
 		map.setView([0, 0], 1);
 		map.once('zoomend', () => {
-			expect(map.getCenter().equals(L.latLng({lat:0, lng:0}))).to.be.true;
+			expect(map.getCenter().equals(new LatLng(0, 0))).to.be.true;
 			// Initial zoom 1, initial distance 50px, final distance 450px
 			expect(map.getZoom()).to.equal(4);
 
@@ -39,7 +42,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('Decreases zoom when pinching in', (done) => {
 		map.setView([0, 0], 4);
 		map.once('zoomend', () => {
-			expect(map.getCenter().equals(L.latLng({lat:0, lng:0}))).to.be.true;
+			expect(map.getCenter().equals(new LatLng(0, 0))).to.be.true;
 			// Initial zoom 4, initial distance 450px, final distance 50px
 			expect(map.getZoom()).to.equal(1);
 
@@ -71,14 +74,14 @@ describe('Map.TouchZoom', () => {
 			expect(spy.callCount > 1).to.be.true;
 			expect(pinchZoomEvent).to.be.true;
 
-			expect(map.getCenter().equals(L.latLng({lat:0, lng:0}))).to.be.true;
+			expect(map.getCenter().equals(new LatLng(0, 0))).to.be.true;
 			// Initial zoom 4, initial distance 450px, final distance 50px
 			expect(map.getZoom()).to.equal(1);
 
 			done();
 		});
 
-		L.rectangle(map.getBounds().pad(-0.2)).addTo(map);
+		new Rectangle(map.getBounds().pad(-0.2)).addTo(map);
 
 		const hand = new Hand({timing: 'fastframe'});
 		const f1 = hand.growFinger(touchEventType);
@@ -94,7 +97,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('Dragging is possible after pinch zoom', (done) => {
 		map.setView([0, 0], 8);
 
-		L.polygon([
+		new Polygon([
 			[0, 0],
 			[0, 1],
 			[1, 1],
@@ -121,7 +124,7 @@ describe('Map.TouchZoom', () => {
 			.down().moveBy(-200, 0, 500).up(100);
 
 		f1.wait(100).moveTo(200, 300, 0).down()
-			.moveBy(5, 0, 20) // We move 5 pixels first to overcome the 3-pixel threshold of L.Draggable (fastframe)
+			.moveBy(5, 0, 20) // We move 5 pixels first to overcome the 3-pixel threshold of Draggable (fastframe)
 			.moveBy(-150, 0, 200) // Dragging
 			.up();
 
@@ -130,7 +133,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('TouchZoom works with disabled map dragging', (done) => {
 		map.remove();
 
-		map = new L.Map(container, {
+		map = new Map(container, {
 			touchZoom: true,
 			inertia: false,
 			zoomAnimation: false,	// If true, the test has to wait extra 250msec,
@@ -139,7 +142,7 @@ describe('Map.TouchZoom', () => {
 
 		map.setView([0, 0], 4);
 		map.once('zoomend', () => {
-			expect(map.getCenter().equals(L.latLng({lat:0, lng:0}))).to.be.true;
+			expect(map.getCenter().equals(new LatLng(0, 0))).to.be.true;
 			// Initial zoom 4, initial distance 450px, final distance 50px
 			expect(map.getZoom()).to.equal(1);
 
@@ -160,7 +163,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is true', (done) => {
 		map.remove();
 
-		map = new L.Map(container, {
+		map = new Map(container, {
 			touchZoom: true,
 			inertia: false,
 			zoomAnimation: true
@@ -168,7 +171,7 @@ describe('Map.TouchZoom', () => {
 
 		map.setView([0, 0], 8);
 
-		const polygon = L.polygon([
+		const polygon = new Polygon([
 			[0, 0],
 			[0, 1],
 			[1, 1],
@@ -222,7 +225,7 @@ describe('Map.TouchZoom', () => {
 	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is false', (done) => {
 		map.remove();
 
-		map = new L.Map(container, {
+		map = new Map(container, {
 			touchZoom: true,
 			inertia: false,
 			zoomAnimation: false
@@ -230,7 +233,7 @@ describe('Map.TouchZoom', () => {
 
 		map.setView([0, 0], 8);
 
-		const polygon = L.polygon([
+		const polygon = new Polygon([
 			[0, 0],
 			[0, 1],
 			[1, 1],


### PR DESCRIPTION
Follow up on #8936. I think we should land these changes, even if they potentially slow down test runs on CI. I've tested this locally, and I see little to no performance changes during development.

Doing a single test run, and measuring it's duration with the `time npm test` command yields the following:

**Karma (on `main`)**
```log
real	0m11.794s
user	0m0.826s
sys	0m0.229s
```

**Karma (this PR)**
```log
real	0m11.797s
user	0m0.812s
sys	0m0.251s
```

I also did some work to get Web Test Runner integrated (not part of this PR), and I have most of the test suite passing now (still working on fixing up `prosthetic-hand`). Just from some of my testing locally, I can see that it runs the tests much faster than on Karma:

**Web Test Runner**
```log
real 0m2.827s
user 0m2.233s
sys 0m0.276s
```