### PR TITLE
Reduce exported API surface from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,8 @@
   },
   "type": "module",
   "exports": {
-    "./src/": "./src/",
-    "./dist/": "./dist/",
-    ".": "./dist/leaflet-src.js"
+    ".": "./dist/leaflet-src.js",
+    "./styles.css": "./dist/leaflet.css"
   },
   "style": "dist/leaflet.css",
   "files": [


### PR DESCRIPTION
Reduces the exported API surface of the package to only include the main module and stylesheet. This is a follow-up of #9658, which increased the exported surface to include everything under the `src` and `dist` directories. These directories are implementation details of the package, and should not be leaked as part of the public API surface.

This PR allows bundlers such as Vite that support package exports to include Leaflet as follows:

```js
import 'leaflet/styles.css';
import { Map } from 'leaflet';
```

The original PR provided the following motivation (aside from not being able to load the stylesheet):

> In addition, I (used to) import source files (such as `import { Map } from "leaflet/src/map/Map";`) because this strategy allows for smaller bundle size. Thus, please also cover the `src` files in `exports` in `package.json`.

This is not a valid strategy of optimizing bundle size. Aside from leaking the entire API surface, including functionality we might want to consider private, or not yet read for public consumption, this does not actually result in a smaller bundle size if any other imports are present. For example:

```js
// Some plugin might import this.
import { Map } from 'leaflet';

// And application code this.
import { Map } from "leaflet/src/map/Map";
```

In the above scenario, both `leaflet/src/map/Map.js` and `leaflet/dist/leaflet-src.js` are now included, leading to code duplication. 