### PR TITLE
Add LabelsRenderer plugin

### DIFF
--- a/docs/_plugins/markers-renderers/leaflet-labels-renderer.md
+++ b/docs/_plugins/markers-renderers/leaflet-labels-renderer.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.LabelsRenderer
+category: markers-renderers
+repo: https://github.com/CarMi0Proggramer/leaflet-labels-renderer
+author: Carlos Miguel
+author-url: https://github.com/CarMi0Proggramer
+demo:
+compatible-v0:
+compatible-v1: true
+---
+
+Adds a custom Canvas renderer to show labels on polylines along the path.


### PR DESCRIPTION
Custom canvas renderer for Leaflet that draws labels along polylines. It's based on the two popular plugins, L.LabelTextCollision and L.Streetlabels. this plugin is focused on just adding labels to polylines and provides a faster rendering time.