### PR TITLE
Removes mozEvent warning

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1417,15 +1417,13 @@ export const Map = Evented.extend({
 
 	_fireDOMEvent(e, type, canvasTargets) {
 
-		if (e.type === 'click') {
+		if (type === 'click') {
 			// Fire a synthetic 'preclick' event which propagates up (mainly for closing popups).
 			// @event preclick: MouseEvent
 			// Fired before mouse click on the map (sometimes useful when you
 			// want something to happen on click before any existing click
 			// handlers start running).
-			const synth = Util.extend({}, e);
-			synth.type = 'preclick';
-			this._fireDOMEvent(synth, synth.type, canvasTargets);
+			this._fireDOMEvent(e, 'preclick', canvasTargets);
 		}
 
 		// Find the layer the event is propagating from and its parents.


### PR DESCRIPTION
Before:
*MouseEvent.mozPressure should not be used. Use PointerEvent.pressure*
![grafik](https://github.com/user-attachments/assets/1f4e0668-5773-4ac5-b6a2-537189238310)


Now:
![grafik](https://github.com/user-attachments/assets/c0494d47-3afe-4dcb-a46d-7a14b473b07d)


Added with #4493