### PR TITLE
Do not propagate click when element has been removed from dom

### DIFF
--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -308,6 +308,21 @@ describe('Popup', () => {
 		expect(map.hasLayer(layer._popup)).to.be.true;
 	});
 
+
+	it('can change popup content with a click on removed DOM', () => {
+		const popup = new Popup()
+			.setLatLng(center)
+			.setContent('<p onclick="this.parentNode.innerHTML = \'changed\'">initial</p>')
+			.openOn(map);
+
+
+		UIEventSimulator.fire('click', popup._container.querySelector('p'));
+
+		expect(popup._container.innerHTML).to.not.contain('initial');
+		expect(popup._container.innerHTML).to.contain('changed');
+		expect(map.hasLayer(popup)).to.be.true;
+	});
+
 	describe('autoPan option should pan popup into visibility', () => {
 		// Helper function which calculates the offset of the map-container & popup-container in pixel
 		function getPopupOffset(map, popup) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1389,7 +1389,7 @@ export const Map = Evented.extend({
 
 	_isClickDisabled(el) {
 		while (el && el !== this._container) {
-			if (el['_leaflet_disable_click']) { return true; }
+			if (el['_leaflet_disable_click'] || !el.parentNode) { return true; }
 			el = el.parentNode;
 		}
 	},


### PR DESCRIPTION
This fixes an edge case where, when the initial click target element is removed (or one of its parents) during the click listener processing, then that click will not be disabled, and thus transmitted to the map.

A concrete exemple would be a popup with a clickable button that would replace the popup content on click. In this case, the click event will be transmitted to the map, which will then close the popup (as for any normal click on the map when a popup is open).

According to my bisecting, this has been introduced in https://github.com/Leaflet/Leaflet/commit/e87ed0cea0ac06199dbb9b1c56817d45901792fd