### PR TITLE
Evergreen language updates and removal

### DIFF
--- a/docs/examples/accessibility/index.md
+++ b/docs/examples/accessibility/index.md
@@ -78,9 +78,8 @@ A simple way to achieve this is to use the HTML
 polyfill:
 
 ```html
-<!-- This map is for aesthetic purposes only, and can not be interacted with! -->
+<!-- This map is for aesthetic purposes only, and can not be interacted with due to the 'inert' property! -->
 <div id='decorative-map' inert></div>
-<script src='https://unpkg.com/wicg-inert@latest/dist/inert.min.js'></script>
 ```
 
 ### Utilizing plugins

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -7,7 +7,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  * @class PosAnimation
  * @aka L.PosAnimation
  * @inherits Evented
- * Used internally for panning animations, utilizing CSS Transitions for modern browsers and a timer fallback for IE6-9.
+ * Used internally for panning animations and utilizing CSS Transitions for modern browsers.
  *
  * @example
  * ```js

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -37,7 +37,6 @@ export const VideoOverlay = ImageOverlay.extend({
 
 		// @option keepAspectRatio: Boolean = true
 		// Whether the video will save aspect ratio after the projection.
-		// Relevant for supported browsers. See [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit)
 		keepAspectRatio: true,
 
 		// @option muted: Boolean = false


### PR DESCRIPTION
Addresses the following items (#8477):

- Remove [the mention of browser support for CSS object-fit](https://github.com/Leaflet/Leaflet/blob/e4e4d5b7ab3fc4a366130412d7a04246ff79ade5/src/layer/VideoOverlay.js#L40) (currently [98.5% support](https://caniuse.com/object-fit)).
- Remove [the mention of timer fallback for IE6-9](https://github.com/Leaflet/Leaflet/blob/fd202ce5b618fd23f998fff79c865b1baedbd41d/src/dom/PosAnimation.js#L10)?
- Change the wording and remove the <script> regarding [the polyfill](https://github.com/Leaflet/Leaflet/blob/4cb8a567bfba93c09f41b692e97a504ff0bdbcf4/docs/examples/accessibility/index.md?plain=1#L78-L83) for the inert attribute in the a11y guidelines.