### PR TITLE
docs: clarify L.Draggable works on any DOM element (#6710)

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -26258,3 +26258,5 @@ var Leaflet = L.noConflict();
 <h2 id='version'>version</h2><p>A constant that represents the Leaflet version in use.</p>
 <pre><code class="language-js">L.version; // contains &quot;1.0.0&quot; (or whatever version is currently in use)
 </code></pre>
+
+


### PR DESCRIPTION
This PR updates the JSDoc comment and regenerated reference.html to clarify that L.Draggable works on any standard DOM element — not just ones positioned via DomUtil.setPosition.

Fixes #6710
