### PR TITLE
Fix: Missing "./dist/leaflet.css" specifier in "leaflet" package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "type": "module",
   "exports": {
+    "./src/": "./src/",
+    "./dist/": "./dist/",
     ".": "./dist/leaflet-src.js"
   },
   "style": "dist/leaflet.css",


### PR DESCRIPTION
I'm bundling an application using Vite. To import `leaflet.css`, I'm using `import "leaflet/dist/leaflet.css";`.

The build fails, because this file is not covered by the `exports` in `package.json`, the error is `[vite:css] [postcss] Missing "./dist/leaflet.css" specifier in "leaflet" package`.

In addition, I (used to) import source files (such as `import { Map } from "leaflet/src/map/Map";`) because this strategy allows for smaller bundle size. Thus, please also cover the `src` files in `exports` in `package.json`.

Here is a small repository illustrating how to use Leaflet with Vite: https://github.com/simon04/leaflet-vite/tree/leaflet-2.0

Regression of #8826.
