### PR TITLE
Rename `LeafletMap` with alias `Map`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,8 @@ For more information checkout the blog post: https://leafletjs.com/2025/05/18/le
 	}
 </script>
 <script type="module">
-	import L, {Map, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	import L, {LeafletMap, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
@@ -94,7 +94,7 @@ For more information checkout the blog post: https://leafletjs.com/2025/05/18/le
 ```
 <script src="https://unpkg.com/leaflet@2.0.0-alpha/dist/leaflet-global.js"></script>
 <script>
-	const map = new L.Map('map').setView([51.505, -0.09], 13);
+	const map = new L.LeafletMap('map').setView([51.505, -0.09], 13);
 	const tiles = new L.TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'

--- a/build/docs-index.leafdoc
+++ b/build/docs-index.leafdoc
@@ -3,7 +3,7 @@ This file just defines the order of the classes in the docs.
 
 
 
-@class Map
+@class LeafletMap
 
 @class Marker
 @class DivOverlay

--- a/debug/map/canvas.html
+++ b/debug/map/canvas.html
@@ -17,7 +17,7 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {GridLayer, Map, LatLng} from 'leaflet';
+			import {GridLayer, LeafletMap, LatLng} from 'leaflet';
 
 			const tiles = new GridLayer();
 
@@ -45,7 +45,7 @@
 				return tile;
 			};
 
-			new Map('map', {center: new LatLng(50.5, 30.51), zoom: 15, layers: [tiles]});
+			new LeafletMap('map', {center: new LatLng(50.5, 30.51), zoom: 15, layers: [tiles]});
 		</script>
 	</body>
 </html>

--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -22,7 +22,7 @@
 			}
 		</style>
 		<script type="module">
-			import {Map, TileLayer, Control, Circle, Polygon, GeoJSON} from 'leaflet';
+			import {LeafletMap, TileLayer, Control, Circle, Polygon, GeoJSON} from 'leaflet';
 
 			const GrayscaleTileLayer = TileLayer.extend({
 				createTile(...args) {
@@ -32,7 +32,7 @@
 				}
 			});
 
-			const map = new Map('map').setView([50.5, 0], 5);
+			const map = new LeafletMap('map').setView([50.5, 0], 5);
 			const tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const regularTiles = new TileLayer(tileUrl).addTo(map);
 			const blackAndWhiteTiles = new GrayscaleTileLayer(tileUrl);

--- a/debug/map/controls.html
+++ b/debug/map/controls.html
@@ -17,14 +17,14 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker, LatLng, Control} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker, LatLng, Control} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 			const osm2 = new TileLayer(osmUrl, {attribution: 'Hello world'});
 
-			const map = new Map('map').addLayer(osm).setView(new LatLng(50.5, 30.512), 15);
+			const map = new LeafletMap('map').addLayer(osm).setView(new LatLng(50.5, 30.512), 15);
 
 			const marker = new Marker(new LatLng(50.5, 30.505));
 			map.addLayer(marker);

--- a/debug/map/geolocation.html
+++ b/debug/map/geolocation.html
@@ -17,11 +17,11 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map} from 'leaflet';
+			import {TileLayer, LeafletMap} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
-			const map = new Map('map', {zoom: 15, layers: [osm]});
+			const map = new LeafletMap('map', {zoom: 15, layers: [osm]});
 			
 			map.on('locationerror', console.error);
 			map.on('locationfound', console.log);

--- a/debug/map/grid.html
+++ b/debug/map/grid.html
@@ -17,7 +17,7 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {GridLayer, Map} from 'leaflet';
+			import {GridLayer, LeafletMap} from 'leaflet';
 
 			const grid = new GridLayer({
 				attribution: 'Grid Layer'
@@ -42,7 +42,7 @@
 				console.log('tileunload', `${tile.coords.x}, ${tile.coords.y}, ${tile.coords.z}`);
 			});
 
-			new Map('map')
+			new LeafletMap('map')
 				.setView([50.5, 30.51], 10)
 				.addLayer(grid);
 		</script>

--- a/debug/map/iframe-map.html
+++ b/debug/map/iframe-map.html
@@ -19,13 +19,13 @@
 		<div id="map"></div>
 		<button id="populate">Populate with 10 markers</button>
 		<script type="module">
-			import {TileLayer, Map, FeatureGroup, LatLng, Marker, DomUtil} from 'leaflet';
+			import {TileLayer, LeafletMap, FeatureGroup, LatLng, Marker, DomUtil} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 

--- a/debug/map/image-overlay.html
+++ b/debug/map/image-overlay.html
@@ -17,13 +17,13 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, LatLngBounds, ImageOverlay} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, LatLngBounds, ImageOverlay} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			map.addLayer(osm);
 
 			const	bounds = new LatLngBounds(

--- a/debug/map/layer-remove-add.html
+++ b/debug/map/layer-remove-add.html
@@ -18,9 +18,9 @@
 		<div id="map"></div>
 		<button id="removeAdd">Remove and Add Layer</button>
 		<script type="module">
-			import {Map, TileLayer, DomUtil} from 'leaflet';
+			import {LeafletMap, TileLayer, DomUtil} from 'leaflet';
 
-			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
+			const map = new LeafletMap('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			}).addTo(map);

--- a/debug/map/map-mobile.html
+++ b/debug/map/map-mobile.html
@@ -17,14 +17,14 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Marker} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, Marker} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 			const latlng = new LatLng(50.5, 30.51);
 
-			const map = new Map('map', {center: latlng, zoom: 15, layers: [osm]});
+			const map = new LeafletMap('map', {center: latlng, zoom: 15, layers: [osm]});
 			
 			const marker = new Marker(latlng);
 

--- a/debug/map/map-popup.html
+++ b/debug/map/map-popup.html
@@ -17,13 +17,13 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker, Circle, Polygon, Popup} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker, Circle, Polygon, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([51.505, -0.09], 13)
 				.addLayer(osm);
 

--- a/debug/map/map-scaled.html
+++ b/debug/map/map-scaled.html
@@ -39,13 +39,13 @@
 			<div id="map"></div>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, Marker, DomEvent} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker, DomEvent} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 

--- a/debug/map/marker-autopan.html
+++ b/debug/map/marker-autopan.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon, TileLayer} from 'leaflet';
+			import {LeafletMap, Marker, Polygon, TileLayer} from 'leaflet';
 
-			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
+			const map = new LeafletMap('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 
 			const markerAutoPan = new Marker([0, -10], {
 				draggable: true,

--- a/debug/map/markers.html
+++ b/debug/map/markers.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon, TileLayer} from 'leaflet';
+			import {LeafletMap, Marker, Polygon, TileLayer} from 'leaflet';
 
-			const map = new Map('map', {center: [0, 0], zoom: 3, maxZoom: 4});
+			const map = new LeafletMap('map', {center: [0, 0], zoom: 3, maxZoom: 4});
 
 			const markerStatic = new Marker([0, -10], {
 				draggable: false,

--- a/debug/map/max-bounds-bouncy.html
+++ b/debug/map/max-bounds-bouncy.html
@@ -19,14 +19,14 @@
 		<div id="map1" style="float: left; width:45%; height: 80%;"></div>
 		<div id="map2" style="float: left; width:45%; height: 80%;"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from 'leaflet';
+			import {TileLayer, LatLngBounds, LatLng, LeafletMap, Rectangle, Polyline} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm1 = new TileLayer(osmUrl, {maxZoom: 18});
 			const osm2 = new TileLayer(osmUrl, {maxZoom: 18});
 			const bounds = new LatLngBounds(new LatLng(49.5, -11.3), new LatLng(61.2, 2.5));
 
-			const map1 = new Map('map1', {
+			const map1 = new LeafletMap('map1', {
 				center: bounds.getCenter(),
 				zoom: 5,
 				layers: [osm1],
@@ -34,7 +34,7 @@
 				maxBoundsViscosity: 0.75
 			});
 
-			const map2 = new Map('map2', {
+			const map2 = new LeafletMap('map2', {
 				center: bounds.getCenter(),
 				zoom: 5,
 				layers: [osm2],

--- a/debug/map/max-bounds-infinite.html
+++ b/debug/map/max-bounds-infinite.html
@@ -17,7 +17,7 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map} from 'leaflet';
+			import {TileLayer, LatLngBounds, LatLng, LeafletMap} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
@@ -26,7 +26,7 @@
 				new LatLng(61.2, Number.POSITIVE_INFINITY)
 			);
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: new LatLng(49.5, 30),
 				zoom: 7,
 				layers: [osm],

--- a/debug/map/max-bounds.html
+++ b/debug/map/max-bounds.html
@@ -17,7 +17,7 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Polyline} from 'leaflet';
+			import {TileLayer, LatLngBounds, LatLng, LeafletMap, Rectangle, Polyline} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
@@ -26,7 +26,7 @@
 				new LatLng(61.2, 2.5)
 			);
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: bounds.getCenter(),
 				zoom: 7,
 				layers: [osm],

--- a/debug/map/opacity.html
+++ b/debug/map/opacity.html
@@ -67,19 +67,19 @@
 			<div id="map6" class="map"></div>
 		</div>
 		<script type="module">
-			import {Map, TileLayer} from 'leaflet';
+			import {LeafletMap, TileLayer} from 'leaflet';
 
 			const mapopts = {
 				center: [35, -122],
 				zoom : 5
 			};
 
-			const map1 = new Map('map1', mapopts);
-			const map2 = new Map('map2', mapopts);
-			const map3 = new Map('map3', mapopts);
-			const map4 = new Map('map4', mapopts);
-			const map5 = new Map('map5', mapopts);
-			const map6 = new Map('map6', mapopts);
+			const map1 = new LeafletMap('map1', mapopts);
+			const map2 = new LeafletMap('map2', mapopts);
+			const map3 = new LeafletMap('map3', mapopts);
+			const map4 = new LeafletMap('map4', mapopts);
+			const map5 = new LeafletMap('map5', mapopts);
+			const map6 = new LeafletMap('map6', mapopts);
 
 			// CASE 1: no opacity set on any layers
 			// OSM Basemap

--- a/debug/map/popup-keep-in-view.html
+++ b/debug/map/popup-keep-in-view.html
@@ -24,13 +24,13 @@
 			<button id="movePopup">Move last popup</button>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, Popup} from 'leaflet';
+			import {TileLayer, LeafletMap, LatLng, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
 
 			const center = [50.5, 30.51];
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView(center, 15)
 				.addLayer(osm);
 

--- a/debug/map/popup.html
+++ b/debug/map/popup.html
@@ -17,12 +17,12 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, FeatureGroup, Marker, Polyline, Polygon, DomUtil, CircleMarker} from 'leaflet';
+			import {TileLayer, LeafletMap, LatLng, FeatureGroup, Marker, Polyline, Polygon, DomUtil, CircleMarker} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
 
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 

--- a/debug/map/scroll.html
+++ b/debug/map/scroll.html
@@ -23,13 +23,13 @@
 			</div>
 		</div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Popup} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, Popup} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {maxZoom: 18});
 			const latlng = new LatLng(50.5, 30.51);
 
-			const map = new Map('map', {center: latlng, zoom: 15, layers: [osm]});
+			const map = new LeafletMap('map', {center: latlng, zoom: 15, layers: [osm]});
 
 			let s = '';
 			for (let i = 0; i < 100; i++) {

--- a/debug/map/simple-proj.html
+++ b/debug/map/simple-proj.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, CRS, Polygon, Marker, ImageOverlay, GridLayer, Circle} from 'leaflet';
+			import {LeafletMap, CRS, Polygon, Marker, ImageOverlay, GridLayer, Circle} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				crs: CRS.Simple
 			}).setView([0, 0], 0);
 

--- a/debug/map/svg-overlay.html
+++ b/debug/map/svg-overlay.html
@@ -18,9 +18,9 @@
 		<div id="map" style='width:750px; height: 450px;'></div>
 		<svg id="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><rect width="200" height="200"/><rect x="75" y="23" width="50" height="50" style="fill:red"/><rect x="75" y="123" width="50" height="50" style="fill:#0013ff"/></svg>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, SVGOverlay} from 'leaflet';
+			import {LeafletMap, TileLayer, LatLngBounds, SVGOverlay} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19}).addTo(map);
 

--- a/debug/map/tile-opacity.html
+++ b/debug/map/tile-opacity.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, LatLng} from 'leaflet';
+			import {LeafletMap, TileLayer, LatLngBounds, LatLng} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			const nexrad = new TileLayer.WMS('https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi', {
 				layers: 'nexrad-n0r-900913',
 				format: 'image/png',

--- a/debug/map/tile.html
+++ b/debug/map/tile.html
@@ -154,7 +154,7 @@
 			<button id="reset">reset</button>
 		</div>
 		<script type="module">
-			import {Map, TileLayer, GridLayer, Point, DomUtil, Marker, ImageOverlay} from 'leaflet';
+			import {LeafletMap, TileLayer, GridLayer, Point, DomUtil, Marker, ImageOverlay} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];
@@ -164,7 +164,7 @@
 			const madBounds = [[40.70, -4.19], [40.12, -3.31]];
 			const mad = [40.40, -3.7];
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				fadeAnimation: false
 			}).setView(dc, 16);
 

--- a/debug/map/tooltip.html
+++ b/debug/map/tooltip.html
@@ -26,10 +26,10 @@
 		</style>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Polygon, Marker, CircleMarker, DivIcon, FeatureGroup, Polyline} from 'leaflet';
+			import {LeafletMap, TileLayer, Polygon, Marker, CircleMarker, DivIcon, FeatureGroup, Polyline} from 'leaflet';
 
 			const center = [41.2058, 9.4307];
-			const map = new Map('map').setView(center, 13);
+			const map = new LeafletMap('map').setView(center, 13);
 
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 

--- a/debug/map/video-overlay.html
+++ b/debug/map/video-overlay.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, VideoOverlay, Control, DomEvent, DomUtil} from 'leaflet';
+			import {LeafletMap, TileLayer, LatLngBounds, VideoOverlay, Control, DomEvent, DomUtil} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 19}).addTo(map);
 
 			const bounds = new LatLngBounds([[32, -130], [13, -100]]);

--- a/debug/map/wms.html
+++ b/debug/map/wms.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, LatLng, Control} from 'leaflet';
+			import {LeafletMap, TileLayer, LatLngBounds, LatLng, Control} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl);
 			const osm2 = new TileLayer(osmUrl);

--- a/debug/map/zoom-delta.html
+++ b/debug/map/zoom-delta.html
@@ -53,7 +53,7 @@
 			<span id="zoom2"></span>
 		</div>		
 		<script type="module">
-			import {TileLayer, LatLng, Map} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap} from 'leaflet';
 
 			const sf = [37.77, -122.42];
 			const trd = [63.41, 10.41];
@@ -63,7 +63,7 @@
 			const osm2 = new TileLayer(osmUrl, {maxZoom: 18});
 			const center = new LatLng(63.41, 10.41);
 
-			const map1 = new Map('map1', {
+			const map1 = new LeafletMap('map1', {
 				center,
 				layers: [osm1],
 				zoom: 5,
@@ -72,7 +72,7 @@
 				wheelPxPerZoomLevel: 50
 			});
 
-			const map2 = new Map('map2', {
+			const map2 = new LeafletMap('map2', {
 				center,
 				layers: [osm2],
 				zoom: 5,

--- a/debug/map/zoom-levels.html
+++ b/debug/map/zoom-levels.html
@@ -17,12 +17,12 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, LatLng, TileLayer, Control, Marker} from 'leaflet';
+			import {LeafletMap, LatLng, TileLayer, Control, Marker} from 'leaflet';
 
 			// Test that changing between layers with differing zoomlevels also updates
 			// the zoomlevels in the map + also
 
-			const map = new Map('map').setView(new LatLng(50.5, 30.51), 0);
+			const map = new LeafletMap('map').setView(new LatLng(50.5, 30.51), 0);
 			const osmAttrib = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: osmAttrib, minZoom: 0, maxZoom: 10}).addTo(map);
 			const osm2 = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: 'Hello world', minZoom: 5, maxZoom: 18});

--- a/debug/map/zoom-pan.html
+++ b/debug/map/zoom-pan.html
@@ -44,7 +44,7 @@
 			<tr><td>on grid load</td><td id='load'></td></tr>
 		</div>
 		<script type="module">
-			import {Map, TileLayer, Polyline, Marker, ImageOverlay} from 'leaflet';
+			import {LeafletMap, TileLayer, Polyline, Marker, ImageOverlay} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];
@@ -54,7 +54,7 @@
 			const madBounds = [[40.70, -4.19], [40.12, -3.31]];
 			const mad = [40.40, -3.7];
 
-			const map = new Map('map', {zoomSnap: 0.25}).setView(dc, 14);
+			const map = new LeafletMap('map', {zoomSnap: 0.25}).setView(dc, 14);
 			const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png').addTo(map);
 			
 			new Polyline([kyiv, trd, lnd, mad, dc, sf]).addTo(map);

--- a/debug/map/zoom-remain-centered.html
+++ b/debug/map/zoom-remain-centered.html
@@ -17,13 +17,13 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Marker, Control} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, Marker, Control} from 'leaflet';
 
 			const osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 			const osm = new TileLayer(osmUrl, {minZoom: 14});
 			const latlng = new LatLng(51.1788409, -1.82618);
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: latlng,
 				zoom: 15,
 				layers: [osm],

--- a/debug/tests/add-remove-layers.html
+++ b/debug/tests/add-remove-layers.html
@@ -21,9 +21,9 @@
 			<button type="button" id="b2">Remove Layer</button>
 		</div>
 		<script type="module">
-			import {LayerGroup, Map, TileLayer, LatLngBounds, Circle, LatLng, Popup, DomUtil, DomEvent} from 'leaflet';
+			import {LayerGroup, LeafletMap, TileLayer, LatLngBounds, Circle, LatLng, Popup, DomUtil, DomEvent} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				minZoom: 1,
 				maxZoom: 17,

--- a/debug/tests/canvas-loop.html
+++ b/debug/tests/canvas-loop.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LayerGroup, CircleMarker} from 'leaflet';
+			import {LeafletMap, TileLayer, LayerGroup, CircleMarker} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: [39.84, -96.591],
 				zoom: 4,
 				preferCanvas: true

--- a/debug/tests/click-on-canvas.html
+++ b/debug/tests/click-on-canvas.html
@@ -17,10 +17,10 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, FeatureGroup, Polyline} from 'leaflet';
+			import {TileLayer, LeafletMap, FeatureGroup, Polyline} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				minZoom: 1,
 				maxZoom: 19,
 				center: [51.505, -0.09],

--- a/debug/tests/custom-panes.html
+++ b/debug/tests/custom-panes.html
@@ -31,11 +31,11 @@
 			<div id="mapSvg"></div>
 		</div>
 		<script type="module">
-			import {TileLayer, Map, Marker, CircleMarker} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker, CircleMarker} from 'leaflet';
 
 			function makeMap(container, options) {
 				const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-				const map = new Map(container, options)
+				const map = new LeafletMap(container, options)
 					.setView([50.5, 30.51], 15)
 					.addLayer(osm);
 

--- a/debug/tests/detached-dom-memory-leak.html
+++ b/debug/tests/detached-dom-memory-leak.html
@@ -19,7 +19,7 @@
 		<button id="start">Start</button>
 		<button id="stop">Stop</button>
 		<script type="module">
-			import {TileLayer, Map} from 'leaflet';
+			import {TileLayer, LeafletMap} from 'leaflet';
 
 			let map;
 			let mapDiv;
@@ -44,7 +44,7 @@
 				mapDiv.style.width = '200px';
 				document.getElementsByTagName('body')[0].appendChild(mapDiv);
 				// attach map to div
-				map = new Map(randomDivId).setView([51.505, -0.09], 13);
+				map = new LeafletMap(randomDivId).setView([51.505, -0.09], 13);
 				map.addLayer(osm);
 			}
 

--- a/debug/tests/dragging-and-copyworldjump.html
+++ b/debug/tests/dragging-and-copyworldjump.html
@@ -25,7 +25,7 @@
 		<div id="map1" style="height: 300px; width: 400px; float:left;"></div>
 		<div id="map2" style="height: 300px; width: 400px; float:left; margin-left: 10px;"></div>
 		<script type="module">
-			import {TileLayer, Marker, Map, LatLng} from 'leaflet';
+			import {TileLayer, Marker, LeafletMap, LatLng} from 'leaflet';
 
 			function addLayerAndMarker(map) {
 				new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -35,14 +35,14 @@
 				new Marker([50.5, 30.5]).addTo(map);
 			}
 
-			const map1 = new Map('map1', {
+			const map1 = new LeafletMap('map1', {
 				center : new LatLng(45.50144, -122.67599),
 				zoom : 0,
 				dragging : true,
 				worldCopyJump : true
 			});
 
-			const map2 = new Map('map2', {
+			const map2 = new LeafletMap('map2', {
 				center: new LatLng(45.50144, -122.67599),
 				zoom: 0,
 				dragging: false,

--- a/debug/tests/dragging-cursors.html
+++ b/debug/tests/dragging-cursors.html
@@ -23,7 +23,7 @@
 		<div>Map dragging disabled:</div>
 		<div id="map2" style="height: 300px;width: 400px; float:left;"></div>
 		<script type="module">
-			import {TileLayer, Marker, Map, LatLng} from 'leaflet';
+			import {TileLayer, Marker, LeafletMap, LatLng} from 'leaflet';
 
 			function addLayerAndMarkers(map) {
 				new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -34,13 +34,13 @@
 				new Marker([50.5, 30.5], {draggable: false}).addTo(map);
 			}
 
-			const map1 = new Map('map1', {
+			const map1 = new LeafletMap('map1', {
 				center : new LatLng(0, -30),
 				zoom : 0,
 				dragging : true,
 			});
 
-			const map2 = new Map('map2', {
+			const map2 = new LeafletMap('map2', {
 				center : new LatLng(0, -30),
 				zoom : 0,
 				dragging : false,

--- a/debug/tests/esm.html
+++ b/debug/tests/esm.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer} from 'leaflet';
+			import {LeafletMap, TileLayer} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: [39.84, -96.591],
 				zoom: 4,
 			});

--- a/debug/tests/event-perf-2.html
+++ b/debug/tests/event-perf-2.html
@@ -17,7 +17,7 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, FeatureGroup, LatLng, Marker} from 'leaflet';
+			import {LeafletMap, TileLayer, FeatureGroup, LatLng, Marker} from 'leaflet';
 
 			/*
 			 * Can be used to profile performance of event system.
@@ -26,7 +26,7 @@
 			 * profiler and examine times for _on, _off and fire.
 			 */
 
-			const map = new Map('map').setView([50.5, 30.51], 15);
+			const map = new LeafletMap('map').setView([50.5, 30.51], 15);
 
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18}).addTo(map);
 

--- a/debug/tests/mousemove-on-polygons.html
+++ b/debug/tests/mousemove-on-polygons.html
@@ -78,7 +78,7 @@
 		</table>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, Polygon, Marker} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, Polygon, Marker} from 'leaflet';
 
 			const osm = new TileLayer(
 				'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -86,7 +86,7 @@
 			);
 
 			const latlng = new LatLng(39.05, 8.4);
-			const map = new Map('map', {center: latlng, zoom: 12, layers: [osm]});
+			const map = new LeafletMap('map', {center: latlng, zoom: 12, layers: [osm]});
 
 			function update(id) {
 				return function () {

--- a/debug/tests/opacity.html
+++ b/debug/tests/opacity.html
@@ -22,11 +22,11 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, LatLng, Map, DivIcon, Point, Marker} from 'leaflet';
+			import {TileLayer, LatLng, LeafletMap, DivIcon, Point, Marker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const latlng = new LatLng(50.5, 30.51);
-			const map = new Map('map', {center: latlng, zoom: 15, layers: [osm]});
+			const map = new LeafletMap('map', {center: latlng, zoom: 15, layers: [osm]});
 
 			// Create a marker, clicking it toggles opacity
 			const opaqueIcon = new DivIcon({

--- a/debug/tests/popup-context-menu-clicks.html
+++ b/debug/tests/popup-context-menu-clicks.html
@@ -18,9 +18,9 @@
 		<div id="map"></div>
 		<button id="populate">Populate with 10 markers</button>
 		<script type="module">
-			import {Map, TileLayer, GeoJSON, Marker} from 'leaflet';
+			import {LeafletMap, TileLayer, GeoJSON, Marker} from 'leaflet';
 
-			const map = new Map('map').setView([36.9, -95.4], 5);
+			const map = new LeafletMap('map').setView([36.9, -95.4], 5);
 
 			map.on('contextmenu', () => {
 				alert('The map has been right-clicked');

--- a/debug/tests/popup-offset.html
+++ b/debug/tests/popup-offset.html
@@ -17,10 +17,10 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map').setView([50.5, 30.51], 15).addLayer(osm);
+			const map = new LeafletMap('map').setView([50.5, 30.51], 15).addLayer(osm);
 
 			new Marker(map.getCenter())
 				.addTo(map)

--- a/debug/tests/popup-resize.html
+++ b/debug/tests/popup-resize.html
@@ -17,10 +17,10 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, Marker} from 'leaflet';
+			import {TileLayer, LeafletMap, Marker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map').setView([50.5, 30.51], 15).addLayer(osm);
+			const map = new LeafletMap('map').setView([50.5, 30.51], 15).addLayer(osm);
 
 			let marker = new Marker(map.getCenter())
 				.addTo(map);

--- a/debug/tests/remove-while-dragging.html
+++ b/debug/tests/remove-while-dragging.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker} from 'leaflet';
+			import {LeafletMap, Marker} from 'leaflet';
 
-			const map = new Map('map').setView([50, 50], 10);
+			const map = new LeafletMap('map').setView([50, 50], 10);
 			const marker = new Marker([50, 50], {draggable: true}).addTo(map);
 
 			setTimeout(() => {

--- a/debug/tests/reuse-popups.html
+++ b/debug/tests/reuse-popups.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, TileLayer, Popup} from 'leaflet';
+			import {LeafletMap, Marker, TileLayer, Popup} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 
 			new Marker([51.5, -0.09])
 				.bindPopup('<b>Hello world!</b><br />I am a popup.')

--- a/debug/tests/rtl.html
+++ b/debug/tests/rtl.html
@@ -23,10 +23,10 @@
 		<p>Click the map to place a popup at the mouse location</p>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Popup} from 'leaflet';
+			import {LeafletMap, TileLayer, Popup} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 

--- a/debug/tests/rtl2.html
+++ b/debug/tests/rtl2.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Popup} from 'leaflet';
+			import {LeafletMap, TileLayer, Popup} from 'leaflet';
 
-			const map = new Map('map').setView([51.505, -0.09], 13);
+			const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 			new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 

--- a/debug/tests/svg-clicks.html
+++ b/debug/tests/svg-clicks.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, LatLngBounds, Polyline} from 'leaflet';
+			import {LeafletMap, TileLayer, LatLngBounds, Polyline} from 'leaflet';
 
-			const map = new Map('map');
+			const map = new LeafletMap('map');
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {minZoom: 1, maxZoom: 17});
 
 			map.addLayer(osm);

--- a/debug/tests/tile-bounds.html
+++ b/debug/tests/tile-bounds.html
@@ -27,9 +27,9 @@
 		<button id="zoomOut" type="button"> Zoom - 0.1 </button>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, GridLayer, Point} from 'leaflet';
+			import {LeafletMap, GridLayer, Point} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: [35, -122],
 				zoom: 5.7,
 				zoomSnap: 0.1

--- a/debug/tests/tile-events.html
+++ b/debug/tests/tile-events.html
@@ -86,7 +86,7 @@
 		<div><button id="nul">NUL</button>(image overlay)</div>
 		<div><button id="stop">stop</button></div>
 		<script type="module">
-			import {Map, TileLayer, GridLayer, Point, DomUtil} from 'leaflet';
+			import {LeafletMap, TileLayer, GridLayer, Point, DomUtil} from 'leaflet';
 
 			const kyiv = [50.5, 30.5];
 			const lnd = [51.51, -0.12];
@@ -98,7 +98,7 @@
 				[40.12, -3.31],
 			];
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: [35, -122],
 				zoom: 5.75,
 				zoomSnap: 0.25,

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -17,10 +17,10 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, BlanketOverlay, Canvas, SVG, CircleMarker} from 'leaflet';
+			import {TileLayer, LeafletMap, LatLng, BlanketOverlay, Canvas, SVG, CircleMarker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: new LatLng(0, 0),
 				zoom: 1,
 				layers: [osm]

--- a/debug/vector/bounds-extend.html
+++ b/debug/vector/bounds-extend.html
@@ -19,7 +19,7 @@
 		<button type="button" id="extendBounds">Extend the bounds of the center rectangle with the upper right rectangle</button>
 		<button type="button" id="extendLatLng">Extend the bounds of the center rectangle with the lower left marker</button>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Map, Rectangle, Marker} from 'leaflet';
+			import {TileLayer, LatLngBounds, LatLng, LeafletMap, Rectangle, Marker} from 'leaflet';
 
 			const bounds1 = new LatLngBounds(
 				new LatLng(54.559322, -5.767822),
@@ -34,7 +34,7 @@
 			let bounds3 = null;
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				layers: [osm],
 				center: bounds1.getCenter(),
 				zoom: 7

--- a/debug/vector/feature-group-bounds.html
+++ b/debug/vector/feature-group-bounds.html
@@ -20,13 +20,13 @@
 		<button id="featureGroupBounds" type="button">Show feature group bounds</button>
 		<script src="geojson-sample.js"></script>
 		<script type="module">
-			import {TileLayer, Map, GeoJSON, LatLng, Marker, Polyline, FeatureGroup, Rectangle} from 'leaflet';
+			import {TileLayer, LeafletMap, GeoJSON, LatLng, Marker, Polyline, FeatureGroup, Rectangle} from 'leaflet';
 			import geojsonSample from './geojson-sample.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			let rectangle;
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: new LatLng(0.78, 102.37),
 				zoom: 7,
 				layers: [osm]

--- a/debug/vector/geojson-types.html
+++ b/debug/vector/geojson-types.html
@@ -15,7 +15,7 @@
 	</head>
 	<body>
 		<script type="module">
-			import {GeoJSON, Map, TileLayer} from 'leaflet';
+			import {GeoJSON, LeafletMap, TileLayer} from 'leaflet';
 
 			const features = [
 				{
@@ -172,7 +172,7 @@
 				div.style.width = '800px';
 				div.style.height = '600px';
 				document.body.appendChild(div);
-				const map = new Map(div).setView([0.0, 0.0], 4);
+				const map = new LeafletMap(div).setView([0.0, 0.0], 4);
 				new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(map);
 				const geojson = new GeoJSON(feature).addTo(map)
 				map.fitBounds(geojson.getBounds());

--- a/debug/vector/geojson.html
+++ b/debug/vector/geojson.html
@@ -44,10 +44,10 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Control, DomUtil, GeoJSON} from 'leaflet';
+			import {LeafletMap, TileLayer, Control, DomUtil, GeoJSON} from 'leaflet';
 			import statesData from './us-states.js';
 
-			const map = new Map('map').setView([37.8, -96], 4);
+			const map = new LeafletMap('map').setView([37.8, -96], 4);
 			const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png');
 
 			map.addLayer(tiles);

--- a/debug/vector/inherit-dash-array.html
+++ b/debug/vector/inherit-dash-array.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Polygon, CircleMarker} from 'leaflet';
+			import {LeafletMap, TileLayer, Polygon, CircleMarker} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: [20, 20],
 				zoom: 3,
 				preferCanvas: true,

--- a/debug/vector/moving-canvas.html
+++ b/debug/vector/moving-canvas.html
@@ -17,14 +17,14 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, CircleMarker} from 'leaflet';
+			import {TileLayer, LeafletMap, CircleMarker} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 				maxZoom: 19,
 				attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 			});
 
-			const map = new Map('map', {preferCanvas: true})
+			const map = new LeafletMap('map', {preferCanvas: true})
 				.setView([50.5, 30.51], 15)
 				.addLayer(osm);
 

--- a/debug/vector/rectangle.html
+++ b/debug/vector/rectangle.html
@@ -20,7 +20,7 @@
 			Set blue rectangle bounds as current map extent.
 		</button>
 		<script type="module">
-			import {TileLayer, LatLngBounds, LatLng, Rectangle, Map} from 'leaflet';
+			import {TileLayer, LatLngBounds, LatLng, Rectangle, LeafletMap} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const bounds = new LatLngBounds(new LatLng(54.559322, -5.767822), new LatLng(56.1210604, -3.021240));
@@ -40,7 +40,7 @@
 
 			rectangle.bindPopup('I\'m a rectangle!');
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				center: bounds.getCenter(),
 				zoom: 7,
 				layers: [osm]

--- a/debug/vector/vector-bounds.html
+++ b/debug/vector/vector-bounds.html
@@ -19,7 +19,7 @@
 		<button id="zoomToPath" type="button">Zoom to path</button>
 		<button id="zoomToPolygon" type="button">Zoom to polygon</button>
 		<script type="module">
-			import {TileLayer, Polyline, LatLng, Polygon, Map} from 'leaflet';
+			import {TileLayer, Polyline, LatLng, Polygon, LeafletMap} from 'leaflet';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 
@@ -49,7 +49,7 @@
 
 			const latlngs2 = polyPoints.map(p => new LatLng(p[0], p[1]));
 			const poly = new Polygon(latlngs2);
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				layers: [osm],
 				center: new LatLng(39.69596043694606, -104.95084762573242),
 				zoom: 12

--- a/debug/vector/vector-canvas.html
+++ b/debug/vector/vector-canvas.html
@@ -20,7 +20,7 @@
 		<button id="removeCircle" type="button">Remove circle</button>
 		<button id="removeAll" type="button">Remove all layers</button>
 		<script type="module">
-			import {TileLayer, LatLng, Canvas, Polyline, Map, LayerGroup, LatLngBounds, Circle, CircleMarker, Polygon} from 'leaflet';
+			import {TileLayer, LatLng, Canvas, Polyline, LeafletMap, LayerGroup, LatLngBounds, Circle, CircleMarker, Polygon} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
@@ -28,7 +28,7 @@
 
 			const canvas = new Canvas();
 			const path = new Polyline(latlngs, {renderer: canvas});
-			const map = new Map('map', {layers: [osm], preferCanvas: true});
+			const map = new LeafletMap('map', {layers: [osm], preferCanvas: true});
 			const group = new LayerGroup();
 
 			map.fitBounds(new LatLngBounds(latlngs));

--- a/debug/vector/vector-drift.html
+++ b/debug/vector/vector-drift.html
@@ -19,9 +19,9 @@
 		<button id="btn-2" type="button">B</button>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, Marker, Polygon} from 'leaflet';
+			import {LeafletMap, Marker, Polygon} from 'leaflet';
 
-			const map = new Map('map', {
+			const map = new LeafletMap('map', {
 				zoomAnimation: false,
 				// preferCanvas: true
 			}).setView([0, 0], 7);

--- a/debug/vector/vector-mobile.html
+++ b/debug/vector/vector-mobile.html
@@ -17,11 +17,11 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, LatLngBounds, Marker, Polyline} from 'leaflet';
+			import {TileLayer, LeafletMap, LatLng, LatLngBounds, Marker, Polyline} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map', {layers: [osm]});
+			const map = new LeafletMap('map', {layers: [osm]});
 			const latlngs = route.map(p => new LatLng(p[0], p[1]));
 
 			map.fitBounds(new LatLngBounds(latlngs));

--- a/debug/vector/vector-simple.html
+++ b/debug/vector/vector-simple.html
@@ -17,9 +17,9 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {Map, TileLayer, Marker, Circle, Polygon} from 'leaflet';
+			import {LeafletMap, TileLayer, Marker, Circle, Polygon} from 'leaflet';
 
-			const map = new Map('map')
+			const map = new LeafletMap('map')
 				.setView([51.505, -0.09], 13);
 
 			map.addLayer(new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18}));

--- a/debug/vector/vector.html
+++ b/debug/vector/vector.html
@@ -17,11 +17,11 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, Map, LatLng, Polyline, LatLngBounds, Marker} from 'leaflet';
+			import {TileLayer, LeafletMap, LatLng, Polyline, LatLngBounds, Marker} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
-			const map = new Map('map', {layers: [osm]});
+			const map = new LeafletMap('map', {layers: [osm]});
 			const latlngs = route.map(p => new LatLng(p[0], p[1]));
 
 			const path = new Polyline(latlngs)

--- a/debug/vector/vector2.html
+++ b/debug/vector/vector2.html
@@ -17,12 +17,12 @@
 	<body>
 		<div id="map"></div>
 		<script type="module">
-			import {TileLayer, SVG, Map, Marker, Canvas, Polyline, Circle, CircleMarker, Control} from 'leaflet';
+			import {TileLayer, SVG, LeafletMap, Marker, Canvas, Polyline, Circle, CircleMarker, Control} from 'leaflet';
 			import route from './route.js';
 
 			const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {maxZoom: 18});
 			const svg = new SVG();
-			const map = new Map('map', {layers: [osm], renderer: svg});
+			const map = new LeafletMap('map', {layers: [osm], renderer: svg});
 
 			map.addLayer(new Marker(route[0]));
 			map.addLayer(new Marker(route[route.length - 1]));

--- a/docs/_posts/2025-05-18-leaflet-2.0.0-alpha.md
+++ b/docs/_posts/2025-05-18-leaflet-2.0.0-alpha.md
@@ -65,9 +65,9 @@ This release marks a major modernization of the Leaflet codebase. We've dropped 
 	}
 </script>
 <script type="module">
-	import L, {Map, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
 
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/download.md
+++ b/docs/download.md
@@ -52,9 +52,9 @@ Then, in your script, import the needed Leaflet Classes as follows:
 
 ```js
 <script type="module">
-	import {Map, TileLayer} from 'leaflet';
+	import {LeafletMap, TileLayer} from 'leaflet';
 
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 	
 	new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,
@@ -103,9 +103,9 @@ Unzip the downloaded archive to your website's directory and add this to the `he
 Then, import Leaflet in your JavaScript file:
 
 ```js
-import {Map, TileLayer} from 'leaflet';
+import {LeafletMap, TileLayer} from 'leaflet';
 
-const map = new Map('map').setView([51.505, -0.09], 13);
+const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
@@ -124,9 +124,9 @@ npm install leaflet
 Then, import Leaflet in your JavaScript file:
 
 ```js
-import {Map, TileLayer} from 'leaflet';
+import {LeafletMap, TileLayer} from 'leaflet';
 
-const map = new Map('map').setView([51.505, -0.09], 13);
+const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,

--- a/docs/edit.html
+++ b/docs/edit.html
@@ -15,7 +15,7 @@
                 cssFile: 'https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet.css',
                 css: 'body {\n\tmargin: 0;\n}\nhtml, body, #map {\n\theight: 100%\n}',
                 jsFile: 'https://cdn.jsdelivr.net/npm/leaflet/dist/leaflet-src.js',
-                js: "import {Map, TileLayer, Marker} from 'leaflet';\n\nconst map = new Map('map', {\n\tcenter: [0, 0],\n\tzoom: 0\n});\n\nnew TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n}).addTo(map);\n\nnew Marker(map.getCenter()).addTo(map);"
+                js: "import {LeafletMap, TileLayer, Marker} from 'leaflet';\n\nconst map = new LeafletMap('map', {\n\tcenter: [0, 0],\n\tzoom: 0\n});\n\nnew TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {\n\t'attribution': 'Map data © <a href=\"https://openstreetmap.org\">OpenStreetMap</a> contributors'\n}).addTo(map);\n\nnew Marker(map.getCenter()).addTo(map);"
             };
 
             const hash = location.hash.substring(1);

--- a/docs/examples/accessibility/example.md
+++ b/docs/examples/accessibility/example.md
@@ -4,9 +4,9 @@ title: Accessible Markers Example
 ---
 
 <script type="module">
-	import L, {Map, TileLayer, Marker, Icon} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, Icon} from 'leaflet';
 
