### PR TITLE
Fix path to 2.0.0-alpha package in docs

### DIFF
--- a/docs/_posts/2025-05-18-leaflet-2.0.0-alpha.md
+++ b/docs/_posts/2025-05-18-leaflet-2.0.0-alpha.md
@@ -56,7 +56,7 @@ This release marks a major modernization of the Leaflet codebase. We've dropped 
 <script type="importmap">
 	{
 		"imports": {
-			"leaflet": "https://unpkg.com/leaflet@2.0.0-alpha1/dist/leaflet.js"
+			"leaflet": "https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet.js"
 		}
 	}
 </script>
@@ -74,7 +74,7 @@ This release marks a major modernization of the Leaflet codebase. We've dropped 
 
 #### Global Script
 ```
-<script src="https://unpkg.com/leaflet@2.0.0-alpha1/dist/leaflet-global.js"></script>
+<script src="https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet-global.js"></script>
 <script>
 	const map = new L.Map('map').setView([51.505, -0.09], 13);
 


### PR DESCRIPTION
Both return 404:
https://unpkg.com/leaflet@2.0.0-alpha1/dist/leaflet-global.js
https://unpkg.com/leaflet@2.0.0-alpha1/dist/leaflet.js

The correct paths seem to be:
https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet-global.js
https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet.js