### PR TITLE
Fix tile gaps on high-DPI displays with scaling

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -873,7 +873,7 @@ export class GridLayer extends Layer {
 	}
 
 	_getTilePos(coords) {
-		return coords.scaleBy(this.getTileSize()).subtract(this._level.origin);
+		return coords.scaleBy(this.getTileSize()).subtract(this._level.origin).round();
 	}
 
 	_wrapCoords(coords) {


### PR DESCRIPTION
Fixes #9731 

Fixes visible 1px gaps between tiles on high-DPI displays with OS-level scaling.

Adds .round() to _getTilePos() to prevent sub-pixel positioning that causes visible 1px gaps between tiles on high-DPI monitors with OS-level scaling.

The issue occurred because tile positions were calculated as floating-point values (e.g., `132.544px`) and used directly in CSS `translate3d()`. On high-DPI displays, this causes browser sub-pixel rendering inconsistencies, creating visible gaps between tiles.



