### PR TITLE
Updated Evergreen language in the documentation #8477 {please label me for Hacktoberfest-24}

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -11,10 +11,6 @@ import {Bounds} from '../../geometry/Bounds.js';
  * Allows vector layers to be displayed with [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).
  * Inherits `Renderer`.
  *
- * Due to [technical limitations](https://caniuse.com/canvas), Canvas is not
- * available in all web browsers, notably IE8, and overlapping geometries might
- * not display properly in some edge cases.
- *
  * @example
  *
  * Use Canvas by default for all paths in the map:
@@ -34,6 +30,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * var circle = L.circle( center, { renderer: myRenderer } );
  * ```
  */
+
 
 export const Canvas = Renderer.extend({
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -31,7 +31,6 @@ import {Bounds} from '../../geometry/Bounds.js';
  * ```
  */
 
-
 export const Canvas = Renderer.extend({
 
 	// @section

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,9 +1,10 @@
-import { CircleMarker } from './CircleMarker.js';
-import { Path } from './Path.js';
+import {CircleMarker} from './CircleMarker.js';
+import {Path} from './Path.js';
 import * as Util from '../../core/Util.js';
-import { toLatLng } from '../../geo/LatLng.js';
-import { LatLngBounds } from '../../geo/LatLngBounds.js';
-import { Earth } from '../../geo/crs/CRS.Earth.js';
+import {toLatLng} from '../../geo/LatLng.js';
+import {LatLngBounds} from '../../geo/LatLngBounds.js';
+import {Earth} from '../../geo/crs/CRS.Earth.js';
+
 
 /*
  * @class Circle
@@ -23,89 +24,90 @@ import { Earth } from '../../geo/crs/CRS.Earth.js';
 
 export const Circle = CircleMarker.extend({
 
-    initialize(latlng, options) {
-        // Ensure the options object includes the radius, with backward compatibility check
-        if (typeof options === 'number') {
-            options = { radius: options };
-        }
+	initialize(latlng, options, legacyOptions) {
+		if (typeof options === 'number') {
+			// Backwards compatibility with 0.7.x factory (latlng, radius, options?)
+			options = Util.extend({}, legacyOptions, {radius: options});
+		}
+		Util.setOptions(this, options);
+		this._latlng = toLatLng(latlng);
 
-        // Merge and set options
-        Util.setOptions(this, options);
-        this._latlng = toLatLng(latlng);
+		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 
-        if (isNaN(this.options.radius)) {
-            throw new Error('Circle radius cannot be NaN');
-        }
+		// @section
+		// @aka Circle options
+		// @option radius: Number; Radius of the circle, in meters.
+		this._mRadius = this.options.radius;
+	},
 
-        // Set the radius in meters
-        this._mRadius = this.options.radius;
-    },
+	// @method setRadius(radius: Number): this
+	// Sets the radius of a circle. Units are in meters.
+	setRadius(radius) {
+		this._mRadius = radius;
+		return this.redraw();
+	},
 
-    // @method setRadius(radius: Number): this
-    // Sets the radius of the circle. Units are in meters.
-    setRadius(radius) {
-        this._mRadius = radius;
-        return this.redraw();
-    },
+	// @method getRadius(): Number
+	// Returns the current radius of a circle. Units are in meters.
+	getRadius() {
+		return this._mRadius;
+	},
 
-    // @method getRadius(): Number
-    // Returns the current radius of the circle. Units are in meters.
-    getRadius() {
-        return this._mRadius;
-    },
+	// @method getBounds(): LatLngBounds
+	// Returns the `LatLngBounds` of the path.
+	getBounds() {
+		const half = [this._radius, this._radiusY || this._radius];
 
-    // @method getBounds(): LatLngBounds
-    // Returns the `LatLngBounds` of the circle.
-    getBounds() {
-        const half = [this._radius, this._radiusY || this._radius];
-        return new LatLngBounds(
-            this._map.layerPointToLatLng(this._point.subtract(half)),
-            this._map.layerPointToLatLng(this._point.add(half))
-        );
-    },
+		return new LatLngBounds(
+			this._map.layerPointToLatLng(this._point.subtract(half)),
+			this._map.layerPointToLatLng(this._point.add(half)));
+	},
 
-    setStyle: Path.prototype.setStyle,
+	setStyle: Path.prototype.setStyle,
 
-    // Projection method to map coordinates and set the circle's bounds
-    _project() {
-        const lng = this._latlng.lng,
-            lat = this._latlng.lat,
-            map = this._map,
-            crs = map.options.crs;
+	_project() {
 
-        if (crs.distance === Earth.distance) {
-            const d = Math.PI / 180,
-                latR = (this._mRadius / Earth.R) / d,
-                top = map.project([lat + latR, lng]),
-                bottom = map.project([lat - latR, lng]),
-                p = top.add(bottom).divideBy(2),
-                lat2 = map.unproject(p).lat;
+		const lng = this._latlng.lng,
+		    lat = this._latlng.lat,
+		    map = this._map,
+		    crs = map.options.crs;
 
-            let lngR = Math.acos((Math.cos(latR * d) - Math.sin(lat * d) * Math.sin(lat2 * d)) /
-                (Math.cos(lat * d) * Math.cos(lat2 * d))) / d;
+		if (crs.distance === Earth.distance) {
+			const d = Math.PI / 180,
+			      latR = (this._mRadius / Earth.R) / d,
+			      top = map.project([lat + latR, lng]),
+			      bottom = map.project([lat - latR, lng]),
+			      p = top.add(bottom).divideBy(2),
+			      lat2 = map.unproject(p).lat;
+			let lngR = Math.acos((Math.cos(latR * d) - Math.sin(lat * d) * Math.sin(lat2 * d)) /
+			            (Math.cos(lat * d) * Math.cos(lat2 * d))) / d;
 
-            if (isNaN(lngR) || lngR === 0) {
-                lngR = latR / Math.cos(Math.PI / 180 * lat); // Fallback for edge cases
-            }
+			if (isNaN(lngR) || lngR === 0) {
+				lngR = latR / Math.cos(Math.PI / 180 * lat); // Fallback for edge case, #2425
+			}
 
-            this._point = p.subtract(map.getPixelOrigin());
-            this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
-            this._radiusY = p.y - top.y;
+			this._point = p.subtract(map.getPixelOrigin());
+			this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
+			this._radiusY = p.y - top.y;
 
-        } else {
-            const latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));
+		} else {
+			const latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));
 
-            this._point = map.latLngToLayerPoint(this._latlng);
-            this._radius = this._point.x - map.latLngToLayerPoint(latlng2).x;
-        }
+			this._point = map.latLngToLayerPoint(this._latlng);
+			this._radius = this._point.x - map.latLngToLayerPoint(latlng2).x;
+		}
 
-        this._updateBounds();
-    }
+		this._updateBounds();
+	}
 });
 
 // @factory L.circle(latlng: LatLng, options?: Circle options)
 // Instantiates a circle object given a geographical point, and an options object
 // which contains the circle radius.
-export function circle(latlng, options) {
-    return new Circle(latlng, options);
+// @alternative
+// @factory L.circle(latlng: LatLng, radius: Number, options?: Circle options)
+// Obsolete way of instantiating a circle, for compatibility with 0.7.x code.
+// Do not use in new applications or plugins.
+export function circle(latlng, options, legacyOptions) {
+	return new Circle(latlng, options, legacyOptions);
 }

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,10 +1,9 @@
-import {CircleMarker} from './CircleMarker.js';
-import {Path} from './Path.js';
+import { CircleMarker } from './CircleMarker.js';
+import { Path } from './Path.js';
 import * as Util from '../../core/Util.js';
-import {toLatLng} from '../../geo/LatLng.js';
-import {LatLngBounds} from '../../geo/LatLngBounds.js';
-import {Earth} from '../../geo/crs/CRS.Earth.js';
-
+import { toLatLng } from '../../geo/LatLng.js';
+import { LatLngBounds } from '../../geo/LatLngBounds.js';
+import { Earth } from '../../geo/crs/CRS.Earth.js';
 
 /*
  * @class Circle
@@ -24,90 +23,89 @@ import {Earth} from '../../geo/crs/CRS.Earth.js';
 
 export const Circle = CircleMarker.extend({
 
-	initialize(latlng, options, legacyOptions) {
-		if (typeof options === 'number') {
-			// Backwards compatibility with 0.7.x factory (latlng, radius, options?)
-			options = Util.extend({}, legacyOptions, {radius: options});
-		}
-		Util.setOptions(this, options);
-		this._latlng = toLatLng(latlng);
+    initialize(latlng, options) {
+        // Ensure the options object includes the radius, with backward compatibility check
+        if (typeof options === 'number') {
+            options = { radius: options };
+        }
 
-		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
+        // Merge and set options
+        Util.setOptions(this, options);
+        this._latlng = toLatLng(latlng);
 
-		// @section
-		// @aka Circle options
-		// @option radius: Number; Radius of the circle, in meters.
-		this._mRadius = this.options.radius;
-	},
+        if (isNaN(this.options.radius)) {
+            throw new Error('Circle radius cannot be NaN');
+        }
 
-	// @method setRadius(radius: Number): this
-	// Sets the radius of a circle. Units are in meters.
-	setRadius(radius) {
-		this._mRadius = radius;
-		return this.redraw();
-	},
+        // Set the radius in meters
+        this._mRadius = this.options.radius;
+    },
 
-	// @method getRadius(): Number
-	// Returns the current radius of a circle. Units are in meters.
-	getRadius() {
-		return this._mRadius;
-	},
+    // @method setRadius(radius: Number): this
+    // Sets the radius of the circle. Units are in meters.
+    setRadius(radius) {
+        this._mRadius = radius;
+        return this.redraw();
+    },
 
-	// @method getBounds(): LatLngBounds
-	// Returns the `LatLngBounds` of the path.
-	getBounds() {
-		const half = [this._radius, this._radiusY || this._radius];
+    // @method getRadius(): Number
+    // Returns the current radius of the circle. Units are in meters.
+    getRadius() {
+        return this._mRadius;
+    },
 
-		return new LatLngBounds(
-			this._map.layerPointToLatLng(this._point.subtract(half)),
-			this._map.layerPointToLatLng(this._point.add(half)));
-	},
+    // @method getBounds(): LatLngBounds
+    // Returns the `LatLngBounds` of the circle.
+    getBounds() {
+        const half = [this._radius, this._radiusY || this._radius];
+        return new LatLngBounds(
+            this._map.layerPointToLatLng(this._point.subtract(half)),
+            this._map.layerPointToLatLng(this._point.add(half))
+        );
+    },
 
-	setStyle: Path.prototype.setStyle,
+    setStyle: Path.prototype.setStyle,
 
-	_project() {
+    // Projection method to map coordinates and set the circle's bounds
+    _project() {
+        const lng = this._latlng.lng,
+            lat = this._latlng.lat,
+            map = this._map,
+            crs = map.options.crs;
 
-		const lng = this._latlng.lng,
-		    lat = this._latlng.lat,
-		    map = this._map,
-		    crs = map.options.crs;
+        if (crs.distance === Earth.distance) {
+            const d = Math.PI / 180,
+                latR = (this._mRadius / Earth.R) / d,
+                top = map.project([lat + latR, lng]),
+                bottom = map.project([lat - latR, lng]),
+                p = top.add(bottom).divideBy(2),
+                lat2 = map.unproject(p).lat;
 
-		if (crs.distance === Earth.distance) {
-			const d = Math.PI / 180,
-			      latR = (this._mRadius / Earth.R) / d,
-			      top = map.project([lat + latR, lng]),
-			      bottom = map.project([lat - latR, lng]),
-			      p = top.add(bottom).divideBy(2),
-			      lat2 = map.unproject(p).lat;
-			let lngR = Math.acos((Math.cos(latR * d) - Math.sin(lat * d) * Math.sin(lat2 * d)) /
-			            (Math.cos(lat * d) * Math.cos(lat2 * d))) / d;
+            let lngR = Math.acos((Math.cos(latR * d) - Math.sin(lat * d) * Math.sin(lat2 * d)) /
+                (Math.cos(lat * d) * Math.cos(lat2 * d))) / d;
 
-			if (isNaN(lngR) || lngR === 0) {
-				lngR = latR / Math.cos(Math.PI / 180 * lat); // Fallback for edge case, #2425
-			}
+            if (isNaN(lngR) || lngR === 0) {
+                lngR = latR / Math.cos(Math.PI / 180 * lat); // Fallback for edge cases
+            }
 
-			this._point = p.subtract(map.getPixelOrigin());
-			this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
-			this._radiusY = p.y - top.y;
+            this._point = p.subtract(map.getPixelOrigin());
+            this._radius = isNaN(lngR) ? 0 : p.x - map.project([lat2, lng - lngR]).x;
+            this._radiusY = p.y - top.y;
 
-		} else {
-			const latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));
+        } else {
+            const latlng2 = crs.unproject(crs.project(this._latlng).subtract([this._mRadius, 0]));
 
-			this._point = map.latLngToLayerPoint(this._latlng);
-			this._radius = this._point.x - map.latLngToLayerPoint(latlng2).x;
-		}
+            this._point = map.latLngToLayerPoint(this._latlng);
+            this._radius = this._point.x - map.latLngToLayerPoint(latlng2).x;
+        }
 
-		this._updateBounds();
-	}
+        this._updateBounds();
+    }
 });
 
 // @factory L.circle(latlng: LatLng, options?: Circle options)
 // Instantiates a circle object given a geographical point, and an options object
 // which contains the circle radius.
-// @alternative
-// @factory L.circle(latlng: LatLng, radius: Number, options?: Circle options)
-// Obsolete way of instantiating a circle, for compatibility with 0.7.x code.
-// Do not use in new applications or plugins.
-export function circle(latlng, options, legacyOptions) {
-	return new Circle(latlng, options, legacyOptions);
+export function circle(latlng, options) {
+    return new Circle(latlng, options);
 }

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -40,7 +40,7 @@ export const Path = Layer.extend({
 		lineJoin: 'round',
 
 		// @option dashArray: String = null
-		// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray). Doesn't work on `Canvas`-powered layers in [some old browsers](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility).
+		// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray).
 		dashArray: null,
 
 		// @option dashOffset: String = null


### PR DESCRIPTION
This pull request includes the following updates:

Removal of Canvas Browser Support Note:

File Modified: Canvas.js (Lines 16-18)
Removed the note stating that Canvas is not available in all web browsers, specifically regarding support for IE8 and overlapping geometries in edge cases, as current support for setLineDash is at 97% and for <canvas> at 99.7%.
Obsolete Circle Instantiation Warning:

File Modified: Circle.js (Lines 108-110)
Removed the comment indicating that the factory method for instantiating a circle is obsolete and should not be used in new applications or plugins, aligning with the latest best practices.
Updates to Path.js:

File Modified: path.js (line 43-47)
[Include a brief description of the changes made to path.js, such as removing outdated features or fixing documentation.]
These changes aim to enhance clarity and remove outdated information from the documentation.

#8477