### PR TITLE
Fix Canvas rendering with setting _redrawRequest to null for requestAnimFrame

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -238,7 +238,7 @@ describe('Canvas', () => {
 			// we need the timeout, because else the requestAnimFrame is not called
 			expect(spy.callCount).to.eql(1);
 			done();
-		}, 5);
+		}, 50);
 	});
 
 	describe('#bringToBack', () => {

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -222,7 +222,7 @@ describe('Canvas', () => {
 		}, this);
 	});
 
-	it.only('adds vectors even if the canvas container was removed', (done) => {
+	it('adds vectors even if the canvas container was removed', (done) => {
 		const layer = new Circle([0, 0]).addTo(map);
 		map.eachLayer((layer) => {
 			map.removeLayer(layer);

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -222,6 +222,25 @@ describe('Canvas', () => {
 		}, this);
 	});
 
+	it.only('adds vectors even if the canvas container was removed', (done) => {
+		const layer = new Circle([0, 0]).addTo(map);
+		map.eachLayer((layer) => {
+			map.removeLayer(layer);
+		});
+
+		const spy = sinon.spy();
+		const canvas = map.getRenderer(layer);
+		canvas._redraw = spy;
+
+		map.addLayer(layer);
+
+		setTimeout(() => {
+			// we need the timeout, because else the requestAnimFrame is not called
+			expect(spy.callCount).to.eql(1);
+			done();
+		}, 5);
+	});
+
 	describe('#bringToBack', () => {
 		it('is a no-op for layers not on a map', () => {
 			const path = new Polyline([[1, 2], [3, 4], [5, 6]]);

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -79,6 +79,7 @@ export const Canvas = Renderer.extend({
 
 	_destroyContainer() {
 		Util.cancelAnimFrame(this._redrawRequest);
+		this._redrawRequest = null;
 		delete this._ctx;
 		Renderer.prototype._destroyContainer.call(this);
 	},


### PR DESCRIPTION
Fixes: #9542

After removing all layers and the canvas layer from the map and then adding a layer back to the map, the canvas `_redraw` function wasn't called. The logic behinde is, that `_redraw` is executed via `Util.requestAnimFrame` and if already a `Util.requestAnimFrame` is set, we don't overwrite it. The problem now is, that if `Util.requestAnimFrame` was already set but then canceled with removing the canvas layer, the variable `_redrawRequest` was still available and no new requestAnimFrame is later created.

https://github.com/Leaflet/Leaflet/blob/2c3ee41dc6b42abec04c9239c4f577d60ee6b472/src/layer/vector/Canvas.js#L213

https://github.com/Leaflet/Leaflet/blob/2c3ee41dc6b42abec04c9239c4f577d60ee6b472/src/layer/vector/Canvas.js#L80-L84