### PR TITLE
Remove initialize placeholder in Class

### DIFF
--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -115,11 +115,6 @@ export class Class {
 		this.callInitHooks();
 	}
 
-	initialize(/* ...args */) {
-		// Override this method in subclasses to implement custom initialization logic.
-		// This method is called automatically when a new instance of the class is created.
-	}
-
 	callInitHooks() {
 		if (this._initHooksCalled) {
 			return;


### PR DESCRIPTION
Fixes: #9900

The problem is that when we call `ClassExtended.include(Evented.prototype);`, it overwrites 
`ClassExtended.initialize` with `Evented.initialize`, which contains no code. This happens 
because `Evented` extends from `Class` but does not define its own `initialize` method.

So everything worked as "expected".


```
const ClassExtended = Class.extend({
	initialize() {
		console.log('ClassExtended init');
		ClassExtended.include(Evented.prototype); // <-- This line causes the problem
	}
});
```

I added the code [here](https://github.com/Leaflet/Leaflet/commit/47167af0e4676a6c09eb0752e6015c1df6687302#diff-8e4854ab0e220475dc22a076300f7f19f24b4480d852e02177dfd05826e4be5d) but it was just for documentation. 

@simon04 please review