### PR TITLE
Add missing variable initializer for .addData()

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -102,7 +102,7 @@ export const GeoJSON = FeatureGroup.extend({
 		if (features) {
 			for (i = 0, len = features.length; i < len; i++) {
 				// only add this if geometry or geometries are set and not null
-				feature = features[i];
+				const feature = features[i];
 				if (feature.geometries || feature.geometry || feature.features || feature.coordinates) {
 					this.addData(feature);
 				}


### PR DESCRIPTION
# Description

Was working on something at work and I noticed this is broken.

Looks like its just a simple oversight,  no big deal. Variable just needs to be initialized.