### PR TITLE
Set referrerPolicy automatically for OpenStreetMap

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -94,14 +94,17 @@ export class TileLayer extends GridLayer {
 
 		options = Util.setOptions(this, options);
 
-		// in case the attribution hasn't been specified, check for known hosts that require attribution
-		if (options.attribution === null && URL.canParse(url)) {
+		// Set required OpenStreetMap attribution and referrerPolicy if it hasn't been specified
+		if (URL.canParse(url)) {
 			const urlHostname = new URL(url).hostname;
-
-			// check for Open Street Map hosts
 			const osmHosts = ['tile.openstreetmap.org', 'tile.osm.org'];
 			if (osmHosts.some(host => urlHostname.endsWith(host))) {
-				options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+				if (options.attribution === null) {
+					options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+				}
+				if (options.referrerPolicy === false) {
+					options.referrerPolicy = 'strict-origin-when-cross-origin';
+				}
 			}
 		}
 


### PR DESCRIPTION
[OpenStreetMap.org's tile use policy ](https://operations.osmfoundation.org/policies/tiles/) requires a valid HTTP Referer, but sites often set a `Referrer-Policy=no-referrer` or `Referrer-Policy=same-origin` which stops the browser sending a HTTP Referer.

This change ensures that the tile fetches send a referer when fetching tiles from tile.openstreetmap.org.

Currently approximately 10% of tile.openstreetmap.org's tile traffic is from sites which are not sending a HTTP Referer.

Disclosure: I am part of the OpenStreetMap.org Operations Team who are responsible for technically enforcing the tile usage policy.

Fixes: #10156