### PR TITLE
Include `prosthetic-hand` from GitHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "leafdoc": "^2.3.0",
         "lint-staged": "^13.0.3",
         "mocha": "^10.0.0",
-        "prosthetic-hand": "^1.4.0",
+        "prosthetic-hand": "github:Leaflet/prosthetic-hand",
         "rollup": "^3.2.1",
         "rollup-plugin-git-version": "^0.3.1",
         "simple-git": "^3.14.1",
@@ -5218,9 +5218,9 @@
     },
     "node_modules/prosthetic-hand": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/prosthetic-hand/-/prosthetic-hand-1.4.0.tgz",
-      "integrity": "sha512-H0YgNfPFkO6x00Viw8+6LnqYisivAt8i3enoLnCxRUlT80DM/9i99BVBcKGUosPJ635CxlJMsYbjYLHCFpvF2w==",
-      "dev": true
+      "resolved": "git+ssh://git@github.com/Leaflet/prosthetic-hand.git#67fbb5d483e3b89a84f694522be77a0f185ee4ea",
+      "dev": true,
+      "license": "Beerware"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "leafdoc": "^2.3.0",
     "lint-staged": "^13.0.3",
     "mocha": "^10.0.0",
-    "prosthetic-hand": "^1.4.0",
+    "prosthetic-hand": "github:Leaflet/prosthetic-hand",
     "rollup": "^3.2.1",
     "rollup-plugin-git-version": "^0.3.1",
     "simple-git": "^3.14.1",

--- a/spec/context.html
+++ b/spec/context.html
@@ -13,6 +13,7 @@ Reloaded before every execution run.
     {
       "imports": {
         "leaflet": "/base/dist/leaflet-src.esm.js",
+        "prosthetic-hand": "/base/node_modules/prosthetic-hand/lib/Hand.js",
         "ui-event-simulator": "/base/node_modules/ui-event-simulator/ui-event-simulator.js"
       }
     }

--- a/spec/debug.html
+++ b/spec/debug.html
@@ -15,6 +15,7 @@ just for immediate execution, without reporting to Karma server.
     {
       "imports": {
         "leaflet": "/base/dist/leaflet-src.esm.js",
+        "prosthetic-hand": "/base/node_modules/prosthetic-hand/lib/Hand.js",
         "ui-event-simulator": "/base/node_modules/ui-event-simulator/ui-event-simulator.js"
       }
     }

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -18,8 +18,7 @@ module.exports = function (/** @type {import('karma').Config} */ config) {
 		customContextFile: 'spec/context.html',
 		customDebugFile: 'spec/debug.html',
 		files: [
-			{pattern: 'node_modules/ui-event-simulator/*', included: false, served: true},
-			'node_modules/prosthetic-hand/dist/prosthetic-hand.js',
+			{pattern: 'node_modules/**', included: false, served: true},
 			{pattern: 'dist/**/*.js', included: false, served: true},
 			{pattern: 'dist/**/*.png', included: false, served: true},
 			{pattern: 'spec/setup.js', type: 'module'},

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -1,4 +1,5 @@
-import {Map, Popup, Marker, FeatureGroup, Point, Icon, DivIcon, DomUtil, Polygon} from 'leaflet';
+import {DivIcon, DomUtil, FeatureGroup, Icon, Map, Marker, Point, Polygon, Popup} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -1,4 +1,5 @@
 import {CircleMarker, FeatureGroup, LayerGroup, Map, Marker, Polygon, Polyline, Rectangle, Tooltip} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -1,4 +1,5 @@
-import {Map, Marker, DomUtil, Point} from 'leaflet';
+import {DomUtil, Map, Marker, Point} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Marker.Drag', () => {

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -1,4 +1,5 @@
-import {Map, Polygon, DomEvent, Marker, Circle, SVG, stamp, Util, Polyline, LayerGroup, Canvas} from 'leaflet';
+import {Canvas, Circle, DomEvent, LayerGroup, Map, Marker, Polygon, Polyline, SVG, Util, stamp} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -1,4 +1,5 @@
-import {Map, DomUtil, Point, LatLng, Marker} from 'leaflet';
+import {DomUtil, LatLng, Map, Marker, Point} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer, touchEventType} from '../../SpecHelper.js';
 

--- a/spec/suites/map/handler/Map.TouchZoomSpec.js
+++ b/spec/suites/map/handler/Map.TouchZoomSpec.js
@@ -1,4 +1,5 @@
 import {LatLng, Map, Polygon, Rectangle} from 'leaflet';
+import Hand from 'prosthetic-hand';
 import {createContainer, removeMapContainer, touchEventType} from '../../SpecHelper.js';
 
 describe('Map.TouchZoom', () => {


### PR DESCRIPTION
Since we still have to refactor more of `prosthetic-hand` we cannot do a release at this point. So in the mean time, we can include it directly from GitHub until we feel it's stable enough for a new release.

Needed to include  https://github.com/Leaflet/prosthetic-hand/pull/41