### PR TITLE
Add aria-keyshortcuts to map container

### DIFF
--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -47,6 +47,9 @@ export const Keyboard = Handler.extend({
 			container.tabIndex = '0';
 		}
 
+		// add aria-attribute for keyboard shortcuts to the container
+		container.ariaKeyShortcuts = Object.values(this.keyCodes).flat().join(' ');
+
 		on(container, {
 			focus: this._onFocus,
 			blur: this._onBlur,


### PR DESCRIPTION
Improves keyboard accessibility by letting assistive technology know which key shortcuts are available through aria-keyshortcuts