### PR TITLE
Docs: add 3rd-party ha-map-card

### DIFF
--- a/docs/_plugins/3rd-party-integration/ha-map-card.md
+++ b/docs/_plugins/3rd-party-integration/ha-map-card.md
@@ -1,0 +1,11 @@
+---
+name: HA Map Card
+category: 3rd-party-integration
+repo: https://github.com/nathan-gs/ha-map-card
+author: Nathan Bijnens
+author-url: https://nathan.gs
+demo: 
+compatible-v0:
+compatible-v1: true
+---
+A [Home Assistant](https://www.home-assistant.io/) map-card based on Leaflet, it contains more advanced features then the stock map-card (also based on Leaflet). 


### PR DESCRIPTION
I want to include the leaflet based ha-map-card.