### PR TITLE
Change Dependabot schedule from weekly to quarterly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     rebase-strategy: disabled
     versioning-strategy: increase
     schedule:
-      interval: weekly
+      interval: quarterly
     labels:
       - dependencies
   - package-ecosystem: github-actions
@@ -14,7 +14,7 @@ updates:
     open-pull-requests-limit: 999
     rebase-strategy: disabled
     schedule:
-      interval: weekly
+      interval: quarterly
     labels:
       - dependencies
   - package-ecosystem: bundler
@@ -22,6 +22,6 @@ updates:
     open-pull-requests-limit: 999
     rebase-strategy: disabled
     schedule:
-      interval: weekly
+      interval: quarterly
     labels:
       - dependencies


### PR DESCRIPTION
Ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval