### PR TITLE
Fix Class.addInitHook with ES6 extends

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -243,6 +243,64 @@ describe('Class', () => {
 		});
 	});
 
+	describe('#extend', () => {
+		it('merges options instead of replacing them', () => {
+			class KlassWithOptions1 extends Class {
+				static {
+					this.setDefaultOptions({
+						foo1: 1,
+						foo2: 2
+					});
+				}
+			}
+			class KlassWithOptions2 extends KlassWithOptions1 {
+				static {
+					this.setDefaultOptions({
+						foo2: 3,
+						foo3: 4
+					});
+				}
+			}
+
+			const a = new KlassWithOptions2();
+			expect(a.options.foo1).to.eql(1);
+			expect(a.options.foo2).to.eql(3);
+			expect(a.options.foo3).to.eql(4);
+		});
+
+		it('inherits constructor hooks', () => {
+			const spy1 = sinon.spy(),
+			spy2 = sinon.spy();
+
+			class Class1 extends Class {}
+			class Class2 extends Class1 {}
+
+			Class1.addInitHook(spy1);
+			Class2.addInitHook(spy2);
+
+			new Class2();
+
+			expect(spy1.called).to.be.true;
+			expect(spy2.called).to.be.true;
+		});
+
+		it('does not call child constructor hooks', () => {
+			const spy1 = sinon.spy(),
+			spy2 = sinon.spy();
+
+			class Class1 extends Class {}
+			class Class2 extends Class1 {}
+
+			Class1.addInitHook(spy1);
+			Class2.addInitHook(spy2);
+
+			new Class1();
+
+			expect(spy1.called).to.be.true;
+			expect(spy2.called).to.eql(false);
+		});
+	});
+
 	describe('#include', () => {
 		let Klass;
 

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -44,8 +44,6 @@ export class Class {
 			Object.assign(proto.options, props.options);
 		}
 
-		proto._initHooks = [];
-
 		return NewClass;
 	}
 
@@ -96,7 +94,9 @@ export class Class {
 			this[fn].apply(this, args);
 		};
 
-		this.prototype._initHooks ??= [];
+		if (!Object.hasOwn(this.prototype, '_initHooks')) { // do not use ??= here
+			this.prototype._initHooks = [];
+		}
 		this.prototype._initHooks.push(init);
 		return this;
 	}


### PR DESCRIPTION
Fixes #9847.
