### PR TITLE
Solution to issue 9067 - Inverting x axis of L.CRS.Simple causes L.Circle to have no radius

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Circle, Map} from 'leaflet';
+import {Circle, Map, Util, CRS, Transformation} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Circle', () => {
@@ -45,6 +45,24 @@ describe('Circle', () => {
 
 			expect(bounds.getSouthWest()).nearLatLng([49.99820, 29.99720]);
 			expect(bounds.getNorthEast()).nearLatLng([50.00179, 30.00279]);
+		});
+	});
+
+	describe('CRS Simple', () => {
+		it('returns a positive radius if the x axis of L.CRS.Simple is inverted', () => {
+			map.remove();
+
+			const crs = Util.extend(CRS.Simple, {
+				transformation: new Transformation(-1, 0, -1, 0),
+			});
+			map = new Map(container, {
+				crs
+			});
+			map.setView([0, 0], 4);
+
+			const circle = new Circle([0, 0], {radius: 200}).addTo(map);
+
+			expect(circle._radius).to.eql(3200);
 		});
 	});
 });

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -94,7 +94,7 @@ export const Circle = CircleMarker.extend({
 			const latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));
 
 			this._point = map.latLngToLayerPoint(this._latlng);
-			this._radius = this._point.x - map.latLngToLayerPoint(latlng2).x;
+			this._radius = Math.abs(this._point.x - map.latLngToLayerPoint(latlng2).x);
 		}
 
 		this._updateBounds();


### PR DESCRIPTION
solves #9067

## Solution to issue 9067 - Inverting x axis of L.CRS.Simple causes L.Circle to have no radius
**Identified cause**: In Circle.js, the radius was being returned as negative once it was altered through different modifications towards itself presumably because of the transformation method requirements and the project method.

**Solution**: Math.abs() surrounded the calculation of the returned radius making it positive instead of negative. “npm run test” was performed to see if this change made additional errors. All tests were successfull.
