### PR TITLE
Fix CI tests to not depend on big Chrome window size

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,13 +102,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - browser: Chrome1280x1024
-          - browser: FirefoxTouch
+          - browser: Chrome
+          - browser: Firefox
           - browser: FirefoxNoTouch
           - browser: FirefoxRetina
-          - browser: Chrome1280x1024
+          - browser: Chrome
             os: windows-latest
-          - browser: Chrome1280x1024
+          - browser: Chrome
             os: macos-latest
           - browser: SafariNative
             os: macos-latest

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -39,15 +39,12 @@ module.exports = function (/** @type {import('karma').Config} */ config) {
 			longestTestsCount: 10
 		},
 		logLevel: config.LOG_WARN,
-		browsers: ['Chrome1280x1024'],
+		browsers: ['Chrome'],
 		customLaunchers: {
-			'Chrome1280x1024': {
-				base: 'ChromeHeadless',
-				// increased viewport is required for some tests (TODO fix tests)
-				// https://github.com/Leaflet/Leaflet/issues/7113#issuecomment-619528577
-				flags: ['--window-size=1280,1024']
+			'Chrome': {
+				base: 'ChromeHeadless'
 			},
-			'FirefoxTouch': {
+			'Firefox': {
 				base: 'FirefoxHeadless',
 				prefs: {
 					'dom.w3c_touch_events.enabled': 1

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -34,7 +34,7 @@ describe('Marker.Drag', () => {
 			const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 
 			const start = new Point(300, 280);
-			const offset = new Point(256, 32);
+			const offset = new Point(56, 32);
 			const finish = start.add(offset);
 
 			const hand = new Hand({
@@ -43,7 +43,7 @@ describe('Marker.Drag', () => {
 					expect(marker.getOffset().equals(offset)).to.be.true;
 
 					expect(map.getCenter()).to.be.nearLatLng([0, 0]);
-					expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 360]);
+					expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 78.75]);
 
 					done();
 				}
@@ -66,7 +66,7 @@ describe('Marker.Drag', () => {
 				const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 
 				const start = new Point(300, 280);
-				const offset = new Point(256, 32);
+				const offset = new Point(56, 32);
 				const finish = start.add(offset);
 
 				const hand = new Hand({
@@ -75,7 +75,7 @@ describe('Marker.Drag', () => {
 						expect(marker.getOffset()).to.eql(offset);
 
 						expect(map.getCenter()).to.be.nearLatLng([0, 0]);
-						expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 360]);
+						expect(marker.getLatLng()).to.be.nearLatLng([-40.979898069620134, 78.75]);
 
 						done();
 					}

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -107,7 +107,7 @@ describe('Map.Drag', () => {
 				map.setView([0, 0], 1);
 
 				const start = new Point(200, 200);
-				const offset = new Point(256, 32);
+				const offset = new Point(56, 32);
 				const finish = start.add(offset);
 
 				const hand = new Hand({
@@ -116,7 +116,7 @@ describe('Map.Drag', () => {
 						expect(map.getOffset()).to.eql(offset);
 
 						expect(map.getZoom()).to.equal(1);
-						expect(map.getCenter()).to.be.nearLatLng([21.943045533, -180]);
+						expect(map.getCenter()).to.be.nearLatLng([21.943045533, -39.375]);
 
 						done();
 					}


### PR DESCRIPTION
Removes the workaround for this https://github.com/Leaflet/Leaflet/issues/7113#issuecomment-619528577
Should make the tests slightly faster and look nicer.