### PR TITLE
Prevent showing outline-box on Chromium when clicking on a vector with a tooltip

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -223,6 +223,10 @@ svg.leaflet-image-layer.leaflet-interactive path {
 .leaflet-container a {
 	color: #0078A8;
 	}
+/* prevent showing outline-box on Chromium when clicking on a vector with a tooltip */
+.leaflet-container path.leaflet-interactive:focus:not(:focus-visible) {
+	outline: 0;
+	}
 .leaflet-zoom-box {
 	border: 2px dotted #38f;
 	background: rgba(255,255,255,0.5);

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -224,7 +224,8 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	color: #0078A8;
 	}
 /* prevent showing outline-box on Chromium when clicking on a vector with a tooltip */
-.leaflet-container path.leaflet-interactive:focus:not(:focus-visible) {
+path.leaflet-interactive:focus:not(:focus-visible) {
+
 	outline: 0;
 	}
 .leaflet-zoom-box {

--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -225,9 +225,9 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 /* prevent showing outline-box on Chromium when clicking on a vector with a tooltip */
 path.leaflet-interactive:focus:not(:focus-visible) {
-
 	outline: 0;
 	}
+
 .leaflet-zoom-box {
 	border: 2px dotted #38f;
 	background: rgba(255,255,255,0.5);


### PR DESCRIPTION
Fixes: #8659

![grafik](https://github.com/Leaflet/Leaflet/assets/19800037/794fc8ba-0f20-4c18-ba28-736910b3d95f)

I tried for an hour to add a test but I wasn't successfull ...