### PR TITLE
Fix Leaflet attribution link

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -27,7 +27,7 @@ export const Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: `<a class="external" target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
+		prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
 	},
 
 	initialize(options) {

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -27,7 +27,7 @@ export const Attribution = Control.extend({
 
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
-		prefix: `<a href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
+		prefix: `<a class="external" target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
 	},
 
 	initialize(options) {


### PR DESCRIPTION
The Leaflet attribution link was not marked as external, which led to the leaflet link getting added to the current path.

This adds the required target attribute to the anchor.