### PR TITLE
Add plugin: Leaflet.IndependoMaps

### DIFF
--- a/docs/_plugins/markers-renderers/leaflet-independo-maps.md
+++ b/docs/_plugins/markers-renderers/leaflet-independo-maps.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.IndependoMaps
+category: markers-renderers
+repo: https://github.com/independo-gmbh/leaflet-independo-maps
+author: Independo GmbH
+author-url: https://www.independo.app
+demo: https://independo-gmbh.github.io/leaflet-independo-maps/
+compatible-v0: false
+compatible-v1: true
+---
+
+Leaflet plugin for displaying points of interest (POIs) as pictograms on a map. It supports customizable marker layouts, accessibility enhancements, and pluggable POI and pictogram services, making it ideal for interactive and inclusive maps.


### PR DESCRIPTION
### Add Leaflet.IndependoMaps Plugin

This PR adds the Leaflet.IndependoMaps plugin to the **Markers & Renderers** category. The plugin allows users to display points of interest (POIs) as pictograms on a map, with features like:

- **Customizable markers** for interactive and accessible maps.
- **Support for pluggable services** to fetch POIs and pictograms.
- **Grid-based marker ordering** to enhance screen reader and keyboard navigation.

Repository: [Leaflet.IndependoMaps](https://github.com/independo-gmbh/leaflet-independo-maps)

Demo: [View live demo](https://independo-gmbh.github.io/leaflet-independo-maps/examples/)
