### PR TITLE
round zoom in redraw fn and add docstring

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -225,10 +225,12 @@ export const GridLayer = Layer.extend({
 
 	// @method redraw: this
 	// Causes the layer to clear all the tiles and request them again.
+	// if the rounded zoom value is out of the min/max tile bounds,
+	// the map will not appear on first load, it will need to be zoomed or panned.
 	redraw() {
 		if (this._map) {
 			this._removeAllTiles();
-			const tileZoom = this._clampZoom(this._map.getZoom());
+			const tileZoom = Math.round(this._clampZoom(this._map.getZoom()));
 			if (tileZoom !== this._tileZoom) {
 				this._tileZoom = tileZoom;
 				this._updateLevels();


### PR DESCRIPTION
**Do not close!**
As discussed with Emil, this is supposed to be a duplicate of #8613, but with an added docstring. I work at Plotly, and we need this bugfix for one of our libraries. 

- Addresses Issue #8276 

- Bugfix taken from PR #8613 

This rounds any fractional zoom level when the method `redraw()` is invoked. If the zoom is fractional, then the map does not load on initial load. 

Edge case not covered: if the tiles min/max native zoom is 2.2 and 2.8 for example, the zoom level will be out of bound when rounded. Logging a separate issue for this. 