### PR TITLE
Automatically update nightly release with latest build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,7 +184,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: dev
-          name: "Nightly Build"
+          name: Development snapshot
           prerelease: true
           files: dist/*
           generate_release_notes: false


### PR DESCRIPTION
This workflow reverts partially #9806. Instead of uploading to S3 we will now have a Github nightly pre-release which updates automatically all build files with a push to the `main` branch. We can then reference on the download page to the assets in the release, like: https://github.com/Leaflet/Leaflet/releases/download/nightly/leaflet.js

This will look like this:
<img width="1312" height="673" alt="grafik" src="https://github.com/user-attachments/assets/4cf3b40b-4c37-4848-a3c8-6bc811acd704" />


`GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` didn't worked on my private test repo, I needed to add a PAT-Token but it should work with GITHUB_TOKEN.

Fixes: #9871