-	const map = new Map('map').setView([50.4501, 30.5234], 4);
+	const map = new LeafletMap('map').setView([50.4501, 30.5234], 4);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/choropleth/example-basic.md
+++ b/docs/examples/choropleth/example-basic.md
@@ -4,9 +4,9 @@ title: Basic States Example
 ---
 <script type="text/javascript" src="us-states.js"></script>
 <script type="module">
-	import L, {Map, TileLayer, GeoJSON} from 'leaflet';
+	import L, {LeafletMap, TileLayer, GeoJSON} from 'leaflet';
 
-	const map = new Map('map').setView([37.8, -96], 4);
+	const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/choropleth/example-color.md
+++ b/docs/examples/choropleth/example-color.md
@@ -5,9 +5,9 @@ title: Choropleth Color Example
 
 <script type="text/javascript" src="us-states.js"></script>
 <script type="module">
-	import L, {Map, TileLayer, GeoJSON} from 'leaflet';
+	import L, {LeafletMap, TileLayer, GeoJSON} from 'leaflet';
 
-	const map = new Map('map').setView([37.8, -96], 4);
+	const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/choropleth/example.md
+++ b/docs/examples/choropleth/example.md
@@ -35,9 +35,9 @@ css: "#map {
 
 <script type="text/javascript" src="us-states.js"></script>
 <script type="module">
