### PR TITLE
docs: replace unpkg with jsDelivr in documentation (fixes #9628)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 - [ ] Wait for the CI to complete and follow the logs to make sure it runs successfully.
 - [ ] Verify that the release was correctly published to NPM by checking:
   - [ ] [Leaflet NPM package page](https://www.npmjs.com/package/leaflet)
-  - [ ] files on [Leaflet unpkg page](https://unpkg.com/leaflet@latest/)
+  - [ ] files on [Leaflet unpkg page](https://cdn.jsdelivr.net/npm/leaflet@latest/)
 - [ ] Make a new release on [Leaflet's GitHub release page](https://github.com/Leaflet/Leaflet/releases/) with the most important parts of the changelog
 - [ ] Download zip archive from https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/vX.X.X/leaflet.zip (where `X.X.X` is the new version number) and upload it as an "asset" of the GitHub release.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@
 - [ ] Wait for the CI to complete and follow the logs to make sure it runs successfully.
 - [ ] Verify that the release was correctly published to NPM by checking:
   - [ ] [Leaflet NPM package page](https://www.npmjs.com/package/leaflet)
-  - [ ] files on [Leaflet unpkg page](https://cdn.jsdelivr.net/npm/leaflet@latest/)
+  - [ ] files on [Leaflet jsDelivr page](https://cdn.jsdelivr.net/npm/leaflet@latest/)
 - [ ] Make a new release on [Leaflet's GitHub release page](https://github.com/Leaflet/Leaflet/releases/) with the most important parts of the changelog
 - [ ] Download zip archive from https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/vX.X.X/leaflet.zip (where `X.X.X` is the new version number) and upload it as an "asset" of the GitHub release.
 

--- a/build/integrity.js
+++ b/build/integrity.js
@@ -9,7 +9,7 @@ import ssri from 'ssri';
 const {version} = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
 
 const getIntegrity = path => new Promise((resolve) => {
-	https.get(`https://unpkg.com/leaflet@${version}/dist/${path}`, (res) => {
+	https.get(`https://cdn.jsdelivr.net/npm/leaflet@${version}/dist/${path}`, (res) => {
 		ssri.fromStream(res, {algorithms: ['sha256']}).then(integrity => resolve(integrity.toString()));
 	});
 });

--- a/docs/_layouts/tutorial_frame.html
+++ b/docs/_layouts/tutorial_frame.html
@@ -9,14 +9,14 @@
 	{% capture root %}{% if page.root %}{{ page.root }}{% else %}{{ layout.root }}{% endif %}{% endcapture %}
 	<link rel="shortcut icon" type="image/x-icon" href="{{ root }}docs/images/favicon.ico" />
 
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin=""/>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin=""/>
 	<script type="importmap">
 		{
 			"imports": {
-				"leaflet": "https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
+				"leaflet": "https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
 			},
 			"integrity": {
-				"https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
+				"https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
 			}
 		}
 	</script>

--- a/docs/_layouts/v2.html
+++ b/docs/_layouts/v2.html
@@ -42,14 +42,14 @@
 	<link rel="stylesheet" href="{{ root }}docs/highlight/styles/github-gist.css" />
 
 	<!-- Leaflet -->
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin=""/>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin=""/>
 	<script type="importmap">
 		{
 			"imports": {
-				"leaflet": "https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
+				"leaflet": "https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
 			},
 			"integrity": {
-				"https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
+				"https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
 			}
 		}
 	</script>

--- a/docs/download.md
+++ b/docs/download.md
@@ -35,15 +35,15 @@ so please read the changelog carefully when upgrading to it.
 The latest stable Leaflet release is available on several CDNs. To start using it with an [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap), place the following in the `head` of your HTML code:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.css" integrity="{{site.integrity_hash_css}}" crossorigin="anonymous" />
 
 <script type="importmap">
 {
 	"imports": {
-		"leaflet": "https://unpkg.com/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.js"
+		"leaflet": "https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.js"
 	},
 	"integrity": {
-		"https://unpkg.com/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
+		"https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version }}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
 	}
 }
 </script>
@@ -69,7 +69,7 @@ Then, in your script, import the needed Leaflet Classes as follows:
 
 Note that the [`integrity` hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) are included for security when using Leaflet from a CDN.
 
-Leaflet is available on the following free CDNs: [unpkg](https://unpkg.com/leaflet/dist/), [cdnjs](https://cdnjs.com/libraries/leaflet), [jsDelivr](https://www.jsdelivr.com/package/npm/leaflet?path=dist).
+Leaflet is available on the following free CDNs: [cdnjs](https://cdnjs.com/libraries/leaflet), [jsDelivr](https://www.jsdelivr.com/package/npm/leaflet?path=dist).
 
 _Disclaimer: These services are external to Leaflet; for questions or support, please contact them directly._
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -69,7 +69,7 @@ Then, in your script, import the needed Leaflet Classes as follows:
 
 Note that the [`integrity` hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) are included for security when using Leaflet from a CDN.
 
-Leaflet is available on the following free CDNs: [cdnjs](https://cdnjs.com/libraries/leaflet), [jsDelivr](https://www.jsdelivr.com/package/npm/leaflet?path=dist).
+Leaflet is available on the following free CDNs: [jsDelivr](https://www.jsdelivr.com/package/npm/leaflet?path=dist), [cdnjs](https://cdnjs.com/libraries/leaflet), [unpkg](https://unpkg.com/leaflet/dist/).
 
 _Disclaimer: These services are external to Leaflet; for questions or support, please contact them directly._
 

--- a/docs/edit.html
+++ b/docs/edit.html
@@ -12,9 +12,9 @@
                 title: 'Leaflet',
                 description: "Leaflet example",
                 html: '<div id="map"></div>',
-                cssFile: 'https://unpkg.com/leaflet/dist/leaflet.css',
+                cssFile: 'https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet.css',
                 css: 'body {\n\tmargin: 0;\n}\nhtml, body, #map {\n\theight: 100%\n}',
-                jsFile: 'https://unpkg.com/leaflet/dist/leaflet-src.js',
+                jsFile: 'https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet-src.js',
                 js: "import {Map, TileLayer, Marker} from 'leaflet';\n\nconst map = new Map('map', {\n\tcenter: [0, 0],\n\tzoom: 0\n});\n\nnew TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n}).addTo(map);\n\nnew Marker(map.getCenter()).addTo(map);"
             };
 
@@ -32,8 +32,8 @@
                     config.cssFile = 'https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/main/leaflet.css',
                     config.jsFile = 'https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/main/leaflet-src.js'
                 } else {
-                    config.cssFile = `https://unpkg.com/leaflet@${config.version}/dist/leaflet.css`
-                    config.jsFile = `https://unpkg.com/leaflet@${config.version}/dist/leaflet-src.js`
+                    config.cssFile = `https://cdn.jsdelivr.net/npm/leaflet@${config.version}/dist/leaflet.css`
+                    config.jsFile = `https://cdn.jsdelivr.net/npm/leaflet@${config.version}/dist/leaflet-src.js`
                 }
 
             }

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -16,7 +16,7 @@ Before writing any code for the map, you need to do the following preparation st
  * Include Leaflet CSS file in the head section of your document:
 
 	```html
-	<link rel="stylesheet" href="https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css"
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.css"
 		integrity="{{site.integrity_hash_css}}"
 		crossorigin=""/>
 	```
@@ -28,10 +28,10 @@ Before writing any code for the map, you need to do the following preparation st
 	<script type="importmap">
 	{
 		"imports": {
-			"leaflet": "https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
+			"leaflet": "https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js"
 		},
 		"integrity": {
-			"https://unpkg.com/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
+			"https://cdn.jsdelivr.net/npm/leaflet@{{ site.latest_leaflet_version}}/dist/leaflet.js": "{{site.integrity_hash_uglified}}"
 		}
 	}
 	</script>


### PR DESCRIPTION
Thank you @Falke-Design for your input and corrections on #9656 for #9628 (Replace unpkg with jsDelivr). I believe I've addressed all feedback in this new PR:

- Only updated current docs/examples (no old posts/plugins)
- No Husky hook (removed as requested)
- Verified via local build (`bundle exec jekyll serve`)

I apologize for the earlier formatting issues, I was more careful this time. However, I am a bit confused on what I should do for the security hashes. I noticed your comment about the hashes being generated by build/integrity.js. Should I run this script to generate new hashes for jsDelivr?

Please let me know if anything else needs adjustment. I’m happy to fix it promptly!