### PR TITLE
#9059 Fix - Removed convoluted map-moving / tooltip showing logic

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -417,15 +417,6 @@ Layer.include({
 			return;
 		}
 
-		// If the map is moving, we will show the tooltip after it's done.
-		if (this._map.dragging && this._map.dragging.moving() && !this._openOnceFlag) {
-			this._openOnceFlag = true;
-			this._map.once('moveend', () => {
-				this._openOnceFlag = false;
-				this._openTooltip(e);
-			});
-			return;
-		}
 
 		this._tooltip._source = e.layer || e.target;
 

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -351,6 +351,7 @@ Layer.include({
 	// Closes the tooltip bound to this layer if it is open.
 	closeTooltip() {
 		if (this._tooltip) {
+			this._map._openOnce  = true;
 			return this._tooltip.close();
 		}
 	},
@@ -416,7 +417,15 @@ Layer.include({
 		if (!this._tooltip || !this._map) {
 			return;
 		}
-
+		// If the map is moving, we will show the tooltip after it's done.
+		if (this._map.dragging && this._map.dragging.moving() && !this.map._openOnce) {
+			this._map._openOnce = true;
+			this._map.once('moveend', () => {
+				this._map._openOnce = false;
+				this._openTooltip(e);
+			});
+			return;
+		}
 
 		this._tooltip._source = e.layer || e.target;
 


### PR DESCRIPTION
Code was deemed to be unecessary and leads to multiple tooltips showing up at once. Removing allows for clean functionality. 

Fixes: #9059