### PR TITLE
resolves 9228 - Automatically attributes OSM if OSM tiles are used and no attribution is provided

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -404,6 +404,20 @@ describe('TileLayer', () => {
 			});
 		});
 
+		it('adds OSM attribution if none are provided and is using OSM tiles', () => {
+			// Uses OSM tiles without providing attribution
+			const layer = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {}).addTo(map);
+			expect(layer.options.attribution).to.eql('&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors');
+		});
+
+		it('doesn\'t add OSM attribution if it\'s specifically set as empty', () => {
+			// Uses OSM tiles without providing attribution
+			const layer = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				attribution: ''
+			}).addTo(map);
+			expect(layer.options.attribution).to.eql('');
+		});
+
 	});
 
 	const _describe = 'crossOrigin' in DomUtil.create('img') ? describe : describe.skip; // skip in IE<11

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -92,6 +92,18 @@ export const TileLayer = GridLayer.extend({
 
 		options = Util.setOptions(this, options);
 
+		// in case the attribution hasn't been specified, check for known hosts that require attribution
+		if (options.attribution === null && URL.canParse(url)) {
+			const urlHostname = new URL(url).hostname;
+
+			// check for Open Street Map hosts
+			const osmHosts = ['tile.openstreetmap.org', 'tile.osm.org'];
+			const isOsmUrl = osmHosts.some(host => urlHostname.endsWith(host));
+			if (isOsmUrl) {
+				options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+			}
+		}
+
 		// detecting retina displays, adjusting tileSize and zoom levels
 		if (options.detectRetina && Browser.retina && options.maxZoom > 0) {
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -98,8 +98,7 @@ export const TileLayer = GridLayer.extend({
 
 			// check for Open Street Map hosts
 			const osmHosts = ['tile.openstreetmap.org', 'tile.osm.org'];
-			const isOsmUrl = osmHosts.some(host => urlHostname.endsWith(host));
-			if (isOsmUrl) {
+			if (osmHosts.some(host => urlHostname.endsWith(host))) {
 				options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			}
 		}


### PR DESCRIPTION
Fixes: #9228 

Automatically attributes OSM if OSM tiles are used and no attribution is provided, resolving issue 9228

Wasn't sure about the test policies, so I created one for each new behaviour added.