-	import L, {Map, TileLayer, Control, DomUtil, GeoJSON} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control, DomUtil, GeoJSON} from 'leaflet';
 
-	const map = new Map('map').setView([37.8, -96], 4);
+	const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/choropleth/index.md
+++ b/docs/examples/choropleth/index.md
@@ -33,7 +33,7 @@ The GeoJSON with state shapes was kindly shared by [Mike Bostock](http://bost.oc
 
 Let's display our states data on the map:
 
-	const map = new Map('map').setView([37.8, -96], 4);
+	const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/crs-simple/crs-simple-example1.md
+++ b/docs/examples/crs-simple/crs-simple-example1.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: CRS.Simple Example
 ---
 <script type="module">
-	import L, {Map, CRS, ImageOverlay} from 'leaflet';
+	import L, {LeafletMap, CRS, ImageOverlay} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple
 	});
 

--- a/docs/examples/crs-simple/crs-simple-example2.md
+++ b/docs/examples/crs-simple/crs-simple-example2.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: CRS.Simple Example
 ---
 <script type="module">
-	import L, {Map, CRS, ImageOverlay, LatLng, Marker} from 'leaflet';
+	import L, {LeafletMap, CRS, ImageOverlay, LatLng, Marker} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple,
 		minZoom: -3
 	});

