### PR TITLE
Remove legacy timer fallbacks for `requestAnimFrame`

### DIFF
--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -162,33 +162,15 @@ function getPrefixed(name) {
 	return window[`webkit${name}`] || window[`moz${name}`] || window[`ms${name}`];
 }
 
-let lastTime = 0;
+export const requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame');
+export const cancelFn = window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') || getPrefixed('CancelRequestAnimationFrame');
 
-// fallback for IE 7-8
-function timeoutDefer(fn) {
-	const time = +new Date(),
-	    timeToCall = Math.max(0, 16 - (time - lastTime));
-
-	lastTime = time + timeToCall;
-	return window.setTimeout(fn, timeToCall);
-}
-
-export const requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer;
-export const cancelFn = window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
-		getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); };
-
-// @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): Number
-// Schedules `fn` to be executed when the browser repaints. `fn` is bound to
-// `context` if given. When `immediate` is set, `fn` is called immediately if
-// the browser doesn't have native support for
-// [`window.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame),
-// otherwise it's delayed. Returns a request ID that can be used to cancel the request.
-export function requestAnimFrame(fn, context, immediate) {
-	if (immediate && requestFn === timeoutDefer) {
-		fn.call(context);
-	} else {
-		return requestFn.call(window, fn.bind(context));
-	}
+// @function requestAnimFrame(fn: Function, context?: Object): Number
+// Schedules `fn` to be executed when the browser repaints. `fn` is bound to `context` if given.
+// See [`window.requestAnimationFrame`](https://developer.mozilla.org/docs/Web/API/window/requestAnimationFrame).
+// Returns a request ID that can be used to cancel the request.
+export function requestAnimFrame(fn, context) {
+	return requestFn.call(window, fn.bind(context));
 }
 
 // @function cancelAnimFrame(id: Number): undefined

--- a/src/map/handler/Map.TouchZoom.js
+++ b/src/map/handler/Map.TouchZoom.js
@@ -97,7 +97,7 @@ export const TouchZoom = Handler.extend({
 		Util.cancelAnimFrame(this._animRequest);
 
 		const moveFn = map._move.bind(map, this._center, this._zoom, {pinch: true, round: false}, undefined);
-		this._animRequest = Util.requestAnimFrame(moveFn, this, true);
+		this._animRequest = Util.requestAnimFrame(moveFn, this);
 
 		DomEvent.preventDefault(e);
 	},


### PR DESCRIPTION
Just some leftover — we no longer support IE7-8 so it's irrelevant.