### PR TITLE
Fix closest layer point edge case

### DIFF
--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -88,19 +88,19 @@ export const Polyline = Path.extend({
 	// Returns the point closest to `p` on the Polyline.
 	closestLayerPoint(p) {
 		let minDistance = Infinity,
-			minPoint = null,
-			p1, p2;
+		minPoint = null,
+		p1, p2;
 		const closest = LineUtil._sqClosestPointOnSegment;
-	
+
 		for (let j = 0, jLen = this._parts.length; j < jLen; j++) {
 			const points = this._parts[j];
-	
+
 			for (let i = 1, len = points.length; i <= len; i++) {
 				p1 = points[i - 1];
 				p2 = points[i % len];
-	
+
 				const sqDist = closest(p, p1, p2, true);
-	
+
 				if (sqDist < minDistance) {
 					minDistance = sqDist;
 					minPoint = closest(p, p1, p2);

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -88,19 +88,19 @@ export const Polyline = Path.extend({
 	// Returns the point closest to `p` on the Polyline.
 	closestLayerPoint(p) {
 		let minDistance = Infinity,
-		    minPoint = null,
-		    p1, p2;
+			minPoint = null,
+			p1, p2;
 		const closest = LineUtil._sqClosestPointOnSegment;
-
+	
 		for (let j = 0, jLen = this._parts.length; j < jLen; j++) {
 			const points = this._parts[j];
-
-			for (let i = 1, len = points.length; i < len; i++) {
+	
+			for (let i = 1, len = points.length; i <= len; i++) {
 				p1 = points[i - 1];
-				p2 = points[i];
-
+				p2 = points[i % len];
+	
 				const sqDist = closest(p, p1, p2, true);
-
+	
 				if (sqDist < minDistance) {
 					minDistance = sqDist;
 					minPoint = closest(p, p1, p2);


### PR DESCRIPTION
This pull request addresses an edge case in the closestLayerPoint function where it did not properly consider the segment between the last and first points of a Polygon.

Details:

    Identified that the closestLayerPoint function was missing the edge case where the point could be on the segment between the last and first points of a Polygon.
    Modified the iteration logic to ensure this segment is also evaluated when finding the closest layer point.

Testing:

    Set up a local test environment with a triangle polygon and markers. Confirmed that the function now correctly identifies points on the edge between the last and first points of the Polygon.
    All existing tests pass, and no regressions were identified.

Related Issues:

    Fixes  #9098 