### PR TITLE
Adding Leaflet Choropleth for Drupal to 3rd party integration (plugins) list

### DIFF
--- a/docs/_plugins/3rd-party-integration/leaflet-choropleth-for-drupal.md
+++ b/docs/_plugins/3rd-party-integration/leaflet-choropleth-for-drupal.md
@@ -1,0 +1,16 @@
+---
+name: Leaflet Choropleth for Drupal
+category: 3rd-party-integration
+repo: https://www.drupal.org/project/leaflet_choropleth
+author: Italo Mairo
+author-url: https://www.drupal.org/u/itamair
+demo: https://www.geodemocracy.com/drupal_geofield_stack_demo/web/leaflet_choropleth
+compatible-v0:
+compatible-v1: true
+---
+
+The Drupal Leaflet Choropleth module provides advanced choropleth mapping capabilities
+for Drupal applications, enabling the visualization of statistical data through
+color-coded geographic regions. This module seamlessly integrates with the
+existing Drupal Leaflet ecosystem to deliver professional-grade thematic mapping
+functionality.


### PR DESCRIPTION
This PR adds the new [Drupal Leaflet Choropleth module](https://www.drupal.org/project/leaflet_choropleth) to the 3rd party integration list.

More info on this Linkedin article: 
https://www.linkedin.com/pulse/introducing-leaflet-choropleth-module-advanced-thematic-italo-mairo-c2gif/?trackingId=taV0k0mETN2l%2FPEd3toiQQ%3D%3D

Live Demo: https://www.geodemocracy.com/drupal_geofield_stack_demo/web/leaflet_choropleth