### PR TITLE
Remove unused test globals from ESLint config

### DIFF
--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -6,11 +6,5 @@ module.exports = {
 	},
 	env: {
 		mocha: true,
-	},
-	globals: {
-		expect: false,
-		chai: false,
-		sinon: false,
-		Hand: false,
 	}
 };


### PR DESCRIPTION
Removes some of the global variables from the ESLint configuration of the tests, as these are now imported from modules instead.