### PR TITLE
New Plugin - leaflet.sidepanel

### DIFF
--- a/docs/_plugins/user-interface/leaflet.sidepanel.md
+++ b/docs/_plugins/user-interface/leaflet.sidepanel.md
@@ -1,0 +1,12 @@
+---
+name: leaflet.sidepanel
+category: user-interface
+repo: https://github.com/cyclingbyte/Leaflet.SidePanel
+author: cyclingbyte
+author-url: https://github.com/cyclingbyte
+demo: https://cyclingbyte.github.io/Leaflet.SidePanel/
+compatible-v0:
+compatible-v1: true
+---
+
+Leaflet plugin to add a slidable sidepanel/sidebar with (optional) tabs.


### PR DESCRIPTION
Its a plugin to add a slidable sidepanel/sidebar with (optional) tabs. (forked from https://github.com/maxwell-ilai/Leaflet.SidePanel and improved, published to npm)

Link to repo: https://github.com/cyclingbyte/Leaflet.SidePanel

There is also a [vue wrapper](https://github.com/cyclingbyte/vue-leaflet-sidepanel), I don't know if it should list in the plugin list or just be linked in the plugin