### PR TITLE
Remove user-agent detection for `Browser.mobile`

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -19,7 +19,7 @@ const chrome = userAgentContains('chrome');
 const safari = !chrome && userAgentContains('safari');
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
-const mobile = typeof orientation !== 'undefined' || userAgentContains('mobile');
+const mobile = typeof orientation !== 'undefined';
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).


### PR DESCRIPTION
This removes the user-agent detection code for `Browser.mobile`, which was originally added (ea680ce21af1e36b136c6108c0d51962e220b9a5) to support older versions of Firefox mobile. This is no longer needed, as Firefox mobile now supports the `orientation` property.