### PR TITLE
Updated leaflet-graphicscale information in plugin documentation

### DIFF
--- a/docs/_plugins/measurement/leafletgraphicscale.md
+++ b/docs/_plugins/measurement/leafletgraphicscale.md
@@ -1,12 +1,12 @@
 ---
 name: leaflet-graphicscale
 category: measurement
-repo: https://github.com/nerik/leaflet-graphicscale
-author: Erik Escoffier
-author-url: https://github.com/nerik
-demo: https://nerik.github.io/leaflet-graphicscale/demo/
+repo: https://github.com/kalisio/leaflet-graphicscale
+author: Kalisio contributors, Erik Escoffier
+author-url: https://github.com/kalisio
+demo: https://kalisio.github.io/leaflet-graphicscale
 compatible-v0:
 compatible-v1: true
 ---
 
-Animated graphic scale control.
+Configurable and animated graphic scale control.


### PR DESCRIPTION
Updated leaflet-graphicscale information to target active fork as original repository is not maintained anymore.