### PR TITLE
fix: resolve flaky Safari test for Canvas renderer

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -234,11 +234,13 @@ describe('Canvas', () => {
 
 		map.addLayer(layer);
 
-		setTimeout(() => {
-			// we need the timeout, because else the requestAnimFrame is not called
-			expect(spy.callCount).to.eql(1);
-			done();
-		}, 50);
+		// Double requestAnimationFrame needed: first to schedule the _redraw, second to verify it executed
+		requestAnimationFrame(() => {
+			requestAnimationFrame(() => {
+				expect(spy.callCount).to.eql(1);
+				done();
+			});
+		});
 	});
 
 	describe('#bringToBack', () => {


### PR DESCRIPTION
Replace `setTimeout(50)` with double `requestAnimationFrame` in `adds vectors even if the canvas container was removed` test. The fixed timeout was unreliable across different Safari versions and system loads.

The double requestAnimationFrame pattern ensures the test waits for the Canvas _redraw method to be scheduled and executed, properly synchronizing with the browser's rendering pipeline.

Related issues:
Fixes: https://github.com/Leaflet/Leaflet/issues/9966