### PR TITLE
Update leaflet-polydraw.md, Enable Leaflet 2.x compatibility

### DIFF
--- a/docs/_plugins/edit-geometries/leaflet-polydraw.md
+++ b/docs/_plugins/edit-geometries/leaflet-polydraw.md
@@ -7,7 +7,7 @@ author-url: https://github.com/AndreasOlausson
 demo: https://polydraw.ao-tech.se
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 A powerful plugin for creating and editing polygons on Leaflet maps. It supports freehand drawing, precise point-to-point creation, and smart merging of overlapping shapes. Includes advanced features like hole creation, vertex editing, and drag-and-drop repositioning.


### PR DESCRIPTION
Adds Leaflet 2.x compatibility flag for plugin testing.

- Enables v2 path handling
- Keeps Leaflet 1.x behavior unchanged
- Verified with both 1.9.4 and 2.0.0-alpha.1 using switch-version.sh