### PR TITLE
Fix fractional zoom level used in GridLayer.redraw()

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -232,7 +232,7 @@ export class GridLayer extends Layer {
 	redraw() {
 		if (this._map) {
 			this._removeAllTiles();
-			const tileZoom = this._clampZoom(this._map.getZoom());
+			const tileZoom = this._clampZoom(Math.round(this._map.getZoom()));
 			if (tileZoom !== this._tileZoom) {
 				this._tileZoom = tileZoom;
 				this._updateLevels();


### PR DESCRIPTION
GridLayer.redraw() currently uses this._map.getZoom() directly, which can contain fractional values when zoomSnap is set to a fractional increment (e.g., 0.1). This causes tile URLs to be generated with fractional zoom levels, such as "/2.4/x/y.png", which tile servers do not accept.

To ensure tile requests always use integer zoom levels, this patch rounds the zoom value before clamping it. This results in correct tile URLs like "/2/x/y.png" during redraw, while preserving normal zoom behavior.

Fixes #9930.