### PR TITLE
Add Terra Draw to plugins list under edit geometries

### DIFF
--- a/docs/_plugins/edit-geometries/terra-draw.md
+++ b/docs/_plugins/edit-geometries/terra-draw.md
@@ -1,0 +1,12 @@
+---
+name: Terra Draw
+category: edit-geometries
+repo: https://github.com/JamesLMilner/terra-draw
+author: James Milner
+author-url: https://github.com/JamesLMilner
+demo: https://terradraw.io
+compatible-v0: false
+compatible-v1: true
+---
+
+Terra Draw's TerraDrawLeafletAdapter allows users to create, select and edit a variety of geometry types (points, lines polygons etc) on a Leaflet map.


### PR DESCRIPTION
Adds [terra-draw](https://www.github.com/JamesLMilner) as a plugin under the edit geometries section. 