### PR TITLE
Fix tooltip init on once moveend

### DIFF
--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -422,7 +422,7 @@ Layer.include({
 			this._openOnceFlag = true;
 			this._map.once('moveend', () => {
 				this._openOnceFlag = false;
-				this._openTooltip(e);
+				this._initTooltipInteractions();
 			});
 			return;
 		}


### PR DESCRIPTION
Fix for https://github.com/Leaflet/Leaflet/issues/9059

The fix for this issue seems to still be working https://github.com/Leaflet/Leaflet/pull/8672

Description: this fixes the issue where a tooltip would pop open while the map is being dragged and stay open (until hovered over again) if hovered over a marker while having a tooltip open next to it.

Notes: I looked into the functionality of `__openTooltip()` by invoking it, and this seems to be the culprit. The tooltip would open and not close. When I used `_initTooltipInteractions()`, it seemed to fix the issue, because then it would just open it if needed to, but keep it closed if not hovered over.