### PR TITLE
set compatible-v2 flag for leaflet.geodesic

### DIFF
--- a/docs/_plugins/markers-renderers/leaflet-geodesic.md
+++ b/docs/_plugins/markers-renderers/leaflet-geodesic.md
@@ -7,7 +7,7 @@ author-url: https://github.com/henrythasler
 demo: https://blog.cyclemap.link/Leaflet.Geodesic/complex-interactive.html
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 Draw geodesic lines and circles. A geodesic line is the shortest path between two given points on the earth surface. It uses Vincenty's formulae for highest precision and distance calculation. Written in TypeScript and available via CDN.


### PR DESCRIPTION
leaflet.geodesic has a first release for leaflet 2.0.0-alpha.1 so I'd like to update the v2-flag here.