### PR TITLE
Implemented `trackResize` for L.Popup

### DIFF
--- a/debug/tests/popup-resize.html
+++ b/debug/tests/popup-resize.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Leaflet debug page - Popup Offset</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
+		<link rel="stylesheet" href="../../dist/leaflet.css" />
+		<link rel="stylesheet" href="../css/screen.css" />
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.esm.js"
+				}
+			}
+		</script>
+	</head>
+	<body>
+		<div id="map"></div>
+		<script type="module">
+			import {TileLayer, Map, Marker} from 'leaflet';
+
+			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
+			const map = new Map('map').setView([50.5, 30.51], 15).addLayer(osm);
+
+			let marker = new Marker(map.getCenter())
+				.addTo(map);
+
+
+marker.bindPopup("foobar", {maxWidth: 600, trackResize: true});  // NOTE: change to true!!
+
+setTimeout(()=>{
+	marker.getPopup().setContent(`Lorem ipsum sit amet.
+	<img id="image" src="https://cataas.com/cat?height=${480 + Math.random() * 80}&v=${Math.random()}" />`);
+}, 2500);
+
+marker.on('click',()=>{
+	marker.getPopup().setContent(`Lorem ipsum sit amet.
+	<img id="image" src="https://cataas.com/cat?height=${480 + Math.random() * 80}&v=${Math.random()}" />`);
+})
+
+marker.openPopup();
+
+
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Fixes #9588

I had to get rid of the manual handling of the popup's `minWidth` and `maxWidth`, because setting the popup's content's width was triggering resizes (even with the same dimensions) and entering an infinite loop. I hope it was a leftover from the IE days.