### PR TITLE
Set `versioning-strategy` for NPM to `increase`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /
     open-pull-requests-limit: 999
     rebase-strategy: disabled
+    versioning-strategy: increase
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
Sets the [`versioning-strategy`](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) for NPM dependencies managed by Dependabot to `increase`. This will force Dependabot to update both the `package.json` and `package-lock.json` file when a new version of a dependency is available. This should avoid the need to bump these version ranges manually in the package file as per #9157.