### PR TITLE
Circle: allow setStyle to update radius

### DIFF
--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -59,3 +59,22 @@ describe('Circle', () => {
 		});
 	});
 });
+
+describe('Circle#setStyle', () => {
+	it('updates radius when style includes radius', () => {
+		const circle = new Circle([0, 0], {radius: 10});
+
+		circle.setStyle({radius: 20});
+		console.log(circle.getRadius());
+		expect(circle.getRadius()).to.equal(20);
+	});
+
+	it('does not change radius if radius not provided', () => {
+		const circle = new Circle([0, 0], {radius: 10});
+
+		circle.setStyle({color: 'red'});
+		console.log(circle.getRadius());
+		expect(circle.options.color).to.equal('red');
+		expect(circle.getRadius()).to.equal(10);
+	});
+});

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -61,7 +61,12 @@ export class Circle extends CircleMarker {
 			this._map.layerPointToLatLng(this._point.add(half)));
 	}
 
-	setStyle = Path.prototype.setStyle;
+	setStyle(options) {
+		const radius = options?.radius ?? this._mRadius;
+		Path.prototype.setStyle.call(this, options);
+		this.setRadius(radius);
+		return this;
+	}
 
 	_project() {
 


### PR DESCRIPTION
This PR updates `Circle#setStyle` to support the `radius` option, 
making its behavior consistent with `CircleMarker#setStyle`.

- Added handling for `radius` in `Circle#setStyle`.
- Added unit tests in `CircleSpec.js` to verify:
  - radius updates when provided in style options
  - radius remains unchanged when not provided
  - other style options (e.g., color) still apply

Fixes #9833