### PR TITLE
Prevent Unmanaged watchPosition on Repeated map.locate() Calls

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -649,6 +649,9 @@ export const Map = Evented.extend({
 		onError = this._handleGeolocationError.bind(this);
 
 		if (options.watch) {
+			if (this._locationWatchId !== undefined) {
+				navigator.geolocation.clearWatch(this._locationWatchId);
+			}
 			this._locationWatchId =
 			        navigator.geolocation.watchPosition(onResponse, onError, options);
 		} else {


### PR DESCRIPTION
When `map.locate({ watch: true })` is called multiple times, Leaflet currently does not clear the previous `watchPosition` listener created via the Geolocation API. This results in multiple active geolocation watchers running in parallel, which can lead to unnecessary resource usage, unexpected behavior, and potential inconsistencies — especially when used in conjunction with options like `setView`.

This pattern can occur naturally in applications that call `map.locate()` again in response to user interactions or reactive state changes. Without explicit cleanup, each invocation adds a new geolocation watcher without stopping the previous one.

This PR introduces a fix to ensure that any existing watcher is properly cleared before starting a new one. This aligns `map.locate({ watch: true })` with expected usage patterns and helps prevent unintended side effects.