### PR TITLE
docs: Add Leaflet 2.x compatible fork of `Leaflet.markercluster` plugin

### DIFF
--- a/docs/_plugins/clustering-decluttering/leaflet-markercluster2
+++ b/docs/_plugins/clustering-decluttering/leaflet-markercluster2
@@ -1,0 +1,15 @@
+---
+name: Leaflet.markercluster
+category: clustering-decluttering
+repo: https://github.com/KristjanESPERANTO/Leaflet.markercluster
+author: Kristjan ESPERANTO
+author-url: https://github.com/KristjanESPERANTO
+demo: https://kristjanesperanto.github.io/Leaflet.markercluster/
+compatible-v0: false
+compatible-v1: false
+compatible-v2: true
+---
+
+Beautiful, sophisticated, high performance marker clustering solution with smooth animations and lots of great features.
+
+Leaflet 2.x compatible fork of `Leaflet.markercluster`.


### PR DESCRIPTION
repo: https://github.com/KristjanESPERANTO/Leaflet.markercluster
demo: https://kristjanesperanto.github.io/Leaflet.markercluster/