### PR TITLE
Convert Control objects to es6 classes

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -18,10 +18,10 @@ const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg
 // @namespace Control.Attribution
 // @constructor Control.Attribution(options: Control.Attribution options)
 // Creates an attribution control.
-export const Attribution = Control.extend({
+export class Attribution extends Control {
 	// @section
 	// @aka Control.Attribution options
-	options: {
+	static options = {
 		// @option position: String = 'bottomright'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -30,13 +30,13 @@ export const Attribution = Control.extend({
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
 		prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
-	},
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);
 
 		this._attributions = {};
-	},
+	}
 
 	onAdd(map) {
 		map.attributionControl = this;
@@ -55,18 +55,18 @@ export const Attribution = Control.extend({
 		map.on('layeradd', this._addAttribution, this);
 
 		return this._container;
-	},
+	}
 
 	onRemove(map) {
 		map.off('layeradd', this._addAttribution, this);
-	},
+	}
 
 	_addAttribution(ev) {
 		if (ev.layer.getAttribution) {
 			this.addAttribution(ev.layer.getAttribution());
 			ev.layer.once('remove', () => this.removeAttribution(ev.layer.getAttribution()));
 		}
-	},
+	}
 
 	// @method setPrefix(prefix: String|false): this
 	// The HTML text shown before the attributions. Pass `false` to disable.
@@ -74,7 +74,7 @@ export const Attribution = Control.extend({
 		this.options.prefix = prefix;
 		this._update();
 		return this;
-	},
+	}
 
 	// @method addAttribution(text: String): this
 	// Adds an attribution text (e.g. `'&copy; OpenStreetMap contributors'`).
@@ -89,7 +89,7 @@ export const Attribution = Control.extend({
 		this._update();
 
 		return this;
-	},
+	}
 
 	// @method removeAttribution(text: String): this
 	// Removes an attribution text.
@@ -102,7 +102,7 @@ export const Attribution = Control.extend({
 		}
 
 		return this;
-	},
+	}
 
 	_update() {
 		if (!this._map) { return; }
@@ -120,7 +120,7 @@ export const Attribution = Control.extend({
 
 		this._container.innerHTML = prefixAndAttribs.join(' <span aria-hidden="true">|</span> ');
 	}
-});
+}
 
 // @namespace Map
 // @section Control options

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -44,10 +44,10 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor Control.Layers(baselayers?: Object, overlays?: Object, options?: Control.Layers options)
 // Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.
