### PR TITLE
Exceptions for plus-lighter workaround to fix white grid

### DIFF
--- a/dist/leaflet.css
+++ b/dist/leaflet.css
@@ -53,10 +53,15 @@
 	width: auto;
 	padding: 0;
 	}
+
+/* Workaround to remove visible grid around tile borders on Chrome */
+/* with exceptions for 110%, 90%, 80% and 67% browser zoom */
+@media not ((1.09 < -webkit-device-pixel-ratio < 1.11) or (0.89 < -webkit-device-pixel-ratio < 0.91) or (0.79 < -webkit-device-pixel-ratio < 0.81) or (0.66 < -webkit-device-pixel-ratio < 0.68)) {
 .leaflet-container img.leaflet-tile {
 	/* See: https://bugs.chromium.org/p/chromium/issues/detail?id=600120 */
 	mix-blend-mode: plus-lighter;
 	}
+}
 
 .leaflet-container.leaflet-touch-zoom {
 	touch-action: pan-x pan-y;


### PR DESCRIPTION
The current workaround for tile gaps in Chrome has the unfortunate side effect of creating a white grid at certain browser zoom levels, see https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-1881642439.
This grid can however be removed with a few exceptions in CSS for specific pixel ratios. A few very thin black lines still remain but are far less distracting. I made extensive tests [here](https://github.com/openstreetmap/iD/pull/10594#issuecomment-2540006158).

currently at 110%
![now](https://github.com/user-attachments/assets/6930c12b-e3b1-45ba-a94b-3e776682d3bf)

with CSS exceptions
![patch](https://github.com/user-attachments/assets/a2601386-5206-4d6f-8c4d-77e11902ff47)

Unfortunately this doesn't fix everything, most notably 90%, but still I think this improvement is worth 1.9.5.