### PR TITLE
Convert Evented and Handler to es6 classes

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -25,7 +25,7 @@ import * as Util from './Util.js';
  * ```
  */
 
-export const Events = {
+export class Evented extends Class {
 	/* @method on(type: String, fn: Function, context?: Object): this
 	 * Adds a listener function (`fn`) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. `'click dblclick'`).
 	 *
@@ -51,7 +51,7 @@ export const Events = {
 		}
 
 		return this;
-	},
+	}
 
 	/* @method off(type: String, fn?: Function, context?: Object): this
 	 * Removes a previously added listener function. If no function is specified, it will remove all the listeners of that particular event from the object. Note that if you passed a custom context to `on`, you must pass the same context to `off` in order to remove the listener.
@@ -87,7 +87,7 @@ export const Events = {
 		}
 
 		return this;
-	},
+	}
 
 	// attach listener (without syntactic sugar now)
 	_on(type, fn, context, _once) {
@@ -114,7 +114,7 @@ export const Events = {
 		this._events ??= {};
 		this._events[type] ??= [];
 		this._events[type].push(newListener);
-	},
+	}
 
 	_off(type, fn, context) {
 		if (!this._events) {
@@ -157,14 +157,16 @@ export const Events = {
 			}
 			listeners.splice(index, 1);
 		}
-	},
+	}
 
 	// @method fire(type: String, data?: Object, propagate?: Boolean): this
 	// Fires an event of the specified type. You can optionally provide a data
 	// object — the first argument of the listener function will contain its
 	// properties. The event can optionally be propagated to event parents.
 	fire(type, data, propagate) {
-		if (!this.listens(type, propagate)) { return this; }
+		if (!this.listens(type, propagate)) {
+			return this;
+		}
 
 		const event = {
 			...data,
@@ -196,7 +198,7 @@ export const Events = {
 		}
 
 		return this;
-	},
+	}
 
 	// @method listens(type: String, propagate?: Boolean): Boolean
 	// @method listens(type: String, fn: Function, context?: Object, propagate?: Boolean): Boolean
@@ -230,7 +232,7 @@ export const Events = {
 			}
 		}
 		return false;
-	},
+	}
 
 	// returns the index (number) or false
 	_listens(type, fn, context) {
@@ -251,7 +253,7 @@ export const Events = {
 		const index = listeners.findIndex(l => l.fn === fn && l.ctx === context);
 		return index === -1 ? false : index;
 
-	},
+	}
 
 	// @method once(…): this
 	// Behaves as [`on(…)`](#evented-on), except the listener will only get fired once and then removed.
@@ -273,7 +275,7 @@ export const Events = {
 		}
 
 		return this;
-	},
+	}
 
 	// @method addEventParent(obj: Evented): this
 	// Adds an event parent - an `Evented` that will receive propagated events
@@ -281,7 +283,7 @@ export const Events = {
 		this._eventParents ??= {};
 		this._eventParents[Util.stamp(obj)] = obj;
 		return this;
-	},
+	}
 
 	// @method removeEventParent(obj: Evented): this
 	// Removes an event parent, so it will stop receiving propagated events
@@ -290,7 +292,7 @@ export const Events = {
 			delete this._eventParents[Util.stamp(obj)];
 		}
 		return this;
-	},
+	}
 
 	_propagateEvent(e) {
 		for (const p of Object.values(this._eventParents ?? {})) {
@@ -300,31 +302,30 @@ export const Events = {
 			}, true);
 		}
 	}
-};
 
-// aliases; we should ditch those eventually
+	// aliases; we should ditch those eventually
 
-// @method addEventListener(…): this
-// Alias to [`on(…)`](#evented-on)
-Events.addEventListener = Events.on;
+	// @method addEventListener(…): this
+	// Alias to [`on(…)`](#evented-on)
+	addEventListener = this.on;
 
-// @method removeEventListener(…): this
-// Alias to [`off(…)`](#evented-off)
+	// @method removeEventListener(…): this
+	// Alias to [`off(…)`](#evented-off)
+	removeEventListener = this.off;
 
-// @method clearAllEventListeners(…): this
-// Alias to [`off()`](#evented-off)
-Events.removeEventListener = Events.clearAllEventListeners = Events.off;
+	// @method clearAllEventListeners(…): this
+	// Alias to [`off()`](#evented-off)
+	clearAllEventListeners = this.off;
 
-// @method addOneTimeEventListener(…): this
-// Alias to [`once(…)`](#evented-once)
-Events.addOneTimeEventListener = Events.once;
+	// @method addOneTimeEventListener(…): this
+	// Alias to [`once(…)`](#evented-once)
+	addOneTimeEventListener = this.once;
 
-// @method fireEvent(…): this
-// Alias to [`fire(…)`](#evented-fire)
-Events.fireEvent = Events.fire;
+	// @method fireEvent(…): this
+	// Alias to [`fire(…)`](#evented-fire)
+	fireEvent = this.fire;
 
-// @method hasEventListeners(…): Boolean
-// Alias to [`listens(…)`](#evented-listens)
-Events.hasEventListeners = Events.listens;
-
-export const Evented = Class.extend(Events);
+	// @method hasEventListeners(…): Boolean
+	// Alias to [`listens(…)`](#evented-listens)
+	hasEventListeners = this.listens;
+}

--- a/src/core/Handler.js
+++ b/src/core/Handler.js
@@ -7,11 +7,17 @@ import {Class} from './Class.js';
 
 // @class Handler
 // Abstract class for map interaction handlers
+export class Handler extends Class {
+	constructor(...args) {
+		super(...args);
+		if (!this.addHooks || !this.removeHooks) {
+			throw new Error('Classes inheriting from `Handler` must implement the addHooks and removeHooks methods.');
+		}
+	}
 
-export const Handler = Class.extend({
 	initialize(map) {
 		this._map = map;
-	},
+	}
 
 	// @method enable(): this
 	// Enables the handler
@@ -21,7 +27,7 @@ export const Handler = Class.extend({
 		this._enabled = true;
 		this.addHooks();
 		return this;
-	},
+	}
 
 	// @method disable(): this
 	// Disables the handler
@@ -31,12 +37,20 @@ export const Handler = Class.extend({
 		this._enabled = false;
 		this.removeHooks();
 		return this;
-	},
+	}
 
 	// @method enabled(): Boolean
 	// Returns `true` if the handler is enabled
 	enabled() {
 		return !!this._enabled;
+	}
+
+	// @section There is static function which can be called without instantiating Handler:
+	// @function addTo(map: Map, name: String): this
+	// Adds a new Handler to the given map with the given name.
+	static addTo(map, name) {
+		map.addHandler(name, this);
+		return this;
 	}
 
 	// @section Extension methods
@@ -45,12 +59,4 @@ export const Handler = Class.extend({
 	// Called when the handler is enabled, should add event hooks.
 	// @method removeHooks()
 	// Called when the handler is disabled, should remove the event hooks added previously.
-});
-
-// @section There is static function which can be called without instantiating Handler:
-// @function addTo(map: Map, name: String): this
-// Adds a new Handler to the given map with the given name.
-Handler.addTo = function (map, name) {
-	map.addHandler(name, this);
-	return this;
-};
+}


### PR DESCRIPTION
- Also throw an exception in Handlers constructor if the hook functions aren't implemented.

The plan if it's desirable is to do this across the board with all the Foo.extend({}) defined classes within leaflet. Potentially dropping that extension method entirely.