### PR TITLE
Use standard `constructor()` instead of `initialize()`

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -1,400 +1,443 @@
 import {expect} from 'chai';
-import {Class, Evented} from 'leaflet';
+import {Class, Evented, withInitHooks} from 'leaflet';
 import sinon from 'sinon';
 
 describe('Class', () => {
-	describe('#extend', () => {
-		let Klass,
-		props,
-		constructor,
-		method;
+	it('sets default options', () => {
+		const instance = new Class();
+		expect(Object.hasOwn(instance, 'options')).to.be.true;
+		expect(instance.options).to.eql({});
+	});
 
-		beforeEach(() => {
-			constructor = sinon.spy();
-			method = sinon.spy();
+	it('calls \'initialize()\' automatically with constructor arguments', () => {
+		const spy = sinon.spy();
+		const warnSpy = sinon.spy(console, 'warn');
 
-			props = {
-				statics: {bla: 1},
-				includes: {mixin: true},
-
-				initialize: constructor,
-				foo: 5,
-				bar: method
-			};
-			Klass = Class.extend(props);
-		});
-
-		it('creates a class with the given constructor & properties', () => {
-			const a = new Klass();
-
-			expect(constructor.called).to.be.true;
-			expect(a.foo).to.eql(5);
-
-			a.bar();
-
-			expect(method.called).to.be.true;
-		});
-
-		it('calls the correct parent initialize function', () => {
-			const initialize = sinon.spy();
-			const initializeDraw = sinon.spy();
-			const initializeEdit = sinon.spy();
-			const Toolbar = Class.extend({
-				initialize() {
-					initialize();
-				}
-			});
-			Toolbar.include(Evented.prototype);
-			const DrawToolbar = Toolbar.extend({
-				initialize(options) {
-					initializeDraw();
-					Toolbar.prototype.initialize.call(this, options);
-				}
-			});
-			const EditToolbar = Toolbar.extend({
-				initialize(options) {
-					initializeEdit();
-					Toolbar.prototype.initialize.call(this, options);
-				}
-			});
-
-			new Toolbar();
-			sinon.assert.calledOnce(initialize);
-			sinon.assert.notCalled(initializeDraw);
-			sinon.assert.notCalled(initializeEdit);
-			initialize.resetHistory();
-
-			new DrawToolbar();
-			sinon.assert.callOrder(initializeDraw, initialize);
-			sinon.assert.notCalled(initializeEdit);
-			initialize.resetHistory();
-			initializeDraw.resetHistory();
-
-			new EditToolbar();
-			sinon.assert.callOrder(initializeEdit, initialize);
-			sinon.assert.notCalled(initializeDraw);
-		});
-
-		it('inherits parent classes\' constructor & properties', () => {
-			const Klass2 = Klass.extend({baz: 2});
-
-			const b = new Klass2();
-
-			expect(b instanceof Klass).to.be.true;
-			expect(b instanceof Klass2).to.be.true;
-
-			expect(constructor.called).to.be.true;
-			expect(b.baz).to.eql(2);
-
-			b.bar();
-
-			expect(method.called).to.be.true;
-		});
-
-		it('does not modify source props object', () => {
-			expect(props).to.eql({
-				statics: {bla: 1},
-				includes: {mixin: true},
-
-				initialize: constructor,
-				foo: 5,
-				bar: method
-			});
-		});
-
-		it('supports static properties', () => {
-			expect(Klass.bla).to.eql(1);
-		});
-
-		it('does not merge \'statics\' property itself', () => {
-			expect('statics' in Klass.prototype).to.be.false;
-		});
-
-		it('inherits parent static properties', () => {
-			const Klass2 = Klass.extend({});
-
-			expect(Klass2.bla).to.eql(1);
-		});
-
-		it('overrides parent static properties', () => {
-			const Klass2 = Klass.extend({statics: {bla: 2}});
-
-			expect(Klass2.bla).to.eql(2);
-		});
-
-		it('includes the given mixin', () => {
-			const a = new Klass();
-			expect(a.mixin).to.be.true;
-		});
-
-		it('does not merge \'includes\' property itself', () => {
-			expect('includes' in Klass.prototype).to.be.false;
-		});
-
-		it('includes multiple mixins', () => {
-			const Klass2 = Class.extend({
-				includes: [{mixin: true}, {mixin2: true}]
-			});
-			const a = new Klass2();
-
-			expect(a.mixin).to.be.true;
-			expect(a.mixin2).to.be.true;
-		});
-
-		it('includes Evented mixins', () => {
-			const Klass2 = Class.extend({
-				includes: Evented.prototype
-			});
-			const a = new Klass2();
-
-			expect(a.on).to.eql(Evented.prototype.on);
-			expect(a.off).to.eql(Evented.prototype.off);
-		});
-
-		it('includes inherited mixins', () => {
-			class A {
-				foo() {}
+		class TestClass extends Class {
+			initialize(...args) {
+				spy(...args);
 			}
-			class B extends A {
-				bar() {}
+		}
+
+		new TestClass(1, 2, 3);
+		console.warn.restore();
+
+		expect(spy.calledWith(1, 2, 3)).to.be.true;
+		expect(warnSpy.calledWith('The \'initialize()\' method is deprecated, use a class constructor instead.')).to.be.true;
+	});
+});
+
+describe('Class#extend', () => {
+	let Klass,
+	props,
+	constructor,
+	method;
+
+	beforeEach(() => {
+		constructor = sinon.spy();
+		method = sinon.spy();
+
+		props = {
+			statics: {bla: 1},
+			includes: {mixin: true},
+
+			initialize: constructor,
+			foo: 5,
+			bar: method
+		};
+		Klass = Class.extend(props);
+	});
+
+	it('creates a class with the given constructor & properties', () => {
+		const a = new Klass();
+
+		expect(constructor.called).to.be.true;
+		expect(a.foo).to.eql(5);
+
+		a.bar();
+
+		expect(method.called).to.be.true;
+	});
+
+	it('calls the correct parent initialize function', () => {
+		const initialize = sinon.spy();
+		const initializeDraw = sinon.spy();
+		const initializeEdit = sinon.spy();
+		const Toolbar = Class.extend({
+			initialize() {
+				initialize();
 			}
-			const Klass2 = Class.extend({
-				includes: B.prototype
-			});
-			const a = new Klass2();
-
-			expect(a.bar).to.eql(B.prototype.bar);
-			expect(a.foo).to.eql(B.prototype.foo);
+		});
+		Toolbar.include(Evented.prototype);
+		const DrawToolbar = Toolbar.extend({
+			initialize(options) {
+				initializeDraw();
+				Toolbar.prototype.initialize.call(this, options);
+			}
+		});
+		const EditToolbar = Toolbar.extend({
+			initialize(options) {
+				initializeEdit();
+				Toolbar.prototype.initialize.call(this, options);
+			}
 		});
 
-		it('grants the ability to include the given mixin', () => {
-			Klass.include({mixin2: true});
+		new Toolbar();
+		sinon.assert.calledOnce(initialize);
+		sinon.assert.notCalled(initializeDraw);
+		sinon.assert.notCalled(initializeEdit);
+		initialize.resetHistory();
 
-			const a = new Klass();
-			expect(a.mixin2).to.be.true;
+		new DrawToolbar();
+		sinon.assert.callOrder(initializeDraw, initialize);
+		sinon.assert.notCalled(initializeEdit);
+		initialize.resetHistory();
+		initializeDraw.resetHistory();
+
+		new EditToolbar();
+		sinon.assert.callOrder(initializeEdit, initialize);
+		sinon.assert.notCalled(initializeDraw);
+	});
+
+	it('inherits parent classes\' constructor & properties', () => {
+		const Klass2 = Klass.extend({baz: 2});
+
+		const b = new Klass2();
+
+		expect(b instanceof Klass).to.be.true;
+		expect(b instanceof Klass2).to.be.true;
+
+		expect(constructor.called).to.be.true;
+		expect(b.baz).to.eql(2);
+
+		b.bar();
+
+		expect(method.called).to.be.true;
+	});
+
+	it('does not modify source props object', () => {
+		expect(props).to.eql({
+			statics: {bla: 1},
+			includes: {mixin: true},
+
+			initialize: constructor,
+			foo: 5,
+			bar: method
+		});
+	});
+
+	it('supports static properties', () => {
+		expect(Klass.bla).to.eql(1);
+	});
+
+	it('does not merge \'statics\' property itself', () => {
+		expect('statics' in Klass.prototype).to.be.false;
+	});
+
+	it('inherits parent static properties', () => {
+		const Klass2 = Klass.extend({});
+
+		expect(Klass2.bla).to.eql(1);
+	});
+
+	it('overrides parent static properties', () => {
+		const Klass2 = Klass.extend({statics: {bla: 2}});
+
+		expect(Klass2.bla).to.eql(2);
+	});
+
+	it('includes the given mixin', () => {
+		const a = new Klass();
+		expect(a.mixin).to.be.true;
+	});
+
+	it('does not merge \'includes\' property itself', () => {
+		expect('includes' in Klass.prototype).to.be.false;
+	});
+
+	it('includes multiple mixins', () => {
+		const Klass2 = Class.extend({
+			includes: [{mixin: true}, {mixin2: true}]
+		});
+		const a = new Klass2();
+
+		expect(a.mixin).to.be.true;
+		expect(a.mixin2).to.be.true;
+	});
+
+	it('includes Evented mixins', () => {
+		const Klass2 = Class.extend({
+			includes: Evented.prototype
+		});
+		const a = new Klass2();
+
+		expect(a.on).to.eql(Evented.prototype.on);
+		expect(a.off).to.eql(Evented.prototype.off);
+	});
+
+	it('includes inherited mixins', () => {
+		class A {
+			foo() {}
+		}
+		class B extends A {
+			bar() {}
+		}
+		const Klass2 = Class.extend({
+			includes: B.prototype
+		});
+		const a = new Klass2();
+
+		expect(a.bar).to.eql(B.prototype.bar);
+		expect(a.foo).to.eql(B.prototype.foo);
+	});
+
+	it('grants the ability to include the given mixin', () => {
+		Klass.include({mixin2: true});
+
+		const a = new Klass();
+		expect(a.mixin2).to.be.true;
+	});
+
+	it('merges options instead of replacing them', () => {
+		const KlassWithOptions1 = Class.extend({
+			options: {
+				foo1: 1,
+				foo2: 2
+			}
+		});
+		const KlassWithOptions2 = KlassWithOptions1.extend({
+			options: {
+				foo2: 3,
+				foo3: 4
+			}
 		});
 
-		it('merges options instead of replacing them', () => {
-			const KlassWithOptions1 = Class.extend({
-				options: {
+		const a = new KlassWithOptions2();
+		expect(a.options.foo1).to.eql(1);
+		expect(a.options.foo2).to.eql(3);
+		expect(a.options.foo3).to.eql(4);
+	});
+
+	it('gives new classes a distinct options object', () => {
+		const K1 = Class.extend({options: {}});
+		const K2 = K1.extend({});
+		expect(K2.prototype.options).not.to.equal(K1.prototype.options);
+	});
+
+	it('inherits options prototypally', () => {
+		const K1 = Class.extend({options: {}});
+		const K2 = K1.extend({options: {}});
+		K1.prototype.options.foo = 'bar';
+		expect(K2.prototype.options.foo).to.eql('bar');
+	});
+
+	it('does not reuse original props.options', () => {
+		const props = {options: {}};
+		const K = Class.extend(props);
+
+		expect(K.prototype.options).not.to.equal(props.options);
+	});
+
+	it('does not replace source props.options object', () => {
+		const K1 = Class.extend({options: {}});
+		const opts = {};
+		const props = {options: opts};
+		K1.extend(props);
+
+		expect(props.options).to.equal(opts);
+	});
+
+	it('prevents change of prototype options', () => {
+		const Klass = Class.extend({options: {}});
+		const instance = new Klass();
+		expect(Klass.prototype.options).to.not.equal(instance.options);
+	});
+
+	it('merges options instead of replacing them', () => {
+		class KlassWithOptions1 extends Class {
+			static {
+				this.setDefaultOptions({
 					foo1: 1,
 					foo2: 2
-				}
-			});
-			const KlassWithOptions2 = KlassWithOptions1.extend({
-				options: {
+				});
+			}
+		}
+		class KlassWithOptions2 extends KlassWithOptions1 {
+			static {
+				this.setDefaultOptions({
 					foo2: 3,
 					foo3: 4
-				}
-			});
-
-			const a = new KlassWithOptions2();
-			expect(a.options.foo1).to.eql(1);
-			expect(a.options.foo2).to.eql(3);
-			expect(a.options.foo3).to.eql(4);
-		});
-
-		it('gives new classes a distinct options object', () => {
-			const K1 = Class.extend({options: {}});
-			const K2 = K1.extend({});
-			expect(K2.prototype.options).not.to.equal(K1.prototype.options);
-		});
-
-		it('inherits options prototypally', () => {
-			const K1 = Class.extend({options: {}});
-			const K2 = K1.extend({options: {}});
-			K1.prototype.options.foo = 'bar';
-			expect(K2.prototype.options.foo).to.eql('bar');
-		});
-
-		it('does not reuse original props.options', () => {
-			const props = {options: {}};
-			const K = Class.extend(props);
-
-			expect(K.prototype.options).not.to.equal(props.options);
-		});
-
-		it('does not replace source props.options object', () => {
-			const K1 = Class.extend({options: {}});
-			const opts = {};
-			const props = {options: opts};
-			K1.extend(props);
-
-			expect(props.options).to.equal(opts);
-		});
-
-		it('prevents change of prototype options', () => {
-			const Klass = Class.extend({options: {}});
-			const instance = new Klass();
-			expect(Klass.prototype.options).to.not.equal(instance.options);
-		});
-
-		it('adds constructor hooks correctly', () => {
-			const spy1 = sinon.spy();
-
-			Klass.addInitHook(spy1);
-			Klass.addInitHook('bar', 1, 2, 3);
-
-			new Klass();
-
-			expect(spy1.called).to.be.true;
-			expect(method.calledWith(1, 2, 3));
-		});
-
-		it('inherits constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			const Klass2 = Klass.extend({});
-
-			Klass.addInitHook(spy1);
-			Klass2.addInitHook(spy2);
-
-			new Klass2();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.be.true;
-		});
-
-		it('does not call child constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			const Klass2 = Klass.extend({});
-
-			Klass.addInitHook(spy1);
-			Klass2.addInitHook(spy2);
-
-			new Klass();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.eql(false);
-		});
-
-		it('calls parent constructor hooks when child has none', () => {
-			const spy1 = sinon.spy();
-
-			Klass.addInitHook(spy1);
-
-			const Klass2 = Klass.extend({});
-			new Klass2();
-
-			expect(spy1.called).to.be.true;
-		});
-	});
-
-	describe('#extend', () => {
-		it('merges options instead of replacing them', () => {
-			class KlassWithOptions1 extends Class {
-				static {
-					this.setDefaultOptions({
-						foo1: 1,
-						foo2: 2
-					});
-				}
+				});
 			}
-			class KlassWithOptions2 extends KlassWithOptions1 {
-				static {
-					this.setDefaultOptions({
-						foo2: 3,
-						foo3: 4
-					});
-				}
+		}
+
+		const a = new KlassWithOptions2();
+		expect(a.options.foo1).to.eql(1);
+		expect(a.options.foo2).to.eql(3);
+		expect(a.options.foo3).to.eql(4);
+	});
+
+	it('automatically adds support for initialization hooks', () => {
+		const TestClass = Class.extend({});
+		expect(TestClass.addInitHook).to.be.a('function');
+	});
+});
+
+describe('Class#include', () => {
+	let Klass;
+
+	beforeEach(() => {
+		Klass = Class.extend({});
+	});
+
+	it('returns the class with the extra methods', () => {
+
+		const q = sinon.spy();
+
+		const Qlass = Klass.include({quux: q});
+
+		const a = new Klass();
+		const b = new Qlass();
+
+		a.quux();
+		expect(q.called).to.be.true;
+
+		b.quux();
+		expect(q.called).to.be.true;
+	});
+
+	it('keeps parent options', () => { // #6070
+
+		const Quux = Class.extend({
+			options: {foo: 'Foo!'}
+		});
+
+		Quux.include({
+			options: {bar: 'Bar!'}
+		});
+
+		const q = new Quux();
+		expect(q.options).to.have.property('foo');
+		expect(q.options).to.have.property('bar');
+	});
+
+	it('does not reuse original props.options', () => {
+		const props = {options: {}};
+		const K = Klass.include(props);
+
+		expect(K.prototype.options).not.to.equal(props.options);
+	});
+
+	it('does not replace source props.options object', () => {
+		const K1 = Klass.include({options: {}});
+		const opts = {};
+		const props = {options: opts};
+		K1.extend(props);
+
+		expect(props.options).to.equal(opts);
+	});
+});
+
+describe('withInitHooks', () => {
+	it('registers and triggers the initialization hooks correctly', () => {
+		const constructASpy = sinon.spy();
+		const initHookASpy = sinon.spy();
+		const constructBSpy = sinon.spy();
+		const initHookBSpy = sinon.spy();
+
+		// Give the spies names so they show up properly in logs.
+		constructASpy.displayName = 'constructA';
+		initHookASpy.displayName = 'initHookA';
+		constructBSpy.displayName = 'constructB';
+		initHookBSpy.displayName = 'initHookB';
+
+		const A = withInitHooks(class A {
+			constructor(argA) {
+				this.constructA = 'constructed A';
+				this.argA = argA;
+				constructASpy(argA);
 			}
-
-			const a = new KlassWithOptions2();
-			expect(a.options.foo1).to.eql(1);
-			expect(a.options.foo2).to.eql(3);
-			expect(a.options.foo3).to.eql(4);
 		});
 
-		it('inherits constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class2();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.be.true;
+		const hookAReturnValue = A.addInitHook(function () {
+			this.hookedA = 'hooked A';
+			initHookASpy();
 		});
 
-		it('does not call child constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class1();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.eql(false);
+		const B = withInitHooks(class B extends A {
+			constructor(argA, argB) {
+				super(argA);
+				this.constructB = 'constructed B';
+				this.argB = argB;
+				constructBSpy(argB);
+			}
 		});
+
+		const hookBReturnValue = B.addInitHook(function () {
+			this.hookedB = 'hooked B';
+			initHookBSpy();
+		});
+
+		const instance = new B('valueA', 'valueB');
+
+		// Assert that the classes returned by addInitHook are the same as the originals.
+		expect(hookAReturnValue).to.equal(A);
+		expect(hookBReturnValue).to.equal(B);
+
+		// Assert that constructors and hooks were called in the expected order.
+		sinon.assert.callOrder(
+			constructASpy,
+			initHookASpy,
+			constructBSpy,
+			initHookBSpy
+		);
+
+		// Assert that the fields set during construction and hooking are present.
+		expect(instance.constructA).to.eql('constructed A');
+		expect(instance.hookedA).to.eql('hooked A');
+		expect(instance.constructB).to.eql('constructed B');
+		expect(instance.hookedB).to.eql('hooked B');
+
+		// Assert that constructor arguments are properly forwarded.
+		expect(instance.argA).to.eql('valueA');
+		expect(instance.argB).to.eql('valueB');
+		expect(constructASpy.calledWith('valueA')).to.be.true;
+		expect(constructBSpy.calledWith('valueB')).to.be.true;
 	});
 
-	describe('#include', () => {
-		let Klass;
+	it('triggers hooks registered with method name and arguments', () => {
+		const methodSpy = sinon.spy();
 
-		beforeEach(() => {
-			Klass = Class.extend({});
+		const TestClass = withInitHooks(class TestClass {
+			testMethod(arg1, arg2, arg3) {
+				methodSpy(arg1, arg2, arg3);
+			}
 		});
 
-		it('returns the class with the extra methods', () => {
+		TestClass.addInitHook('testMethod', 'value1', 'value2', 'value3');
 
-			const q = sinon.spy();
+		new TestClass();
 
-			const Qlass = Klass.include({quux: q});
-
-			const a = new Klass();
-			const b = new Qlass();
-
-			a.quux();
-			expect(q.called).to.be.true;
-
-			b.quux();
-			expect(q.called).to.be.true;
-		});
-
-		it('keeps parent options', () => { // #6070
-
-			const Quux = Class.extend({
-				options: {foo: 'Foo!'}
-			});
-
-			Quux.include({
-				options: {bar: 'Bar!'}
-			});
-
-			const q = new Quux();
-			expect(q.options).to.have.property('foo');
-			expect(q.options).to.have.property('bar');
-		});
-
-		it('does not reuse original props.options', () => {
-			const props = {options: {}};
-			const K = Klass.include(props);
-
-			expect(K.prototype.options).not.to.equal(props.options);
-		});
-
-		it('does not replace source props.options object', () => {
-			const K1 = Klass.include({options: {}});
-			const opts = {};
-			const props = {options: opts};
-			K1.extend(props);
-
-			expect(props.options).to.equal(opts);
-		});
+		expect(methodSpy.calledOnce).to.be.true;
+		expect(methodSpy.calledWith('value1', 'value2', 'value3')).to.be.true;
 	});
 
-	// TODO Class.mergeOptions
+	it('throws an error when \'addInitHook()\' is called on an unwrapped named class', () => {
+		const WrappedParent = withInitHooks(class WrappedParent {});
+		class TestClass extends WrappedParent {}
+
+		expect(() => {
+			TestClass.addInitHook(() => {});
+		}).to.throw(Error, 'The \'addInitHook()\' method can only be called on classes wrapped with \'withInitHooks()\'. Try wrapping your class:\n\nconst TestClass = withInitHooks(class TestClass { ... });\n');
+	});
+
+	it('throws an error when \'addInitHook()\' is called on unwrapped anonymous class', () => {
+		const WrappedParent = withInitHooks(class WrappedParent {});
+		// Wrapped with an IFFE to prevent the class from getting the name 'TestClass'.
+		const TestClass = (() => class extends WrappedParent {})();
+
+		expect(() => {
+			TestClass.addInitHook(() => {});
+		}).to.throw(Error, 'The \'addInitHook()\' method can only be called on classes wrapped with \'withInitHooks()\'. Try wrapping your class:\n\nconst (anonymous) = withInitHooks(class (anonymous) { ... });\n');
+	});
 });

--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control.js';
 import {Map} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
@@ -18,7 +19,7 @@ const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg
 // @namespace Control.Attribution
 // @constructor Control.Attribution(options: Control.Attribution options)
 // Creates an attribution control.
-export class Attribution extends Control {
+export const Attribution = withInitHooks(class Attribution extends Control {
 
 	static {
 		// @section
@@ -35,7 +36,8 @@ export class Attribution extends Control {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._attributions = {};
@@ -123,7 +125,7 @@ export class Attribution extends Control {
 
 		this._container.innerHTML = prefixAndAttribs.join(' <span aria-hidden="true">|</span> ');
 	}
-}
+});
 
 // @namespace Map
 // @section Control options

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -1,5 +1,6 @@
 
 import {Control} from './Control.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
@@ -44,7 +45,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor Control.Layers(baselayers?: Object, overlays?: Object, options?: Control.Layers options)
 // Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.
-export class Layers extends Control {
+export const Layers = withInitHooks(class Layers extends Control {
 
 	static {
 		// @section
@@ -85,7 +86,8 @@ export class Layers extends Control {
 		});
 	}
 
-	initialize(baseLayers, overlays, options) {
+	constructor(baseLayers, overlays, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._layerControlInputs = [];
@@ -438,4 +440,4 @@ export class Layers extends Control {
 		});
 	}
 
-}
+});

--- a/src/control/Control.Scale.js
+++ b/src/control/Control.Scale.js
@@ -1,5 +1,6 @@
 
 import {Control} from './Control.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
 /*
@@ -17,7 +18,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor Control.Scale(options?: Control.Scale options)
 // Creates an scale control with the given options.
-export class Scale extends Control {
+export const Scale = withInitHooks(class Scale extends Control {
 
 	static {
 		// @section
@@ -130,4 +131,4 @@ export class Scale extends Control {
 
 		return pow10 * d;
 	}
-}
+});

--- a/src/control/Control.Zoom.js
+++ b/src/control/Control.Zoom.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control.js';
 import {Map} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
 
@@ -14,7 +15,7 @@ import * as DomEvent from '../dom/DomEvent.js';
 // @namespace Control.Zoom
 // @constructor Control.Zoom(options: Control.Zoom options)
 // Creates a zoom control
-export class Zoom extends Control {
+export const Zoom = withInitHooks(class Zoom extends Control {
 
 	static {
 		// @section
@@ -125,7 +126,7 @@ export class Zoom extends Control {
 			this._zoomInButton.setAttribute('aria-disabled', 'true');
 		}
 	}
-}
+});
 
 // @namespace Map
 // @section Control options

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -1,5 +1,5 @@
 
-import {Class} from '../core/Class.js';
+import {Class, withInitHooks} from '../core/Class.js';
 import {Map} from '../map/Map.js';
 import * as Util from '../core/Util.js';
 import * as DomUtil from '../dom/DomUtil.js';
@@ -12,7 +12,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  * All other controls extend from this class.
  */
 
-export class Control extends Class {
+export const Control = withInitHooks(class Control extends Class {
 
 	static {
 		// @section
@@ -26,7 +26,8 @@ export class Control extends Class {
 	}
 
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -109,7 +110,7 @@ export class Control extends Class {
 			this._map.getContainer().focus();
 		}
 	}
-}
+});
 
 /* @section Extension methods
  * @uninheritable

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -7,7 +7,7 @@ import * as Util from './Util.js';
 
 // Thanks to John Resig and Dean Edwards for inspiration!
 
-export class Class {
+export const Class = withInitHooks(class Class {
 	// @function extend(props: Object): Function
 	// [Extends the current class](#class-inheritance) given the properties to be included.
 	// Deprecated - use `class X extends Class` instead!
@@ -44,7 +44,8 @@ export class Class {
 			Object.assign(proto.options, props.options);
 		}
 
-		return NewClass;
+		// enable initialization hooks for backwards compatibility
+		return withInitHooks(NewClass);
 	}
 
 	// @function include(properties: Object): this
@@ -89,55 +90,53 @@ export class Class {
 
 	// @function addInitHook(fn: Function): this
 	// Adds a [constructor hook](#class-constructor-hooks) to the class.
-	static addInitHook(fn, ...args) { // (Function) || (String, args...)
-		const init = typeof fn === 'function' ? fn : function () {
-			this[fn].apply(this, args);
-		};
-
-		if (!Object.hasOwn(this.prototype, '_initHooks')) { // do not use ??= here
-			this.prototype._initHooks = [];
-		}
-		this.prototype._initHooks.push(init);
-		return this;
-	}
 
 	constructor(...args) {
-		this._initHooksCalled = false;
-
 		Util.setOptions(this);
 
 		// call the constructor
 		if (this.initialize) {
+			console.warn('The \'initialize()\' method is deprecated, use a class constructor instead.');
 			this.initialize(...args);
 		}
-
-		// call all constructor hooks
-		this.callInitHooks();
 	}
+});
 
-	callInitHooks() {
-		if (this._initHooksCalled) {
-			return;
-		}
+// @function withInitHooks(Object TargetClass): Function
+// Decorates a class to be able to use [constructor hooks](#class-constructor-hooks) functionality.
+/**
+ * @template T
+ * @param {T} TargetClass
+ * @returns {T}
+ */
+export function withInitHooks(TargetClass) {
+	const hooks = [];
+	const proxy = new Proxy(TargetClass, {
+		construct(target, args, newTarget) {
+			const instance = Reflect.construct(target, args, newTarget);
 
-		// collect all prototypes in chain
-		const prototypes = [];
-		let current = this;
-
-		while ((current = Object.getPrototypeOf(current)) !== null) {
-			prototypes.push(current);
-		}
-
-		// reverse so the parent prototype is first
-		prototypes.reverse();
-
-		// call init hooks on each prototype
-		for (const proto of prototypes) {
-			for (const hook of proto._initHooks ?? []) {
-				hook.call(this);
+			for (const hook of hooks) {
+				hook.call(instance);
 			}
+
+			return instance;
+		}
+	});
+
+	TargetClass.addInitHook = function addInitHook(fn, ...args) {
+		if (this !== proxy) {
+			const className = this.name || '(anonymous)';
+			throw new Error(`The 'addInitHook()' method can only be called on classes wrapped with 'withInitHooks()'. Try wrapping your class:\n\nconst ${className} = withInitHooks(class ${className} { ... });\n`);
 		}
 
-		this._initHooksCalled = true;
-	}
+		const init = typeof fn === 'function' ? fn : function () {
+			this[fn].apply(this, args);
+		};
+
+		hooks.push(init);
+
+		return this;
+	};
+
+	return proxy;
 }

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -1,4 +1,4 @@
-import {Class} from './Class.js';
+import {Class, withInitHooks} from './Class.js';
 import * as Util from './Util.js';
 
 /*
@@ -25,7 +25,7 @@ import * as Util from './Util.js';
  * ```
  */
 
-export class Evented extends Class {
+export const Evented = withInitHooks(class Evented extends Class {
 	/* @method on(type: String, fn: Function, context?: Object): this
 	 * Adds a listener function (`fn`) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. `'click dblclick'`).
 	 *
@@ -307,4 +307,4 @@ export class Evented extends Class {
 			}, true);
 		}
 	}
-};
+});

--- a/src/core/Handler.js
+++ b/src/core/Handler.js
@@ -1,4 +1,4 @@
-import {Class} from './Class.js';
+import {Class, withInitHooks} from './Class.js';
 
 /*
 	Handler is a base class for handler classes that are used internally to inject
@@ -8,8 +8,9 @@ import {Class} from './Class.js';
 // @class Handler
 // Abstract class for map interaction handlers
 
-export class Handler extends Class {
-	initialize(map) {
+export const Handler = withInitHooks(class Handler extends Class {
+	constructor(map) {
+		super();
 		this._map = map;
 	}
 
@@ -45,7 +46,7 @@ export class Handler extends Class {
 	// Called when the handler is enabled, should add event hooks.
 	// @method removeHooks()
 	// Called when the handler is disabled, should remove the event hooks added previously.
-}
+});
 
 // @section There is static function which can be called without instantiating Handler:
 // @function addTo(map: Map, name: String): this

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,5 @@
 export {default as Browser} from './Browser.js';
-export {Class} from './Class.js';
+export {Class, withInitHooks} from './Class.js';
 export {Evented} from './Events.js';
 export {Handler} from './Handler.js';
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../core/Class.js';
 import {Evented} from '../core/Events.js';
 import * as DomEvent from './DomEvent.js';
 import * as DomUtil from './DomUtil.js';
@@ -19,7 +20,7 @@ import * as PointerEvents from './DomEvent.PointerEvents.js';
  * ```
  */
 
-export class Draggable extends Evented {
+export const Draggable = withInitHooks(class Draggable extends Evented {
 
 	static {
 		this.setDefaultOptions({
@@ -34,7 +35,8 @@ export class Draggable extends Evented {
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).
-	initialize(element, dragStartTarget, preventOutline, options) {
+	constructor(element, dragStartTarget, preventOutline, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._element = element;
@@ -198,4 +200,4 @@ export class Draggable extends Evented {
 		}
 	}
 
-}
+});

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -1,4 +1,5 @@
 import {Evented} from '../core/Events.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
 
@@ -31,7 +32,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  *
  */
 
-export class PosAnimation extends Evented {
+export const PosAnimation = withInitHooks(class PosAnimation extends Evented {
 
 	// @method run(el: HTMLElement, newPos: Point, duration?: Number, easeLinearity?: Number)
 	// Run an animation of a given element to a new position, optionally setting
@@ -108,4 +109,4 @@ export class PosAnimation extends Evented {
 	_easeOut(t) {
 		return 1 - (1 - t) ** this._easeOutPower;
 	}
-}
+});

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -1,5 +1,6 @@
 import {Layer} from './Layer.js';
 import * as DomUtil from '../dom/DomUtil.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import {Bounds} from '../geometry/Bounds.js';
@@ -15,7 +16,7 @@ import {Bounds} from '../geometry/Bounds.js';
  * that rely on one single HTML element
  */
 
-export class BlanketOverlay extends Layer {
+export const BlanketOverlay = withInitHooks(class BlanketOverlay extends Layer {
 
 	static {
 		// @section
@@ -35,7 +36,8 @@ export class BlanketOverlay extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -165,4 +167,4 @@ export class BlanketOverlay extends Layer {
 	_onZoomEnd() {}
 	_onViewReset() {}
 	_onSettled() {}
-}
+});

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -1,6 +1,7 @@
 import {Map} from '../map/Map.js';
 import {Layer} from './Layer.js';
 import {FeatureGroup} from './FeatureGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {LatLng} from '../geo/LatLng.js';
 import {Point} from '../geometry/Point.js';
@@ -13,7 +14,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  */
 
 // @namespace DivOverlay
-export class DivOverlay extends Layer {
+export const DivOverlay = withInitHooks(class DivOverlay extends Layer {
 
 	static {
 		// @section
@@ -42,7 +43,9 @@ export class DivOverlay extends Layer {
 		});
 	}
 
-	initialize(options, source) {
+	constructor(options, source) {
+		super();
+
 		if (options instanceof LatLng || Array.isArray(options)) {
 			this._latlng = new LatLng(options);
 			Util.setOptions(this, source);
@@ -315,7 +318,7 @@ export class DivOverlay extends Layer {
 		return [0, 0];
 	}
 
-}
+});
 
 Map.include({
 	_initOverlay(OverlayClass, content, latlng, options) {

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -1,4 +1,5 @@
 import {LayerGroup} from './LayerGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import {LatLngBounds} from '../geo/LatLngBounds.js';
 
 /*
@@ -24,7 +25,7 @@ import {LatLngBounds} from '../geo/LatLngBounds.js';
 
 // @constructor FeatureGroup(layers?: Layer[], options?: Object)
 // Create a feature group, optionally given an initial set of layers and an `options` object.
-export class FeatureGroup extends LayerGroup {
+export const FeatureGroup = withInitHooks(class FeatureGroup extends LayerGroup {
 
 	addLayer(layer) {
 		if (this.hasLayer(layer)) {
@@ -85,4 +86,4 @@ export class FeatureGroup extends LayerGroup {
 		}
 		return bounds;
 	}
-}
+});

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -1,5 +1,6 @@
 import {LayerGroup} from './LayerGroup.js';
 import {FeatureGroup} from './FeatureGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {Marker} from './marker/Marker.js';
 import {Circle} from './vector/Circle.js';
@@ -35,7 +36,7 @@ import * as LineUtil from '../geometry/LineUtil.js';
 // Creates a GeoJSON layer. Optionally accepts an object in
 // [GeoJSON format](https://tools.ietf.org/html/rfc7946) to display on the map
 // (you can alternatively add it later with `addData` method) and an `options` object.
-export class GeoJSON extends FeatureGroup {
+export const GeoJSON = withInitHooks(class GeoJSON extends FeatureGroup {
 
 	/* @section
 	 * @aka GeoJSON options
@@ -87,7 +88,8 @@ export class GeoJSON extends FeatureGroup {
 	 * Whether default Markers for "Point" type Features inherit from group options.
 	 */
 
-	initialize(geojson, options) {
+	constructor(geojson, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._layers = {};
@@ -303,7 +305,7 @@ export class GeoJSON extends FeatureGroup {
 		};
 	}
 
-}
+});
 
 const PointToGeoJSON = {
 	toGeoJSON(precision) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -1,4 +1,5 @@
 import {Layer} from './Layer.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {LatLngBounds} from '../geo/LatLngBounds.js';
 import {Bounds} from '../geometry/Bounds.js';
@@ -22,7 +23,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 // @constructor ImageOverlay(imageUrl: String, bounds: LatLngBounds, options?: ImageOverlay options)
 // Instantiates an image overlay object given the URL of the image and the
 // geographical bounds it is tied to.
-export class ImageOverlay extends Layer {
+export const ImageOverlay = withInitHooks(class ImageOverlay extends Layer {
 
 	static {
 		// @section
@@ -67,7 +68,9 @@ export class ImageOverlay extends Layer {
 		});
 	}
 
-	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
+	constructor(url, bounds, options) { // (String, LatLngBounds, Object)
+		super();
+
 		this._url = url;
 		this._bounds = new LatLngBounds(bounds);
 
@@ -273,4 +276,4 @@ export class ImageOverlay extends Layer {
 	getCenter() {
 		return this._bounds.getCenter();
 	}
-}
+});

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -1,5 +1,6 @@
 import {Evented} from '../core/Events.js';
 import {Map} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -26,7 +27,7 @@ import * as Util from '../core/Util.js';
  */
 
 
-export class Layer extends Evented {
+export const Layer = withInitHooks(class Layer extends Evented {
 
 	static {
 		// Classes extending `Layer` will inherit the following options:
@@ -114,7 +115,7 @@ export class Layer extends Evented {
 		this.fire('add');
 		map.fire('layeradd', {layer: this});
 	}
-}
+});
 
 /* @section Extension methods
  * @uninheritable

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -1,5 +1,6 @@
 
 import {Layer} from './Layer.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -21,9 +22,11 @@ import * as Util from '../core/Util.js';
 
 // @constructor LayerGroup(layers?: Layer[], options?: Object)
 // Create a layer group, optionally given an initial set of layers and an `options` object.
-export class LayerGroup extends Layer {
+export const LayerGroup = withInitHooks(class LayerGroup extends Layer {
 
-	initialize(layers, options) { // for compatibility of code using `LayerGroup.extend`
+	constructor(layers, options) {
+		super();
+
 		Util.setOptions(this, options);
 
 		this._layers = {};
@@ -123,4 +126,4 @@ export class LayerGroup extends Layer {
 	getLayerId(layer) {
 		return Util.stamp(layer);
 	}
-}
+});

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -1,4 +1,5 @@
 import {DivOverlay} from './DivOverlay.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import {Point} from '../geometry/Point.js';
@@ -45,7 +46,7 @@ import {FeatureGroup} from './FeatureGroup.js';
 // @alternative
 // @constructor Popup(latlng: LatLng, options?: Popup options)
 // Instantiates a `Popup` object given `latlng` where the popup will open and an optional `options` object that describes its appearance and location.
-export class Popup extends DivOverlay {
+export const Popup = withInitHooks(class Popup extends DivOverlay {
 
 	static {
 		// @section
@@ -337,7 +338,7 @@ export class Popup extends DivOverlay {
 		return new Point(this._source?._getPopupAnchor ? this._source._getPopupAnchor() : [0, 0]);
 	}
 
-}
+});
 
 
 /* @namespace Map

--- a/src/layer/SVGOverlay.js
+++ b/src/layer/SVGOverlay.js
@@ -1,4 +1,5 @@
 import {ImageOverlay} from './ImageOverlay.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -24,7 +25,7 @@ import * as Util from '../core/Util.js';
 // @constructor SVGOverlay(svg: String|SVGElement, bounds: LatLngBounds, options?: SVGOverlay options)
 // Instantiates an image overlay object given an SVG element and the geographical bounds it is tied to.
 // A viewBox attribute is required on the SVG element to zoom in and out properly.
-export class SVGOverlay extends ImageOverlay {
+export const SVGOverlay = withInitHooks(class SVGOverlay extends ImageOverlay {
 	_initImage() {
 		const el = this._image = this._url;
 
@@ -39,4 +40,4 @@ export class SVGOverlay extends ImageOverlay {
 	// @method getElement(): SVGElement
 	// Returns the instance of [`SVGElement`](https://developer.mozilla.org/docs/Web/API/SVGElement)
 	// used by this overlay.
-}
+});

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -4,6 +4,7 @@ import {Map} from '../map/Map.js';
 import {Layer} from './Layer.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {FeatureGroup} from './FeatureGroup.js';
 
@@ -51,7 +52,7 @@ import {FeatureGroup} from './FeatureGroup.js';
 // @alternative
 // @constructor Tooltip(latlng: LatLng, options?: Tooltip options)
 // Instantiates a `Tooltip` object given `latlng` where the tooltip will open and an optional `options` object that describes its appearance and location.
-export class Tooltip extends DivOverlay {
+export const Tooltip = withInitHooks(class Tooltip extends DivOverlay {
 
 	static {
 		// @section
@@ -222,7 +223,7 @@ export class Tooltip extends DivOverlay {
 		return new Point(this._source?._getTooltipAnchor && !this.options.sticky ? this._source._getTooltipAnchor() : [0, 0]);
 	}
 
-}
+});
 
 // @namespace Map
 // @section Methods for Layers and Controls

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -1,6 +1,7 @@
 import {ImageOverlay} from './ImageOverlay.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -24,7 +25,7 @@ import * as Util from '../core/Util.js';
 // @constructor VideoOverlay(video: String|Array|HTMLVideoElement, bounds: LatLngBounds, options?: VideoOverlay options)
 // Instantiates an image overlay object given the URL of the video (or array of URLs, or even a video element) and the
 // geographical bounds it is tied to.
-export class VideoOverlay extends ImageOverlay {
+export const VideoOverlay = withInitHooks(class VideoOverlay extends ImageOverlay {
 
 	static {
 		// @section
@@ -103,4 +104,4 @@ export class VideoOverlay extends ImageOverlay {
 	// @method getElement(): HTMLVideoElement
 	// Returns the instance of [`HTMLVideoElement`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement)
 	// used by this overlay.
-}
+});

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -1,4 +1,5 @@
 import {Icon} from './Icon.js';
+import {withInitHooks} from '../../core/Class.js';
 import {Point} from '../../geometry/Point.js';
 
 /*
@@ -21,7 +22,7 @@ import {Point} from '../../geometry/Point.js';
 
 // @constructor DivIcon(options: DivIcon options)
 // Creates a `DivIcon` instance with the given options.
-export class DivIcon extends Icon {
+export const DivIcon = withInitHooks(class DivIcon extends Icon {
 
 	static {
 		this.setDefaultOptions({
@@ -68,4 +69,4 @@ export class DivIcon extends Icon {
 	createShadow() {
 		return null;
 	}
-}
+});

--- a/src/layer/marker/Icon.Default.js
+++ b/src/layer/marker/Icon.Default.js
@@ -1,4 +1,5 @@
 import {Icon} from './Icon.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 
 /*
@@ -16,7 +17,7 @@ import * as DomUtil from '../../dom/DomUtil.js';
  * `Marker.prototype.options.icon` with your own icon instead.
  */
 
-export class IconDefault extends Icon {
+export const IconDefault = withInitHooks(class IconDefault extends Icon {
 
 	static {
 		this.setDefaultOptions({
@@ -68,4 +69,4 @@ export class IconDefault extends Icon {
 		if (!link) { return ''; }
 		return link.href.substring(0, link.href.length - 'leaflet.css'.length - 1);
 	}
-}
+});

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -1,4 +1,4 @@
-import {Class} from '../../core/Class.js';
+import {Class, withInitHooks} from '../../core/Class.js';
 import {setOptions} from '../../core/Util.js';
 import {Point} from '../../geometry/Point.js';
 import Browser from '../../core/Browser.js';
@@ -32,7 +32,7 @@ import Browser from '../../core/Browser.js';
 
 // @constructor Icon(options: Icon options)
 // Creates an icon instance with the given options.
-export class Icon extends Class {
+export const Icon = withInitHooks(class Icon extends Class {
 
 	static {
 		/* @section
@@ -86,7 +86,8 @@ export class Icon extends Class {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		setOptions(this, options);
 	}
 
@@ -158,4 +159,4 @@ export class Icon extends Class {
 	_getIconUrl(name) {
 		return Browser.retina && this.options[`${name}RetinaUrl`] || this.options[`${name}Url`];
 	}
-}
+});

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../../core/Class.js';
 import {Handler} from '../../core/Handler.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import {Draggable} from '../../dom/Draggable.js';
@@ -22,8 +23,10 @@ import {Point} from '../../geometry/Point.js';
  * Marker dragging handler. Only valid when the marker is on the map (Otherwise set [`marker.options.draggable`](#marker-draggable)).
  */
 
-export class MarkerDrag extends Handler {
-	initialize(marker) {
+export const MarkerDrag = withInitHooks(class MarkerDrag extends Handler {
+	constructor(marker) {
+		super();
+
 		this._marker = marker;
 	}
 
@@ -155,4 +158,4 @@ export class MarkerDrag extends Handler {
 			.fire('moveend')
 			.fire('dragend', e);
 	}
-}
+});

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -1,5 +1,6 @@
 import {Layer} from '../Layer.js';
 import {IconDefault} from './Icon.Default.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Point} from '../../geometry/Point.js';
@@ -21,7 +22,7 @@ import {MarkerDrag} from './Marker.Drag.js';
 
 // @constructor Marker(latlng: LatLng, options? : Marker options)
 // Instantiates a Marker object given a geographical point and optionally an options object.
-export class Marker extends Layer {
+export const Marker = withInitHooks(class Marker extends Layer {
 
 	static {
 		// @section
@@ -110,7 +111,8 @@ export class Marker extends Layer {
 	 * In addition to [shared layer methods](#Layer) like `addTo()` and `remove()` and [popup methods](#Popup) like bindPopup() you can also use the following methods:
 	 */
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 	}
@@ -411,4 +413,4 @@ export class Marker extends Layer {
 	_getTooltipAnchor() {
 		return this.options.icon.options.tooltipAnchor;
 	}
-}
+});

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -1,4 +1,5 @@
 import {Layer} from '../Layer.js';
+import {withInitHooks} from '../../core/Class.js';
 import Browser from '../../core/Browser.js';
 import * as Util from '../../core/Util.js';
 import * as DomUtil from '../../dom/DomUtil.js';
@@ -73,7 +74,7 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
 
 // @constructor GridLayer(options?: GridLayer options)
 // Creates a new instance of GridLayer with the supplied options.
-export class GridLayer extends Layer {
+export const GridLayer = withInitHooks(class GridLayer extends Layer {
 
 	static {
 	// @section
@@ -152,7 +153,8 @@ export class GridLayer extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -894,4 +896,4 @@ export class GridLayer extends Layer {
 	_noTilesToLoad() {
 		return Object.values(this._tiles).every(t => t.loaded);
 	}
-}
+});

--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -1,4 +1,5 @@
 import {TileLayer} from './TileLayer.js';
+import {withInitHooks} from '../../core/Class.js';
 import {setOptions} from '../../core/Util.js';
 import Browser from '../../core/Browser.js';
 import {EPSG4326} from '../../geo/crs/CRS.EPSG4326.js';
@@ -23,7 +24,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor TileLayer.WMS(baseUrl: String, options: TileLayer.WMS options)
 // Instantiates a WMS tile layer object given a base URL of the WMS service and a WMS parameters/options object.
-export class TileLayerWMS extends TileLayer {
+export const TileLayerWMS = withInitHooks(class TileLayerWMS extends TileLayer {
 
 	static {
 		// @section
@@ -68,7 +69,8 @@ export class TileLayerWMS extends TileLayer {
 		});
 	}
 
-	initialize(url, options) {
+	constructor(url, options) {
+		super();
 
 		this._url = url;
 
@@ -131,4 +133,4 @@ export class TileLayerWMS extends TileLayer {
 
 		return this;
 	}
-}
+});

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -1,4 +1,5 @@
 import {GridLayer} from './GridLayer.js';
+import {withInitHooks} from '../../core/Class.js';
 import Browser from '../../core/Browser.js';
 import * as Util from '../../core/Util.js';
 import * as DomEvent from '../../dom/DomEvent.js';
@@ -34,7 +35,7 @@ import * as DomEvent from '../../dom/DomEvent.js';
 
 // @constructor TileLayer(urlTemplate: String, options?: TileLayer options)
 // Instantiates a tile layer object given a `URL template` and optionally an options object.
-export class TileLayer extends GridLayer {
+export const TileLayer = withInitHooks(class TileLayer extends GridLayer {
 
 	static {
 		// @section
@@ -88,7 +89,8 @@ export class TileLayer extends GridLayer {
 		});
 	}
 
-	initialize(url, options) {
+	constructor(url, options) {
+		super();
 
 		this._url = url;
 
@@ -289,4 +291,4 @@ export class TileLayer extends GridLayer {
 	_clampZoom(zoom) {
 		return Math.round(super._clampZoom(zoom));
 	}
-}
+});

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -1,5 +1,6 @@
 import {Renderer} from './Renderer.js';
 import * as DomEvent from '../../dom/DomEvent.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
@@ -32,7 +33,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor Canvas(options?: Renderer options)
 // Creates a Canvas renderer with the given options.
-export class Canvas extends Renderer {
+export const Canvas = withInitHooks(class Canvas extends Renderer {
 
 	static {
 		// @section
@@ -471,4 +472,4 @@ export class Canvas extends Renderer {
 
 		this._requestRedraw(layer);
 	}
-}
+});

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,7 +1,6 @@
 import {CircleMarker} from './CircleMarker.js';
 import {Path} from './Path.js';
-import * as Util from '../../core/Util.js';
-import {LatLng} from '../../geo/LatLng.js';
+import {withInitHooks} from '../../core/Class.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
 import {Earth} from '../../geo/crs/CRS.Earth.js';
 
@@ -24,11 +23,10 @@ import {Earth} from '../../geo/crs/CRS.Earth.js';
 // @constructor Circle(latlng: LatLng, options?: Circle options)
 // Instantiates a circle object given a geographical point, and an options object
 // which contains the circle radius.
-export class Circle extends CircleMarker {
+export const Circle = withInitHooks(class Circle extends CircleMarker {
 
-	initialize(latlng, options) {
-		Util.setOptions(this, options);
-		this._latlng = new LatLng(latlng);
+	constructor(latlng, options) {
+		super(latlng, options);
 
 		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 
@@ -103,4 +101,4 @@ export class Circle extends CircleMarker {
 
 		this._updateBounds();
 	}
-}
+});

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -1,4 +1,5 @@
 import {Path} from './Path.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -13,7 +14,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor CircleMarker(latlng: LatLng, options?: CircleMarker options)
 // Instantiates a circle marker object given a geographical point, and an optional options object.
-export class CircleMarker extends Path {
+export const CircleMarker = withInitHooks(class CircleMarker extends Path {
 
 	static {
 		// @section
@@ -27,7 +28,8 @@ export class CircleMarker extends Path {
 		});
 	}
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 		this._radius = this.options.radius;
@@ -103,4 +105,4 @@ export class CircleMarker extends Path {
 	_containsPoint(p) {
 		return p.distanceTo(this._point) <= this._radius + this._clickTolerance();
 	}
-}
+});

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -1,4 +1,5 @@
 import {Layer} from '../Layer.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 
 /*
@@ -9,7 +10,7 @@ import * as Util from '../../core/Util.js';
  * overlays (Polygon, Polyline, Circle). Do not use it directly. Extends `Layer`.
  */
 
-export class Path extends Layer {
+export const Path = withInitHooks(class Path extends Layer {
 
 	static {
 		// @section
@@ -142,4 +143,4 @@ export class Path extends Layer {
 		return (this.options.stroke ? this.options.weight / 2 : 0) +
 		  (this._renderer.options.tolerance || 0);
 	}
-}
+});

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -4,6 +4,7 @@ import * as LineUtil from '../../geometry/LineUtil.js';
 import {Point} from '../../geometry/Point.js';
 import {Bounds} from '../../geometry/Bounds.js';
 import * as PolyUtil from '../../geometry/PolyUtil.js';
+import {withInitHooks} from '../../core/Class.js';
 
 /*
  * @class Polygon
@@ -51,7 +52,7 @@ import * as PolyUtil from '../../geometry/PolyUtil.js';
  */
 
 // @constructor Polygon(latlngs: LatLng[], options?: Polyline options)
-export class Polygon extends Polyline {
+export const Polygon = withInitHooks(class Polygon extends Polyline {
 
 	static {
 		this.setDefaultOptions({
@@ -152,4 +153,4 @@ export class Polygon extends Polyline {
 		return inside || super._containsPoint(p, true);
 	}
 
-}
+});

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -1,4 +1,5 @@
 import {Path} from './Path.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import * as LineUtil from '../../geometry/LineUtil.js';
 import {LatLng} from '../../geo/LatLng.js';
@@ -48,7 +49,7 @@ import {Point} from '../../geometry/Point.js';
 // optionally an options object. You can create a `Polyline` object with
 // multiple separate lines (`MultiPolyline`) by passing an array of arrays
 // of geographic points.
-export class Polyline extends Path {
+export const Polyline = withInitHooks(class Polyline extends Path {
 
 	static {
 		// @section
@@ -65,7 +66,8 @@ export class Polyline extends Path {
 		});
 	}
 
-	initialize(latlngs, options) {
+	constructor(latlngs, options) {
+		super();
 		Util.setOptions(this, options);
 		this._setLatLngs(latlngs);
 	}
@@ -289,4 +291,4 @@ export class Polyline extends Path {
 		}
 		return false;
 	}
-}
+});

--- a/src/layer/vector/Rectangle.js
+++ b/src/layer/vector/Rectangle.js
@@ -1,5 +1,6 @@
 import {Polygon} from './Polygon.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
+import {withInitHooks} from '../../core/Class.js';
 
 /*
  * Rectangle extends Polygon and creates a rectangle when passed a LatLngBounds object.
@@ -27,18 +28,18 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
  */
 
 // @constructor Rectangle(latLngBounds: LatLngBounds, options?: Polyline options)
-export class Rectangle extends Polygon {
-	initialize(latLngBounds, options) {
-		super.initialize(this._boundsToLatLngs(latLngBounds), options);
+export const Rectangle = withInitHooks(class Rectangle extends Polygon {
+	constructor(latLngBounds, options) {
+		super(Rectangle.#boundsToLatLngs(latLngBounds), options);
 	}
 
 	// @method setBounds(latLngBounds: LatLngBounds): this
 	// Redraws the rectangle with the passed bounds.
 	setBounds(latLngBounds) {
-		return this.setLatLngs(this._boundsToLatLngs(latLngBounds));
+		return this.setLatLngs(Rectangle.#boundsToLatLngs(latLngBounds));
 	}
 
-	_boundsToLatLngs(latLngBounds) {
+	static #boundsToLatLngs(latLngBounds) {
 		latLngBounds = new LatLngBounds(latLngBounds);
 		return [
 			latLngBounds.getSouthWest(),
@@ -47,4 +48,4 @@ export class Rectangle extends Polygon {
 			latLngBounds.getSouthEast()
 		];
 	}
-}
+});

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -1,4 +1,5 @@
 import {BlanketOverlay} from '../BlanketOverlay.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 
 /*
@@ -23,9 +24,10 @@ import * as Util from '../../core/Util.js';
  * its map has moved
  */
 
-export class Renderer extends BlanketOverlay {
+export const Renderer = withInitHooks(class Renderer extends BlanketOverlay {
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, {...options, continuous: false});
 		Util.stamp(this);
 		this._layers ??= {};
@@ -70,4 +72,4 @@ export class Renderer extends BlanketOverlay {
 	// the 'update' event whenever appropriate (before/after rendering).
 	_update() {}
 
-}
+});

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -1,4 +1,5 @@
 import {Renderer} from './Renderer.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import {splitWords, stamp} from '../../core/Util.js';
 import {svgCreate, pointsToPath} from './SVG.Util.js';
@@ -36,7 +37,7 @@ export const create = svgCreate;
 // @namespace SVG
 // @constructor SVG(options?: Renderer options)
 // Creates a SVG renderer with the given options.
-export class SVG extends Renderer {
+export const SVG = withInitHooks(class SVG extends Renderer {
 
 	_initContainer() {
 		this._container = create('svg');
@@ -189,5 +190,5 @@ export class SVG extends Renderer {
 	_bringToBack(layer) {
 		DomUtil.toBack(layer._path);
 	}
-}
+});
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {Evented} from '../core/Events.js';
 import {EPSG3857} from '../geo/crs/CRS.EPSG3857.js';
@@ -48,7 +49,7 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // @constructor LeafletMap(el: HTMLElement, options?: LeafletMap options)
 // Instantiates a map object given an instance of a `<div>` HTML element
 // and optionally an object literal with `LeafletMap options`.
-export class Map extends Evented {
+export const Map = withInitHooks(class Map extends Evented {
 
 	static {
 		this.setDefaultOptions({
@@ -144,7 +145,8 @@ export class Map extends Evented {
 		});
 	}
 
-	initialize(id, options) { // (HTMLElement or String, Object)
+	constructor(id, options) { // (HTMLElement or String, Object)
+		super();
 		options = Util.setOptions(this, options);
 
 		// Make sure to assign internal flags at the beginning,
@@ -170,8 +172,6 @@ export class Map extends Evented {
 		if (options.center && options.zoom !== undefined) {
 			this.setView(new LatLng(options.center), options.zoom, {reset: true});
 		}
-
-		this.callInitHooks();
 
 		// don't animate on browsers without hardware-accelerated transitions or old Android
 		this._zoomAnimated = this.options.zoomAnimation;
@@ -1764,6 +1764,6 @@ export class Map extends Evented {
 
 		this._moveEnd(true);
 	}
-}
+});
 
 export const LeafletMap = Map;

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
@@ -19,8 +20,9 @@ Map.mergeOptions({
 	boxZoom: true
 });
 
-export class BoxZoom extends Handler {
-	initialize(map) {
+export const BoxZoom = withInitHooks(class BoxZoom extends Handler {
+	constructor(map) {
+		super();
 		this._map = map;
 		this._container = map._container;
 		this._pane = map._panes.overlayPane;
@@ -143,7 +145,7 @@ export class BoxZoom extends Handler {
 			this._resetState();
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property boxZoom: Handler

--- a/src/map/handler/Map.DoubleClickZoom.js
+++ b/src/map/handler/Map.DoubleClickZoom.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 
 /*
  * Handler.DoubleClickZoom is used to handle double-click zoom on the map, enabled by default.
@@ -17,7 +18,7 @@ Map.mergeOptions({
 	doubleClickZoom: true
 });
 
-export class DoubleClickZoom extends Handler {
+export const DoubleClickZoom = withInitHooks(class DoubleClickZoom extends Handler {
 	addHooks() {
 		this._map.on('dblclick', this._onDoubleClick, this);
 	}
@@ -38,7 +39,7 @@ export class DoubleClickZoom extends Handler {
 			map.setZoomAround(e.containerPoint, zoom);
 		}
 	}
-}
+});
 
 // @section Handlers
 //

--- a/src/map/handler/Map.Drag.js
+++ b/src/map/handler/Map.Drag.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import {Draggable} from '../../dom/Draggable.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -50,7 +51,7 @@ Map.mergeOptions({
 	maxBoundsViscosity: 0.0
 });
 
-export class Drag extends Handler {
+export const Drag = withInitHooks(class Drag extends Handler {
 	addHooks() {
 		if (!this._draggable) {
 			const map = this._map;
@@ -224,7 +225,7 @@ export class Drag extends Handler {
 			}
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property dragging: Handler

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import {on, off, stop} from '../../dom/DomEvent.js';
 import {Point} from '../../geometry/Point.js';
 
@@ -21,7 +22,7 @@ Map.mergeOptions({
 	keyboardPanDelta: 80
 });
 
-export class Keyboard extends Handler {
+export const Keyboard = withInitHooks(class Keyboard extends Handler {
 
 	static keyCodes = {
 		left:    ['ArrowLeft'],
@@ -32,7 +33,9 @@ export class Keyboard extends Handler {
 		zoomOut: ['Minus', 'NumpadSubtract', 'Digit6', 'Slash']
 	};
 
-	initialize(map) {
+	constructor(map) {
+		super();
+
 		this._map = map;
 
 		this._setPanDelta(map.options.keyboardPanDelta);
@@ -176,7 +179,7 @@ export class Keyboard extends Handler {
 
 		stop(e);
 	}
-}
+});
 
 // @section Handlers
 // @section Handlers

--- a/src/map/handler/Map.PinchZoom.js
+++ b/src/map/handler/Map.PinchZoom.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import * as PointerEvents from '../../dom/DomEvent.PointerEvents.js';
 
@@ -24,7 +25,7 @@ Map.mergeOptions({
 	bounceAtZoomLimits: true
 });
 
-export class PinchZoom extends Handler {
+export const PinchZoom = withInitHooks(class PinchZoom extends Handler {
 	addHooks() {
 		this._map._container.classList.add('leaflet-touch-zoom');
 		DomEvent.on(this._map._container, 'pointerdown', this._onPointerStart, this);
@@ -123,7 +124,7 @@ export class PinchZoom extends Handler {
 			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property pinchZoom: Handler

--- a/src/map/handler/Map.ScrollWheelZoom.js
+++ b/src/map/handler/Map.ScrollWheelZoom.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 
 /*
@@ -27,7 +28,7 @@ Map.mergeOptions({
 	wheelPxPerZoomLevel: 60
 });
 
-export class ScrollWheelZoom extends Handler {
+export const ScrollWheelZoom = withInitHooks(class ScrollWheelZoom extends Handler {
 	addHooks() {
 		DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
 
@@ -83,7 +84,7 @@ export class ScrollWheelZoom extends Handler {
 			map.setZoomAround(this._lastMousePos, zoom + delta);
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property scrollWheelZoom: Handler

--- a/src/map/handler/Map.TapHold.js
+++ b/src/map/handler/Map.TapHold.js
@@ -1,5 +1,6 @@
 import {Map} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import {Point} from '../../geometry/Point.js';
 import Browser from '../../core/Browser.js';
@@ -26,7 +27,7 @@ Map.mergeOptions({
 	tapTolerance: 15
 });
 
-export class TapHold extends Handler {
+export const TapHold = withInitHooks(class TapHold extends Handler {
 	addHooks() {
 		DomEvent.on(this._map._container, 'pointerdown', this._onDown, this);
 	}
@@ -93,7 +94,7 @@ export class TapHold extends Handler {
 
 		e.target.dispatchEvent(simulatedEvent);
 	}
-}
+});
 
 // @section Handlers
 // @property tapHold: Handler


### PR DESCRIPTION
Changes all built-in Leaflet classes from the custom `initialize()` method to a standardized `constructor()`. I have tried to maintain backwards compatibility with existing Leaflet code as much as possible, but there were some cases where breaking changes could not be avoided (see below).

Previously, we were using the `constructor()` of the super-most class (`Class`) to run any initialization hooks, however due to fundamental incompatibilities (see #9889) of mixing `constructor()` and `initialize()`, a new mechanism for running initialization hooks had to be introduced.

The new implementation makes use of a [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to intercept the constructor of any class wrapped by the new `withInitHooks()` function. Once intercepted, the class will be constructed [using reflection](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect) upon instantiation, after which the hooks registered with `addInitHook()` will be trigged, exactly in the same manner as they were before.

Wrapping classes that require initialization hooks with `withInitHooks()` is required, because there is no way to hook into the [`extends` keyword](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends), leaving us otherwise unable to intercept their constructor. For this reason, all built-in Leaflet classes that extend from `Class` are wrapped manually, ensuring some degree of backwards compatibility:

```js
import { Map } from 'leaflet';

// Remains functional due to being wrapped with `withInitHooks()` by default.
Map.addInitHook(function () {});
```

## Breaking changes (as things stand now)

### Missing `initialize()` method on Leaflet built-ins

Since this change replaces all `initialize()` methods from the built-in Leaflet classes with a standard `constructor()`, it is no longer possible to call this method as if it were the constructor:

```js
import { Marker } from 'leaflet';

class MyMarker extends Marker {
  initialize(latlng, options) {
    // Though `initialize()` will still be called, it is no longer possible to call `initialize()`
    // on the super-class, as it no longer exists.
    Marker.prototype.initialize.call(this, latlng, options);
  }
}

// Instead a `constructor` must be used by `MyMarker`.
class MyMarker extends Marker {
  constructor(latlng, options) {
    super(latlng, options);
  }
}
```

Or, with 'legacy' classes using `Class#extend()`:

```js
import { Marker } from 'leaflet';

const MyMarker = Marker.extend({
  initialize(latlng, options) {
    // Also here the `initialize()` method does not exist on the super class.
    Marker.prototype.initialize.call(this, latlng, options);
  }
});

// Instead a `constructor` must be used by `MyMarker`.
const MyMarker = Marker.extend({
  constructor(latlng, options) {
    super.constructor(latlng, options);
  }
});
```

As far as I can tell, there is no way to preserve the old behavior here, and this will be a necessary breaking change, but I am open to suggestions. Perhaps we could somehow patch classes that use the `Class#extend()` method, but I have not yet found a way to do so without introducing weird bugs or edge cases.

### No initialization hooks for classes using `extends` keyword

Extending classes using the `extends` keyword no longer guarantees initialization hooks will be triggered:

```js
import { Class } from 'leaflet';

class Foo extends Class {}

// Will throw an error due to the inability to intercept the
// constructor of `Foo` to execute the initialization hooks.
Foo.addInitHook(function () {});
```

To fix this, users can wrap their classes manually with `withInitHooks()`:

```js
import { Class, withInitHooks } from 'leaflet';

const Foo = withInitHooks(class Foo extends Class {});

// Will work, as we can intercept the constructor with `withInitHooks()`.
Foo.addInitHook(function () {});

// There is also no requirement to extend `Class`, calling `withInitHooks()` on
// a regular class will also work.
const Bar = withInitHooks(class Bar {});
```

The 'legacy' classes using `Class#extend()` are automatically wrapped with `withInitHooks()`, and will therefore keep working as expected:

```js
import { Class } from 'leaflet';

const Foo = Class.extend({});

// Will work, as we can intercept the constructor when calling `Class#extend()`.
Foo.addInitHook(function () {});
```

Closes #9889