### PR TITLE
docs: update leaflet.tilelayer.colorfilter for leaflet v2 compatibility

### DIFF
--- a/docs/_plugins/tile-image-display/leaflet-tilelayer-colorfilter.md
+++ b/docs/_plugins/tile-image-display/leaflet-tilelayer-colorfilter.md
@@ -5,9 +5,9 @@ repo: https://github.com/xtk93x/Leaflet.TileLayer.ColorFilter
 author: Cláudio Kawakani
 author-url: https://github.com/xtk93x
 demo: https://xtk93x.github.io/Leaflet.TileLayer.ColorFilter/
-compatible-v0:
+compatible-v0: true
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 A simple and lightweight Leaflet plugin to apply CSS filters on map tiles.


### PR DESCRIPTION
This PR updates the documentation for the Leaflet.TileLayer.ColorFilter plugin to reflect the new v2.0.0 release, which adds compatibility with Leaflet 2.0. 

The new build process also generates a global file to maintain backward compatibility with Leaflet 1.x and older.

**Link to new plugin release:**
https://github.com/xtk93x/Leaflet.TileLayer.ColorFilter/releases/tag/v2.0.0

Thanks!