### PR TITLE
Fix hover underline in flag + Leaflet attribution prefix

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -397,6 +397,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	vertical-align: baseline !important;
 	width: 1em;
 	height: 0.6669em;
+	margin-right: 0.277em;
 	}
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -27,7 +27,7 @@ export const Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: `<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag} Leaflet</a>`
+		prefix: `<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
 	},
 
 	initialize(options) {


### PR DESCRIPTION
When hovering the Leaflet attribution link that is shown by default on the bottom right of the map, the underline was extending to the space between the flag and the "Leaflet" text, which does not look very nice (see "before" screenshot below). This is fixed by:
- Removing the space between the flag and the "Leaflet" text
- Adding a margin-right that corresponds to the width of the removed space to the `leaflet-attribution-flag` CSS class

The value for the margin-right (0.277em) is based on measuring the width of the space using browser dev tools:
- The font size for the attribution is 12px by default, i.e. 1px = 1/12em
- The browser dev tools measured 3.333px width for the space
- 3.333px = 3.333/12em = 0.277em

## Screenshots

Showing the bottom right corner of `debug/tests/esm.html` with Firefox responsive design mode at 820x620px with DPR 3.

### Before (main branch)

![attribution_main](https://github.com/Leaflet/Leaflet/assets/3082173/30c32808-613d-4e1c-b2b2-f9ba0fd6b946)

### After (this PR)

![attribution_PR](https://github.com/Leaflet/Leaflet/assets/3082173/c83fc69b-301a-461d-9b79-15427d0a7987)
