### PR TITLE
Back-port SSR support to v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,6 +133,34 @@ jobs:
           BUNDLEMON_PROJECT_ID: 61e0545915f6c3000980d0ed
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
+  test-ssr:
+    needs: setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Restore setup
+        uses: actions/cache@v4
+        with:
+          path: ./*
+          key: ${{ runner.os }}-${{ github.ref }}-${{ github.sha }}-setup
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Run Node.js SSR script
+        run: node ./spec/ssr/ssr_node.mjs
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run Deno SSR script
+        run: deno run ./spec/ssr/ssr_deno.js
+
   test:
     needs: build
     runs-on: ${{ matrix.os || 'ubuntu-20.04' }}

--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -12,13 +12,16 @@ const watch = process.argv.indexOf('-w') > -1 || process.argv.indexOf('--watch')
 const version = release ? pkg.version : `${pkg.version}+${gitRev.branch()}.${gitRev.short()}`;
 const banner = createBanner(version);
 
-const outro = `var oldL = window.L;
-exports.noConflict = function() {
-	window.L = oldL;
-	return this;
-}
-// Always export us to window global (see #2364)
-window.L = exports;`;
+const outro = `if (typeof window !== 'undefined') {
+	var oldL = window.L;
+	exports.noConflict = function() {
+		window.L = oldL;
+		return this;
+	}
+	
+	// Always export us to window global (see #2364)
+	window.L = exports;
+}`;
 
 /** @type {import('rollup').RollupOptions} */
 const config = {

--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -1,13 +1,15 @@
 var json = require('@rollup/plugin-json');
 
-const outro = `var oldL = window.L;
-exports.noConflict = function() {
-	window.L = oldL;
-	return this;
-}
-
-// Always export us to window global (see #2364)
-window.L = exports;`;
+const outro = `if (typeof window !== 'undefined') {
+	var oldL = window.L;
+	exports.noConflict = function() {
+		window.L = oldL;
+		return this;
+	}
+	
+	// Always export us to window global (see #2364)
+	window.L = exports;
+}`;
 
 // Karma configuration
 module.exports = function (config) {

--- a/spec/ssr/ssr_deno.js
+++ b/spec/ssr/ssr_deno.js
@@ -1,0 +1,2 @@
+import L from '../../dist/leaflet-src.esm.js';
+console.log(L.version);

--- a/spec/ssr/ssr_deno.js
+++ b/spec/ssr/ssr_deno.js
@@ -1,2 +1,2 @@
-import L from '../../dist/leaflet-src.esm.js';
-console.log(L.version);
+import {version} from '../../dist/leaflet-src.esm.js';
+console.log(version);

--- a/spec/ssr/ssr_node.mjs
+++ b/spec/ssr/ssr_node.mjs
@@ -1,0 +1,2 @@
+import L from '../../dist/leaflet-src.js';
+console.log(L.version);

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -16,16 +16,16 @@ import {svgCreate} from '../layer/vector/SVG.Util';
  * ```
  */
 
-var style = document.documentElement.style;
+var style = typeof document === 'undefined' ? undefined : document.documentElement.style;
 
 // @property ie: Boolean; `true` for all Internet Explorer versions (not Edge).
-var ie = 'ActiveXObject' in window;
+var ie = typeof window === 'undefined' ? false : 'ActiveXObject' in window;
 
 // @property ielt9: Boolean; `true` for Internet Explorer versions less than 9.
-var ielt9 = ie && !document.addEventListener;
+var ielt9 = typeof document === 'undefined' ? false : ie && !document.addEventListener;
 
 // @property edge: Boolean; `true` for the Edge web browser.
-var edge = 'msLaunchUri' in navigator && !('documentMode' in document);
+var edge = typeof navigator === 'undefined' ? false : 'msLaunchUri' in navigator && !('documentMode' in document);
 
 // @property webkit: Boolean;
 // `true` for webkit-based browsers like Chrome and Safari (including mobile versions).
@@ -39,12 +39,12 @@ var android = userAgentContains('android');
 var android23 = userAgentContains('android 2') || userAgentContains('android 3');
 
 /* See https://stackoverflow.com/a/17961266 for details on detecting stock Android */
-var webkitVer = parseInt(/WebKit\/([0-9]+)|$/.exec(navigator.userAgent)[1], 10); // also matches AppleWebKit
+var webkitVer = typeof navigator === 'undefined' ? 0 : parseInt(/WebKit\/([0-9]+)|$/.exec(navigator.userAgent)[1], 10); // also matches AppleWebKit
 // @property androidStock: Boolean; **Deprecated.** `true` for the Android stock browser (i.e. not Chrome)
-var androidStock = android && userAgentContains('Google') && webkitVer < 537 && !('AudioNode' in window);
+var androidStock = typeof window === 'undefined' ? false : android && userAgentContains('Google') && webkitVer < 537 && !('AudioNode' in window);
 
 // @property opera: Boolean; `true` for the Opera browser
-var opera = !!window.opera;
+var opera = typeof window === 'undefined' ? false : !!window.opera;
 
 // @property chrome: Boolean; `true` for the Chrome browser.
 var chrome = !edge && userAgentContains('chrome');
@@ -62,23 +62,23 @@ var phantom = userAgentContains('phantom');
 var opera12 = 'OTransition' in style;
 
 // @property win: Boolean; `true` when the browser is running in a Windows platform
-var win = navigator.platform.indexOf('Win') === 0;
+var win = typeof navigator === 'undefined' ? false : navigator.platform.indexOf('Win') === 0;
 
 // @property ie3d: Boolean; `true` for all Internet Explorer versions supporting CSS transforms.
 var ie3d = ie && ('transition' in style);
 
 // @property webkit3d: Boolean; `true` for webkit-based browsers supporting CSS transforms.
-var webkit3d = ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23;
+var webkit3d = typeof window === 'undefined' ? false : ('WebKitCSSMatrix' in window) && ('m11' in new window.WebKitCSSMatrix()) && !android23;
 
 // @property gecko3d: Boolean; `true` for gecko-based browsers supporting CSS transforms.
-var gecko3d = 'MozPerspective' in style;
+var gecko3d = typeof document === 'undefined' ? false : 'MozPerspective' in style;
 
 // @property any3d: Boolean
 // `true` for all browsers supporting CSS transforms.
-var any3d = !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
+var any3d = typeof window === 'undefined' ? false : !window.L_DISABLE_3D && (ie3d || webkit3d || gecko3d) && !opera12 && !phantom;
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
-var mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
+var mobile = typeof orientation === 'undefined' ? false : typeof orientation !== 'undefined' || userAgentContains('mobile');
 
 // @property mobileWebkit: Boolean; `true` for all webkit-based browsers in a mobile device.
 var mobileWebkit = mobile && webkit;
@@ -89,23 +89,23 @@ var mobileWebkit3d = mobile && webkit3d;
 
 // @property msPointer: Boolean
 // `true` for browsers implementing the Microsoft touch events model (notably IE10).
-var msPointer = !window.PointerEvent && window.MSPointerEvent;
+var msPointer = typeof window === 'undefined' ? false : !window.PointerEvent && window.MSPointerEvent;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
-var pointer = !!(window.PointerEvent || msPointer);
+var pointer = typeof window === 'undefined' ? false : !!(window.PointerEvent || msPointer);
 
 // @property touchNative: Boolean
 // `true` for all browsers supporting [touch events](https://developer.mozilla.org/docs/Web/API/Touch_events).
 // **This does not necessarily mean** that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-var touchNative = 'ontouchstart' in window || !!window.TouchEvent;
+var touchNative = typeof window === 'undefined' ? false : 'ontouchstart' in window || !!(window.TouchEvent);
 
 // @property touch: Boolean
 // `true` for all browsers supporting either [touch](#browser-touch) or [pointer](#browser-pointer) events.
 // Note: pointer events will be preferred (if available), and processed for all `touch*` listeners.
-var touch = !window.L_NO_TOUCH && (touchNative || pointer);
+var touch = typeof window === 'undefined' ? false : !window.L_NO_TOUCH && (touchNative || pointer);
 
 // @property mobileOpera: Boolean; `true` for the Opera browser in a mobile device.
 var mobileOpera = mobile && opera;
@@ -116,7 +116,7 @@ var mobileGecko = mobile && gecko;
 
 // @property retina: Boolean
 // `true` for browsers on a high-resolution "retina" screen or on any screen when browser's display zoom is more than 100%.
-var retina = (window.devicePixelRatio || (window.screen.deviceXDPI / window.screen.logicalXDPI)) > 1;
+var retina = typeof window === 'undefined' || typeof window.devicePixelRatio === 'undefined' ? false : window.devicePixelRatio > 1;
 
 // @property passiveEvents: Boolean
 // `true` for browsers that support passive events.
@@ -139,14 +139,14 @@ var passiveEvents = (function () {
 // @property canvas: Boolean
 // `true` when the browser supports [`<canvas>`](https://developer.mozilla.org/docs/Web/API/Canvas_API).
 var canvas = (function () {
-	return !!document.createElement('canvas').getContext;
+	return typeof document === 'undefined' ? false : !!document.createElement('canvas').getContext;
 }());
 
 // @property svg: Boolean
 // `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
-var svg = !!(document.createElementNS && svgCreate('svg').createSVGRect);
+var svg = typeof document === 'undefined' ? false : !!(document.createElementNS && svgCreate('svg').createSVGRect);
 
-var inlineSvg = !!svg && (function () {
+var inlineSvg = !!svg && typeof document === 'undefined' ? false : (function () {
 	var div = document.createElement('div');
 	div.innerHTML = '<svg/>';
 	return (div.firstChild && div.firstChild.namespaceURI) === 'http://www.w3.org/2000/svg';
@@ -169,17 +169,18 @@ var vml = !svg && (function () {
 	}
 }());
 
-
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
-var mac = navigator.platform.indexOf('Mac') === 0;
+var mac = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.indexOf('Mac') === 0;
 
 // @property mac: Boolean; `true` when the browser is running in a Linux platform
-var linux = navigator.platform.indexOf('Linux') === 0;
+var linux = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.indexOf('Linux') === 0;
 
 function userAgentContains(str) {
+	if (typeof navigator === 'undefined' || typeof navigator.userAgent === 'undefined') {
+		return false;
+	}
 	return navigator.userAgent.toLowerCase().indexOf(str) >= 0;
 }
-
 
 export default {
 	ie: ie,

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -59,7 +59,7 @@ var phantom = userAgentContains('phantom');
 
 // @property opera12: Boolean
 // `true` for the Opera browser supporting CSS transforms (version 12 or later).
-var opera12 = 'OTransition' in style;
+var opera12 = typeof document === 'undefined' ? false : 'OTransition' in style;
 
 // @property win: Boolean; `true` when the browser is running in a Windows platform
 var win = typeof navigator === 'undefined' ? false : navigator.platform.indexOf('Win') === 0;
@@ -146,7 +146,7 @@ var canvas = (function () {
 // `true` when the browser supports [SVG](https://developer.mozilla.org/docs/Web/SVG).
 var svg = typeof document === 'undefined' ? false : !!(document.createElementNS && svgCreate('svg').createSVGRect);
 
-var inlineSvg = !!svg && typeof document === 'undefined' ? false : (function () {
+var inlineSvg = typeof document === 'undefined' ? false : !!svg && (function () {
 	var div = document.createElement('div');
 	div.innerHTML = '<svg/>';
 	return (div.firstChild && div.firstChild.namespaceURI) === 'http://www.w3.org/2000/svg';

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -200,7 +200,7 @@ export var emptyImageUrl = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAA
 // inspired by https://paulirish.com/2011/requestanimationframe-for-smart-animating/
 
 function getPrefixed(name) {
-    return typeof window === 'undefined' ? undefined : window['webkit' + name] || window['moz' + name] || window['ms' + name];
+	return typeof window === 'undefined' ? undefined : window['webkit' + name] || window['moz' + name] || window['ms' + name];
 }
 
 var lastTime = 0;
@@ -208,7 +208,7 @@ var lastTime = 0;
 // fallback for IE 7-8
 function timeoutDefer(fn) {
 	var time = +new Date(),
-	    timeToCall = Math.max(0, 16 - (time - lastTime));
+	timeToCall = Math.max(0, 16 - (time - lastTime));
 
 	lastTime = time + timeToCall;
 	return typeof window === 'undefined' ? falseFn : window.setTimeout(fn, timeToCall);

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -200,7 +200,7 @@ export var emptyImageUrl = 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAA
 // inspired by https://paulirish.com/2011/requestanimationframe-for-smart-animating/
 
 function getPrefixed(name) {
-	return window['webkit' + name] || window['moz' + name] || window['ms' + name];
+    return typeof window === 'undefined' ? undefined : window['webkit' + name] || window['moz' + name] || window['ms' + name];
 }
 
 var lastTime = 0;
@@ -211,11 +211,11 @@ function timeoutDefer(fn) {
 	    timeToCall = Math.max(0, 16 - (time - lastTime));
 
 	lastTime = time + timeToCall;
-	return window.setTimeout(fn, timeToCall);
+	return typeof window === 'undefined' ? falseFn : window.setTimeout(fn, timeToCall);
 }
 
-export var requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer;
-export var cancelFn = window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
+export var requestFn = typeof window === 'undefined' ? falseFn : window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer;
+export var cancelFn = typeof window === 'undefined' ? falseFn : window.cancelAnimationFrame || getPrefixed('CancelAnimationFrame') ||
 		getPrefixed('CancelRequestAnimationFrame') || function (id) { window.clearTimeout(id); };
 
 // @function requestAnimFrame(fn: Function, context?: Object, immediate?: Boolean): Number
@@ -235,7 +235,7 @@ export function requestAnimFrame(fn, context, immediate) {
 // @function cancelAnimFrame(id: Number): undefined
 // Cancels a previous `requestAnimFrame`. See also [window.cancelAnimationFrame](https://developer.mozilla.org/docs/Web/API/window/cancelAnimationFrame).
 export function cancelAnimFrame(id) {
-	if (id) {
+	if (id && typeof window != 'undefined') {
 		cancelFn.call(window, id);
 	}
 }

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -96,7 +96,7 @@ function batchRemove(obj, filterFn) {
 var mouseSubst = {
 	mouseenter: 'mouseover',
 	mouseleave: 'mouseout',
-	wheel: !('onwheel' in window) && 'mousewheel'
+	wheel: typeof window === 'undefined' ? false : !('onwheel' in window) && 'mousewheel'
 };
 
 function addOne(obj, type, fn, context) {

--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -268,7 +268,7 @@ export function getMousePosition(e, container) {
 // We need double the scroll pixels (see #7403 and #4538) for all Browsers
 // except OSX (Mac) -> 3x, Chrome running on Linux 1x
 
-var wheelPxFactor =
+var wheelPxFactor = typeof window === 'undefined' ? 1 :
 	(Browser.linux && Browser.chrome) ? window.devicePixelRatio :
 	Browser.mac ? window.devicePixelRatio * 3 :
 	window.devicePixelRatio > 0 ? 2 * window.devicePixelRatio : 1;

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -196,6 +196,9 @@ function _setOpacityIE(el, value) {
 // that is a valid style name for an element. If no such name is found,
 // it returns false. Useful for vendor-prefixed styles like `transform`.
 export function testProp(props) {
+	if (typeof document === 'undefined') {
+		return false;
+	}
 	var style = document.documentElement.style;
 
 	for (var i = 0; i < props.length; i++) {
@@ -244,13 +247,8 @@ export function getPosition(el) {
 	// this method is only used for elements previously positioned using setPosition,
 	// so it's safe to cache the position for performance
 
-    return el._leaflet_pos || new Point(0, 0);
+	return el._leaflet_pos || new Point(0, 0);
 }
-
-const documentStyle = typeof document === 'undefined' ? {} : document.documentElement.style;
-// Safari still needs a vendor prefix, we need to detect with property name is supported.
-const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
-let prevUserSelect;
 
 // @function disableTextSelection()
 // Prevents the user from generating `selectstart` DOM events, usually generated
@@ -263,18 +261,21 @@ let prevUserSelect;
 export var disableTextSelection;
 export var enableTextSelection;
 var _userSelect;
-if ('onselectstart' in document) {
+if (typeof document === 'undefined') {
+	disableTextSelection = function () { };
+	enableTextSelection = function () { };
+} else if ('onselectstart' in document) {
 	disableTextSelection = function () {
-        if (typeof window === 'undefined') {
-            return;
-        }
-        DomEvent.on(window, 'selectstart', DomEvent.preventDefault);
+		if (typeof window === 'undefined') {
+			return;
+		}
+		DomEvent.on(window, 'selectstart', DomEvent.preventDefault);
 	};
 	enableTextSelection = function () {
-        if (typeof window === 'undefined') {
-            return;
-        }
-        DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
+		if (typeof window === 'undefined') {
+			return;
+		}
+		DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
 	};
 } else {
 	var userSelectProperty = testProp(
@@ -299,18 +300,18 @@ if ('onselectstart' in document) {
 // As [`L.DomUtil.disableTextSelection`](#domutil-disabletextselection), but
 // for `dragstart` DOM events, usually generated when the user drags an image.
 export function disableImageDrag() {
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 	DomEvent.on(window, 'dragstart', DomEvent.preventDefault);
 }
 
 // @function enableImageDrag()
 // Cancels the effects of a previous [`L.DomUtil.disableImageDrag`](#domutil-disabletextselection).
 export function enableImageDrag() {
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 	DomEvent.off(window, 'dragstart', DomEvent.preventDefault);
 }
 
@@ -329,9 +330,9 @@ export function preventOutline(element) {
 	_outlineElement = element;
 	_outlineStyle = element.style.outlineStyle;
 	element.style.outlineStyle = 'none';
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 	DomEvent.on(window, 'keydown', restoreOutline);
 }
 
@@ -342,9 +343,9 @@ export function restoreOutline() {
 	_outlineElement.style.outlineStyle = _outlineStyle;
 	_outlineElement = undefined;
 	_outlineStyle = undefined;
-    if (typeof window === 'undefined') {
-        return;
-    }
+	if (typeof window === 'undefined') {
+		return;
+	}
 	DomEvent.off(window, 'keydown', restoreOutline);
 }
 

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -244,8 +244,13 @@ export function getPosition(el) {
 	// this method is only used for elements previously positioned using setPosition,
 	// so it's safe to cache the position for performance
 
-	return el._leaflet_pos || new Point(0, 0);
+    return el._leaflet_pos || new Point(0, 0);
 }
+
+const documentStyle = typeof document === 'undefined' ? {} : document.documentElement.style;
+// Safari still needs a vendor prefix, we need to detect with property name is supported.
+const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
+let prevUserSelect;
 
 // @function disableTextSelection()
 // Prevents the user from generating `selectstart` DOM events, usually generated
@@ -260,10 +265,16 @@ export var enableTextSelection;
 var _userSelect;
 if ('onselectstart' in document) {
 	disableTextSelection = function () {
-		DomEvent.on(window, 'selectstart', DomEvent.preventDefault);
+        if (typeof window === 'undefined') {
+            return;
+        }
+        DomEvent.on(window, 'selectstart', DomEvent.preventDefault);
 	};
 	enableTextSelection = function () {
-		DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
+        if (typeof window === 'undefined') {
+            return;
+        }
+        DomEvent.off(window, 'selectstart', DomEvent.preventDefault);
 	};
 } else {
 	var userSelectProperty = testProp(
@@ -288,12 +299,18 @@ if ('onselectstart' in document) {
 // As [`L.DomUtil.disableTextSelection`](#domutil-disabletextselection), but
 // for `dragstart` DOM events, usually generated when the user drags an image.
 export function disableImageDrag() {
+    if (typeof window === 'undefined') {
+        return;
+    }
 	DomEvent.on(window, 'dragstart', DomEvent.preventDefault);
 }
 
 // @function enableImageDrag()
 // Cancels the effects of a previous [`L.DomUtil.disableImageDrag`](#domutil-disabletextselection).
 export function enableImageDrag() {
+    if (typeof window === 'undefined') {
+        return;
+    }
 	DomEvent.off(window, 'dragstart', DomEvent.preventDefault);
 }
 
@@ -312,6 +329,9 @@ export function preventOutline(element) {
 	_outlineElement = element;
 	_outlineStyle = element.style.outlineStyle;
 	element.style.outlineStyle = 'none';
+    if (typeof window === 'undefined') {
+        return;
+    }
 	DomEvent.on(window, 'keydown', restoreOutline);
 }
 
@@ -322,6 +342,9 @@ export function restoreOutline() {
 	_outlineElement.style.outlineStyle = _outlineStyle;
 	_outlineElement = undefined;
 	_outlineStyle = undefined;
+    if (typeof window === 'undefined') {
+        return;
+    }
 	DomEvent.off(window, 'keydown', restoreOutline);
 }
 


### PR DESCRIPTION
Hello! I'm using Leaflet in an Angular app, for which i have made a workaround for the lack of SSR support. But i noticed that in main a commit was made for Leaflet v2 to support SSR by making references to browser-only variables conditional. It didn't look too complicated to I cherry-picked that commit into v1 and also updated everything that was supported in the in-progress branch for v2. The two SSR test files seem to be fully functional. I have also tested this build in my Angular application and it works perfectly. I can now remove the SSR workaround and even upgrade to the new Vite build system.

Considering development velocity for v2 is low it would be really great is we can make a v1 release containing these SSR fixes. Nothing will break by doing this so it will most likely be safe for a minor release.

Thanks a lot for your great work on Leaflet.