### PR TITLE
Clear timeouts on remove (#9575)

### DIFF
--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -92,6 +92,24 @@ describe('Map', () => {
 			map.setZoom(2);
 		});
 
+		// For #9575
+		it('does not throw if removed before transition end complete', (done) => {
+			map.setView([0, 0], 1).setMaxBounds([[0, 1], [2, 3]]);
+
+			map._createAnimProxy();
+
+			setTimeout(() => {
+				map.remove();
+				map = null;
+			}, 10);
+
+			setTimeout(() => {
+				done();
+			}, 300);
+
+			map.setZoom(2);
+		});
+
 		it('throws error if container is reused by other instance', () => {
 			map.remove();
 			const map2 = new Map(container);

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -172,6 +172,7 @@ export const GridLayer = Layer.extend({
 		map._removeZoomLimit(this);
 		this._container = null;
 		this._tileZoom = undefined;
+		clearTimeout(this._pruneTimeout);
 	},
 
 	// @method bringToFront: this
@@ -886,7 +887,7 @@ export const GridLayer = Layer.extend({
 			} else {
 				// Wait a bit more than 0.2 secs (the duration of the tile fade-in)
 				// to trigger a pruning.
-				setTimeout(this._pruneTiles.bind(this), 250);
+				this._pruneTimeout = setTimeout(this._pruneTiles.bind(this), 250);
 			}
 		}
 	},

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -64,6 +64,12 @@ export const Canvas = Renderer.extend({
 		this._draw();
 	},
 
+	onRemove() {
+		Renderer.prototype.onRemove.call(this);
+
+		clearTimeout(this._mouseHoverThrottleTimeout);
+	},
+
 	_initContainer() {
 		const container = this._container = document.createElement('canvas');
 
@@ -409,7 +415,7 @@ export const Canvas = Renderer.extend({
 		this._fireEvent(this._hoveredLayer ? [this._hoveredLayer] : false, e);
 
 		this._mouseHoverThrottled = true;
-		setTimeout((() => {
+		this._mouseHoverThrottleTimeout = setTimeout((() => {
 			this._mouseHoverThrottled = false;
 		}), 32);
 	},

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -772,6 +772,9 @@ export const Map = Evented.extend({
 
 		this._clearHandlers();
 
+		clearTimeout(this._transitionEndTimer);
+		clearTimeout(this._sizeTimer);
+
 		if (this._loaded) {
 			// @section Map state change events
 			// @event unload: Event
@@ -1719,7 +1722,7 @@ export const Map = Evented.extend({
 		this._move(this._animateToCenter, this._animateToZoom, undefined, true);
 
 		// Work around webkit not firing 'transitionend', see https://github.com/Leaflet/Leaflet/issues/3689, 2693
-		setTimeout(this._onZoomTransitionEnd.bind(this), 250);
+		this._transitionEndTimer = setTimeout(this._onZoomTransitionEnd.bind(this), 250);
 	},
 
 	_onZoomTransitionEnd() {

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -36,6 +36,7 @@ export const ScrollWheelZoom = Handler.extend({
 
 	removeHooks() {
 		DomEvent.off(this._map._container, 'wheel', this._onWheelScroll, this);
+		clearTimeout(this._timer);
 	},
 
 	_onWheelScroll(e) {

--- a/src/map/handler/Map.TapHold.js
+++ b/src/map/handler/Map.TapHold.js
@@ -32,6 +32,7 @@ export const TapHold = Handler.extend({
 
 	removeHooks() {
 		DomEvent.off(this._map._container, 'touchstart', this._onDown, this);
+		clearTimeout(this._holdTimeout);
 	},
 
 	_onDown(e) {


### PR DESCRIPTION
Fixes: https://github.com/Leaflet/Leaflet/issues/9575

When the map was removed, it wasn't tidying up a timeout which lead to Uncaught TypeError: Cannot read properties of undefined (reading '_leaflet_pos'). The fix is to keep a handle to the timeout and clear it when the map is removed.

Also clears other timeouts which had a timeout  period of greater than 0.