### PR TITLE
Improve documentation about renderer and pane

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -33,6 +33,7 @@ export const Layer = Evented.extend({
 	options: {
 		// @option pane: String = 'overlayPane'
 		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
+		// If the `renderer` option is set, it will override the `pane` option.
 		pane: 'overlayPane',
 
 		// @option attribution: String = null

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -33,7 +33,7 @@ export const Layer = Evented.extend({
 	options: {
 		// @option pane: String = 'overlayPane'
 		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
-		// If the `renderer` option is set, it will override the `pane` option.
+		// Not effective if the `renderer` option is set (the `renderer` option will override the `pane` option).
 		pane: 'overlayPane',
 
 		// @option attribution: String = null

--- a/src/layer/vector/Renderer.getRenderer.js
+++ b/src/layer/vector/Renderer.getRenderer.js
@@ -11,6 +11,7 @@ Map.include({
 		// @namespace Path; @option renderer: Renderer
 		// Use this specific instance of `Renderer` for this path. Takes
 		// precedence over the map's [default renderer](#map-renderer).
+		// If set, it will override the `pane` option of the path.
 		let renderer = layer.options.renderer || this._getPaneRenderer(layer.options.pane) || this.options.renderer || this._renderer;
 
 		if (!renderer) {


### PR DESCRIPTION
Fixes: #7586

> No, it's gonna be one or the other. You should consider spawning L.Canvas renderers with explicit panes, then tell your L.Paths to use that renderer (instead of telling your L.Paths to be in a specific pane). When dealing with L.Paths, an explicit renderer takes precedence over a explicit pane (the thing goes path→renderer→pane, and not path→pane→renderer; if there's no explicit renderer, then it's path→default-renderer-for-pane→pane).
>
>    Is this a bug ?
>
> No, but I'll say that this is a potential documentation improvement, since the docs don't make clear the precedence of renderers over panes.

*Comment of [IvanSanchez](https://github.com/IvanSanchez) in https://github.com/Leaflet/Leaflet/issues/7586#issuecomment-850460317*