### PR TITLE
Enable `@eslint/css` linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,14 @@
 import config from 'eslint-config-mourner';
+import css from '@eslint/css';
 import scriptTags from '@mapbox/eslint-plugin-script-tags';
 import importPlugin from 'eslint-plugin-import-x';
 import globals from 'globals';
 
 export default [
-	...config,
-	{
-		files: ['*.js', '*.cjs'],
-	},
+	...config.map(c => ({
+		...c,
+		files: ['**/*.js', '**/*.cjs'],
+	})),
 	{
 		languageOptions: {
 			ecmaVersion: 'latest',
@@ -15,7 +16,7 @@ export default [
 	},
 	{
 		ignores: [
-			'dist',
+			'dist/*.js',
 			'docs/docs/highlight',
 			'docs/examples/choropleth/us-states.js',
 			'docs/examples/geojson/sample-geojson.js',
@@ -29,6 +30,7 @@ export default [
 		]
 	},
 	{
+		files: ['**/*.js', '**/*.cjs'],
 		plugins: {
 			import: importPlugin
 		},
@@ -54,6 +56,11 @@ export default [
 			'prefer-spread': 'off',
 			'no-new': 'off'
 		}
+	},
+	{
+		files: ['**/*.css'],
+		language: 'css/css',
+		...css.configs.recommended,
 	},
 	{
 		files: ['spec/**'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.9.2",
       "license": "BSD-2-Clause",
       "devDependencies": {
+        "@eslint/css": "^0.7.0",
         "@mapbox/eslint-plugin-script-tags": "^1.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "bundlemon": "^3.0.3",
@@ -613,6 +614,48 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
       "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css/-/css-0.7.0.tgz",
+      "integrity": "sha512-d6mo8etv4igrTGxgvWSgA5+TsppfObM/Xhlu8JWbkqNBiaJXztUNH45R1B4i1GL2PNIFMLREI3Kh9lTBi19l7g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.13.0",
+        "@eslint/css-tree": "^3.3.3",
+        "@eslint/plugin-kit": "^0.2.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-3.4.0.tgz",
+      "integrity": "sha512-QehZa9/EJbgLKBcJKjJyme3Txnahx67pD9NWEl/bNORbZi+XxQk4T/6t3j1ZiL21iuQ2VOruQWKiQhFk+XdXHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.20.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@eslint/css/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4838,6 +4881,13 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.20.0.tgz",
+      "integrity": "sha512-/d3otgvmquUkAN2RVxSg6lIbQrYX7isR4aC5Hvw8JuHvzctR3eUG50WmsAZjb9MkbJ5LbijPSy7uIxEtQDGI0w==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -6174,6 +6224,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://leafletjs.com/",
   "description": "JavaScript library for mobile-friendly interactive maps",
   "devDependencies": {
+    "@eslint/css": "^0.7.0",
     "@mapbox/eslint-plugin-script-tags": "^1.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "bundlemon": "^3.0.3",


### PR DESCRIPTION
https://eslint.org/blog/2025/02/eslint-css-support/

https://github.com/eslint/css

```
$ eslint .

/Users/simon/src/Leaflet/dist/leaflet.css
   23:2  warning  Property 'user-select' is not a widely available baseline feature         css/use-baseline
  228:2  warning  Property 'outline' is not a widely available baseline feature             css/use-baseline
  532:2  warning  Property 'user-select' is not a widely available baseline feature         css/use-baseline
  603:3  warning  Property 'print-color-adjust' is not a widely available baseline feature  css/use-baseline

/Users/simon/src/Leaflet/docs/docs/css/main.css
   829:14  warning  Value 'break-word' of property 'word-break' is not a widely available baseline feature  css/use-baseline
  1020:15  warning  Value 'break-word' of property 'word-break' is not a widely available baseline feature  css/use-baseline
  1116:23  warning  Selector 'has' is not a widely available baseline feature                               css/use-baseline

/Users/simon/src/Leaflet/docs/docs/css/normalize.css
  97:3  warning  Property 'outline' is not a widely available baseline feature  css/use-baseline
```

Fixes #7806.