--- a/docs/examples/crs-simple/crs-simple-example3.md
+++ b/docs/examples/crs-simple/crs-simple-example3.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: CRS.Simple Example
 ---
 <script type="module">
-	import L, {Map, CRS, ImageOverlay, LatLng, Marker, Polyline} from 'leaflet';
+	import L, {LeafletMap, CRS, ImageOverlay, LatLng, Marker, Polyline} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple,
 		minZoom: -3
 	});

--- a/docs/examples/crs-simple/index.md
+++ b/docs/examples/crs-simple/index.md
@@ -33,7 +33,7 @@ The game has a built-in square coordinate system, as can be seen in the corners.
 
 A Leaflet map has one CRS (and *one* CRS *only*), that can be changed when creating the map. For our game map we'll use `CRS.Simple`, which represents a square grid:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple
 	});
 
@@ -57,7 +57,7 @@ In the default Leaflet CRS, `CRS.Earth`, 360 degrees of longitude are mapped to 
 
 In a `CRS.Simple`, one horizontal map unit is mapped to one horizontal pixel, and *idem* with vertical. This means that the whole map is about 1000x1000 pixels big and won't fit in our HTML container. Luckily, we can set `minZoom` to values lower than zero:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple,
 		minZoom: -5
 	});

--- a/docs/examples/custom-icons/example-one-icon.md
+++ b/docs/examples/custom-icons/example-one-icon.md
@@ -3,8 +3,8 @@ layout: tutorial_frame
 title: Single Custom Icon Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Marker, Icon} from 'leaflet';
-	const map = new Map('map').setView([51.5, -0.09], 13);
+	import L, {LeafletMap, TileLayer, Marker, Icon} from 'leaflet';
+	const map = new LeafletMap('map').setView([51.5, -0.09], 13);
 
 	new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/docs/examples/custom-icons/example.md
+++ b/docs/examples/custom-icons/example.md
@@ -3,8 +3,8 @@ layout: tutorial_frame
 title: Custom Icons Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Marker, Icon} from 'leaflet';
-	const map = new Map('map').setView([51.5, -0.09], 13);
+	import L, {LeafletMap, TileLayer, Marker, Icon} from 'leaflet';
+	const map = new LeafletMap('map').setView([51.5, -0.09], 13);
 
 	new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/docs/examples/extending-1-classes/class-diagram.md
+++ b/docs/examples/extending-1-classes/class-diagram.md
@@ -7,11 +7,11 @@ css: "#map {
         }"
 ---
 <script type="module">
-	import L, {Map, CRS, ImageOverlay} from 'leaflet';
+	import L, {LeafletMap, CRS, ImageOverlay} from 'leaflet';
 
 	const bounds = [[0, 0], [1570, 1910]];
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple,
 		maxZoom: 0,
 		minZoom: -4,

--- a/docs/examples/extending-2-layers/canvascircles.md
+++ b/docs/examples/extending-2-layers/canvascircles.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: CanvasCircles Example
 ---
 <script type="module">
-	import L, {Map, GridLayer} from 'leaflet';
+	import L, {LeafletMap, GridLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [0, 0],
 		zoom: 0
 	});

--- a/docs/examples/extending-2-layers/gridcoords.md
+++ b/docs/examples/extending-2-layers/gridcoords.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Grid Coordinates Example
 ---
 <script type="module">
-	import L, {Map, GridLayer} from 'leaflet';
+	import L, {LeafletMap, GridLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [0, 0],
 		zoom: 0
 	});

--- a/docs/examples/extending-2-layers/index.md
+++ b/docs/examples/extending-2-layers/index.md
@@ -58,7 +58,7 @@ And then, include that file when showing a map:
 	<script src='leaflet.js'>
 	<script src='L.KittenLayer.js'>
 	<script>
-		const map = new Map('map-div-id');
+		const map = new LeafletMap('map-div-id');
 		new TileLayer.Kitten().addTo(map);
 	</script>
 	…

--- a/docs/examples/extending-2-layers/kittenlayer.md
+++ b/docs/examples/extending-2-layers/kittenlayer.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: KittenLayer Example
 ---
 <script type="module">
-	import L, {Map, CRS, TileLayer} from 'leaflet';
+	import L, {LeafletMap, CRS, TileLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: CRS.Simple,
 		center: [0, 0],
 		zoom: 5

--- a/docs/examples/extending-2-layers/pixelorigin.md
+++ b/docs/examples/extending-2-layers/pixelorigin.md
@@ -24,11 +24,11 @@ title: Pixel Origin Examples
 <div id='info' style=''></div>
 
 <script type="module">
-	import L, {Map, TileLayer, Marker, DivIcon, Polyline, DomUtil} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, DivIcon, Polyline, DomUtil} from 'leaflet';
 
 	const trd = [63.41, 10.41];
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [40, 0],
 		zoom: 1
 	});

--- a/docs/examples/extending-3-controls/index.md
+++ b/docs/examples/extending-3-controls/index.md
@@ -52,7 +52,7 @@ Our handler can now be enabled by running `map.tilt.enable()` and disabled by `m
 
 Moreover, if the map has a property named the same as the handler, then that handler will be enabled by default if that options is `true`, so this will enable our handler by default:
 
-	const map = new Map('mapDiv', { tilt: true });
+	const map = new LeafletMap('mapDiv', { tilt: true });
 
 To see this example, you'll need a mobile browser which [supports the `deviceorientation` event](http://caniuse.com/#search=deviceorientation) - and even so, this event is particularly flaky and ill-specified, so beware.
 

--- a/docs/examples/extending-3-controls/tilt.md
+++ b/docs/examples/extending-3-controls/tilt.md
@@ -25,7 +25,7 @@ title: Tilt Handler Example
 
 
 <script type="module">
-	import L, {Map, Handler, Point, DomEvent, TileLayer} from 'leaflet';
+	import L, {LeafletMap, Handler, Point, DomEvent, TileLayer} from 'leaflet';
 
 	const trd = [63.41, 10.41];
 	
@@ -54,7 +54,7 @@ title: Tilt Handler Example
 	
 	Map.addInitHook('addHandler', 'tilt', TiltHandler);
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [0, 0],
 		zoom: 1,
 		tilt: true

--- a/docs/examples/extending-3-controls/watermark.md
+++ b/docs/examples/extending-3-controls/watermark.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Watermark Control Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Control, DomUtil} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control, DomUtil} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [40, 0],
 		zoom: 1
 	});

--- a/docs/examples/geojson/example.md
+++ b/docs/examples/geojson/example.md
@@ -5,9 +5,9 @@ title: GeoJSON Example
 <script src="sample-geojson.js" type="text/javascript"></script>
 
 <script type="module">
-	import L, {Map, TileLayer, Marker, Icon, GeoJSON, CircleMarker} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, Icon, GeoJSON, CircleMarker} from 'leaflet';
 
-	const map = new Map('map').setView([39.74739, -105], 13);
+	const map = new LeafletMap('map').setView([39.74739, -105], 13);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/layers-control/example.md
+++ b/docs/examples/layers-control/example.md
@@ -3,7 +3,7 @@ layout: tutorial_frame
 title: Layers Control Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Marker, LayerGroup, Control} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, LayerGroup, Control} from 'leaflet';
 	const cities = new LayerGroup();
 	const mLittleton = new Marker([39.61, -105.02]).bindPopup('This is Littleton, CO.').addTo(cities);
 	const mDenver = new Marker([39.74, -104.99]).bindPopup('This is Denver, CO.').addTo(cities);
@@ -19,7 +19,7 @@ title: Layers Control Example
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'
 	});
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [39.73, -104.99],
 		zoom: 10,
 		layers: [osm, cities]

--- a/docs/examples/layers-control/index.md
+++ b/docs/examples/layers-control/index.md
@@ -41,7 +41,7 @@ const osmHOT = new TileLayer('https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.
 	maxZoom: 19,
 	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Tiles style by <a href="https://www.hotosm.org/" target="_blank">Humanitarian OpenStreetMap Team</a> hosted by <a href="https://openstreetmap.fr/" target="_blank">OpenStreetMap France</a>'});
 
-const map = new Map('map', {
+const map = new LeafletMap('map', {
 	center: [39.73, -104.99],
 	zoom: 10,
 	layers: [osm, cities]

--- a/docs/examples/map-panes/example.md
+++ b/docs/examples/map-panes/example.md
@@ -5,8 +5,8 @@ title: Custom Pane Example
 <script type="text/javascript" src="eu-countries.js"></script>
 
 <script type="module">
-	import L, {Map, TileLayer, GeoJSON} from 'leaflet';
-	const map = new Map('map');
+	import L, {LeafletMap, TileLayer, GeoJSON} from 'leaflet';
+	const map = new LeafletMap('map');
 
 	map.createPane('labels');
 

--- a/docs/examples/map-panes/index.md
+++ b/docs/examples/map-panes/index.md
@@ -60,7 +60,7 @@ We can use the defaults for the basemap tiles and some overlays like GeoJSON lay
 Custom map panes are created on a per-map basis, so first create an instance of `L.Map` and the pane:
 
 
-    const map = new Map('map');
+    const map = new LeafletMap('map');
     map.createPane('labels');
 
 

--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -11,8 +11,8 @@ css: "body {
 	}"
 ---
 <script type="module">
-	import L, {Map, TileLayer, Marker, Circle} from 'leaflet';
-	const map = new Map('map').fitWorld();
+	import L, {LeafletMap, TileLayer, Marker, Circle} from 'leaflet';
+	const map = new LeafletMap('map').fitWorld();
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/mobile/index.md
+++ b/docs/examples/mobile/index.md
@@ -32,7 +32,7 @@ Also, we need to tell the mobile browser to disable unwanted scaling of the page
 We'll now initialize the map in the JavaScript code like we did in the [quick start guide](../quick-start/), showing the whole world:
 
 ```javascript
-const map =  new Map('map').fitWorld();
+const map =  new LeafletMap('map').fitWorld();
 
 new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,

--- a/docs/examples/overlays/example-image.md
+++ b/docs/examples/overlays/example-image.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Image Overlay Tutorial
 ---
 <script type="module">
-	import L, {Map, TileLayer, LatLngBounds, ImageOverlay, Rectangle} from 'leaflet';
+	import L, {LeafletMap, TileLayer, LatLngBounds, ImageOverlay, Rectangle} from 'leaflet';
 
-	const map = new Map('map').setView([37.8, -96], 4);
+	const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 	const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/overlays/example-nocontrols.md
+++ b/docs/examples/overlays/example-nocontrols.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Video Overlay Tutorial
 ---
 <script type="module">
-	import L, {Map, TileLayer, LatLngBounds, VideoOverlay} from 'leaflet';
+	import L, {LeafletMap, TileLayer, LatLngBounds, VideoOverlay} from 'leaflet';
 
-	const map = new Map('map');
+	const map = new LeafletMap('map');
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/overlays/example-svg.md
+++ b/docs/examples/overlays/example-svg.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: SVG Overlay Tutorial
 ---
 <script type="module">
-	import L, {Map, TileLayer, LatLngBounds, SVGOverlay} from 'leaflet';
+	import L, {LeafletMap, TileLayer, LatLngBounds, SVGOverlay} from 'leaflet';
 
-	const map = new Map('map');
+	const map = new LeafletMap('map');
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/overlays/example-video.md
+++ b/docs/examples/overlays/example-video.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Video Overlay Tutorial (Video with Controls)
 ---
 <script type="module">
-	import L, {Map, TileLayer, LatLngBounds, VideoOverlay, Control, DomUtil, DomEvent} from 'leaflet';
+	import L, {LeafletMap, TileLayer, LatLngBounds, VideoOverlay, Control, DomUtil, DomEvent} from 'leaflet';
 
