### PR TITLE
Replace Util.extend with ES6 Object.assign or object spread

### DIFF
--- a/spec/suites/core/UtilSpec.js
+++ b/spec/suites/core/UtilSpec.js
@@ -3,40 +3,6 @@ import {Util} from 'leaflet';
 import sinon from 'sinon';
 
 describe('Util', () => {
-	describe('#extend', () => {
-		let a;
-
-		beforeEach(() => {
-			a = {
-				foo: 5,
-				bar: 'asd'
-			};
-		});
-
-		it('extends the first argument with the properties of the second', () => {
-			Util.extend(a, {
-				bar: 7,
-				baz: 3
-			});
-
-			expect(a).to.eql({
-				foo: 5,
-				bar: 7,
-				baz: 3
-			});
-		});
-
-		it('accepts more than 2 arguments', () => {
-			Util.extend(a, {bar: 7}, {baz: 3});
-
-			expect(a).to.eql({
-				foo: 5,
-				bar: 7,
-				baz: 3
-			});
-		});
-	});
-
 	describe('#stamp', () => {
 		it('sets a unique id on the given object and returns it', () => {
 			const a = {},

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Control, DomEvent, DomUtil, Map, extend} from 'leaflet';
+import {Control, DomEvent, DomUtil, Map} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
@@ -84,13 +84,14 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		UIEventSimulator.fire('click', container, click);
 
 		const event = spy.lastCall.args[0];
-		const expectedProps = extend(click, {
+		const expectedProps = {
+			...click,
 			type: 'dblclick',
 			// bubbles: true,    // not important, as we do not actually dispatch the event
 			// cancelable: true, //
 			detail: 2,
 			target: container
-		});
+		};
 		for (const [prop, expectedValue] of Object.entries(expectedProps)) {
 			expect(event[prop]).to.equal(expectedValue);
 		}

--- a/spec/suites/dom/DomEvent.PointerSpec.js
+++ b/spec/suites/dom/DomEvent.PointerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Browser, DomEvent, Util, extend} from 'leaflet';
+import {Browser, DomEvent, Util} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 
@@ -127,7 +127,7 @@ describe('DomEvent.Pointer', () => {
 			expect(containIn([pointer1, pointer2], evt.touches)).to.be.true;
 
 			// pointermove/touchmove (multitouch)
-			extend(pointer1, {clientX:11, clientY:11});
+			Object.assign(pointer1, {clientX:11, clientY:11});
 			UIEventSimulator.fire('pointermove', el, pointer1);
 			evt = listeners.touchmove.lastCall.args[0];
 			expect(evt.type).to.equal('pointermove');

--- a/spec/suites/geo/crs/CRSSpec.js
+++ b/spec/suites/geo/crs/CRSSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {CRS, Util, extend, latLng, latLngBounds, point} from 'leaflet';
+import {CRS, Util, latLng, latLngBounds, point} from 'leaflet';
 import '../../SpecHelper.js';
 
 describe('CRS.EPSG3857', () => {
@@ -218,7 +218,7 @@ describe('CRS.Simple', () => {
 		});
 
 		it('wraps coords if configured', () => {
-			const crs = extend({}, CRS.Simple, {
+			const crs = Object.assign({}, CRS.Simple, {
 				wrapLng: [-200, 200],
 				wrapLat: [-200, 200]
 			});
@@ -242,7 +242,7 @@ describe('CRS', () => {
 });
 
 describe('CRS.ZoomNotPowerOfTwo', () => {
-	const crs = extend({}, CRS, {
+	const crs = Object.assign({}, CRS, {
 		scale(zoom) {
 			return 256 * 1.5 ** zoom;
 		},

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Circle, Map, Util, CRS, Transformation} from 'leaflet';
+import {Circle, Map, CRS, Transformation} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Circle', () => {
@@ -52,9 +52,10 @@ describe('Circle', () => {
 		it('returns a positive radius if the x axis of L.CRS.Simple is inverted', () => {
 			map.remove();
 
-			const crs = Util.extend(CRS.Simple, {
+			const crs = {
+				...CRS.Simple,
 				transformation: new Transformation(-1, 0, -1, 0),
-			});
+			};
 			map = new Map(container, {
 				crs
 			});

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Browser, Map, Point, extend} from 'leaflet';
+import {Browser, Map, Point} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -156,7 +156,7 @@ describe('Map.TapHoldSpec.js', () => {
 	});
 
 	it('.originalEvent has expected properties', () => {
-		extend(posStart, {
+		Object.assign(posStart, {
 			screenX: 2,
 			screenY: 2,
 		});
@@ -166,7 +166,7 @@ describe('Map.TapHoldSpec.js', () => {
 		clock.tick(650);
 
 		const originalEvent = spy.lastCall.args[0].originalEvent;
-		const expectedProps = extend({
+		const expectedProps = Object.assign({
 			type: 'contextmenu',
 			bubbles: true,
 			cancelable: true,

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -23,21 +23,25 @@ export class Class {
 
 		// mix static properties into the class
 		if (statics) {
-			Util.extend(NewClass, statics);
+			Object.assign(NewClass, statics);
 		}
 
 		// mix includes into the prototype
-		if (includes) {
-			Util.extend.apply(null, [proto].concat(includes));
+		if (Array.isArray(includes)) {
+			for (const include of includes) {
+				Object.assign(proto, include);
+			}
+		} else if (includes) {
+			Object.assign(proto, includes);
 		}
 
 		// mix given properties into the prototype
-		Util.extend(proto, props);
+		Object.assign(proto, props);
 
 		// merge options
 		if (proto.options) {
 			proto.options = parentProto.options ? Object.create(parentProto.options) : {};
-			Util.extend(proto.options, props.options);
+			Object.assign(proto.options, props.options);
 		}
 
 		proto._initHooks = [];
@@ -49,7 +53,7 @@ export class Class {
 	// [Includes a mixin](#class-includes) into the current class.
 	static include(props) {
 		const parentOptions = this.prototype.options;
-		Util.extend(this.prototype, props);
+		Object.assign(this.prototype, props);
 		if (props.options) {
 			this.prototype.options = parentOptions;
 			this.mergeOptions(props.options);
@@ -60,7 +64,8 @@ export class Class {
 	// @function mergeOptions(options: Object): this
 	// [Merges `options`](#class-options) into the defaults of the class.
 	static mergeOptions(options) {
-		Util.extend(this.prototype.options, options);
+		this.prototype.options ??= {};
+		Object.assign(this.prototype.options, options);
 		return this;
 	}
 

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -167,11 +167,12 @@ export const Events = {
 	fire(type, data, propagate) {
 		if (!this.listens(type, propagate)) { return this; }
 
-		const event = Util.extend({}, data, {
+		const event = {
+			...data,
 			type,
 			target: this,
 			sourceTarget: data?.sourceTarget || this
-		});
+		};
 
 		if (this._events) {
 			const listeners = this._events[type];
@@ -294,10 +295,11 @@ export const Events = {
 
 	_propagateEvent(e) {
 		for (const p of Object.values(this._eventParents ?? {})) {
-			p.fire(e.type, Util.extend({
+			p.fire(e.type, {
 				layer: e.target,
-				propagatedFrom: e.target
-			}, e), true);
+				propagatedFrom: e.target,
+				...e
+			}, true);
 		}
 	}
 };

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -4,22 +4,6 @@
  * Various utility functions, used by Leaflet internally.
  */
 
-// @function extend(dest: Object, src?: Object): Object
-// Merges the properties (including properties inherited through the prototype chain)
-// of the `src` object (or multiple objects) into `dest` object and returns the latter.
-// Has an `L.extend` shortcut.
-export function extend(dest, ...args) {
-	let j, len, src;
-
-	for (j = 0, len = args.length; j < len; j++) {
-		src = args[j];
-		for (const i in src) {
-			dest[i] = src[i];
-		}
-	}
-	return dest;
-}
-
 // @property lastId: Number
 // Last unique ID used by [`stamp()`](#util-stamp)
 export let lastId = 0;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -5,4 +5,4 @@ export {Handler} from './Handler.js';
 
 import * as Util from './Util.js';
 export {Util};
-export {extend, stamp, setOptions} from './Util.js';
+export {stamp, setOptions} from './Util.js';

--- a/src/geo/crs/CRS.EPSG3395.js
+++ b/src/geo/crs/CRS.EPSG3395.js
@@ -1,7 +1,6 @@
 import {Earth} from './CRS.Earth.js';
 import {Mercator} from '../projection/Projection.Mercator.js';
 import {toTransformation} from '../../geometry/Transformation.js';
-import * as Util from '../../core/Util.js';
 
 /*
  * @namespace CRS
@@ -9,7 +8,8 @@ import * as Util from '../../core/Util.js';
  *
  * Rarely used by some commercial tile providers. Uses Elliptical Mercator projection.
  */
-export const EPSG3395 = Util.extend({}, Earth, {
+export const EPSG3395 = {
+	...Earth,
 	code: 'EPSG:3395',
 	projection: Mercator,
 
@@ -17,4 +17,4 @@ export const EPSG3395 = Util.extend({}, Earth, {
 		const scale = 0.5 / (Math.PI * Mercator.R);
 		return toTransformation(scale, 0.5, -scale, 0.5);
 	})()
-});
+};

--- a/src/geo/crs/CRS.EPSG3857.js
+++ b/src/geo/crs/CRS.EPSG3857.js
@@ -1,7 +1,6 @@
 import {Earth} from './CRS.Earth.js';
 import {SphericalMercator} from '../projection/Projection.SphericalMercator.js';
 import {toTransformation} from '../../geometry/Transformation.js';
-import * as Util from '../../core/Util.js';
 
 /*
  * @namespace CRS
@@ -12,7 +11,8 @@ import * as Util from '../../core/Util.js';
  * Map's `crs` option.
  */
 
-export const EPSG3857 = Util.extend({}, Earth, {
+export const EPSG3857 = {
+	...Earth,
 	code: 'EPSG:3857',
 	projection: SphericalMercator,
 
@@ -20,8 +20,9 @@ export const EPSG3857 = Util.extend({}, Earth, {
 		const scale = 0.5 / (Math.PI * SphericalMercator.R);
 		return toTransformation(scale, 0.5, -scale, 0.5);
 	})()
-});
+};
 
-export const EPSG900913 = Util.extend({}, EPSG3857, {
+export const EPSG900913 = {
+	...EPSG3857,
 	code: 'EPSG:900913'
-});
+};

--- a/src/geo/crs/CRS.EPSG4326.js
+++ b/src/geo/crs/CRS.EPSG4326.js
@@ -1,7 +1,6 @@
 import {Earth} from './CRS.Earth.js';
 import {LonLat} from '../projection/Projection.LonLat.js';
 import {toTransformation} from '../../geometry/Transformation.js';
-import * as Util from '../../core/Util.js';
 
 /*
  * @namespace CRS
@@ -16,8 +15,9 @@ import * as Util from '../../core/Util.js';
  * or (-180,-90) for `TileLayer`s with [the `tms` option](#tilelayer-tms) set.
  */
 
-export const EPSG4326 = Util.extend({}, Earth, {
+export const EPSG4326 = {
+	...Earth,
 	code: 'EPSG:4326',
 	projection: LonLat,
 	transformation: toTransformation(1 / 180, 1, -1 / 180, 0.5)
-});
+};

--- a/src/geo/crs/CRS.Earth.js
+++ b/src/geo/crs/CRS.Earth.js
@@ -1,5 +1,4 @@
 import {CRS} from './CRS.js';
-import * as Util from '../../core/Util.js';
 
 /*
  * @namespace CRS
@@ -11,7 +10,8 @@ import * as Util from '../../core/Util.js';
  * meters.
  */
 
-export const Earth = Util.extend({}, CRS, {
+export const Earth = {
+	...CRS,
 	wrapLng: [-180, 180],
 
 	// Mean Earth Radius, as recommended for use by
@@ -22,12 +22,12 @@ export const Earth = Util.extend({}, CRS, {
 	// distance between two geographical points using spherical law of cosines approximation
 	distance(latlng1, latlng2) {
 		const rad = Math.PI / 180,
-		    lat1 = latlng1.lat * rad,
-		    lat2 = latlng2.lat * rad,
-		    sinDLat = Math.sin((latlng2.lat - latlng1.lat) * rad / 2),
-		    sinDLon = Math.sin((latlng2.lng - latlng1.lng) * rad / 2),
-		    a = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon,
-		    c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+		lat1 = latlng1.lat * rad,
+		lat2 = latlng2.lat * rad,
+		sinDLat = Math.sin((latlng2.lat - latlng1.lat) * rad / 2),
+		sinDLon = Math.sin((latlng2.lng - latlng1.lng) * rad / 2),
+		a = sinDLat * sinDLat + Math.cos(lat1) * Math.cos(lat2) * sinDLon * sinDLon,
+		c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
 		return this.R * c;
 	}
-});
+};

--- a/src/geo/crs/CRS.Simple.js
+++ b/src/geo/crs/CRS.Simple.js
@@ -1,7 +1,6 @@
 import {CRS} from './CRS.js';
 import {LonLat} from '../projection/Projection.LonLat.js';
 import {toTransformation} from '../../geometry/Transformation.js';
-import * as Util from '../../core/Util.js';
 
 /*
  * @namespace CRS
@@ -13,7 +12,8 @@ import * as Util from '../../core/Util.js';
  * simple euclidean distance.
  */
 
-export const Simple = Util.extend({}, CRS, {
+export const Simple = {
+	...CRS,
 	projection: LonLat,
 	transformation: toTransformation(1, 0, -1, 0),
 
@@ -27,10 +27,10 @@ export const Simple = Util.extend({}, CRS, {
 
 	distance(latlng1, latlng2) {
 		const dx = latlng2.lng - latlng1.lng,
-		    dy = latlng2.lat - latlng1.lat;
+		dy = latlng2.lat - latlng1.lat;
 
 		return Math.sqrt(dx * dx + dy * dy);
 	},
 
 	infinite: true
-});
+};

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -136,7 +136,7 @@ export const GeoJSON = FeatureGroup.extend({
 			return this.eachLayer(this.resetStyle, this);
 		}
 		// reset any custom styles
-		layer.options = Util.extend({}, layer.defaultOptions);
+		layer.options = {...layer.defaultOptions};
 		this._setLayerStyle(layer, this.options.style);
 		return this;
 	},
@@ -280,7 +280,7 @@ export function latLngsToCoords(latlngs, levelsDeep, close, precision) {
 
 export function getFeature(layer, newGeometry) {
 	return layer.feature ?
-		Util.extend({}, layer.feature, {geometry: newGeometry}) :
+		{...layer.feature, geometry: newGeometry} :
 		asFeature(newGeometry);
 }
 

--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -1,5 +1,5 @@
 import {TileLayer} from './TileLayer.js';
-import {extend, setOptions} from '../../core/Util.js';
+import {setOptions} from '../../core/Util.js';
 import Browser from '../../core/Browser.js';
 import {EPSG4326} from '../../geo/crs/CRS.EPSG4326.js';
 import {toBounds} from '../../geometry/Bounds.js';
@@ -69,7 +69,7 @@ export const TileLayerWMS = TileLayer.extend({
 
 		this._url = url;
 
-		const wmsParams = extend({}, this.defaultWmsParams);
+		const wmsParams = {...this.defaultWmsParams};
 
 		// all keys that are not TileLayer options go to WMS params
 		for (const i of Object.keys(options)) {
@@ -120,7 +120,7 @@ export const TileLayerWMS = TileLayer.extend({
 	// Merges an object with the new parameters and re-requests tiles on the current screen (unless `noRedraw` was set to true).
 	setParams(params, noRedraw) {
 
-		extend(this.wmsParams, params);
+		Object.assign(this.wmsParams, params);
 
 		if (!noRedraw) {
 			this.redraw();

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -188,6 +188,7 @@ export const TileLayer = GridLayer.extend({
 	// Classes extending `TileLayer` can override this function to provide custom tile URL naming schemes.
 	getTileUrl(coords) {
 		const data = {
+			...this.options,
 			r: Browser.retina ? '@2x' : '',
 			s: this._getSubdomain(coords),
 			x: coords.x,
@@ -202,7 +203,7 @@ export const TileLayer = GridLayer.extend({
 			data['-y'] = invertedY;
 		}
 
-		return Util.template(this._url, Util.extend(data, this.options));
+		return Util.template(this._url, data);
 	},
 
 	_tileOnLoad(done, tile) {

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -27,7 +27,7 @@ export const Circle = CircleMarker.extend({
 	initialize(latlng, options, legacyOptions) {
 		if (typeof options === 'number') {
 			// Backwards compatibility with 0.7.x factory (latlng, radius, options?)
-			options = Util.extend({}, legacyOptions, {radius: options});
+			options = {...legacyOptions, radius: options};
 		}
 		Util.setOptions(this, options);
 		this._latlng = toLatLng(latlng);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -181,8 +181,8 @@ export const Map = Evented.extend({
 		if (this._loaded && !options.reset && options !== true) {
 
 			if (options.animate !== undefined) {
-				options.zoom = Util.extend({animate: options.animate}, options.zoom);
-				options.pan = Util.extend({animate: options.animate, duration: options.duration}, options.pan);
+				options.zoom = {animate: options.animate, ...options.zoom};
+				options.pan = {animate: options.animate, duration: options.duration, ...options.pan};
 			}
 
 			// try animating pan or zoom
@@ -552,10 +552,11 @@ export const Map = Evented.extend({
 	invalidateSize(options) {
 		if (!this._loaded) { return this; }
 
-		options = Util.extend({
+		options = {
 			animate: false,
-			pan: true
-		}, options === true ? {animate: true} : options);
+			pan: true,
+			...(options === true ? {animate: true} : options)
+		};
 
 		const oldSize = this.getSize();
 		this._sizeChanged = true;
@@ -617,14 +618,15 @@ export const Map = Evented.extend({
 	// See `Locate options` for more details.
 	locate(options) {
 
-		options = this._locateOptions = Util.extend({
+		options = this._locateOptions = {
 			timeout: 10000,
-			watch: false
+			watch: false,
 			// setView: false
 			// maxZoom: <Number>
 			// maximumAge: 0
 			// enableHighAccuracy: false
-		}, options);
+			...options
+		};
 
 		if (!('geolocation' in navigator)) {
 			this._handleGeolocationError({
@@ -1414,7 +1416,10 @@ export const Map = Evented.extend({
 			// Fired before mouse click on the map (sometimes useful when you
 			// want something to happen on click before any existing click
 			// handlers start running).
-			const synth = Util.extend({}, e);
+			const synth =  {};
+			for (const i in e) {
+				synth[i] = e[i];
+			}
 			synth.type = 'preclick';
 			this._fireDOMEvent(synth, synth.type, canvasTargets);
 		}


### PR DESCRIPTION
According to MDN, both are considered Baseline: Widely available

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
