### PR TITLE
docs: update leaflet-bouncemarker for v2

### DIFF
--- a/docs/_plugins/overlay-animations/leaflet-bouncemarker.md
+++ b/docs/_plugins/overlay-animations/leaflet-bouncemarker.md
@@ -7,7 +7,7 @@ author-url: https://github.com/maximeh
 demo: https://maximeh.github.io/leaflet.bouncemarker/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 Make a marker bounce when you add it to a map.


### PR DESCRIPTION
Updating the documentation since the plugin has been made compatible with v2 as well.