### PR TITLE
Update Leaflet.TileLayer.Swiss compatibility for Leaflet v2

### DIFF
--- a/docs/_plugins/basemap-providers/leaflet-tilelayer-swiss.md
+++ b/docs/_plugins/basemap-providers/leaflet-tilelayer-swiss.md
@@ -7,7 +7,7 @@ author-url: https://github.com/rkaravia
 demo: https://leaflet-tilelayer-swiss.karavia.ch/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 Displays national maps of Switzerland using map tiles from Swisstopo.


### PR DESCRIPTION
As of v2.4.0, Leaflet.TileLayer.Swiss is compatible with Leaflet v2. See https://github.com/rkaravia/Leaflet.TileLayer.Swiss/blob/main/CHANGELOG.md