### PR TITLE
Changed slogan with evergreen wording #8477

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Leaflet maintainers.
 
 <img width="600" src="https://rawgit.com/Leaflet/Leaflet/main/src/images/logo.svg" alt="Leaflet" />
 
-Leaflet is the leading open-source JavaScript library for **mobile-friendly interactive maps**.
+Leaflet is the leading open-source JavaScript library for **building powerful interactive maps*.
 Weighing just about 42 KB of gzipped JS plus 4 KB of gzipped CSS code, it has all the mapping [features][] most developers ever need.
 
 Leaflet is designed with *simplicity*, *performance* and *usability* in mind.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Leaflet maintainers.
 
 <img width="600" src="https://rawgit.com/Leaflet/Leaflet/main/src/images/logo.svg" alt="Leaflet" />
 
-Leaflet is the leading open-source JavaScript library for **building powerful interactive maps*.
+Leaflet is the leading open-source JavaScript library for **building powerful interactive maps**.
+
 Weighing just about 42 KB of gzipped JS plus 4 KB of gzipped CSS code, it has all the mapping [features][] most developers ever need.
 
 Leaflet is designed with *simplicity*, *performance* and *usability* in mind.

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -9,11 +9,11 @@
 
 	{% if title == '' %}
 	<meta property="og:title" content="Leaflet — an open-source JavaScript library for interactive maps" />
-	<meta property="og:description" content="Leaflet is a modern, lightweight open-source JavaScript library for mobile-friendly interactive maps." />
+	<meta property="og:description" content="Leaflet is a modern, lightweight open-source JavaScript library for building powerful interactive maps." />
 	<meta property="og:image" content="{{ root }}docs/images/logo.png" />
 	<meta property="og:image:alt" content="Leaflet">
 	<meta itemprop="name" content="Leaflet">
-	<meta itemprop="description" content="Leaflet — a modern, lightweight open-source JavaScript library for mobile-friendly interactive maps.">
+	<meta itemprop="description" content="Leaflet — a modern, lightweight open-source JavaScript library for building powerful interactive maps.">
 	<meta itemprop="image" content="{{ root }}docs/images/logo.png">
 	{% endif %}
 
@@ -60,7 +60,7 @@
 
 <header>
 	<h1><a href="https://leafletjs.com/"><img src="{{ root }}docs/images/logo.png" alt="Leaflet" width="300" /></a></h1>
-	<p class="tagline">an open-source JavaScript library<br> for mobile-friendly interactive maps</p>
+	<p class="tagline">an open-source JavaScript library<br> for building powerful interactive maps</p>
 </header>
 
 <nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@ layout: v2
 
 <div class="announcement">May 18, 2023 — <a href="/2022/09/21/leaflet-1.9.0.html">Leaflet 1.9.4</a> has been released!</div>
 
-<p>Leaflet is the leading open-source JavaScript library for mobile-friendly interactive maps.
+<p>Leaflet is the leading open-source JavaScript library for building powerful interactive maps.
 Weighing just about <abbr title="42 KB gzipped &mdash; that's 142 KB minified and 431 KB in the source form, with 14.5 KB of CSS (3.5 KB gzipped) and 6 KB of images.">42 KB of JS</abbr>,
 it&nbsp;has all the mapping <a href="#features">features</a> most developers ever need.</p>
 


### PR DESCRIPTION
The issue: Is the slogan "A library for [mobile-friendly](https://github.com/Leaflet/Leaflet/search?q=an+open-source+JavaScript+library+for+mobile-friendly+interactive+maps) interactive maps" dated?

Updated the slogan so it says instead of building "mobile friendly interactive maps" to "building powerful interactive maps". Hopefully this showcases Leaflet's strengths as an open-source flexible lightweight solution.

#8477 