-export const Layers = Control.extend({
+export class Layers extends Control {
 	// @section
 	// @aka Control.Layers options
-	options: {
+	static options = {
 		// @option collapsed: Boolean = true
 		// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
 		collapsed: true,
@@ -75,7 +75,7 @@ export const Layers = Control.extend({
 		sortFunction(layerA, layerB, nameA, nameB) {
 			return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
 		}
-	},
+	};
 
 	initialize(baseLayers, overlays, options) {
 		Util.setOptions(this, options);
@@ -93,7 +93,7 @@ export const Layers = Control.extend({
 		for (const [name, layer] of Object.entries(overlays ?? {})) {
 			this._addLayer(layer, name, true);
 		}
-	},
+	}
 
 	onAdd(map) {
 		this._initLayout();
@@ -112,13 +112,13 @@ export const Layers = Control.extend({
 		}
 
 		return this._container;
-	},
+	}
 
 	addTo(map) {
 		Control.prototype.addTo.call(this, map);
 		// Trigger expand after Layers Control has been inserted into DOM so that is now has an actual height.
 		return this._expandIfNotCollapsed();
-	},
+	}
 
 	onRemove() {
 		this._map.off('zoomend', this._checkDisabledLayers, this);
@@ -128,21 +128,21 @@ export const Layers = Control.extend({
 		}
 
 		this._map.off('resize', this._expandIfNotCollapsed, this);
-	},
+	}
 
 	// @method addBaseLayer(layer: Layer, name: String): this
 	// Adds a base layer (radio button entry) with the given name to the control.
 	addBaseLayer(layer, name) {
 		this._addLayer(layer, name);
 		return (this._map) ? this._update() : this;
-	},
+	}
 
 	// @method addOverlay(layer: Layer, name: String): this
 	// Adds an overlay (checkbox entry) with the given name to the control.
 	addOverlay(layer, name) {
 		this._addLayer(layer, name, true);
 		return (this._map) ? this._update() : this;
-	},
+	}
 
 	// @method removeLayer(layer: Layer): this
 	// Remove the given layer from the control.
@@ -154,7 +154,7 @@ export const Layers = Control.extend({
 			this._layers.splice(this._layers.indexOf(obj), 1);
 		}
 		return (this._map) ? this._update() : this;
-	},
+	}
 
 	// @method expand(): this
 	// Expand the control container if collapsed.
@@ -170,7 +170,7 @@ export const Layers = Control.extend({
 		}
 		this._checkDisabledLayers();
 		return this;
-	},
+	}
 
 	// @method collapse(): this
 	// Collapse the control container if expanded.
@@ -182,7 +182,7 @@ export const Layers = Control.extend({
 			this._container.classList.remove('leaflet-control-layers-expanded');
 		}
 		return this;
-	},
+	}
 
 	_initLayout() {
 		const className = 'leaflet-control-layers',
@@ -230,7 +230,7 @@ export const Layers = Control.extend({
 		this._overlaysList = DomUtil.create('div', `${className}-overlays`, section);
 
 		container.appendChild(section);
-	},
+	}
 
 	_getLayer(id) {
 		for (const layer of this._layers) {
@@ -238,7 +238,7 @@ export const Layers = Control.extend({
 				return layer;
 			}
 		}
-	},
+	}
 
 	_addLayer(layer, name, overlay) {
 		if (this._map) {
@@ -261,7 +261,7 @@ export const Layers = Control.extend({
 		}
 
 		this._expandIfNotCollapsed();
-	},
+	}
 
 	_update() {
 		if (!this._container) { return this; }
@@ -288,7 +288,7 @@ export const Layers = Control.extend({
 		this._separator.style.display = overlaysPresent && baseLayersPresent ? '' : 'none';
 
 		return this;
-	},
+	}
 
 	_onLayerChange(e) {
 		if (!this._handlingClick) {
@@ -313,7 +313,7 @@ export const Layers = Control.extend({
 		if (type) {
 			this._map.fire(type, obj);
 		}
-	},
+	}
 
 	_addItem(obj) {
 		const label = document.createElement('label'),
@@ -348,7 +348,7 @@ export const Layers = Control.extend({
 
 		this._checkDisabledLayers();
 		return label;
-	},
+	}
 
 	_onInputClick(e) {
 		// expanding the control on mobile with a click can cause adding a layer - we don't want this
@@ -387,7 +387,7 @@ export const Layers = Control.extend({
 		this._handlingClick = false;
 
 		this._refocusOnMap(e);
-	},
+	}
 
 	_checkDisabledLayers() {
 		const inputs = this._layerControlInputs,
@@ -399,14 +399,14 @@ export const Layers = Control.extend({
 			                 (layer.options.maxZoom !== undefined && zoom > layer.options.maxZoom);
 
 		}
-	},
+	}
 
 	_expandIfNotCollapsed() {
 		if (this._map && !this.options.collapsed) {
 			this.expand();
 		}
 		return this;
-	},
+	}
 
 	_expandSafely() {
 		const section = this._section;
@@ -419,4 +419,4 @@ export const Layers = Control.extend({
 		});
 	}
 
-});
+}

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -17,10 +17,10 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor Control.Scale(options?: Control.Scale options)
 // Creates an scale control with the given options.
-export const Scale = Control.extend({
+export class Scale extends Control {
 	// @section
 	// @aka Control.Scale options
-	options: {
+	static options = {
 		// @option position: String = 'bottomleft'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -40,7 +40,7 @@ export const Scale = Control.extend({
 
 		// @option updateWhenIdle: Boolean = false
 		// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
-	},
+	};
 
 	onAdd(map) {
 		const className = 'leaflet-control-scale',
@@ -53,11 +53,11 @@ export const Scale = Control.extend({
 		map.whenReady(this._update, this);
 
 		return container;
-	},
+	}
 
 	onRemove(map) {
 		map.off(this.options.updateWhenIdle ? 'moveend' : 'move', this._update, this);
-	},
+	}
 
 	_addScales(options, className, container) {
 		if (options.metric) {
@@ -66,7 +66,7 @@ export const Scale = Control.extend({
 		if (options.imperial) {
 			this._iScale = DomUtil.create('div', className, container);
 		}
-	},
+	}
 
 	_update() {
 		const map = this._map,
@@ -77,7 +77,7 @@ export const Scale = Control.extend({
 			map.containerPointToLatLng([this.options.maxWidth, y]));
 
 		this._updateScales(maxMeters);
-	},
+	}
 
 	_updateScales(maxMeters) {
 		if (this.options.metric && maxMeters) {
@@ -86,14 +86,14 @@ export const Scale = Control.extend({
 		if (this.options.imperial && maxMeters) {
 			this._updateImperial(maxMeters);
 		}
-	},
+	}
 
 	_updateMetric(maxMeters) {
 		const meters = this._getRoundNum(maxMeters),
 		    label = meters < 1000 ? `${meters} m` : `${meters / 1000} km`;
 
 		this._updateScale(this._mScale, label, meters / maxMeters);
-	},
+	}
 
 	_updateImperial(maxMeters) {
 		const maxFeet = maxMeters * 3.2808399;
@@ -108,12 +108,12 @@ export const Scale = Control.extend({
 			feet = this._getRoundNum(maxFeet);
 			this._updateScale(this._iScale, `${feet} ft`, feet / maxFeet);
 		}
-	},
+	}
 
 	_updateScale(scale, text, ratio) {
 		scale.style.width = `${Math.round(this.options.maxWidth * ratio)}px`;
 		scale.innerHTML = text;
-	},
+	}
 
 	_getRoundNum(num) {
 		const pow10 = 10 ** ((`${Math.floor(num)}`).length - 1);
@@ -126,4 +126,4 @@ export const Scale = Control.extend({
 
 		return pow10 * d;
 	}
-});
+}

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -14,10 +14,10 @@ import * as DomEvent from '../dom/DomEvent.js';
 // @namespace Control.Zoom
 // @constructor Control.Zoom(options: Control.Zoom options)
 // Creates a zoom control
-export const Zoom = Control.extend({
+export class Zoom extends Control {
 	// @section
 	// @aka Control.Zoom options
-	options: {
+	static options = {
 		// @option position: String = 'topleft'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -38,7 +38,7 @@ export const Zoom = Control.extend({
 		// @option zoomOutTitle: String = 'Zoom out'
 		// The title set on the 'zoom out' button.
 		zoomOutTitle: 'Zoom out'
-	},
+	};
 
 	onAdd(map) {
 		const zoomName = 'leaflet-control-zoom',
@@ -54,35 +54,35 @@ export const Zoom = Control.extend({
 		map.on('zoomend zoomlevelschange', this._updateDisabled, this);
 
 		return container;
-	},
+	}
 
 	onRemove(map) {
 		map.off('zoomend zoomlevelschange', this._updateDisabled, this);
-	},
+	}
 
 	disable() {
 		this._disabled = true;
 		this._updateDisabled();
 		return this;
-	},
+	}
 
 	enable() {
 		this._disabled = false;
 		this._updateDisabled();
 		return this;
-	},
+	}
 
 	_zoomIn(e) {
 		if (!this._disabled && this._map._zoom < this._map.getMaxZoom()) {
 			this._map.zoomIn(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
 		}
-	},
+	}
 
 	_zoomOut(e) {
 		if (!this._disabled && this._map._zoom > this._map.getMinZoom()) {
 			this._map.zoomOut(this._map.options.zoomDelta * (e.shiftKey ? 3 : 1));
 		}
-	},
+	}
 
 	_createButton(html, title, className, container, fn) {
 		const link = DomUtil.create('a', className, container);
@@ -102,7 +102,7 @@ export const Zoom = Control.extend({
 		DomEvent.on(link, 'click', this._refocusOnMap, this);
 
 		return link;
-	},
+	}
 
 	_updateDisabled() {
 		const map = this._map,
@@ -122,7 +122,7 @@ export const Zoom = Control.extend({
 			this._zoomInButton.setAttribute('aria-disabled', 'true');
 		}
 	}
-});
+}
 
 // @namespace Map
 // @section Control options

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -11,20 +11,19 @@ import * as DomUtil from '../dom/DomUtil.js';
  * Control is a base class for implementing map controls. Handles positioning.
  * All other controls extend from this class.
  */
-
-export const Control = Class.extend({
+export class Control extends Class {
 	// @section
 	// @aka Control Options
-	options: {
+	static options = {
 		// @option position: String = 'topright'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
 		position: 'topright'
-	},
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);
-	},
+	}
 
 	/* @section
 	 * Classes extending Control will inherit the following methods:
@@ -34,7 +33,7 @@ export const Control = Class.extend({
 	 */
 	getPosition() {
 		return this.options.position;
-	},
+	}
 
 	// @method setPosition(position: string): this
 	// Sets the position of the control.
@@ -48,13 +47,13 @@ export const Control = Class.extend({
 		map?.addControl(this);
 
 		return this;
-	},
+	}
 
 	// @method getContainer: HTMLElement
 	// Returns the HTMLElement that contains the control.
 	getContainer() {
 		return this._container;
-	},
+	}
 
 	// @method addTo(map: Map): this
 	// Adds the control to the given map.
@@ -77,7 +76,7 @@ export const Control = Class.extend({
 		this._map.on('unload', this.remove, this);
 
 		return this;
-	},
+	}
 
 	// @method remove: this
 	// Removes the control from the map it is currently active on.
@@ -96,7 +95,7 @@ export const Control = Class.extend({
 		this._map = null;
 
 		return this;
-	},
+	}
 
 	_refocusOnMap(e) {
 		// We exclude keyboard-click event to keep the focus on the control for accessibility.
@@ -105,7 +104,7 @@ export const Control = Class.extend({
 			this._map.getContainer().focus();
 		}
 	}
-});
+}
 
 /* @section Extension methods
  * @uninheritable

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -84,6 +84,9 @@ export class Class {
 		this._initHooksCalled = false;
 
 		Util.setOptions(this);
+		if (this.constructor?.options) {
+			Util.setOptions(this, this.constructor?.options);
+		}
 
 		// call the constructor
 		if (this.initialize) {


### PR DESCRIPTION
- Convert Control objects to es6 classes

- Default options now defined as static properties within the classes.

- Updates Class constructor to setOptions with the static defaults.

See also #9777 