### PR TITLE
Fix: type selector "svg" cannot be directly after nesting selector "&"

### DIFF
--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -208,7 +208,7 @@
 
 .leaflet-zoom-animated {
 	transform-origin: 0 0;
-	&svg {
+	svg& {
 		will-change: transform;
 	}
 }


### PR DESCRIPTION
```
▲ [WARNING] Cannot use type selector "svg" directly after nesting selector "&" [css-syntax-error]

CSS nesting syntax does not allow the "&" selector to come before a type selector. You can wrap this selector in ":is(...)" as a workaround. This restriction exists to avoid problems with SASS nesting, where the same syntax means something very different that has no equivalent in real CSS (appending a suffix to the parent selector).
```
