### PR TITLE
Add maxWheelZoomSpeed option (#9377)

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -280,7 +280,8 @@ export function getWheelPxFactor() {
 // Events from pointing devices without precise scrolling are mapped to
 // a best guess of 60 pixels.
 export function getWheelDelta(e) {
-	return (e.deltaY && e.deltaMode === 0) ? -e.deltaY / getWheelPxFactor() : // Pixels
+	return (e.deltaY && e.deltaMode === 0 && e.ctrlKey) ? 6 * -e.deltaY / getWheelPxFactor() : // Trackpad pinch
+	       (e.deltaY && e.deltaMode === 0) ? -e.deltaY / getWheelPxFactor() : // Pixels
 	       (e.deltaY && e.deltaMode === 1) ? -e.deltaY * 20 : // Lines
 	       (e.deltaY && e.deltaMode === 2) ? -e.deltaY * 60 : // Pages
 	       (e.deltaX || e.deltaZ) ? 0 :	// Skip horizontal/depth wheel events

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -15,10 +15,15 @@ Map.mergeOptions({
 	// it will zoom to the center of the view regardless of where the mouse was.
 	scrollWheelZoom: true,
 
-	// @option wheelDebounceTime: Number = 40
-	// Limits the rate at which a wheel can fire (in milliseconds). By default
-	// user can't zoom via wheel more often than once per 40 ms.
-	wheelDebounceTime: 40,
+	// @option maxWheelZoomSpeed: Number = 10
+	// The maximum rate at which the map zoom may change due to scrolling, in
+	// zoom levels per second.
+	maxWheelZoomSpeed: 10,
+
+	// @option wheelTimeout: Number = 1000
+	// The duration of mouse wheel inactivity, in milliseconds, after which
+	// accumulated inertia is discarded.
+	wheelTimeout: 1000,
 
 	// @option wheelPxPerZoomLevel: Number = 60
 	// How many scroll pixels (as reported by [L.DomEvent.getWheelDelta](#domevent-getwheeldelta))
@@ -31,7 +36,8 @@ export const ScrollWheelZoom = Handler.extend({
 	addHooks() {
 		DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
 
-		this._delta = 0;
+		this._inertia = 0;
+		this._timeAtLastZoom = 0;
 	},
 
 	removeHooks() {
@@ -39,48 +45,41 @@ export const ScrollWheelZoom = Handler.extend({
 	},
 
 	_onWheelScroll(e) {
-		const delta = DomEvent.getWheelDelta(e);
+		const map = this._map;
+		const wheelDelta = DomEvent.getWheelDelta(e);
+		const elapsed = Date.now() - this._timeAtLastZoom;
 
-		const debounce = this._map.options.wheelDebounceTime;
-
-		this._delta += delta;
-		this._lastMousePos = this._map.mouseEventToContainerPoint(e);
-
-		if (!this._startTime) {
-			this._startTime = +new Date();
+		// If this is the beginning of a gesture, or if the gesture has changed
+		// direction, discard any accumulated inertia.
+		if (
+			elapsed > map.options.wheelTimeout ||
+			(wheelDelta > 0 && this._inertia < 0) ||
+			(wheelDelta < 0 && this._inertia > 0)
+		) {
+			this._inertia = 0;
+			this._timeAtLastZoom = Date.now();
 		}
-
-		const left = Math.max(debounce - (+new Date() - this._startTime), 0);
-
-		clearTimeout(this._timer);
-		this._timer = setTimeout(this._performZoom.bind(this), left);
+		this._inertia += wheelDelta / map.options.wheelPxPerZoomLevel;
+		const max = map.options.maxWheelZoomSpeed * elapsed / 1000;
+		const delta = Number.isFinite(max) ?
+			(
+				this._inertia < 0 ?
+					Math.max(this._inertia, -max) :
+					Math.min(this._inertia, max)
+			) :
+			this._inertia; // unclamped
+		const mapZoom = map.getZoom();
+		const zoom = map._limitZoom(mapZoom + delta); // clamp and snap
+		if (zoom !== mapZoom && !map._animatingZoom) {
+			this._inertia -= zoom - mapZoom; // consume some inertia
+			const center = map.options.scrollWheelZoom === 'center' ?
+				map.getCenter() :
+				map.mouseEventToContainerPoint(e);
+			map.setZoomAround(center, zoom);
+			this._timeAtLastZoom = Date.now();
+		}
 
 		DomEvent.stop(e);
-	},
-
-	_performZoom() {
-		const map = this._map,
-		    zoom = map.getZoom(),
-		    snap = this._map.options.zoomSnap || 0;
-
-		map._stop(); // stop panning and fly animations if any
-
-		// map the delta with a sigmoid function to -4..4 range leaning on -1..1
-		const d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4),
-		    d3 = 4 * Math.log(2 / (1 + Math.exp(-Math.abs(d2)))) / Math.LN2,
-		    d4 = snap ? Math.ceil(d3 / snap) * snap : d3,
-		    delta = map._limitZoom(zoom + (this._delta > 0 ? d4 : -d4)) - zoom;
-
-		this._delta = 0;
-		this._startTime = null;
-
-		if (!delta) { return; }
-
-		if (map.options.scrollWheelZoom === 'center') {
-			map.setZoom(zoom + delta);
-		} else {
-			map.setZoomAround(this._lastMousePos, zoom + delta);
-		}
 	}
 });
 


### PR DESCRIPTION
This pull request replaces the `wheelDebounceTime` option with the more useful `maxWheelZoomSpeed` option. It also improves support for zooming via trackpad pinch gestures. It fixes issue #9377.

Further testing on a variety of devices, browsers, and operating systems would be appreciated.