### PR TITLE
Add "Leaflet.a11y" to the plugin list

### DIFF
--- a/docs/_plugins/frameworks-build-systems/leaflet-a11y.md
+++ b/docs/_plugins/frameworks-build-systems/leaflet-a11y.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.a11y
+category: frameworks-build-systems
+repo: https://github.com/nfreear/leaflet.a11y
+author: Nick Freear
+author-url: https://nick.freear.org.uk/
+demo: https://nfreear.github.io/leaflet.a11y/
+compatible-v0:
+compatible-v1: true
+---
+
+An accessibility and localization/translation plugin for Leaflet.


### PR DESCRIPTION
Hi,

This is an accessibility and localization/ translation plugin for Leaflet. Please can it be added to the [plugin list][] on the site?

The plugin does _not_ replace [accessibility][] efforts in [core Leaflet][bugs]. It is a means to provide interim fixes, and potentially test fixes.

* Code: [github.com - @nfreear/leaflet.a11y](https://github.com/nfreear/leaflet.a11y)

Thank you!

Nick

[plugin list]: https://leafletjs.com/plugins.html
[accessibility]: https://leafletjs.com/examples/accessibility/
[bugs]: https://github.com/Leaflet/Leaflet/labels/accessibility
