### PR TITLE
Fix video control / seek bar usage in safari

### DIFF
--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import {LatLngBounds, Map, VideoOverlay} from 'leaflet';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
+import Hand from 'prosthetic-hand';
 
 describe('VideoOverlay', () => {
 	let container, map;
@@ -9,7 +10,7 @@ describe('VideoOverlay', () => {
 	beforeEach(() => {
 		container = container = createContainer();
 		map = new Map(container);
-		map.setView([55.8, 37.6], 6);	// view needs to be set so when layer is added it is initilized
+		map.setView([20, -115], 4);	// view needs to be set so when layer is added it is initilized
 	});
 
 	afterEach(() => {
@@ -28,5 +29,53 @@ describe('VideoOverlay', () => {
 		const videoOverlay = new VideoOverlay(videoUrls, videoBounds).addTo(map);
 
 		expect(map.hasLayer(videoOverlay)).to.be.true;
+	});
+
+	it('drags the map while mousemove on video', (done) => {
+
+		const videoUrls = [
+			'https://www.mapbox.com/bites/00188/patricia_nasa.webm',
+			'https://www.mapbox.com/bites/00188/patricia_nasa.mp4'
+		];
+
+		const videoOverlay = new VideoOverlay(videoUrls, videoBounds, {interactive: true}).addTo(map);
+		(videoOverlay.getElement()).controls = true;
+		expect(map.hasLayer(videoOverlay)).to.be.true;
+
+		const hand = new Hand({
+			timing: 'fastframe',
+			onStop() {
+				expect(map.getCenter()).nearLatLng([19.973348786110613, -114.96093750000001], 0.01);
+				done();
+			}});
+		const mouse = hand.growFinger('mouse');
+		mouse.moveTo(200, 200, 100)
+			.down().moveBy(10, 10, 50).up();
+	});
+
+	it('don\'t drags the map if video has enabled controls', (done) => {
+
+		const videoUrls = [
+			'https://www.mapbox.com/bites/00188/patricia_nasa.webm',
+			'https://www.mapbox.com/bites/00188/patricia_nasa.mp4'
+		];
+
+		const videoOverlay = new VideoOverlay(videoUrls, videoBounds, {interactive: true}).addTo(map);
+		(videoOverlay.getElement()).controls = true;
+		expect(map.hasLayer(videoOverlay)).to.be.true;
+
+		setTimeout(() => {
+			const center = map.getCenter();
+
+			const hand = new Hand({
+				timing: 'fastframe',
+				onStop() {
+					expect(map.getCenter()).nearLatLng(center, 0.01);
+					done();
+				}});
+			const mouse = hand.growFinger('mouse');
+			mouse.moveTo(200, 200, 10)
+				.down().moveBy(10, 10, 10).up();
+		}, 20);
 	});
 });

--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -76,6 +76,6 @@ describe('VideoOverlay', () => {
 			const mouse = hand.growFinger('mouse');
 			mouse.moveTo(200, 200, 10)
 				.down().moveBy(50, 50, 10).up();
-		}, 20);
+		}, 100);
 	});
 });

--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -53,7 +53,7 @@ describe('VideoOverlay', () => {
 			.down().moveBy(50, 50, 10).up();
 	});
 
-	it.only('don\'t drags the map if video has enabled controls', (done) => {
+	it('don\'t drags the map if video has enabled controls', (done) => {
 
 		const videoUrls = [
 			'https://www.mapbox.com/bites/00188/patricia_nasa.webm',

--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -45,15 +45,15 @@ describe('VideoOverlay', () => {
 		const hand = new Hand({
 			timing: 'fastframe',
 			onStop() {
-				expect(map.getCenter()).nearLatLng([19.973348786110613, -114.96093750000001], 0.01);
+				expect(map.getCenter()).nearLatLng([19.973348786110613, -114.96093750000001], 0.03);
 				done();
 			}});
 		const mouse = hand.growFinger('mouse');
 		mouse.moveTo(200, 200, 100)
-			.down().moveBy(10, 10, 50).up();
+			.down().moveBy(50, 50, 10).up();
 	});
 
-	it('don\'t drags the map if video has enabled controls', (done) => {
+	it.only('don\'t drags the map if video has enabled controls', (done) => {
 
 		const videoUrls = [
 			'https://www.mapbox.com/bites/00188/patricia_nasa.webm',
@@ -70,12 +70,12 @@ describe('VideoOverlay', () => {
 			const hand = new Hand({
 				timing: 'fastframe',
 				onStop() {
-					expect(map.getCenter()).nearLatLng(center, 0.01);
+					expect(map.getCenter()).nearLatLng(center, 0.03);
 					done();
 				}});
 			const mouse = hand.growFinger('mouse');
 			mouse.moveTo(200, 200, 10)
-				.down().moveBy(10, 10, 10).up();
+				.down().moveBy(50, 50, 10).up();
 		}, 20);
 	});
 });

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -1,5 +1,6 @@
 import {ImageOverlay} from './ImageOverlay.js';
 import * as DomUtil from '../dom/DomUtil.js';
+import * as DomEvent from '../dom/DomEvent.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -56,8 +57,12 @@ export const VideoOverlay = ImageOverlay.extend({
 		if (this._zoomAnimated) { vid.classList.add('leaflet-zoom-animated'); }
 		if (this.options.className) { vid.classList.add(...Util.splitWords(this.options.className)); }
 
-		vid.onselectstart = Util.falseFn;
-		vid.onmousemove = Util.falseFn;
+		DomEvent.on(vid, 'mousedown', (e) => {
+			if (vid.controls) {
+				// Prevent the map from moving when the video or the seekbar is moved
+				DomEvent.stopPropagation(e);
+			}
+		});
 
 		// @event load: Event
 		// Fired when the video has finished loading the first frame


### PR DESCRIPTION
When the controls of a html5 video in a VideoOverlay are enabled, moving the seekbar wasn't possible it always dragged the map. With removing `vid.onmousemove = Util.falseFn;` we fix this.
The new `mousedown -> stopPropagation` logic prevents in Safari, dragging the map if the user holds down and moves inside of the VideoOverlay.

Fixes: #9445

![safari_video_seekbar](https://github.com/user-attachments/assets/ae787b6f-d894-4866-ac19-41e81e275f1d)