-	const map = new Map('map');
+	const map = new LeafletMap('map');
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/overlays/index.md
+++ b/docs/examples/overlays/index.md
@@ -27,7 +27,7 @@ const imageOverlay = new ImageOverlay(imageUrl, latLngBounds, options);
 First of all, create a Leaflet map and add a background `L.TileLayer` in the usual way:
 
 ```
-const map = new Map('map').setView([37.8, -96], 4);
+const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,
@@ -97,7 +97,7 @@ If a video can be shown in a webpage in this way, then Leaflet can display it in
 First of all, create a Leaflet map and add a background `L.TileLayer` in the usual way:
 
 ```
-const map = new Map('map').setView([37.8, -96], 4);
+const map = new LeafletMap('map').setView([37.8, -96], 4);
 
 const osm = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 	maxZoom: 19,

--- a/docs/examples/quick-start/example-basic.md
+++ b/docs/examples/quick-start/example-basic.md
@@ -5,9 +5,9 @@ customMapContainer: "true"
 ---
 <div id='map' style='width: 600px; height: 400px;'></div>
 <script type="module">
-	import L, {Map, TileLayer} from 'leaflet';
+	import L, {LeafletMap, TileLayer} from 'leaflet';
 
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/quick-start/example-overlays.md
+++ b/docs/examples/quick-start/example-overlays.md
@@ -5,9 +5,9 @@ customMapContainer: "true"
 ---
 <div id='map' style='width: 600px; height: 400px;'></div>
 <script type="module">
-	import L, {Map, TileLayer, Marker, Circle, Polygon} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, Circle, Polygon} from 'leaflet';
 
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/quick-start/example.md
+++ b/docs/examples/quick-start/example.md
@@ -5,9 +5,9 @@ customMapContainer: "true"
 ---
 <div id='map' style='width: 600px; height: 400px;'></div>
 <script type="module">
-	import L, {Map, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
 
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 	const tiles = new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		maxZoom: 19,

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -61,8 +61,8 @@ Let's create a map of the center of London with pretty OpenStreetMap tiles. From
 
 ```javascript
 <script type="module">
-	import {Map, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
-	const map = new Map('map').setView([51.505, -0.09], 13);
+	import {LeafletMap, TileLayer, Marker, Circle, Polygon, Popup} from 'leaflet';
+	const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 	// ...
 </script>

--- a/docs/examples/wms/index.md
+++ b/docs/examples/wms/index.md
@@ -33,7 +33,7 @@ The base WMS URL is simply the `GetCapabilities` URL, without any parameters, li
 
 And the way to use that in a Leaflet map is simply:
 
-	const map = new Map(mapDiv, mapOptions);
+	const map = new LeafletMap(mapDiv, mapOptions);
 
 	const wmsLayer = new TileLayer.WMS('http://ows.mundialis.de/services/service?', wmsOptions).addTo(map);
 
@@ -108,7 +108,7 @@ From a GIS point of view, WMS handling in Leaflet is quite basic. There's no `Ge
 
 Also note that Leaflet supports very few [coordinate systems](https://en.wikipedia.org/wiki/Spatial_reference_system): `CRS:3857`, `CRS:3395` and `CRS:4326` (See the documentation for `L.CRS`). If your WMS service doesn't serve images in those coordinate systems, you might need to use [Proj4Leaflet](https://github.com/kartena/Proj4Leaflet) to use a different coordinate system in Leaflet. Other than that, just use the right CRS when initializing your map, and any WMS layers added will use it:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		crs: L.CRS.EPSG4326
 	});
 

--- a/docs/examples/wms/wms-example-crs.md
+++ b/docs/examples/wms/wms-example-crs.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: WMS CRS Example
 ---
 <script type="module">
-	import L, {Map, CRS, TileLayer} from 'leaflet';
+	import L, {LeafletMap, CRS, TileLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [0, 0],
 		zoom: 1,
 		crs: CRS.EPSG4326

--- a/docs/examples/wms/wms-example1.md
+++ b/docs/examples/wms/wms-example1.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: WMS Example 1
 ---
 <script type="module">
-	import L, {Map, CRS, TileLayer} from 'leaflet';
+	import L, {LeafletMap, CRS, TileLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [-17, -67],
 		zoom: 3
 	});

--- a/docs/examples/wms/wms-example2.md
+++ b/docs/examples/wms/wms-example2.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: WMS Example 2
 ---
 <script type="module">
-	import L, {Map, CRS, TileLayer} from 'leaflet';
+	import L, {LeafletMap, CRS, TileLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [-17, -67],
 		zoom: 3
 	});

--- a/docs/examples/wms/wms-example3.md
+++ b/docs/examples/wms/wms-example3.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: WMS Example 3
 ---
 <script type="module">
-	import L, {Map, CRS, TileLayer, Control} from 'leaflet';
+	import L, {LeafletMap, CRS, TileLayer, Control} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		center: [-17, -67],
 		zoom: 3
 	});

--- a/docs/examples/zoom-levels/example-delta.md
+++ b/docs/examples/zoom-levels/example-delta.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: No Zoom Snap Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Control, DomUtil} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control, DomUtil} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 0,
 		maxZoom: 18,
 		zoomSnap: 0,

--- a/docs/examples/zoom-levels/example-fractional.md
+++ b/docs/examples/zoom-levels/example-fractional.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Fractional Zoom Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Control, DomUtil} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control, DomUtil} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 0,
 		maxZoom: 1,
 		zoomSnap: 0.25,

--- a/docs/examples/zoom-levels/example-scale.md
+++ b/docs/examples/zoom-levels/example-scale.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Zoom Scale Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Control} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 1,
 		maxZoom: 1,
 		dragging: false

--- a/docs/examples/zoom-levels/example-setzoom.md
+++ b/docs/examples/zoom-levels/example-setzoom.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Zoom Control Example
 ---
 <script type="module">
-	import L, {Map, TileLayer, Control, DomUtil} from 'leaflet';
+	import L, {LeafletMap, TileLayer, Control, DomUtil} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 0,
 		maxZoom: 1
 	});

--- a/docs/examples/zoom-levels/example-zero.md
+++ b/docs/examples/zoom-levels/example-zero.md
@@ -3,9 +3,9 @@ layout: tutorial_frame
 title: Zoom Level Zero Example
 ---
 <script type="module">
-	import L, {Map, TileLayer} from 'leaflet';
+	import L, {LeafletMap, TileLayer} from 'leaflet';
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 0,
 		maxZoom: 0
 	});

--- a/docs/examples/zoom-levels/index.md
+++ b/docs/examples/zoom-levels/index.md
@@ -37,7 +37,7 @@ To understand how zoom levels work, first we need a basic introduction to <i>geo
 
 Let's have a look at a simple map locked at zoom zero:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		minZoom: 0,
 		maxZoom: 0
 	});
@@ -215,7 +215,7 @@ If you set a value of `0.1`, the valid zoom levels of the map will be `0`, `0.1`
 
 The following example uses a `zoomSnap` value of `0.25`:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		zoomSnap: 0.25
 	});
 
@@ -242,7 +242,7 @@ option controls how fast the mousewheel zooms in or out.
 
 Here is an example with `zoomSnap` set to zero:
 
