### PR TITLE
Add setClassName method to SVG Paths

### DIFF
--- a/debug/vector/set-class-name.html
+++ b/debug/vector/set-class-name.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>Leaflet debug page - Vector Simple</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=0" />
+		<link rel="stylesheet" href="../../dist/leaflet.css" />
+		<link rel="stylesheet" href="../css/screen.css" />
+		<style>
+			.mapped-item {
+				stroke: #aa6;
+			}
+			.mapped-item.modified {
+				stroke: #c44;
+			}
+			.mapped-item.highlighted {
+				stroke: #ee8;
+			}
+			.mapped-item.modified.highlighted {
+				stroke: #f66;
+			}
+		</style>
+		<script type="importmap">
+			{
+				"imports": {
+					"leaflet": "../../dist/leaflet-src.js"
+				}
+			}
+		</script>
+	</head>
+	<body>
+		<div id="map"></div>
+		<table>
+			<tr><th>circle</th><th>polygon</th></tr>
+			<tr>
+				<td><label><input type="checkbox" id="circleHighlighted" autocomplete="off">highlighted</label></td>
+				<td><label><input type="checkbox" id="polygonHighlighted" autocomplete="off">highlighted</label></td>
+			</tr>
+			<tr>
+				<td><label><input type="checkbox" id="circleModified" autocomplete="off">modified</label></td>
+				<td><label><input type="checkbox" id="polygonModified" autocomplete="off" checked>modified</label></td>
+			</tr>
+			<tr>
+				<td><button id="circleReset">Reset classes</button></td>
+				<td><button id="polygonReset">Reset classes</button></td>
+			</tr>
+		</table>
+		<script type="module">
+			import {Map, TileLayer, Circle, Polygon} from 'leaflet';
+
+			const map = new Map('map')
+				.setView([51.505, -0.09], 13);
+
+			map.addLayer(new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18}));
+
+			const circle = new Circle([51.508, -0.11], 500, {className: 'mapped-item'})
+				.bindPopup('I am a circle.')
+				.addTo(map);
+
+			const polygon = new Polygon([[51.509, -0.08], [51.503, -0.06], [51.51,  -0.047]], {className: 'mapped-item modified'})
+				.bindPopup('I am a polygon.')
+				.addTo(map);
+
+			for (const [item, itemName] of [[circle, 'circle'], [polygon, 'polygon']]) {
+				const updateListener = () => {
+					const classList = ['mapped-item'];
+					if (document.getElementById(`${itemName}Highlighted`).checked) classList.push('highlighted');
+					if (document.getElementById(`${itemName}Modified`).checked) classList.push('modified');
+					item.setClassName(classList.join(' '));
+				};
+
+				const resetListener = () => {
+					document.getElementById(`${itemName}Highlighted`).checked = false;
+					document.getElementById(`${itemName}Modified`).checked = false;
+					item.setClassName();
+				};
+
+				document.getElementById(`${itemName}Highlighted`).addEventListener('input', updateListener);
+				document.getElementById(`${itemName}Modified`).addEventListener('input', updateListener);
+				document.getElementById(`${itemName}Reset`).addEventListener('click', resetListener);
+			}
+		</script>
+	</body>
+</html>

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -273,6 +273,48 @@ describe('Polyline', () => {
 		});
 	});
 
+	describe('#setClassName', () => {
+		it('should add multiple css classes', () => {
+			const polyln = polyline([]);
+
+			polyln.addTo(map);
+			polyln.setClassName('added-class-one added-class-two');
+
+			expect(polyln.options.className).to.equal('added-class-one added-class-two');
+			expect(polyln._path.classList).to.include.members(['added-class-one', 'added-class-two']);
+		});
+
+		it('should add and remove css classes', () => {
+			const polyln = polyline([], {className: 'removed-class'});
+
+			polyln.addTo(map);
+			polyln.setClassName('added-class');
+
+			expect(polyln.options.className).to.equal('added-class');
+			expect(polyln._path.classList).not.to.include.members(['removed-class']);
+			expect(polyln._path.classList).to.include.members(['added-class']);
+		});
+
+		it('should remove multiple css classes using an undefined value', () => {
+			const polyln = polyline([], {className: 'removed-class-one removed-class-two'});
+
+			polyln.addTo(map);
+			polyln.setClassName();
+
+			expect(polyln._path.classList).not.to.include.members(['removed-class-one']);
+			expect(polyln._path.classList).not.to.include.members(['removed-class-two']);
+		});
+
+		it('should remove multiple css classes using an empty string', () => {
+			const polyln = polyline([], {className: 'removed-class-one removed-class-two'});
+
+			polyln.addTo(map);
+			polyln.setClassName('');
+
+			expect(polyln._path.classList).not.to.include.members(['removed-class-one']).and.not.to.include.members(['removed-class-two']);
+		});
+	});
+
 	describe('#distance', () => {
 		it('calculates closestLayerPoint', () => {
 			const p1 = map.latLngToLayerPoint([55.8, 37.6]);

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -112,6 +112,16 @@ export const Path = Layer.extend({
 		return this;
 	},
 
+	// @method setClassName(className: String): this
+	// Sets a custom class name on the Path element. Only for SVG renderer.
+	setClassName(className) {
+		Util.setOptions(this, {className});
+		if (this._renderer) {
+			this._renderer._updateClassName(this);
+		}
+		return this;
+	},
+
 	// @method bringToFront(): this
 	// Brings the layer to the top of all path layers.
 	bringToFront() {

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -53,6 +53,8 @@ export const Renderer = BlanketOverlay.extend({
 		}
 	},
 
+	_updateClassName() {},
+
 	_updatePaths() {
 		for (const id in this._layers) {
 			if (Object.hasOwn(this._layers, id)) {

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -1,6 +1,6 @@
 import {Renderer} from './Renderer.js';
 import * as DomUtil from '../../dom/DomUtil.js';
-import {splitWords, stamp} from '../../core/Util.js';
+import {stamp} from '../../core/Util.js';
 import {svgCreate, pointsToPath} from './SVG.Util.js';
 export {pointsToPath};
 
@@ -81,18 +81,12 @@ export const SVG = Renderer.extend({
 	_initPath(layer) {
 		const path = layer._path = create('path');
 
-		// @namespace Path
-		// @option className: String = null
-		// Custom class name set on an element. Only for SVG renderer.
-		if (layer.options.className) {
-			path.classList.add(...splitWords(layer.options.className));
-		}
-
 		if (layer.options.interactive) {
 			path.classList.add('leaflet-interactive');
 		}
 
 		this._updateStyle(layer);
+		this._updateClassName(layer);
 		this._layers[stamp(layer)] = layer;
 	},
 
@@ -148,6 +142,26 @@ export const SVG = Renderer.extend({
 		} else {
 			path.setAttribute('fill', 'none');
 		}
+	},
+
+	_updateClassName(layer) {
+		const path = layer._path,
+		    options = layer.options;
+
+		if (!path) { return; }
+
+		const extraClasses = [];
+		for (const c of path.classList) {
+			if (c === 'leaflet-interactive') {
+				extraClasses.push(c);
+			}
+		}
+
+		// @namespace Path
+		// @option className: String = null
+		// Custom class name set on an element. Only for SVG renderer.
+		path.classList.value = options.className;
+		path.classList.add(...extraClasses);
 	},
 
 	_updatePoly(layer, closed) {


### PR DESCRIPTION
`setStyle` on svg paths ignores `className` (#2662) and this is by desing because `className` is not a style (#2936). But I still want to update it somehow. This PR adds `setClassName()` as suggested in #2936.