### PR TITLE
Add Leaflet.Polydraw to plugins list

### DIFF
--- a/docs/_plugins/edit-geometries/leaflet-polydraw.md
+++ b/docs/_plugins/edit-geometries/leaflet-polydraw.md
@@ -1,0 +1,12 @@
+---
+name: Leaflet.Polydraw
+category: edit-geometries
+repo: https://github.com/AndreasOlausson/leaflet-polydraw
+author: AndreasOlausson
+author-url: https://github.com/AndreasOlausson
+demo: https://polydraw.ao-tech.se
+compatible-v0:
+compatible-v1: true
+---
+
+A powerful plugin for creating and editing polygons on Leaflet maps. It supports freehand drawing, precise point-to-point creation, and samrt merging of overlapping shapes. Includes advanced features like hole creation, vertex editing, and drag-and-drop repositioning.

--- a/docs/_plugins/edit-geometries/leaflet-polydraw.md
+++ b/docs/_plugins/edit-geometries/leaflet-polydraw.md
@@ -9,4 +9,4 @@ compatible-v0:
 compatible-v1: true
 ---
 
-A powerful plugin for creating and editing polygons on Leaflet maps. It supports freehand drawing, precise point-to-point creation, and samrt merging of overlapping shapes. Includes advanced features like hole creation, vertex editing, and drag-and-drop repositioning.
+A powerful plugin for creating and editing polygons on Leaflet maps. It supports freehand drawing, precise point-to-point creation, and smart merging of overlapping shapes. Includes advanced features like hole creation, vertex editing, and drag-and-drop repositioning.


### PR DESCRIPTION
**Leaflet.Polydraw** is a versatile plugin for creating and editing polygons on Leaflet maps. It supports freehand drawing, point-to-point creation, and intelligent merging of overlapping shapes. Additional features include hole creation, vertex editing, and drag-and-drop repositioning — ideal for advanced GIS and mapping workflows.

**Plugin Details**
```yaml
  name: Leaflet.Polydraw
  category: edit-geometries
  repo: https://github.com/AndreasOlausson/leaflet-polydraw
  author: AndreasOlausson
  author-url: https://github.com/AndreasOlausson
  demo: https://polydraw.ao-tech.se
  compatible-v1: true
```
I have reviewed the plugin submission guidelines and believe this plugin meets the criteria for inclusion.

Thank you for considering this contribution.

— Andreas Olausson
