### PR TITLE
Add a plugin: Leaflet.BootstrapDropdowns

### DIFF
--- a/docs/_plugins/user-interface/leaflet-bootstrap-dropdowns.md
+++ b/docs/_plugins/user-interface/leaflet-bootstrap-dropdowns.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.BootstrapDropdowns
+category: user-interface
+repo: https://github.com/mfhsieh/leaflet-bootstrap-dropdowns/
+author: mfhsieh
+author-url: https://github.com/mfhsieh
+demo: https://mfhsieh.github.io/leaflet-bootstrap-dropdowns/
+compatible-v0:
+compatible-v1: true
+---
+
+A Leaflet plugin to show [bootstrap dropdowns](https://getbootstrap.com/docs/5.3/components/dropdowns/).


### PR DESCRIPTION
A Leaflet plugin to show [bootstrap dropdowns](https://getbootstrap.com/docs/5.3/components/dropdowns/). Tested on desktop and mobile versions of Chrome, Edge, Firefox, and Safari.

* Demo Page: [demo](https://mfhsieh.github.io/leaflet-bootstrap-dropdowns/) 
* Source Code: [Github](https://github.com/mfhsieh/leaflet-bootstrap-dropdowns)