### PR TITLE
Fix l.setZIndex is not a function

### DIFF
--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -115,7 +115,7 @@ export class LayerGroup extends Layer {
 	// @method setZIndex(zIndex: Number): this
 	// Calls `setZIndex` on every layer contained in this group, passing the z-index.
 	setZIndex(zIndex) {
-		return this.eachLayer(l => l.setZIndex(zIndex));
+		return this.eachLayer(l => l.setZIndex?.(zIndex));
 	}
 
 	// @method getLayerId(layer: Layer): Number


### PR DESCRIPTION
Regression of #9680 (4b8018199b852eb240105013ee335d47e1a684fa).

```
Uncaught (in promise) TypeError: l.setZIndex is not a function
    setZIndex LayerGroup.js:118
    eachLayer LayerGroup.js:96
    setZIndex LayerGroup.js:118
    _addLayer Control.Layers.js:279
    addOverlay Control.Layers.js:151
```
