### PR TITLE
fix: The map container needs an accessible name (#9119)

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -249,6 +249,13 @@ describe('Map', () => {
 				map2.remove(); // clean up
 				expect(zoom).to.equal(13);
 			});
+
+			it('should have an accessible name [a11y]', () => {
+				const container = map.getContainer();
+				const name = container.getAttribute('aria-label');
+
+				expect(name).to.equal('Map');
+			});
 		});
 
 		it('changes previous zoom level', () => {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -69,6 +69,11 @@ export const Map = Evented.extend({
 		// [`setMaxBounds`](#map-setmaxbounds) method.
 		maxBounds: undefined,
 
+		// @option name: String = 'Map'
+		// Short text for the `aria-label` attribute of the map container.
+		// [Useful for accessibility](https://leafletjs.com/examples/accessibility/).
+		name: 'Map',
+
 		// @option renderer: Renderer = *
 		// The default method for drawing vector layers on the map. `L.SVG`
 		// or `L.Canvas` by default depending on browser support.
@@ -1116,6 +1121,11 @@ export const Map = Evented.extend({
 
 		if (position !== 'absolute' && position !== 'relative' && position !== 'fixed' && position !== 'sticky') {
 			container.style.position = 'relative';
+		}
+
+		// Give the container an accessible name [accessibility, a11y]
+		if (!container.hasAttribute('aria-label')) {
+			container.setAttribute('aria-label', this.options.name);
 		}
 
 		this._initPanes();


### PR DESCRIPTION
Hi,

This pull request fixes #9119.

* File affected:  `src/map/Map.js`
* Map option: `title` (default, title = "Map") (Was: `name`)
* It includes a unit test: `spec/suites/map/MapSpec.js`

Feedback welcome!

Nick