### PR TITLE
Add a plugin: Leaflet.SimpleLocate

### DIFF
--- a/docs/_plugins/geolocation/leaflet-simple-locate.md
+++ b/docs/_plugins/geolocation/leaflet-simple-locate.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.SimpleLocate
+category: geolocation
+repo: https://github.com/mfhsieh/leaflet-simple-locate/
+author: mfhsieh
+author-url: https://github.com/mfhsieh
+demo: https://mfhsieh.github.io/leaflet-simple-locate/
+compatible-v0:
+compatible-v1: true
+---
+
+A Leaflet plugin displaying device location and orientation on the map, with orientation adjusted according to screen rotation.


### PR DESCRIPTION
A Leaflet plugin displaying device location and orientation on the map, with orientation adjusted according to screen rotation. Tested on desktop and mobile versions of Chrome, Edge, Firefox, and Safari.

* Demo Page: [demo](https://mfhsieh.github.io/leaflet-simple-locate/) (Click the button on the demo page to activate, double-click to deactivate.)