### PR TITLE
Possibility to refresh GridLayer tiles

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -272,6 +272,17 @@ export const GridLayer = Layer.extend({
 		return document.createElement('div');
 	},
 
+	// @method refreshTiles: void
+	// Triggers creating of new tile HTML element for each existing tile
+	refreshTiles() {
+		for (const key in this._tiles) {
+			if (Object.hasOwn(this._tiles, key)) {
+				const tile = this._tiles[key];
+				this._initTileElement(tile.coords, this._tileUpdate.bind(this, tile));
+			}
+		}
+	},
+
 	// @section
 	// @method getTileSize: Point
 	// Normalizes the [tileSize option](#gridlayer-tilesize) into a point. Used by the `createTile()` method.
@@ -794,6 +805,24 @@ export const GridLayer = Layer.extend({
 		});
 	},
 
+	_initTileElement(coords, done) {
+		const el = this.createTile(this._wrapCoords(coords), done);
+
+		this._initTile(el);
+
+		// if createTile is defined with a second argument ("done" callback),
+		// we know that tile is async and will be ready later; otherwise
+		if (this.createTile.length < 2) {
+			// mark tile as ready, but delay one frame for opacity animation to happen
+			Util.requestAnimFrame(done.bind(this, null, el));
+		}
+
+		const tilePos = this._getTilePos(coords);
+		DomUtil.setPosition(el, tilePos);
+
+		return el;
+	},
+
 	_initTile(tile) {
 		tile.classList.add('leaflet-tile');
 
@@ -806,34 +835,22 @@ export const GridLayer = Layer.extend({
 	},
 
 	_addTile(coords, container) {
-		const tilePos = this._getTilePos(coords),
-		    key = this._tileCoordsToKey(coords);
+		const el = this._initTileElement(coords, this._tileReady.bind(this, coords));
 
-		const tile = this.createTile(this._wrapCoords(coords), this._tileReady.bind(this, coords));
-
-		this._initTile(tile);
-
-		// if createTile is defined with a second argument ("done" callback),
-		// we know that tile is async and will be ready later; otherwise
-		if (this.createTile.length < 2) {
-			// mark tile as ready, but delay one frame for opacity animation to happen
-			Util.requestAnimFrame(this._tileReady.bind(this, coords, null, tile));
-		}
-
-		DomUtil.setPosition(tile, tilePos);
+		const key = this._tileCoordsToKey(coords);
 
 		// save tile in cache
 		this._tiles[key] = {
-			el: tile,
+			el,
 			coords,
 			current: true
 		};
 
-		container.appendChild(tile);
+		container.appendChild(el);
 		// @event tileloadstart: TileEvent
 		// Fired when a tile is requested and starts loading.
 		this.fire('tileloadstart', {
-			tile,
+			tile: el,
 			coords
 		});
 	},
@@ -889,6 +906,27 @@ export const GridLayer = Layer.extend({
 				setTimeout(this._pruneTiles.bind(this), 250);
 			}
 		}
+	},
+
+	_tileUpdate(tile, err, el) {
+		if (err) {
+			this.fire('tileerror', {
+				error: err,
+				tile: el,
+				coords: tile.coords
+			});
+			return;
+		}
+
+		el.classList.add('leaflet-tile-loaded');
+		tile.el.replaceWith(el);
+		tile.el = el;
+		tile.loaded = +new Date();
+
+		this.fire('tileupdate', {
+			tile: el,
+			coords: tile.coords
+		});
 	},
 
 	_getTilePos(coords) {


### PR DESCRIPTION
Hi, please consider the possibility to merge this PR.

**Background**
We are happy to use Leaflet in our Karelics.Cloud platform. One problem we faced with is map tiles update. If map was changed and client wants to update tiles the only available GridLayer method is 'redraw' - it deletes all tiles and creates them back. Blinking caused by tiles removal looks bad in case updates happen often.

**What was done**
In general, GridLayer logic was not touched. Just piece of code was extracted from __addTile_ into __initTileElement_ method to be reused.
Only new thing is method **_reloadTiles_**. It creates new HTML elements for each existing tile and replaces tile's HTML element with new one on success. There is no tile removal, so visually this way to update tiles looks much better.

Give me know in case some edge case was not considered. Thanks!