-	const map = new Map('map', {
+	const map = new LeafletMap('map', {
 		zoomDelta: 0.25,
 		zoomSnap: 0
 	});

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,9 +19,9 @@ and a simple, readable&nbsp;<a title="Leaflet source code repository on GitHub" 
 
 <p>Here we create a map in the <code>'map'</code> div, add <abbr title="Here we use OpenStreetMap tiles, but Leaflet doesn't force you to &mdash; use whatever works for you, it's open source!">tiles of our choice</abbr>, and then add a marker with some text in a popup:</p>
 
-<pre class="basic-code javascript"><code>import {Map, TileLayer, Marker} from 'leaflet';
+<pre class="basic-code javascript"><code>import {LeafletMap, TileLayer, Marker} from 'leaflet';
 
-const map = new Map('map').setView([51.505, -0.09], 13);
+const map = new LeafletMap('map').setView([51.505, -0.09], 13);
 
 new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
     attribution: '&amp;copy; &lt;a href="https://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors'
@@ -196,9 +196,9 @@ and spreading the word about Leaflet among your colleagues and friends.</p>
 </div>
 
 <script type="module">
-    import {Map, TileLayer, Marker} from 'leaflet';
+    import {LeafletMap, TileLayer, Marker} from 'leaflet';
     
-    const map = new Map('map').setView([51.505, -0.159], 15);
+    const map = new LeafletMap('map').setView([51.505, -0.159], 15);
     
     new TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/docs/reference-2.0.0.html
+++ b/docs/reference-2.0.0.html
@@ -138,7 +138,7 @@ bodyclass: api-page
 
 
 <pre><code class="language-js">// initialize the map on the &quot;map&quot; div with a given center and zoom
-const map = new Map('map', {
+const map = new LeafletMap('map', {
 	center: [51.505, -0.09],
 	zoom: 13
 });
@@ -14873,12 +14873,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use SVG by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new SVG()
 });
 </code></pre>
 <p>Use a SVG renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new SVG({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -15490,12 +15490,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use Canvas by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new Canvas()
 });
 </code></pre>
 <p>Use a Canvas renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new Canvas({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/docs/reference-2.0.0.html
+++ b/docs/reference-2.0.0.html
@@ -138,7 +138,7 @@ bodyclass: api-page
 
 
 <pre><code class="language-js">// initialize the map on the &quot;map&quot; div with a given center and zoom
-const map = new LeafletMap('map', {
+const map = new Map('map', {
 	center: [51.505, -0.09],
 	zoom: 13
 });
@@ -14873,12 +14873,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use SVG by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new LeafletMap('map', {
+<pre><code class="language-js">const map = new Map('map', {
 	renderer: new SVG()
 });
 </code></pre>
 <p>Use a SVG renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new LeafletMap('map');
+<pre><code class="language-js">const map = new Map('map');
 const myRenderer = new SVG({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -15490,12 +15490,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use Canvas by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new LeafletMap('map', {
+<pre><code class="language-js">const map = new Map('map', {
 	renderer: new Canvas()
 });
 </code></pre>
 <p>Use a Canvas renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new LeafletMap('map');
+<pre><code class="language-js">const map = new Map('map');
 const myRenderer = new Canvas({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -140,7 +140,7 @@ bodyclass: api-page
 
 
 <pre><code class="language-js">// initialize the map on the &quot;map&quot; div with a given center and zoom
-const map = new LeafletMap('map', {
+const map = new Map('map', {
 	center: [51.505, -0.09],
 	zoom: 13
 });
@@ -14420,12 +14420,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use SVG by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new LeafletMap('map', {
+<pre><code class="language-js">const map = new Map('map', {
 	renderer: new SVG()
 });
 </code></pre>
 <p>Use a SVG renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new LeafletMap('map');
+<pre><code class="language-js">const map = new Map('map');
 const myRenderer = new SVG({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -15001,12 +15001,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use Canvas by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new LeafletMap('map', {
+<pre><code class="language-js">const map = new Map('map', {
 	renderer: new Canvas()
 });
 </code></pre>
 <p>Use a Canvas renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new LeafletMap('map');
+<pre><code class="language-js">const map = new Map('map');
 const myRenderer = new Canvas({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -140,7 +140,7 @@ bodyclass: api-page
 
 
 <pre><code class="language-js">// initialize the map on the &quot;map&quot; div with a given center and zoom
-const map = new Map('map', {
+const map = new LeafletMap('map', {
 	center: [51.505, -0.09],
 	zoom: 13
 });
@@ -14420,12 +14420,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use SVG by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new SVG()
 });
 </code></pre>
 <p>Use a SVG renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new SVG({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -15001,12 +15001,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use Canvas by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new Canvas()
 });
 </code></pre>
 <p>Use a Canvas renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new Canvas({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/spec/suites/control/Control.AttributionSpec.js
+++ b/spec/suites/control/Control.AttributionSpec.js
@@ -1,4 +1,4 @@
-import {Map, Control, Layer} from 'leaflet';
+import {LeafletMap, Control, Layer} from 'leaflet';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 import {expect} from 'chai';
 
@@ -7,7 +7,7 @@ describe('Control.Attribution', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 
 		control = new Control.Attribution({
 			prefix: 'prefix'

--- a/spec/suites/control/Control.LayersSpec.js
+++ b/spec/suites/control/Control.LayersSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Control, Map, Marker, TileLayer, Util} from 'leaflet';
+import {Control, LeafletMap, Marker, TileLayer, Util} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, pointerType, removeMapContainer} from '../SpecHelper.js';
@@ -9,7 +9,7 @@ describe('Control.Layers', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 
 		map.setView([0, 0], 14);
 	});
@@ -277,7 +277,7 @@ describe('Control.Layers', () => {
 			// gives it an actual size.
 			map.remove();
 			container.style.height = container.style.width = '200px';
-			map = new Map(container);
+			map = new LeafletMap(container);
 
 			for (; i < 20; i += 1) {
 				// Default text size: 12px => 12 * 20 = 240px height (not even considering padding/margin).
@@ -299,7 +299,7 @@ describe('Control.Layers', () => {
 			// gives it an actual size.
 			map.remove();
 			container.style.height = container.style.width = '200px';
-			map = new Map(container);
+			map = new LeafletMap(container);
 
 			layersCtrl.addTo(map);
 			expect(layersCtrl._section.classList.contains('leaflet-control-layers-scrollbar')).to.be.false;

--- a/spec/suites/control/Control.ScaleSpec.js
+++ b/spec/suites/control/Control.ScaleSpec.js
@@ -1,8 +1,8 @@
-import {Map, Control} from 'leaflet';
+import {LeafletMap, Control} from 'leaflet';
 
 describe('Control.Scale', () => {
 	it('can be added to an unloaded map', () => {
-		const map = new Map(document.createElement('div'));
+		const map = new LeafletMap(document.createElement('div'));
 		new Control.Scale().addTo(map);
 	});
 });

--- a/spec/suites/control/ControlSpec.js
+++ b/spec/suites/control/ControlSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Control, DomUtil, Map} from 'leaflet';
+import {Control, DomUtil, LeafletMap} from 'leaflet';
 import sinon from 'sinon';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 
@@ -14,7 +14,7 @@ describe('Control', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 
 		map.setView([0, 0], 1);
 		control = new Control();

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Control, DomEvent, DomUtil, Map} from 'leaflet';
+import {Control, DomEvent, DomUtil, LeafletMap} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
@@ -91,7 +91,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 
 	it('respects disableClickPropagation', () => {
 		const spyMap = sinon.spy();
-		const map = new Map(container).setView([51.505, -0.09], 13);
+		const map = new LeafletMap(container).setView([51.505, -0.09], 13);
 		map.on('dblclick', spyMap);
 
 		const spyCtrl = sinon.spy();
@@ -115,7 +115,7 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 
 	it('doesn\'t fire double-click while clicking on a label with `for` attribute', () => {
 		const spyMap = sinon.spy();
-		const map = new Map(container).setView([51.505, -0.09], 13);
+		const map = new LeafletMap(container).setView([51.505, -0.09], 13);
 		map.on('dblclick', spyMap);
 
 		let div;

--- a/spec/suites/dom/DomEventSpec.js
+++ b/spec/suites/dom/DomEventSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomEvent, Map, Util} from 'leaflet';
+import {DomEvent, LeafletMap, Util} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 
@@ -566,7 +566,7 @@ describe('DomEvent', () => {
 			const grandChild = document.createElement('div');
 			child.appendChild(grandChild);
 
-			const map = new Map(el).setView([0, 0], 0);
+			const map = new LeafletMap(el).setView([0, 0], 0);
 			const mapClickListener = sinon.spy();
 			const mapOtherListener = sinon.spy();
 			map.on('click', mapClickListener);          // control case

--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Bounds, LineUtil, Map, LatLng, Point, Polyline} from 'leaflet';
+import {Bounds, LineUtil, LeafletMap, LatLng, Point, Polyline} from 'leaflet';
 import sinon from 'sinon';
 import '../SpecHelper.js';
 
@@ -114,7 +114,7 @@ describe('LineUtil', () => {
 	describe('#polylineCenter', () => {
 		let map, crs, zoom;
 		beforeEach(() => {
-			map = new Map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
+			map = new LeafletMap(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
 		});
 

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Bounds, Map, Point, PolyUtil, Polygon} from 'leaflet';
+import {Bounds, LeafletMap, Point, PolyUtil, Polygon} from 'leaflet';
 import sinon from 'sinon';
 import '../SpecHelper.js';
 
@@ -47,7 +47,7 @@ describe('PolyUtil', () => {
 	describe('#polygonCenter', () => {
 		let map, crs, zoom;
 		beforeEach(() => {
-			map = new Map(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
+			map = new LeafletMap(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
 			zoom = map.getZoom();
 		});

--- a/spec/suites/layer/GeoJSONSpec.js
+++ b/spec/suites/layer/GeoJSONSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Circle, CircleMarker, FeatureGroup, GeoJSON, LatLng, Layer, LayerGroup, Map, Marker, Polygon, Polyline, TileLayer} from 'leaflet';
+import {Circle, CircleMarker, FeatureGroup, GeoJSON, LatLng, Layer, LayerGroup, LeafletMap, Marker, Polygon, Polyline, TileLayer} from 'leaflet';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 
 describe('GeoJSON', () => {
@@ -106,7 +106,7 @@ describe('GeoJSON', () => {
 
 		beforeEach(() => {
 			container = createContainer();
-			map = new Map(container);
+			map = new LeafletMap(container);
 			map.setView([0, 0], 1);
 		});
 

--- a/spec/suites/layer/ImageOverlaySpec.js
+++ b/spec/suites/layer/ImageOverlaySpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {LatLngBounds, Map, ImageOverlay} from 'leaflet';
+import {LatLngBounds, LeafletMap, ImageOverlay} from 'leaflet';
 import sinon from 'sinon';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 
@@ -9,7 +9,7 @@ describe('ImageOverlay', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView([55.8, 37.6], 6);	// view needs to be set so when layer is added it is initilized
 	});
 

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DivIcon, DomUtil, FeatureGroup, Icon, Map, Marker, Point, Polygon, Popup} from 'leaflet';
+import {DivIcon, DomUtil, FeatureGroup, Icon, LeafletMap, Marker, Point, Polygon, Popup} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
@@ -11,7 +11,7 @@ describe('Popup', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView(center, 6);
 	});
 

--- a/spec/suites/layer/TooltipSpec.js
+++ b/spec/suites/layer/TooltipSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {CircleMarker, FeatureGroup, LayerGroup, Map, Marker, Polygon, Polyline, Rectangle, Tooltip} from 'leaflet';
+import {CircleMarker, FeatureGroup, LayerGroup, LeafletMap, Marker, Polygon, Polyline, Rectangle, Tooltip} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
@@ -11,7 +11,7 @@ describe('Tooltip', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView(center, 6);
 	});
 

--- a/spec/suites/layer/VideoOverlaySpec.js
+++ b/spec/suites/layer/VideoOverlaySpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {LatLngBounds, Map, VideoOverlay} from 'leaflet';
+import {LatLngBounds, LeafletMap, VideoOverlay} from 'leaflet';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
 import Hand from 'prosthetic-hand';
 
@@ -9,7 +9,7 @@ describe('VideoOverlay', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView([20, -115], 4);	// view needs to be set so when layer is added it is initilized
 	});
 

--- a/spec/suites/layer/marker/Icon.DefaultSpec.js
+++ b/spec/suites/layer/marker/Icon.DefaultSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Icon, Map, Marker, Browser} from 'leaflet';
+import {Icon, LeafletMap, Marker, Browser} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Icon.Default', () => {
@@ -7,7 +7,7 @@ describe('Icon.Default', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 
 		map.setView([0, 0], 0);
 		new Marker([0, 0]).addTo(map);

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, Map, Marker, Point} from 'leaflet';
+import {DomUtil, LeafletMap, Marker, Point} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
 
@@ -9,7 +9,7 @@ describe('Marker.Drag', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		container.style.width = '600px';
 		container.style.height = '600px';
 		map.setView([0, 0], 0);

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Browser, DivIcon, Icon, LatLng, Map, Marker, Point} from 'leaflet';
+import {Browser, DivIcon, Icon, LatLng, LeafletMap, Marker, Point} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -12,7 +12,7 @@ describe('Marker', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 
 		map.setView([0, 0], 0);
 		icon1 = new Icon.Default();

--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, GridLayer, Map, Point, Util} from 'leaflet';
+import {DomUtil, GridLayer, LeafletMap, Point, Util} from 'leaflet';
 import sinon from 'sinon';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
@@ -12,7 +12,7 @@ describe('GridLayer', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		container.style.width = '800px';
 		container.style.height = '600px';
 	});
@@ -36,7 +36,7 @@ describe('GridLayer', () => {
 
 		it('works when map has fadeAnimated=false (IE8 is exempt)', (done) => {
 			map.remove();
-			map = new Map(container, {fadeAnimation: false}).setView([0, 0], 0);
+			map = new LeafletMap(container, {fadeAnimation: false}).setView([0, 0], 0);
 
 			const grid = new GridLayer().setOpacity(0.5).addTo(map);
 			grid.on('load', () => {
@@ -94,7 +94,7 @@ describe('GridLayer', () => {
 
 		it('removes tiles for unused zoom levels', (done) => {
 			map.remove();
-			map = new Map(container, {fadeAnimation: false});
+			map = new LeafletMap(container, {fadeAnimation: false});
 			map.setView([0, 0], 1);
 
 			const grid = new GridLayer();

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Browser, CRS, Map, TileLayer, Util, LatLng} from 'leaflet';
+import {Browser, CRS, LeafletMap, TileLayer, Util, LatLng} from 'leaflet';
 import sinon from 'sinon';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
@@ -165,7 +165,7 @@ describe('TileLayer', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		container.style.width = '800px';
 		container.style.height = '600px';
 	});
@@ -335,7 +335,7 @@ describe('TileLayer', () => {
 			simplediv.style.visibility = 'hidden';
 
 			document.body.appendChild(simplediv);
-			const simpleMap = new Map(simplediv, {
+			const simpleMap = new LeafletMap(simplediv, {
 				crs: CRS.Simple
 			}).setView([0, 0], 5);
 			const layer = new TileLayer('http://example.com/{z}/{-y}/{x}.png');

--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Canvas, Circle, DomEvent, LayerGroup, Map, Marker, Polygon, Polyline, SVG, Util} from 'leaflet';
+import {Canvas, Circle, DomEvent, LayerGroup, LeafletMap, Marker, Polygon, Polyline, SVG, Util} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
@@ -14,7 +14,7 @@ describe('Canvas', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {preferCanvas: true, zoomControl: false});
+		map = new LeafletMap(container, {preferCanvas: true, zoomControl: false});
 		map.setView([0, 0], 6);
 		latLngs = [p2ll(0, 0), p2ll(0, 100), p2ll(100, 100), p2ll(100, 0)];
 	});
@@ -285,7 +285,7 @@ describe('Canvas', () => {
 			map.remove();
 
 			const canvas = new Canvas();
-			map = new Map(container, {renderer: canvas});
+			map = new LeafletMap(container, {renderer: canvas});
 			map.setView([0, 0], 6);
 			new Polygon(latLngs).addTo(map);
 

--- a/spec/suites/layer/vector/CircleMarkerSpec.js
+++ b/spec/suites/layer/vector/CircleMarkerSpec.js
@@ -1,5 +1,5 @@
 ﻿import {expect} from 'chai';
-import {CircleMarker, LatLng, Map, Point} from 'leaflet';
+import {CircleMarker, LatLng, LeafletMap, Point} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('CircleMarker', () => {
@@ -7,7 +7,7 @@ describe('CircleMarker', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView([0, 0], 1);
 	});
 

--- a/spec/suites/layer/vector/CircleSpec.js
+++ b/spec/suites/layer/vector/CircleSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Circle, Map, CRS, Transformation} from 'leaflet';
+import {Circle, LeafletMap, CRS, Transformation} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Circle', () => {
@@ -7,7 +7,7 @@ describe('Circle', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView([0, 0], 4);
 		circle = new Circle([50, 30], {radius: 200}).addTo(map);
 	});
@@ -48,7 +48,7 @@ describe('Circle', () => {
 			class crs extends CRS.Simple {
 				static transformation = new Transformation(-1, 0, -1, 0);
 			}
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				crs
 			});
 			map.setView([0, 0], 4);

--- a/spec/suites/layer/vector/PathSpec.js
+++ b/spec/suites/layer/vector/PathSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {LayerGroup, Map, Polygon, Polyline} from 'leaflet';
+import {LayerGroup, LeafletMap, Polygon, Polyline} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -9,7 +9,7 @@ describe('Path', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 		map.setView([0, 0], 0);
 	});
 

--- a/spec/suites/layer/vector/PolygonSpec.js
+++ b/spec/suites/layer/vector/PolygonSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {LineUtil, Map, LatLng, Polygon} from 'leaflet';
+import {LineUtil, LeafletMap, LatLng, Polygon} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Polygon', () => {
@@ -7,7 +7,7 @@ describe('Polygon', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new LeafletMap(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {

--- a/spec/suites/layer/vector/PolylineSpec.js
+++ b/spec/suites/layer/vector/PolylineSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Map, LatLng, Polyline} from 'leaflet';
+import {LeafletMap, LatLng, Polyline} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Polyline', () => {
@@ -7,7 +7,7 @@ describe('Polyline', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new LeafletMap(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {

--- a/spec/suites/layer/vector/RectangleSpec.js
+++ b/spec/suites/layer/vector/RectangleSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Canvas, LineUtil, Map, Polygon, LatLng, Rectangle} from 'leaflet';
+import {Canvas, LineUtil, LeafletMap, Polygon, LatLng, Rectangle} from 'leaflet';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
 describe('Rectangle', () => {
@@ -7,7 +7,7 @@ describe('Rectangle', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {center: [55.8, 37.6], zoom: 6});
+		map = new LeafletMap(container, {center: [55.8, 37.6], zoom: 6});
 	});
 
 	afterEach(() => {
@@ -119,7 +119,7 @@ describe('Rectangle', () => {
 		it('doesn\'t apply `focus` listener if element is undefined', () => {
 			map.remove();
 
-			map = new Map(container, {renderer: new Canvas()});
+			map = new LeafletMap(container, {renderer: new Canvas()});
 			map.setView([0, 0], 6);
 			expect(() => {
 				new Polygon([[[2, 3], [4, 5]]]).addTo(map).bindTooltip('test');

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Bounds, Canvas, CircleMarker, DivIcon, DomEvent, GridLayer, Handler, LatLngBounds, Layer, Map, Marker, Point, Polygon, TileLayer, Util, Control, LatLng} from 'leaflet';
+import {Bounds, Canvas, CircleMarker, DivIcon, DomEvent, GridLayer, Handler, LatLngBounds, Layer, LeafletMap, Marker, Point, Polygon, TileLayer, Util, Control, LatLng} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../SpecHelper.js';
@@ -10,7 +10,7 @@ describe('Map', () => {
 
 	beforeEach(() => {
 		container = container = createContainer();
-		map = new Map(container);
+		map = new LeafletMap(container);
 	});
 
 	afterEach(() => {
@@ -41,12 +41,12 @@ describe('Map', () => {
 
 		describe('corner case checking', () => {
 			it('throws an exception upon reinitialization', () => {
-				expect(() => new Map(container))
+				expect(() => new LeafletMap(container))
 					.to.throw('Map container is already initialized.');
 			});
 
 			it('throws an exception if a container is not found', () => {
-				expect(() => new Map('nonexistentdivelement'))
+				expect(() => new LeafletMap('nonexistentdivelement'))
 					.to.throw('Map container not found.');
 			});
 		});
@@ -112,7 +112,7 @@ describe('Map', () => {
 
 		it('throws error if container is reused by other instance', () => {
 			map.remove();
-			const map2 = new Map(container);
+			const map2 = new LeafletMap(container);
 
 			expect(() => {
 				map.remove();
@@ -198,14 +198,14 @@ describe('Map', () => {
 		});
 
 		it('defaults to zoom passed as map option', () => {
-			const map = new Map(document.createElement('div'), {zoom: 13});
+			const map = new LeafletMap(document.createElement('div'), {zoom: 13});
 			const zoom = map.setView([51.605, -0.11]).getZoom();
 			map.remove(); // clean up
 			expect(zoom).to.equal(13);
 		});
 
 		it('passes duration option to panBy', () => {
-			const map = new Map(document.createElement('div'), {zoom: 13, center: [0, 0]});
+			const map = new LeafletMap(document.createElement('div'), {zoom: 13, center: [0, 0]});
 			map.panBy = sinon.spy();
 			map.setView([51.605, -0.11], 13, {animate: true, duration: 13});
 			map.remove(); // clean up
@@ -239,7 +239,7 @@ describe('Map', () => {
 			});
 
 			it('overwrites zoom passed as map option', () => {
-				const map2 = new Map(document.createElement('div'), {zoom: 13});
+				const map2 = new LeafletMap(document.createElement('div'), {zoom: 13});
 				map2.setZoom(15);
 				const zoom = map2.getZoom();
 
@@ -261,7 +261,7 @@ describe('Map', () => {
 			});
 
 			it('does not overwrite zoom passed as map option', () => {
-				const map2 = new Map(document.createElement('div'), {zoom: 13});
+				const map2 = new LeafletMap(document.createElement('div'), {zoom: 13});
 				map2.setView([0, 0]);
 				map2.setZoom(15);
 				const zoom = map2.getZoom();
@@ -356,7 +356,7 @@ describe('Map', () => {
 		});
 
 		it('throws if map is not loaded', () => {
-			const unloadedMap = new Map(document.createElement('div'));
+			const unloadedMap = new LeafletMap(document.createElement('div'));
 
 			expect(() => unloadedMap.setZoomAround([5, 5], 4)).to.throw();
 		});
@@ -383,7 +383,7 @@ describe('Map', () => {
 
 	describe('#getBounds', () => {
 		it('is safe to call from within a moveend callback during initial load (#1027)', () => {
-			const map = new Map(document.createElement('div'));
+			const map = new LeafletMap(document.createElement('div'));
 			map.on('moveend', () => {
 				map.getBounds();
 			});
@@ -623,7 +623,7 @@ describe('Map', () => {
 		it('minZoom and maxZoom options overrides any minZoom and maxZoom set on layers', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {minZoom: 2, maxZoom: 20});
+			map = new LeafletMap(container, {minZoom: 2, maxZoom: 20});
 
 			new TileLayer('', {minZoom: 4, maxZoom: 10}).addTo(map);
 			new TileLayer('', {minZoom: 6, maxZoom: 17}).addTo(map);
@@ -636,7 +636,7 @@ describe('Map', () => {
 		it('layer minZoom overrides map zoom if map has no minZoom set and layer minZoom is bigger than map zoom', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {zoom: 10});
+			map = new LeafletMap(container, {zoom: 10});
 
 			new TileLayer('', {minZoom: 15}).addTo(map);
 
@@ -646,7 +646,7 @@ describe('Map', () => {
 		it('layer maxZoom overrides map zoom if map has no maxZoom set and layer maxZoom is smaller than map zoom', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {zoom: 20});
+			map = new LeafletMap(container, {zoom: 20});
 
 			new TileLayer('', {maxZoom: 15}).addTo(map);
 
@@ -656,7 +656,7 @@ describe('Map', () => {
 		it('map\'s zoom is adjusted to layer\'s minZoom even if initialized with smaller value', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {zoom: 10});
+			map = new LeafletMap(container, {zoom: 10});
 
 			new TileLayer('', {minZoom: 15}).addTo(map);
 
@@ -666,7 +666,7 @@ describe('Map', () => {
 		it('map\'s zoom is adjusted to layer\'s maxZoom even if initialized with larger value', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {zoom: 20});
+			map = new LeafletMap(container, {zoom: 20});
 
 			new TileLayer('', {maxZoom: 15}).addTo(map);
 
@@ -703,7 +703,7 @@ describe('Map', () => {
 
 		it('automatically enabled, when has a property named the same as the handler', () => {
 			map.remove();
-			map = new Map(container, {clickHandler: true});
+			map = new LeafletMap(container, {clickHandler: true});
 
 			map.addHandler('clickHandler', getHandler());
 
@@ -785,7 +785,7 @@ describe('Map', () => {
 		});
 
 		it('return empty pane when map deleted', () => {
-			const map2 = new Map(document.createElement('div'));
+			const map2 = new LeafletMap(document.createElement('div'));
 			map2.remove();
 
 			expect(map2.getPanes()).to.eql({});
@@ -799,7 +799,7 @@ describe('Map', () => {
 
 		it('return undefined on empty container id', () => {
 			const container2 = createContainer();
-			const map2 = new Map(container2);
+			const map2 = new LeafletMap(container2);
 			map2.remove(); // clean up
 
 			expect(map2.getContainer()._leaflet_id).to.eql(undefined);
@@ -812,7 +812,7 @@ describe('Map', () => {
 		});
 
 		it('return map size if not specified', () => {
-			const map2 = new Map(document.createElement('div'));
+			const map2 = new LeafletMap(document.createElement('div'));
 
 			expect(map2.getSize()).to.eql(new Point(0, 0));
 
@@ -838,7 +838,7 @@ describe('Map', () => {
 
 		it('return previous size on empty map', () => {
 			const container2 = createContainer();
-			const map2 = new Map(container2);
+			const map2 = new LeafletMap(container2);
 
 			map2.remove(); // clean up
 
@@ -869,7 +869,7 @@ describe('Map', () => {
 
 		it('throw error if center and zoom were not set / map not loaded', () => {
 			const container2 = createContainer();
-			const map2 = new Map(container2);
+			const map2 = new LeafletMap(container2);
 
 			expect(map2.getPixelBounds).to.throw();
 
@@ -900,7 +900,7 @@ describe('Map', () => {
 
 		it('throw error if center and zoom were not set / map not loaded', () => {
 			const container2 = createContainer();
-			const map2 = new Map(container2);
+			const map2 = new LeafletMap(container2);
 
 			expect(map2.getPixelOrigin).to.throw();
 
@@ -1320,7 +1320,7 @@ describe('Map', () => {
 			const center = [0, 0];
 
 			// The edge case is only if view is set directly during map initialization
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				center,
 				zoom: 0
 			});
@@ -1364,7 +1364,7 @@ describe('Map', () => {
 			const center = [0, 0];
 
 			// The edge case is only if view is set directly during map initialization
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				center,
 				zoom: 0,
 				trackResize: false
@@ -1398,7 +1398,7 @@ describe('Map', () => {
 				expect(spy.called).to.be.false;
 
 				// make sure afterEach works correctly
-				map = new Map(container);
+				map = new LeafletMap(container);
 				done();
 				// we need the 10 ms to be sure that the ResizeObserver is not triggered
 			}, 10);
@@ -1916,7 +1916,7 @@ describe('Map', () => {
 		it('prevents default action of contextmenu if there is any listener', () => {
 			removeMapContainer(map, container);
 			container = createContainer();
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				renderer: new Canvas(),
 				center: [0, 0],
 				zoom: 0

--- a/spec/suites/map/handler/Map.BoxZoom.js
+++ b/spec/suites/map/handler/Map.BoxZoom.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Map} from 'leaflet';
+import {LeafletMap} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -9,7 +9,7 @@ describe('Map.BoxZoom', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			center: [0, 0],
 			zoom: 3
 		});

--- a/spec/suites/map/handler/Map.BoxZoom.js
+++ b/spec/suites/map/handler/Map.BoxZoom.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
-describe('Map.BoxZoom', () => {
+describe('LeafletMap.BoxZoom', () => {
 	let container, map;
 
 	beforeEach(() => {
@@ -143,7 +143,7 @@ describe('Map.BoxZoom', () => {
 		const stub = sinon.stub(map.boxZoom, '_clearDeferredResetState');
 		stub.callsFake(() => {
 			resetTimeout = map.boxZoom._resetStateTimeout !== 0;
-			Map.BoxZoom.prototype._clearDeferredResetState.call(map.boxZoom);
+			LeafletMap.BoxZoom.prototype._clearDeferredResetState.call(map.boxZoom);
 		});
 
 		let clientX = 100;

--- a/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
+++ b/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Map} from 'leaflet';
+import {LeafletMap} from 'leaflet';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
@@ -8,7 +8,7 @@ describe('Map.DoubleClickZoom', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			center: [0, 0],
 			zoom: 3,
 			zoomAnimation: false
@@ -60,7 +60,7 @@ describe('Map.DoubleClickZoom', () => {
 
 	it('can be disabled using doubleClickZoom: false', (done) => {
 		map.remove();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			center: [0, 0],
 			zoom: 3,
 			doubleClickZoom: false,

--- a/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
+++ b/spec/suites/map/handler/Map.DoubleClickZoomSpec.js
@@ -3,7 +3,7 @@ import {LeafletMap} from 'leaflet';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
-describe('Map.DoubleClickZoom', () => {
+describe('LeafletMap.DoubleClickZoom', () => {
 	let container, map;
 
 	beforeEach(() => {

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, LatLng, Map, Marker, Point} from 'leaflet';
+import {DomUtil, LatLng, LeafletMap, Marker, Point} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
@@ -19,7 +19,7 @@ describe('Map.Drag', () => {
 
 	describe('#addHook', () => {
 		it('calls the map with dragging enabled', () => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true
 			});
 
@@ -29,7 +29,7 @@ describe('Map.Drag', () => {
 		});
 
 		it('calls the map with dragging and worldCopyJump enabled', () => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				worldCopyJump: true
 			});
@@ -41,7 +41,7 @@ describe('Map.Drag', () => {
 
 		it('calls the map with dragging disabled and worldCopyJump enabled; ' +
 			'enables dragging after setting center and zoom', () => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: false,
 				worldCopyJump: true
 			});
@@ -133,7 +133,7 @@ describe('Map.Drag', () => {
 		});
 
 		it('does not change the center of the map when pointer is moved less than the drag threshold', (done) => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -164,7 +164,7 @@ describe('Map.Drag', () => {
 		});
 
 		it('does not trigger preclick nor click', (done) => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -196,7 +196,7 @@ describe('Map.Drag', () => {
 
 		it('does not trigger preclick nor click when dragging on top of a static marker', (done) => {
 			container.style.width = container.style.height = '600px';
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -236,7 +236,7 @@ describe('Map.Drag', () => {
 
 		it('does not trigger preclick nor click when dragging a marker', (done) => {
 			container.style.width = container.style.height = '600px';
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -275,7 +275,7 @@ describe('Map.Drag', () => {
 		});
 
 		it('does not change the center of the map when drag is disabled on click', (done) => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -338,7 +338,7 @@ describe('Map.Drag', () => {
 		});
 
 		it.skipIfNotTouch('does not change the center of the map when finger is moved less than the drag threshold', (done) => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false
 			});
@@ -370,7 +370,7 @@ describe('Map.Drag', () => {
 		});
 
 		it.skipIfNotTouch('reset itself after pointerup', (done) => {
-			map = new Map(container, {
+			map = new LeafletMap(container, {
 				dragging: true,
 				inertia: false,
 				zoomAnimation: false	// If true, the test has to wait extra 250msec

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -53,7 +53,7 @@ describe('Map.Drag', () => {
 		});
 	});
 
-	const MyMap = Map.extend({
+	const MyMap = LeafletMap.extend({
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
 		},

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
 
-describe('Map.Drag', () => {
+describe('LeafletMap.Drag', () => {
 	let container, map;
 
 	beforeEach(() => {

--- a/spec/suites/map/handler/Map.KeyboardSpec.js
+++ b/spec/suites/map/handler/Map.KeyboardSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Map, Popup} from 'leaflet';
+import {LeafletMap, Popup} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -18,7 +18,7 @@ describe('Map.Keyboard', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			zoomAnimation: false	// If true, the test has to wait extra 250msec
 		});
 

--- a/spec/suites/map/handler/Map.KeyboardSpec.js
+++ b/spec/suites/map/handler/Map.KeyboardSpec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
-describe('Map.Keyboard', () => {
+describe('LeafletMap.Keyboard', () => {
 	const KEYCODE_LOWERCASE_A = 'KeyA';
 	const KEYCODE_ARROW_LEFT = 'ArrowLeft';
 	const KEYCODE_ARROW_UP = 'ArrowUp';
@@ -23,7 +23,7 @@ describe('Map.Keyboard', () => {
 		});
 
 		// make keyboard-caused panning instant to cut down on test running time
-		map.panBy = function (offset) { return Map.prototype.panBy.call(this, offset, {animate: false}); };
+		map.panBy = function (offset) { return LeafletMap.prototype.panBy.call(this, offset, {animate: false}); };
 
 		map.setView([0, 0], 5);
 

--- a/spec/suites/map/handler/Map.PinchZoomSpec.js
+++ b/spec/suites/map/handler/Map.PinchZoomSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {LatLng, Map, Polygon, Rectangle} from 'leaflet';
+import {LatLng, LeafletMap, Polygon, Rectangle} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
@@ -10,7 +10,7 @@ describe('Map.PinchZoom', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			pinchZoom: true,
 			inertia: false,
 			zoomAnimation: false	// If true, the test has to wait extra 250msec
@@ -137,7 +137,7 @@ describe('Map.PinchZoom', () => {
 	it.skipIfNotTouch('PinchZoom works with disabled map dragging', (done) => {
 		map.remove();
 
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			pinchZoom: true,
 			inertia: false,
 			zoomAnimation: false,	// If true, the test has to wait extra 250msec,
@@ -167,7 +167,7 @@ describe('Map.PinchZoom', () => {
 	it.skipIfNotTouch('Layer is rendered correctly while pinch zoom when zoomAnim is true', (done) => {
 		map.remove();
 
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			pinchZoom: true,
 			inertia: false,
 			zoomAnimation: true
@@ -229,7 +229,7 @@ describe('Map.PinchZoom', () => {
 	it('Layer is rendered correctly while pinch zoom when zoomAnim is false', (done) => {
 		map.remove();
 
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			pinchZoom: true,
 			inertia: false,
 			zoomAnimation: false
@@ -276,7 +276,7 @@ describe('Map.PinchZoom', () => {
 		const warnSpy = sinon.spy(console, 'warn');
 
 		const localContainer = createContainer();
-		const localMap = new Map(localContainer, {
+		const localMap = new LeafletMap(localContainer, {
 			touchZoom: false
 		});
 
@@ -293,7 +293,7 @@ describe('Map.PinchZoom', () => {
 		const warnSpy = sinon.spy(console, 'warn');
 
 		const localContainer = createContainer();
-		const localMap = new Map(localContainer, {
+		const localMap = new LeafletMap(localContainer, {
 			touchZoom: true,
 			pinchZoom: false
 		});

--- a/spec/suites/map/handler/Map.PinchZoomSpec.js
+++ b/spec/suites/map/handler/Map.PinchZoomSpec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
 import UIEventSimulator from 'ui-event-simulator';
 
-describe('Map.PinchZoom', () => {
+describe('LeafletMap.PinchZoom', () => {
 	let container, map;
 
 	beforeEach(() => {

--- a/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
+++ b/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
-describe('Map.ScrollWheelZoom', () => {
+describe('LeafletMap.ScrollWheelZoom', () => {
 	let container, map;
 	const wheel = 'onwheel' in window ? 'wheel' : 'mousewheel';
 	const scrollIn = {

--- a/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
+++ b/spec/suites/map/handler/Map.ScrollWheelZoomSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomEvent, Map} from 'leaflet';
+import {DomEvent, LeafletMap} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -18,7 +18,7 @@ describe('Map.ScrollWheelZoom', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			center: [0, 0],
 			zoom: 3,
 			zoomAnimation: false

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Browser, Map, Point} from 'leaflet';
+import {Browser, LeafletMap, Point} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -13,7 +13,7 @@ describe('Map.TapHoldSpec.js', () => {
 
 	beforeEach(() => {
 		container = createContainer();
-		map = new Map(container, {
+		map = new LeafletMap(container, {
 			center: [51.505, -0.09],
 			zoom: 13,
 			tapHold: true

--- a/spec/suites/map/handler/Map.TapHoldSpec.js
+++ b/spec/suites/map/handler/Map.TapHoldSpec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
 
-describe('Map.TapHoldSpec.js', () => {
+describe('LeafletMap.TapHoldSpec.js', () => {
 	let container, clock, spy, map;
 
 	const posStart = {clientX:1, clientY:1};

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -125,7 +125,7 @@ export class Attribution extends Control {
 	}
 }
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Control options
 // @option attributionControl: Boolean = true
 // Whether a [attribution control](#control-attribution) is added to the map by default.

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -316,7 +316,7 @@ export class Layers extends Control {
 
 		const obj = this._getLayer(Util.stamp(e.target));
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Layer events
 		// @event baselayerchange: LayersControlEvent
 		// Fired when the base layer is changed through the [layers control](#control-layers).

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -127,7 +127,7 @@ export class Zoom extends Control {
 	}
 }
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Control options
 // @option zoomControl: Boolean = true
 // Whether a [zoom control](#control-zoom) is added to the map by default.

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -123,7 +123,7 @@ export class Control extends Class {
  * Optional method. Should contain all clean up code that removes the listeners previously added in [`onAdd`](#control-onadd). Called on [`control.remove()`](#control-remove).
  */
 
-/* @namespace Map
+/* @namespace LeafletMap
  * @section Methods for Layers and Controls
  */
 Map.include({

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -138,7 +138,7 @@ export class Layer extends Evented {
  */
 
 
-/* @namespace Map
+/* @namespace LeafletMap
  * @section Layer events
  *
  * @event layeradd: LayerEvent

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -149,7 +149,7 @@ export class Popup extends DivOverlay {
 	onAdd(map) {
 		DivOverlay.prototype.onAdd.call(this, map);
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Popup events
 		// @event popupopen: PopupEvent
 		// Fired when a popup is opened in the map
@@ -172,7 +172,7 @@ export class Popup extends DivOverlay {
 	onRemove(map) {
 		DivOverlay.prototype.onRemove.call(this, map);
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Popup events
 		// @event popupclose: PopupEvent
 		// Fired when a popup in the map is closed
@@ -316,7 +316,7 @@ export class Popup extends DivOverlay {
 			dy = containerPos.y - paddingTL.y;
 		}
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Popup events
 		// @event autopanstart: Event
 		// Fired when the map starts autopanning when opening a popup.
@@ -340,7 +340,7 @@ export class Popup extends DivOverlay {
 }
 
 
-/* @namespace Map
+/* @namespace LeafletMap
  * @section Interaction Options
  * @option closePopupOnClick: Boolean = true
  * Set it to `false` if you don't want popups to close when user clicks the map.
@@ -350,7 +350,7 @@ Map.mergeOptions({
 });
 
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Methods for Layers and Controls
 Map.include({
 	// @method openPopup(popup: Popup): this

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -90,7 +90,7 @@ export class Tooltip extends DivOverlay {
 		DivOverlay.prototype.onAdd.call(this, map);
 		this.setOpacity(this.options.opacity);
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Tooltip events
 		// @event tooltipopen: TooltipEvent
 		// Fired when a tooltip is opened in the map.
@@ -110,7 +110,7 @@ export class Tooltip extends DivOverlay {
 	onRemove(map) {
 		DivOverlay.prototype.onRemove.call(this, map);
 
-		// @namespace Map
+		// @namespace LeafletMap
 		// @section Tooltip events
 		// @event tooltipclose: TooltipEvent
 		// Fired when a tooltip in the map is closed.
@@ -224,7 +224,7 @@ export class Tooltip extends DivOverlay {
 
 }
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Methods for Layers and Controls
 Map.include({
 

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -15,7 +15,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * Use Canvas by default for all paths in the map:
  *
  * ```js
- * const map = new Map('map', {
+ * const map = new LeafletMap('map', {
  * 	renderer: new Canvas()
  * });
  * ```
@@ -23,7 +23,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * Use a Canvas renderer with extra padding for specific vector geometries:
  *
  * ```js
- * const map = new Map('map');
+ * const map = new LeafletMap('map');
  * const myRenderer = new Canvas({ padding: 0.5 });
  * const line = new Polyline( coordinates, { renderer: myRenderer } );
  * const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/src/layer/vector/Renderer.getRenderer.js
+++ b/src/layer/vector/Renderer.getRenderer.js
@@ -3,7 +3,7 @@ import {Canvas} from './Canvas.js';
 import {SVG} from './SVG.js';
 
 Map.include({
-	// @namespace Map; @method getRenderer(layer: Path): Renderer
+	// @namespace LeafletMap; @method getRenderer(layer: Path): Renderer
 	// Returns the instance of `Renderer` that should be used to render the given
 	// `Path`. It will ensure that the `renderer` options of the map and paths
 	// are respected, and that the renderers do exist on the map.
@@ -38,7 +38,7 @@ Map.include({
 	},
 
 	_createRenderer(options) {
-		// @namespace Map; @option preferCanvas: Boolean = false
+		// @namespace LeafletMap; @option preferCanvas: Boolean = false
 		// Whether `Path`s should be rendered on a `Canvas` renderer.
 		// By default, all `Path`s are rendered in a `SVG` renderer.
 		return (this.options.preferCanvas && new Canvas(options)) || new SVG(options);

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -18,7 +18,7 @@ export const create = svgCreate;
  * Use SVG by default for all paths in the map:
  *
  * ```js
- * const map = new Map('map', {
+ * const map = new LeafletMap('map', {
  * 	renderer: new SVG()
  * });
  * ```
@@ -26,7 +26,7 @@ export const create = svgCreate;
  * Use a SVG renderer with extra padding for specific vector geometries:
  *
  * ```js
- * const map = new Map('map');
+ * const map = new LeafletMap('map');
  * const myRenderer = new SVG({ padding: 0.5 });
  * const line = new Polyline( coordinates, { renderer: myRenderer } );
  * const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -12,7 +12,7 @@ import {PosAnimation} from '../dom/PosAnimation.js';
 import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 
 /*
- * @class Map
+ * @class LeafletMap
  * @inherits Evented
  *
  * The central class of the API — it is used to create a map on a page and manipulate it.
@@ -48,7 +48,7 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // @constructor LeafletMap(el: HTMLElement, options?: LeafletMap options)
 // Instantiates a map object given an instance of a `<div>` HTML element
 // and optionally an object literal with `LeafletMap options`.
-export class Map extends Evented {
+export class LeafletMap extends Evented {
 
 	static {
 		this.setDefaultOptions({
@@ -1465,7 +1465,7 @@ export class Map extends Evented {
 		for (const t of targets) {
 			t.fire(type, data, true);
 			if (data.originalEvent._stopped ||
-				(t.options.bubblingPointerEvents === false && Map._pointerEvents.includes(type))) { return; }
+				(t.options.bubblingPointerEvents === false && LeafletMap._pointerEvents.includes(type))) { return; }
 		}
 	}
 
@@ -1766,4 +1766,4 @@ export class Map extends Evented {
 	}
 }
 
-export const LeafletMap = Map;
+export const Map = LeafletMap;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -21,7 +21,7 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
  *
  * ```js
  * // initialize the map on the "map" div with a given center and zoom
- * const map = new Map('map', {
+ * const map = new LeafletMap('map', {
  * 	center: [51.505, -0.09],
  * 	zoom: 13
  * });
@@ -30,16 +30,6 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
  */
 
 // @section
-// @constructor Map(id: String, options?: Map options)
-// Instantiates a map object given the DOM ID of a `<div>` element
-// and optionally an object literal with `Map options`.
-//
-// @alternative
-// @constructor Map(el: HTMLElement, options?: Map options)
-// Instantiates a map object given an instance of a `<div>` HTML element
-// and optionally an object literal with `Map options`.
-//
-// @alternative
 // @constructor LeafletMap(id: String, options?: LeafletMap options)
 // Instantiates a map object given the DOM ID of a `<div>` element
 // and optionally an object literal with `LeafletMap options`.
@@ -48,6 +38,16 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // @constructor LeafletMap(el: HTMLElement, options?: LeafletMap options)
 // Instantiates a map object given an instance of a `<div>` HTML element
 // and optionally an object literal with `LeafletMap options`.
+//
+// @alternative
+// @constructor Map(id: String, options?: Map options)
+// Instantiates a map object given the DOM ID of a `<div>` element
+// and optionally an object literal with `Map options`.
+//
+// @alternative
+// @constructor Map(el: HTMLElement, options?: Map options)
+// Instantiates a map object given an instance of a `<div>` HTML element
+// and optionally an object literal with `Map options`.
 export class LeafletMap extends Evented {
 
 	static {

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -10,7 +10,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * (zoom to a selected bounding box), enabled by default.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 Map.mergeOptions({
 	// @option boxZoom: Boolean = true

--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -5,7 +5,7 @@ import {Handler} from '../../core/Handler.js';
  * Handler.DoubleClickZoom is used to handle double-click zoom on the map, enabled by default.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 
 Map.mergeOptions({

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -8,7 +8,7 @@ import {Bounds} from '../../geometry/Bounds.js';
  * Handler.MapDrag is used to make the map draggable (with panning inertia), enabled by default.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 Map.mergeOptions({
 	// @option dragging: Boolean = true

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -8,7 +8,7 @@ import {Point} from '../../geometry/Point.js';
  * Map.Keyboard is handling keyboard interaction with the map, enabled by default.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Keyboard Navigation Options
 Map.mergeOptions({
 	// @option keyboard: Boolean = true

--- a/src/map/handler/Map.PinchZoom.js
+++ b/src/map/handler/Map.PinchZoom.js
@@ -7,7 +7,7 @@ import * as PointerEvents from '../../dom/DomEvent.PointerEvents.js';
  * Handler.PinchZoom is used by Map to add pinch zoom on supported mobile browsers.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 Map.mergeOptions({
 	// @section Touch interaction options

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -6,7 +6,7 @@ import * as DomEvent from '../../dom/DomEvent.js';
  * Handler.ScrollWheelZoom is used by Map to enable mouse scroll wheel zoom on the map.
  */
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 Map.mergeOptions({
 	// @section Mouse wheel options

--- a/src/map/handler/Map.TapHold.js
+++ b/src/map/handler/Map.TapHold.js
@@ -12,7 +12,7 @@ import * as PointerEvents from '../../dom/DomEvent.PointerEvents.js';
 
 const tapHoldDelay = 600;
 
-// @namespace Map
+// @namespace LeafletMap
 // @section Interaction Options
 Map.mergeOptions({
 	// @section Touch interaction options


### PR DESCRIPTION
Avoid confusion in JavaScript debugger for LeafletMap instances.

Follow-up: #9804
