### PR TITLE
Update compatible-v2 flag for Leaflet.Control.Layers.Tree

### DIFF
--- a/docs/_plugins/layer-switching-controls/leaflet-control-layers-tree.md
+++ b/docs/_plugins/layer-switching-controls/leaflet-control-layers-tree.md
@@ -7,7 +7,7 @@ author-url: https://github.com/jjimenezshaw/
 demo: https://jjimenezshaw.github.io/Leaflet.Control.Layers.Tree/examples/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 L.Control.Layers extension that supports a Tree structure, both for base and overlay layers. Simple and highly configurable.


### PR DESCRIPTION
After latest changes in https://github.com/jjimenezshaw/Leaflet.Control.Layers.Tree to make it Leaflet v2 compatible.