### PR TITLE
Add a plugin: Leaflet.MultiMarkers

### DIFF
--- a/docs/_plugins/overlay-data-formats/leaflet-multi-markers.md
+++ b/docs/_plugins/overlay-data-formats/leaflet-multi-markers.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.MultiMarkers
+category: overlay-data-formats
+repo: https://github.com/mfhsieh/leaflet-multi-markers
+author: mfhsieh
+author-url: https://github.com/mfhsieh/
+demo: https://mfhsieh.github.io/leaflet-multi-markers/
+compatible-v0: 
+compatible-v1: true
+---
+
+A Leaflet plugin for displaying a large number of highly customizable markers, such as those from a CSV file read using <a href="https://www.papaparse.com/">Papa Parse</a>.


### PR DESCRIPTION
A Leaflet plugin for displaying a large number of highly customizable markers, such as those from a CSV file read using [Papa Parse](https://www.papaparse.com/). It can easily handle both overall and individual settings for icons, markers, and popups.

L.MultiMarkers inherits from [L.LayerGroup](https://leafletjs.com/reference.html#layergroup). And this plugin utilizes [Leaflet.IconEx](https://github.com/mfhsieh/leaflet-iconex) to display icons.

* Source Code: [Github](https://github.com/mfhsieh/leaflet-multi-markers)
* Demo Page: [demo](https://mfhsieh.github.io/leaflet-multi-markers/) (code: [index.html](https://github.com/mfhsieh/leaflet-multi-markers/blob/main/index.html), data: [example.csv](https://github.com/mfhsieh/leaflet-multi-markers/blob/main/examples/example.csv))
* Current Version: v1.0.0
* Tested on desktop and mobile versions of Chrome, Edge, Firefox, and Safari.
