### PR TITLE
Fixes showing tooltip while panning the map

### DIFF
--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -456,7 +456,7 @@ describe('Tooltip', () => {
 		expect(eventSpy.calledOnce).to.be.true;
 	});
 
-	it('don\'t opens the tooltip on marker mouseover while dragging map', () => {
+	it('don\'t opens the tooltip on marker mouseover while dragging map', (done) => {
 		// Sometimes the mouse is moving faster then the map while dragging and then the marker can be hover and
 		// the tooltip opened / closed.
 		const layer = new Marker(center).addTo(map).bindTooltip('Tooltip');
@@ -469,11 +469,20 @@ describe('Tooltip', () => {
 		expect(tooltip.isOpen()).to.be.false;
 
 		// simulate map not dragging anymore
-		map.dragging.moving = function () {
-			return false;
-		};
-		UIEventSimulator.fireAt('mouseover', 210, 195);
-		expect(tooltip.isOpen()).to.be.true;
+		map.dragging.moving = () => false;
+
+		map.on('moveend', () => {
+			expect(tooltip.isOpen()).to.be.false;
+
+			UIEventSimulator.fireAt('mouseover', 210, 195);
+			expect(tooltip.isOpen()).to.be.true;
+
+			done();
+		});
+
+		// calls moveend and triggers openTooltip if the layer was added to the map
+		map.setView(map.getCenter());
+
 	});
 
 	it('closes the tooltip on marker mouseout while dragging map and don\'t open it again', () => {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -418,12 +418,14 @@ Layer.include({
 		}
 
 		// If the map is moving, we will show the tooltip after it's done.
-		if (this._map.dragging && this._map.dragging.moving() && !this._openOnceFlag) {
-			this._openOnceFlag = true;
-			this._map.once('moveend', () => {
-				this._openOnceFlag = false;
-				this._openTooltip(e);
-			});
+		if (this._map.dragging && this._map.dragging.moving()) {
+			if (e.type === 'add' && !this._moveEndOpensTooltip) {
+				this._moveEndOpensTooltip = true;
+				this._map.once('moveend', () => {
+					this._moveEndOpensTooltip = false;
+					this._openTooltip(e);
+				});
+			}
 			return;
 		}
 


### PR DESCRIPTION
Fixes #9059

The problem was that this code should only apply to new added layers #8591 and not for existing layers with tooltips. This is now solved by checking for the `add` event.

supersedes: #9137, #9065

@dscarb21 & @HappyViki feel free to let a review here
