### PR TITLE
Remove Event.cancelBubble fallback

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -163,12 +163,13 @@ function removeOne(obj, type, fn, context, id) {
 // ```
 export function stopPropagation(e) {
 
-	if (e.stopPropagation) {
+	if (e instanceof Event) {
 		e.stopPropagation();
 	} else if (e.originalEvent) {  // In case of Leaflet event.
 		e.originalEvent._stopped = true;
 	} else {
-		e.cancelBubble = true;
+		// custom Leaflet event
+		console.debug('Unsupported event', e);
 	}
 
 	return this;


### PR DESCRIPTION
Event.cancelBubble is deprecated, see https://developer.mozilla.org/en-US/docs/Web/API/Event/cancelBubble
