### PR TITLE
Fix demo link on azure-maps-leaflet-plugin

### DIFF
--- a/docs/_plugins/basemap-providers/azure-maps-leaflet-plugin.md
+++ b/docs/_plugins/basemap-providers/azure-maps-leaflet-plugin.md
@@ -4,7 +4,7 @@ category: basemap-providers
 repo: https://github.com/Azure-Samples/azure-maps-leaflet
 author: Ricky Brundritt
 author-url: https://github.com/rbrundritt
-demo: https://azuremapscodesamples.azurewebsites.net/?search=leaflet
+demo: https://samples.azuremaps.com/?search=leaflet
 compatible-v0:
 compatible-v1: true
 ---


### PR DESCRIPTION
Fixing link to azure-maps-leaflet demo as previous link is now dead.

First raised in https://github.com/Azure-Samples/azure-maps-leaflet/issues/7#issuecomment-2139074033