### PR TITLE
Speed up Karma runner by narrowing down files Karma serves

### DIFF
--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function (/** @type {import('karma').Config} */ config) {
 		customContextFile: 'spec/context.html',
 		customDebugFile: 'spec/debug.html',
 		files: [
-			{pattern: 'node_modules/**', included: false, served: true},
+			{pattern: 'node_modules/ui-event-simulator/**/*.js', included: false, served: true},
+			{pattern: 'node_modules/prosthetic-hand/**/*.js', included: false, served: true},
 			{pattern: 'dist/**/*.js', included: false, served: true},
 			{pattern: 'dist/**/*.png', included: false, served: true},
 			{pattern: 'spec/setup.js', type: 'module'},


### PR DESCRIPTION
- Fix CI warnings about too many files open by excluding Karma from serving the whole of `node_modules`; this also seems to speed up CI runs, shaving off about a minute.
- ~~Skip `requestAnimFrame` test for now because it fails on Windows for mystery reasons https://github.com/Leaflet/Leaflet/issues/9230 — at this moment it's more important to have a functioning CI that's not red all the time.~~