### PR TITLE
Remove `Class.extend()` entirely

### DIFF
--- a/debug/map/control-layers.html
+++ b/debug/map/control-layers.html
@@ -24,13 +24,13 @@
 		<script type="module">
 			import {LeafletMap, TileLayer, Control, Circle, Polygon, GeoJSON} from 'leaflet';
 
-			const GrayscaleTileLayer = TileLayer.extend({
+			class GrayscaleTileLayer extends TileLayer {
 				createTile(...args) {
-					const element = TileLayer.prototype.createTile.call(this, ...args);
+					const element = super.createTile(...args);
 					element.classList.add('grayscale-tile');
 					return element;
 				}
-			});
+			}
 
 			const map = new LeafletMap('map').setView([50.5, 0], 5);
 			const tileUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/debug/map/video-overlay.html
+++ b/debug/map/video-overlay.html
@@ -43,7 +43,7 @@
 			overlay.on('dblclick', () => console.log('Double click on image.'));
 
 			overlay.on('load', () => {
-				const MyPauseControl = Control.extend({
+				class MyPauseControl extends Control {
 					onAdd() {
 						const button = DomUtil.create('button');
 						button.textContent = '⏸';
@@ -52,9 +52,9 @@
 						});
 						return button;
 					}
-				});
+				}
 
-				const MyPlayControl = Control.extend({
+				class MyPlayControl extends Control {
 					onAdd() {
 						const button = DomUtil.create('button');
 						button.textContent = '⏵';
@@ -63,7 +63,7 @@
 						});
 						return button;
 					}
-				});
+				}
 
 				new MyPauseControl().addTo(map);
 				new MyPlayControl().addTo(map);

--- a/debug/vector/blanket.html
+++ b/debug/vector/blanket.html
@@ -26,7 +26,7 @@
 				layers: [osm]
 			});
 
-			const DebugBlanket = BlanketOverlay.extend({
+			class DebugBlanket extends BlanketOverlay {
 				_initContainer() {
 					const container = this._container = document.createElement('div');
 					container.style.border = '2px solid black';
@@ -34,7 +34,7 @@
 					container.style.display = 'flex';
 					container.style.justifyContent = 'center';
 					container.style.alignItems = 'center';
-				},
+				}
 
 				_onSettled() {
 					this._container.innerHTML = `
@@ -44,7 +44,7 @@
 					map bounds: <br>${this._map.getBounds().toBBoxString().split(',').map(n => Number(n).toFixed(6)).join('<br>')}<br>
 					px bounds: ${this._bounds.min}, ${this._bounds.max}`;
 				}
-			});
+			}
 
 			new DebugBlanket({
 				padding: -0.1,

--- a/docs/examples/custom-icons/example-one-icon.md
+++ b/docs/examples/custom-icons/example-one-icon.md
@@ -10,16 +10,18 @@ title: Single Custom Icon Example
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 
-	const LeafIcon = Icon.extend({
-		options: {
-			shadowUrl: 'leaf-shadow.png',
-			iconSize:     [38, 95],
-			shadowSize:   [50, 64],
-			iconAnchor:   [22, 94],
-			shadowAnchor: [4, 62],
-			popupAnchor:  [-3, -76]
+	class LeafIcon extends Icon {
+		static {
+			this.setDefaultOptions({
+				shadowUrl: 'leaf-shadow.png',
+				iconSize:     [38, 95],
+				shadowSize:   [50, 64],
+				iconAnchor:   [22, 94],
+				shadowAnchor: [4, 62],
+				popupAnchor:  [-3, -76]
+			});
 		}
-	});
+	}
 
 	const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'});
 

--- a/docs/examples/custom-icons/example.md
+++ b/docs/examples/custom-icons/example.md
@@ -10,16 +10,18 @@ title: Custom Icons Example
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 	}).addTo(map);
 
-	const LeafIcon = Icon.extend({
-		options: {
-			shadowUrl: 'leaf-shadow.png',
-			iconSize:     [38, 95],
-			shadowSize:   [50, 64],
-			iconAnchor:   [22, 94],
-			shadowAnchor: [4, 62],
-			popupAnchor:  [-3, -76]
+	class LeafIcon extends Icon {
+		static {
+			this.setDefaultOptions({
+				shadowUrl: 'leaf-shadow.png',
+				iconSize:     [38, 95],
+				shadowSize:   [50, 64],
+				iconAnchor:   [22, 94],
+				shadowAnchor: [4, 62],
+				popupAnchor:  [-3, -76]
+			});
 		}
-	});
+	}
 
 	const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'});
 	const redIcon = new LeafIcon({iconUrl: 'leaf-red.png'});

--- a/docs/examples/custom-icons/index.md
+++ b/docs/examples/custom-icons/index.md
@@ -26,19 +26,23 @@ Note that the white area in the images is actually transparent.
 
 Marker icons in Leaflet are defined by [L.Icon](/reference.html#icon) objects, which are passed as an option when creating markers. Let's create a green leaf icon:
 
-	const greenIcon = new Icon({
-		iconUrl: 'leaf-green.png',
-		shadowUrl: 'leaf-shadow.png',
-		iconSize:     [38, 95], // size of the icon
-		shadowSize:   [50, 64], // size of the shadow
-		iconAnchor:   [22, 94], // point of the icon which will correspond to marker's location
-		shadowAnchor: [4, 62],  // the same for the shadow
-		popupAnchor:  [-3, -76] // point from which the popup should open relative to the iconAnchor
-	});
+```js
+const greenIcon = new Icon({
+	iconUrl: 'leaf-green.png',
+	shadowUrl: 'leaf-shadow.png',
+	iconSize:     [38, 95], // size of the icon
+	shadowSize:   [50, 64], // size of the shadow
+	iconAnchor:   [22, 94], // point of the icon which will correspond to marker's location
+	shadowAnchor: [4, 62],  // the same for the shadow
+	popupAnchor:  [-3, -76] // point from which the popup should open relative to the iconAnchor
+});
+```
 
 Now putting a marker with this icon on a map is easy:
 
-	const marker = new Marker([51.5, -0.09], {icon: greenIcon}).addTo(map);
+```js
+const marker = new Marker([51.5, -0.09], {icon: greenIcon}).addTo(map);
+```
 
 {% include frame.html url="example-one-icon.html" %}
 
@@ -46,27 +50,35 @@ Now putting a marker with this icon on a map is easy:
 
 What if we need to create several icons that have lots in common? Let's define our own icon class containing the shared options, inheriting from `L.Icon`! It's really easy in Leaflet:
 
-	const LeafIcon = Icon.extend({
-		options: {
+```js
+class LeafIcon extends Icon {
+	static {
+		this.setDefaultOptions({
 			shadowUrl: 'leaf-shadow.png',
 			iconSize:     [38, 95],
 			shadowSize:   [50, 64],
 			iconAnchor:   [22, 94],
 			shadowAnchor: [4, 62],
 			popupAnchor:  [-3, -76]
-		}
-	});
+		});
+	}
+}
+```
 
 Now we can create all three of our leaf icons from this class and use them:
 
-	const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'}),
-		redIcon = new LeafIcon({iconUrl: 'leaf-red.png'}),
-		orangeIcon = new LeafIcon({iconUrl: 'leaf-orange.png'});
+```js
+const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'}),
+	redIcon = new LeafIcon({iconUrl: 'leaf-red.png'}),
+	orangeIcon = new LeafIcon({iconUrl: 'leaf-orange.png'});
+```
 
 OK, let's finally put some markers with these icons on the map:
 
-	new Marker([51.5, -0.09], {icon: greenIcon}).addTo(map).bindPopup("I am a green leaf.");
-	new Marker([51.495, -0.083], {icon: redIcon}).addTo(map).bindPopup("I am a red leaf.");
-	new Marker([51.49, -0.1], {icon: orangeIcon}).addTo(map).bindPopup("I am an orange leaf.");
+```js
+new Marker([51.5, -0.09], {icon: greenIcon}).addTo(map).bindPopup("I am a green leaf.");
+new Marker([51.495, -0.083], {icon: redIcon}).addTo(map).bindPopup("I am a red leaf.");
+new Marker([51.49, -0.1], {icon: orangeIcon}).addTo(map).bindPopup("I am an orange leaf.");
+```
 
 That's it. Now take a look at the [full example](example.html), the [`L.Icon` docs](/reference.html#icon), or browse [other examples](../../examples.html).

--- a/docs/examples/extending-2-layers/canvascircles.md
+++ b/docs/examples/extending-2-layers/canvascircles.md
@@ -10,7 +10,7 @@ title: CanvasCircles Example
 		zoom: 0
 	});
 
-	GridLayer.CanvasCircles = GridLayer.extend({
+	class CanvasCirclesGridLayer extends GridLayer {
 		createTile(coords) {
 			const tile = document.createElement('canvas');
 
@@ -27,9 +27,9 @@ title: CanvasCircles Example
 
 			return tile;
 		}
-	});
+	}
 
-	const cavasGridLayer = new GridLayer.CanvasCircles();
+	const cavasGridLayer = new CanvasCirclesGridLayer();
 	map.addLayer(cavasGridLayer);
 
 	globalThis.L = L; // only for debugging in the developer console

--- a/docs/examples/extending-2-layers/gridcoords.md
+++ b/docs/examples/extending-2-layers/gridcoords.md
@@ -10,7 +10,7 @@ title: Grid Coordinates Example
 		zoom: 0
 	});
 
-	GridLayer.DebugCoords = GridLayer.extend({
+	class DebugCoordsGridLayer extends GridLayer {
 		createTile(coords, done) {
 			const tile = document.createElement('div');
 			tile.innerHTML = [coords.x, coords.y, coords.z].join(', ');
@@ -22,9 +22,9 @@ title: Grid Coordinates Example
 
 			return tile;
 		}
-	});
+	}
 	
-	const debugCoordsGrid = new GridLayer.DebugCoords();
+	const debugCoordsGrid = new DebugCoordsGridLayer();
 	map.addLayer(debugCoordsGrid);
 
 	globalThis.L = L; // only for debugging in the developer console

--- a/docs/examples/extending-2-layers/index.md
+++ b/docs/examples/extending-2-layers/index.md
@@ -17,52 +17,25 @@ One of them is `L.TileLayer.getTileUrl()`. This method is called internally by `
 
 Let's illustrate with a custom `L.TileLayer` that will display random kitten images from [Cataas](https://cataas.com):
 
-	TileLayer.Kitten = TileLayer.extend({
-		getTileUrl(coords) {
-			const i = Math.ceil(Math.random() * 4) - 1;
-			const tag = ['orange', 'hat', 'cute', 'small'];
-			return `https://cataas.com/cat/${tag[i]}?width=256&height=256`;
-		},
-		getAttribution() {
-			return '<a href="https://cataas.com/">CATAAS - Cat as a service</a>';
-		}
-	});
+```js
+class KittenTileLayer extends TileLayer {
+	getTileUrl(coords) {
+		const i = Math.ceil(Math.random() * 4) - 1;
+		const tag = ['orange', 'hat', 'cute', 'small'];
+		return `https://cataas.com/cat/${tag[i]}?width=256&height=256`;
+	}
 
-    new TileLayer.Kitten().addTo(map);
+	getAttribution() {
+		return '<a href="https://cataas.com/">CATAAS - Cat as a service</a>';
+	}
+}
+
+new KittenTileLayer().addTo(map);
+```
 
 {% include frame.html url="kittenlayer.html" %}
 
 Normally, `getTileUrl()` receives the tile coordinates (as `coords.x`, `coords.y` and `coords.z`) and generates a tile URL from them. In our example, we ignore those and simply use a random number to get a different kitten every time.
-
-### Splitting Away the Plugin Code
-
-In the previous example, `L.TileLayer.Kitten` is defined in the same place as it's used. For plugins, it's better to split the plugin code into its own file, and include that file when it's used.
-
-For the KittenLayer, you should create a file like `L.KittenLayer.js` with:
-
-	TileLayer.Kitten = TileLayer.extend({
-		getTileUrl(coords) {
-			const i = Math.ceil(Math.random() * 4) - 1;
-			const tag = ['orange', 'hat', 'cute', 'small'];
-			return `https://cataas.com/cat/${tag[i]}?width=256&height=256`;
-		},
-		getAttribution() {
-			return '<a href="https://cataas.com/">CATAAS - Cat as a service</a>';
-		}
-	});
-
-And then, include that file when showing a map:
-
-	<html>
-	…
-	<script src='leaflet.js'>
-	<script src='L.KittenLayer.js'>
-	<script>
-		const map = new LeafletMap('map-div-id');
-		new TileLayer.Kitten().addTo(map);
-	</script>
-	…
-
 
 ### `L.GridLayer` and DOM Elements
 
@@ -72,30 +45,34 @@ Another extension method is `L.GridLayer.createTile()`. Where `L.TileLayer` assu
 
 An example of a custom `GridLayer` is showing the tile coordinates in a `<div>`. This is particularly useful when debugging the internals of Leaflet, and for understanding how the tile coordinates work:
 
-	GridLayer.DebugCoords = GridLayer.extend({
-		createTile(coords) {
-			const tile = document.createElement('div');
-			tile.innerHTML = [coords.x, coords.y, coords.z].join(', ');
-			tile.style.outline = '1px solid red';
-			return tile;
-		}
-	});
+```js
+class DebugCoordsGridLayer extends GridLayer {
+	createTile(coords) {
+		const tile = document.createElement('div');
+		tile.innerHTML = [coords.x, coords.y, coords.z].join(', ');
+		tile.style.outline = '1px solid red';
+		return tile;
+	}
+}
 
-	map.addLayer(new GridLayer.DebugCoords() );
+map.addLayer(new DebugCoordsGridLayer());
+```
 
 
 If the element has to do some asynchronous initialization, then use the second function parameter `done` and call it back when the tile is ready (for example, when an image has been fully loaded) or when there is an error. In here, we'll just delay the tiles artificially:
 
-	createTile(coords, done) {
-		const tile = document.createElement('div');
-		tile.innerHTML = [coords.x, coords.y, coords.z].join(', ');
-		tile.style.outline = '1px solid red';
+```js
+createTile(coords, done) {
+	const tile = document.createElement('div');
+	tile.innerHTML = [coords.x, coords.y, coords.z].join(', ');
+	tile.style.outline = '1px solid red';
 
-        // Syntax is 'done(error, tile)'
-		setTimeout(() => done(null, tile), 500 + Math.random() * 1500);
+	// Syntax is 'done(error, tile)'
+	setTimeout(() => done(null, tile), 500 + Math.random() * 1500);
 
-		return tile;
-	}
+	return tile;
+}
+```
 
 {% include frame.html url="gridcoords.html" %}
 
@@ -103,25 +80,27 @@ With these custom `GridLayer`s, a plugin can have full control of the HTML eleme
 
 A very basic `<canvas>` `GridLayer` looks like:
 
-	GridLayer.CanvasCircles = GridLayer.extend({
-		createTile(coords) {
-			const tile = document.createElement('canvas');
+```js
+class CanvasCirclesGridLayer extends GridLayer {
+	createTile(coords) {
+		const tile = document.createElement('canvas');
 
-			const tileSize = this.getTileSize();
-			tile.setAttribute('width', tileSize.x);
-			tile.setAttribute('height', tileSize.y);
+		const tileSize = this.getTileSize();
+		tile.setAttribute('width', tileSize.x);
+		tile.setAttribute('height', tileSize.y);
 
-			const ctx = tile.getContext('2d');
+		const ctx = tile.getContext('2d');
 
-			// Draw whatever is needed in the canvas context
-			// For example, circles which get bigger as we zoom in
-			ctx.beginPath();
-			ctx.arc(tileSize.x/2, tileSize.x/2, 4 + coords.z*4, 0, 2*Math.PI, false);
-			ctx.fill();
+		// Draw whatever is needed in the canvas context
+		// For example, circles which get bigger as we zoom in
+		ctx.beginPath();
+		ctx.arc(tileSize.x/2, tileSize.x/2, 4 + coords.z*4, 0, 2*Math.PI, false);
+		ctx.fill();
 
-			return tile;
-		}
-	});
+		return tile;
+	}
+}
+```
 
 {% include frame.html url="canvascircles.html" %}
 
@@ -157,35 +136,37 @@ At their core, all `L.Layer`s are HTML elements inside a map pane, their positio
 
 In other words: the map calls the `onAdd()` method of the layer, then the layer creates its HTML element(s) (commonly named 'container' element) and adds them to the map pane. Conversely, when the layer is removed from the map, its `onRemove()` method is called. The layer must update its contents when added to the map, and reposition them when the map view is updated. A layer skeleton looks like:
 
-	const CustomLayer = Layer.extend({
-		onAdd(map) {
-			const pane = map.getPane(this.options.pane);
-			this._container = DomUtil.create(…);
+```js
+class CustomLayer extends Layer {
+	onAdd(map) {
+		const pane = map.getPane(this.options.pane);
+		this._container = DomUtil.create(…);
 
-			pane.appendChild(this._container);
+		pane.appendChild(this._container);
 
-			// Calculate initial position of container with `L.Map.latLngToLayerPoint()`, `getPixelOrigin()` and/or `getPixelBounds()`
+		// Calculate initial position of container with `L.Map.latLngToLayerPoint()`, `getPixelOrigin()` and/or `getPixelBounds()`
 
-			DomUtil.setPosition(this._container, point);
+		DomUtil.setPosition(this._container, point);
 
-			// Add and position children elements if needed
+		// Add and position children elements if needed
 
-			map.on('zoomend viewreset', this._update, this);
-		},
+		map.on('zoomend viewreset', this._update, this);
+	}
 
-		onRemove(map) {
-			this._container.remove();
-			map.off('zoomend viewreset', this._update, this);
-		},
+	onRemove(map) {
+		this._container.remove();
+		map.off('zoomend viewreset', this._update, this);
+	}
 
-		_update() {
-			// Recalculate position of container
+	_update() {
+		// Recalculate position of container
 
-			DomUtil.setPosition(this._container, point);        
+		DomUtil.setPosition(this._container, point);        
 
-			// Add/remove/reposition children elements if needed
-		}
-	});
+		// Add/remove/reposition children elements if needed
+	}
+}
+```
 
 How to exactly position the HTML elements for a layer depends on the specifics of the layer, but this introduction should help you to read Leaflet's layer code, and create new layers.
 
@@ -195,9 +176,11 @@ Some use cases don't need the whole `onAdd` code to be recreated, but instead th
 
 To give an example, we can have a subclass of `L.Polyline` that will always be red (ignoring the options), like:
 
-	Polyline.Red = Polyline.extend({
-		onAdd(map) {
-			this.options.color = 'red';
-			Polyline.prototype.onAdd.call(this, map);
-		}
-	});
+```js
+class RedPolyline extends Polyline {
+	onAdd(map) {
+		this.options.color = 'red';
+		super.onAdd(map);
+	}
+}
+```

--- a/docs/examples/extending-2-layers/kittenlayer.md
+++ b/docs/examples/extending-2-layers/kittenlayer.md
@@ -11,18 +11,18 @@ title: KittenLayer Example
 		zoom: 5
 	});
 
-	TileLayer.Kitten = TileLayer.extend({
+	class KittenTileLayer extends TileLayer {
 		getTileUrl(coords) {
 			const i = Math.ceil(Math.random() * 4) - 1;
 			const tag = ['orange', 'hat', 'cute', 'small'];
 			return `https://cataas.com/cat/${tag[i]}?width=256&height=256`;
-		},
+		}
 		getAttribution() {
 			return '<a href="https://cataas.com/">CATAAS - Cat as a service</a>';
 		}
-	});
+	}
 
-	const kittenTiles = new TileLayer.Kitten();
+	const kittenTiles = new KittenTileLayer();
 	map.addLayer(kittenTiles);
 
 	globalThis.L = L; // only for debugging in the developer console

--- a/docs/examples/extending-3-controls/index.md
+++ b/docs/examples/extending-3-controls/index.md
@@ -15,34 +15,38 @@ Map handlers are a new concept in Leaflet 1.0, and their function is to process 
 
 Handlers are relatively simple: they just need an `addHooks()` method (which runs when the handler is enabled in a map) and a `removeHooks()`, which runs when the handler is disabled. A skeleton for handlers is:
 
-	const CustomHandler = Handler.extend({
-		addHooks() {
-			DomEvent.on(document, 'eventname', this._doSomething, this);
-		},
+```js
+class CustomHandler extends Handler {
+	addHooks() {
+		DomEvent.on(document, 'eventname', this._doSomething, this);
+	}
 
-		removeHooks() {
-			DomEvent.off(document, 'eventname', this._doSomething, this);
-		},
+	removeHooks() {
+		DomEvent.off(document, 'eventname', this._doSomething, this);
+	}
 
-		_doSomething(event) { … }
-	});
+	_doSomething(event) { … }
+}
+```
 
 This can be illustrated with a simple handler to pan the map when a mobile device is tilted, through [`deviceorientation` events](https://developer.mozilla.org/en-US/docs/Web/API/Detecting_device_orientation):
 
-	const TiltHandler = Handler.extend({
-		addHooks() {
-			DomEvent.on(window, 'deviceorientation', this._tilt, this);
-		},
+```js
+class TiltHandler extends Handler {
+	addHooks() {
+		DomEvent.on(window, 'deviceorientation', this._tilt, this);
+	}
 
-		removeHooks() {
-			DomEvent.off(window, 'deviceorientation', this._tilt, this);
-		},
+	removeHooks() {
+		DomEvent.off(window, 'deviceorientation', this._tilt, this);
+	}
 
-		_tilt(ev) {
-			// Treat Gamma angle as horizontal pan (1 degree = 1 pixel) and Beta angle as vertical pan
-			this._map.panBy( new Point( ev.gamma, ev.beta ) );
-		}
-	});
+	_tilt(ev) {
+		// Treat Gamma angle as horizontal pan (1 degree = 1 pixel) and Beta angle as vertical pan
+		this._map.panBy( new Point( ev.gamma, ev.beta ) );
+	}
+}
+```
 
 The handler can be attached to the map using `map.addHandler('tilt', L.TiltHandler)` - this will store an instance of `L.TiltHandler` as `map.tilt`. However, it's more usual to attach handlers to all maps with the `addInitHook` syntax:
 
@@ -68,22 +72,24 @@ To make a control, simply inherit from `L.Control` and implement `onAdd()` and `
 
 The simplest example of a custom control would be a watermark, which is just an image:
 
-	Control.Watermark = Control.extend({
-		onAdd(map) {
-			const img = DomUtil.create('img');
+```js
+class WatermarkControl extends Control {
+	onAdd(map) {
+		const img = DomUtil.create('img');
 
-			img.src = '../../docs/images/logo.png';
-			img.style.width = '200px';
+		img.src = '../../docs/images/logo.png';
+		img.style.width = '200px';
 
-			return img;
-		},
+		return img;
+	}
 
-		onRemove(map) {
-			// Nothing to do here
-		}
-	});
+	onRemove(map) {
+		// Nothing to do here
+	}
+}
 
-	new Control.Watermark({ position: 'bottomleft' }).addTo(map);
+new WatermarkControl({ position: 'bottomleft' }).addTo(map);
+```
 
 {% include frame.html url="watermark.html" %}
 

--- a/docs/examples/extending-3-controls/tilt.md
+++ b/docs/examples/extending-3-controls/tilt.md
@@ -29,14 +29,14 @@ title: Tilt Handler Example
 
 	const trd = [63.41, 10.41];
 	
-	const TiltHandler = Handler.extend({
+	class TiltHandler extends Handler {
 		addHooks() {
 			DomEvent.on(window, 'deviceorientation', this._tilt, this);
-		},
+		}
 	
 		removeHooks() {
 			DomEvent.off(window, 'deviceorientation', this._tilt, this);
-		},
+		}
 
 		_tilt(ev) {
 			// Treat Gamma angle as horizontal pan (1 degree = 1 pixel) and Beta angle as vertical pan
@@ -50,7 +50,7 @@ title: Tilt Handler Example
 			}
 			document.getElementById('info').innerHTML = info;
 		}
-	});
+	}
 	
 	Map.addInitHook('addHandler', 'tilt', TiltHandler);
 

--- a/docs/examples/extending-3-controls/watermark.md
+++ b/docs/examples/extending-3-controls/watermark.md
@@ -15,7 +15,7 @@ title: Watermark Control Example
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);
 
-	Control.Watermark = Control.extend({
+	class WatermarkControl extends Control {
 		onAdd(map) {
 			const img = DomUtil.create('img');
 
@@ -23,14 +23,14 @@ title: Watermark Control Example
 			img.style.width = '200px';
 
 			return img;
-		},
+		}
 
 		onRemove(map) {
 			// Nothing to do here
 		}
-	});
+	}
 	
-	const watermarkControl = new Control.Watermark({position: 'bottomleft'}).addTo(map);
+	const watermarkControl = new WatermarkControl({position: 'bottomleft'}).addTo(map);
 
 	globalThis.L = L; // only for debugging in the developer console
 	globalThis.map = map; // only for debugging in the developer console

--- a/docs/examples/overlays/example-video.md
+++ b/docs/examples/overlays/example-video.md
@@ -31,7 +31,7 @@ title: Video Overlay Tutorial (Video with Controls)
 	}).addTo(map);
 
 	videoOverlay.on('load', () => {
-		const MyPauseControl = Control.extend({
+		class MyPauseControl extends Control {
 			onAdd() {
 				const button = DomUtil.create('button');
 				button.title = 'Pause';
@@ -41,8 +41,8 @@ title: Video Overlay Tutorial (Video with Controls)
 				});
 				return button;
 			}
-		});
-		const MyPlayControl = Control.extend({
+		}
+		class MyPlayControl extends Control {
 			onAdd() {
 				const button = DomUtil.create('button');
 				button.title = 'Play';
@@ -52,7 +52,7 @@ title: Video Overlay Tutorial (Video with Controls)
 				});
 				return button;
 			}
-		});
+		}
 
 		const pauseControl = (new MyPauseControl()).addTo(map);
 		const playControl = (new MyPlayControl()).addTo(map);

--- a/docs/examples/overlays/index.md
+++ b/docs/examples/overlays/index.md
@@ -161,9 +161,9 @@ videoOverlay.getElement().pause();
 
 This allows us to build custom interfaces. For example, we can build a small subclass of `L.Control` to play/pause this video overlay once it's loaded:
 
-```
+```js
 videoOverlay.on('load', function () {
-	const MyPauseControl = Control.extend({
+	class MyPauseControl extends Control {
 		onAdd() {
 			const button = DomUtil.create('button');
 			button.title = 'Pause';
@@ -173,8 +173,8 @@ videoOverlay.on('load', function () {
 			});
 			return button;
 		}
-	});
-	const MyPlayControl = Control.extend({
+	}
+	class MyPlayControl extends Control {
 		onAdd() {
 			const button = DomUtil.create('button');
 			button.title = 'Play';
@@ -184,7 +184,7 @@ videoOverlay.on('load', function () {
 			});
 			return button;
 		}
-	});
+	}
 
 	const pauseControl = (new MyPauseControl()).addTo(map);
 	const playControl = (new MyPlayControl()).addTo(map);

--- a/docs/examples/zoom-levels/example-delta.md
+++ b/docs/examples/zoom-levels/example-delta.md
@@ -18,7 +18,7 @@ title: No Zoom Snap Example
 		attribution: cartodbAttribution
 	}).addTo(map);
 
-	const ZoomViewer = Control.extend({
+	class ZoomViewer extends Control {
 		onAdd() {
 			const container = DomUtil.create('div');
 			const gauge = DomUtil.create('div');
@@ -31,7 +31,7 @@ title: No Zoom Snap Example
 			container.appendChild(gauge);
 			return container;
 		}
-	});
+	}
 
 	const zoomViewerControl = (new ZoomViewer()).addTo(map);
 

--- a/docs/examples/zoom-levels/example-fractional.md
+++ b/docs/examples/zoom-levels/example-fractional.md
@@ -33,7 +33,7 @@ title: Fractional Zoom Example
 
 	const zoomingInterval = setInterval(zoomCycle, 8000);
 
-	const ZoomViewer = Control.extend({
+	class ZoomViewer extends Control {
 		onAdd() {
 			const container = DomUtil.create('div');
 			const gauge = DomUtil.create('div');
@@ -46,7 +46,7 @@ title: Fractional Zoom Example
 			container.appendChild(gauge);
 			return container;
 		}
-	});
+	}
 
 	const zoomViewerControl = (new ZoomViewer()).addTo(map);
 

--- a/docs/examples/zoom-levels/example-setzoom.md
+++ b/docs/examples/zoom-levels/example-setzoom.md
@@ -26,7 +26,7 @@ title: Zoom Control Example
 
 	}, 4000);
 
-	const ZoomViewer = Control.extend({
+	class ZoomViewer extends Control {
 		onAdd() {
 			const gauge = DomUtil.create('div');
 			gauge.style.width = '200px';
@@ -37,7 +37,7 @@ title: Zoom Control Example
 			});
 			return gauge;
 		}
-	});
+	}
 
 	const zoomViewer = (new ZoomViewer()).addTo(map);
 

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -1,289 +1,9 @@
 import {expect} from 'chai';
-import {Class, Evented} from 'leaflet';
+import {Class} from 'leaflet';
 import sinon from 'sinon';
 
 describe('Class', () => {
-	describe('#extend', () => {
-		let Klass,
-		props,
-		constructor,
-		method;
-
-		beforeEach(() => {
-			constructor = sinon.spy();
-			method = sinon.spy();
-
-			props = {
-				statics: {bla: 1},
-				includes: {mixin: true},
-
-				initialize: constructor,
-				foo: 5,
-				bar: method
-			};
-			Klass = Class.extend(props);
-		});
-
-		it('creates a class with the given constructor & properties', () => {
-			const a = new Klass();
-
-			expect(constructor.called).to.be.true;
-			expect(a.foo).to.eql(5);
-
-			a.bar();
-
-			expect(method.called).to.be.true;
-		});
-
-		it('calls the correct parent initialize function', () => {
-			const initialize = sinon.spy();
-			const initializeDraw = sinon.spy();
-			const initializeEdit = sinon.spy();
-			const Toolbar = Class.extend({
-				initialize() {
-					initialize();
-				}
-			});
-			Toolbar.include(Evented.prototype);
-			const DrawToolbar = Toolbar.extend({
-				initialize(options) {
-					initializeDraw();
-					Toolbar.prototype.initialize.call(this, options);
-				}
-			});
-			const EditToolbar = Toolbar.extend({
-				initialize(options) {
-					initializeEdit();
-					Toolbar.prototype.initialize.call(this, options);
-				}
-			});
-
-			new Toolbar();
-			sinon.assert.calledOnce(initialize);
-			sinon.assert.notCalled(initializeDraw);
-			sinon.assert.notCalled(initializeEdit);
-			initialize.resetHistory();
-
-			new DrawToolbar();
-			sinon.assert.callOrder(initializeDraw, initialize);
-			sinon.assert.notCalled(initializeEdit);
-			initialize.resetHistory();
-			initializeDraw.resetHistory();
-
-			new EditToolbar();
-			sinon.assert.callOrder(initializeEdit, initialize);
-			sinon.assert.notCalled(initializeDraw);
-		});
-
-		it('inherits parent classes\' constructor & properties', () => {
-			const Klass2 = Klass.extend({baz: 2});
-
-			const b = new Klass2();
-
-			expect(b instanceof Klass).to.be.true;
-			expect(b instanceof Klass2).to.be.true;
-
-			expect(constructor.called).to.be.true;
-			expect(b.baz).to.eql(2);
-
-			b.bar();
-
-			expect(method.called).to.be.true;
-		});
-
-		it('does not modify source props object', () => {
-			expect(props).to.eql({
-				statics: {bla: 1},
-				includes: {mixin: true},
-
-				initialize: constructor,
-				foo: 5,
-				bar: method
-			});
-		});
-
-		it('supports static properties', () => {
-			expect(Klass.bla).to.eql(1);
-		});
-
-		it('does not merge \'statics\' property itself', () => {
-			expect('statics' in Klass.prototype).to.be.false;
-		});
-
-		it('inherits parent static properties', () => {
-			const Klass2 = Klass.extend({});
-
-			expect(Klass2.bla).to.eql(1);
-		});
-
-		it('overrides parent static properties', () => {
-			const Klass2 = Klass.extend({statics: {bla: 2}});
-
-			expect(Klass2.bla).to.eql(2);
-		});
-
-		it('includes the given mixin', () => {
-			const a = new Klass();
-			expect(a.mixin).to.be.true;
-		});
-
-		it('does not merge \'includes\' property itself', () => {
-			expect('includes' in Klass.prototype).to.be.false;
-		});
-
-		it('includes multiple mixins', () => {
-			const Klass2 = Class.extend({
-				includes: [{mixin: true}, {mixin2: true}]
-			});
-			const a = new Klass2();
-
-			expect(a.mixin).to.be.true;
-			expect(a.mixin2).to.be.true;
-		});
-
-		it('includes Evented mixins', () => {
-			const Klass2 = Class.extend({
-				includes: Evented.prototype
-			});
-			const a = new Klass2();
-
-			expect(a.on).to.eql(Evented.prototype.on);
-			expect(a.off).to.eql(Evented.prototype.off);
-		});
-
-		it('includes inherited mixins', () => {
-			class A {
-				foo() {}
-			}
-			class B extends A {
-				bar() {}
-			}
-			const Klass2 = Class.extend({
-				includes: B.prototype
-			});
-			const a = new Klass2();
-
-			expect(a.bar).to.eql(B.prototype.bar);
-			expect(a.foo).to.eql(B.prototype.foo);
-		});
-
-		it('grants the ability to include the given mixin', () => {
-			Klass.include({mixin2: true});
-
-			const a = new Klass();
-			expect(a.mixin2).to.be.true;
-		});
-
-		it('merges options instead of replacing them', () => {
-			const KlassWithOptions1 = Class.extend({
-				options: {
-					foo1: 1,
-					foo2: 2
-				}
-			});
-			const KlassWithOptions2 = KlassWithOptions1.extend({
-				options: {
-					foo2: 3,
-					foo3: 4
-				}
-			});
-
-			const a = new KlassWithOptions2();
-			expect(a.options.foo1).to.eql(1);
-			expect(a.options.foo2).to.eql(3);
-			expect(a.options.foo3).to.eql(4);
-		});
-
-		it('gives new classes a distinct options object', () => {
-			const K1 = Class.extend({options: {}});
-			const K2 = K1.extend({});
-			expect(K2.prototype.options).not.to.equal(K1.prototype.options);
-		});
-
-		it('inherits options prototypally', () => {
-			const K1 = Class.extend({options: {}});
-			const K2 = K1.extend({options: {}});
-			K1.prototype.options.foo = 'bar';
-			expect(K2.prototype.options.foo).to.eql('bar');
-		});
-
-		it('does not reuse original props.options', () => {
-			const props = {options: {}};
-			const K = Class.extend(props);
-
-			expect(K.prototype.options).not.to.equal(props.options);
-		});
-
-		it('does not replace source props.options object', () => {
-			const K1 = Class.extend({options: {}});
-			const opts = {};
-			const props = {options: opts};
-			K1.extend(props);
-
-			expect(props.options).to.equal(opts);
-		});
-
-		it('prevents change of prototype options', () => {
-			const Klass = Class.extend({options: {}});
-			const instance = new Klass();
-			expect(Klass.prototype.options).to.not.equal(instance.options);
-		});
-
-		it('adds constructor hooks correctly', () => {
-			const spy1 = sinon.spy();
-
-			Klass.addInitHook(spy1);
-			Klass.addInitHook('bar', 1, 2, 3);
-
-			new Klass();
-
-			expect(spy1.called).to.be.true;
-			expect(method.calledWith(1, 2, 3));
-		});
-
-		it('inherits constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			const Klass2 = Klass.extend({});
-
-			Klass.addInitHook(spy1);
-			Klass2.addInitHook(spy2);
-
-			new Klass2();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.be.true;
-		});
-
-		it('does not call child constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			const Klass2 = Klass.extend({});
-
-			Klass.addInitHook(spy1);
-			Klass2.addInitHook(spy2);
-
-			new Klass();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.eql(false);
-		});
-
-		it('calls parent constructor hooks when child has none', () => {
-			const spy1 = sinon.spy();
-
-			Klass.addInitHook(spy1);
-
-			const Klass2 = Klass.extend({});
-			new Klass2();
-
-			expect(spy1.called).to.be.true;
-		});
-	});
-
-	describe('#extend', () => {
+	describe('#extends', () => {
 		it('merges options instead of replacing them', () => {
 			class KlassWithOptions1 extends Class {
 				static {
@@ -345,7 +65,7 @@ describe('Class', () => {
 		let Klass;
 
 		beforeEach(() => {
-			Klass = Class.extend({});
+			Klass = class extends Class {};
 		});
 
 		it('returns the class with the extra methods', () => {
@@ -366,9 +86,11 @@ describe('Class', () => {
 
 		it('keeps parent options', () => { // #6070
 
-			const Quux = Class.extend({
-				options: {foo: 'Foo!'}
-			});
+			class Quux extends Class {
+				static {
+					this.setDefaultOptions({foo: 'Foo!'});
+				}
+			}
 
 			Quux.include({
 				options: {bar: 'Bar!'}
@@ -384,15 +106,6 @@ describe('Class', () => {
 			const K = Klass.include(props);
 
 			expect(K.prototype.options).not.to.equal(props.options);
-		});
-
-		it('does not replace source props.options object', () => {
-			const K1 = Klass.include({options: {}});
-			const opts = {};
-			const props = {options: opts};
-			K1.extend(props);
-
-			expect(props.options).to.equal(opts);
 		});
 	});
 

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -419,11 +419,11 @@ describe('Events', () => {
 			spy2 = sinon.spy(),
 			spy3 = sinon.spy();
 
-			const Klass = Evented.extend({
-				on: spy1,
-				off: spy2,
-				fire: spy3
-			});
+			class Klass extends Evented {
+				on = spy1;
+				off = spy2;
+				fire = spy3;
+			}
 
 			const obj = new Klass();
 

--- a/spec/suites/dom/DomEvent.DoubleTapSpec.js
+++ b/spec/suites/dom/DomEvent.DoubleTapSpec.js
@@ -97,11 +97,11 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		const spyCtrl = sinon.spy();
 		const ctrl = DomUtil.create('div');
 		DomEvent.disableClickPropagation(ctrl);
-		const MyControl = Control.extend({
+		class MyControl extends Control {
 			onAdd() {
 				return ctrl;
 			}
-		});
+		}
 		map.addControl(new MyControl());
 		DomEvent.on(ctrl, 'dblclick', spyCtrl);
 
@@ -119,14 +119,14 @@ describe('DomEvent.DoubleTapSpec.js', () => {
 		map.on('dblclick', spyMap);
 
 		let div;
-		const MyControl = Control.extend({
+		class MyControl extends Control {
 			onAdd() {
 				div = DomUtil.create('div');
 				div.innerHTML = '<input type="checkbox" id="input">' +
 					'<label for="input" style="background: #ffffff; width: 100px; height: 100px;display: block;">Click Me</label>';
 				return div;
 			}
-		});
+		}
 		map.addControl(new MyControl());
 		// click on the label
 		UIEventSimulator.fire('click', div.children[1], {detail: 1});

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -19,14 +19,15 @@ describe('Marker.Drag', () => {
 		removeMapContainer(map, container);
 	});
 
-	const MyMarker = Marker.extend({
+	class MyMarker extends Marker {
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
-		},
+		}
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
 		}
-	}).addInitHook('on', 'add', function () {
+	}
+	MyMarker.addInitHook('on', 'add', function () {
 		this._initialPos = this._getPosition();
 	});
 

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -459,7 +459,11 @@ describe('TileLayer', () => {
 		});
 
 		it('consults options.foo for {foo}', () => {
-			const OSMLayer = TileLayer.extend({options: {foo: 'bar'}});
+			class OSMLayer extends TileLayer {
+				static {
+					this.setDefaultOptions({foo: 'bar'});
+				}
+			}
 			const layer = new OSMLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}').addTo(map);
 			map.options.zoomSnap = 0;
 			map._resetView(new LatLng(0, 0), 2.3);

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -676,17 +676,18 @@ describe('Map', () => {
 
 	describe('#addHandler', () => {
 		function getHandler(callback = () => {}) {
-			return Handler.extend({
+			class CustomHandler extends Handler {
 				addHooks() {
 					DomEvent.on(window, 'click', this.handleClick, this);
-				},
+				}
 
 				removeHooks() {
 					DomEvent.off(window, 'click', this.handleClick, this);
-				},
+				}
 
-				handleClick: callback
-			});
+				handleClick = callback;
+			}
+			return CustomHandler;
 		}
 
 		it('checking enabled method', () => {

--- a/spec/suites/map/handler/Map.DragSpec.js
+++ b/spec/suites/map/handler/Map.DragSpec.js
@@ -53,14 +53,15 @@ describe('LeafletMap.Drag', () => {
 		});
 	});
 
-	const MyMap = LeafletMap.extend({
+	class MyMap extends LeafletMap {
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
-		},
+		}
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
 		}
-	}).addInitHook('on', 'load', function () {
+	}
+	MyMap.addInitHook('on', 'load', function () {
 		this._initialPos = this._getPosition();
 	});
 

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -8,45 +8,6 @@ import * as Util from './Util.js';
 // Thanks to John Resig and Dean Edwards for inspiration!
 
 export class Class {
-	// @function extend(props: Object): Function
-	// [Extends the current class](#class-inheritance) given the properties to be included.
-	// Deprecated - use `class X extends Class` instead!
-	// Returns a Javascript function that is a class constructor (to be called with `new`).
-	static extend({statics, includes, ...props}) {
-		const NewClass = class extends this {};
-
-		// inherit parent's static properties
-		Object.setPrototypeOf(NewClass, this);
-
-		const parentProto = this.prototype;
-		const proto = NewClass.prototype;
-
-		// mix static properties into the class
-		if (statics) {
-			Object.assign(NewClass, statics);
-		}
-
-		// mix includes into the prototype
-		if (Array.isArray(includes)) {
-			for (const include of includes) {
-				NewClass.include(include);
-			}
-		} else if (includes) {
-			NewClass.include(includes);
-		}
-
-		// mix given properties into the prototype
-		Object.assign(proto, props);
-
-		// merge options
-		if (proto.options) {
-			proto.options = parentProto.options ? Object.create(parentProto.options) : {};
-			Object.assign(proto.options, props.options);
-		}
-
-		return NewClass;
-	}
-
 	// @function include(properties: Object): this
 	// [Includes a mixin](#class-includes) into the current class.
 	static include(props) {

--- a/src/core/Class.leafdoc
+++ b/src/core/Class.leafdoc
@@ -3,22 +3,22 @@
 
 Class powers the OOP facilities of Leaflet and is used to create almost all of the Leaflet classes documented here.
 
-In addition to implementing a simple classical inheritance model, it introduces several special properties for convenient code organization — options, includes and statics.
+It implements a simple classical inheritance model using JavaScript's standard `extends` keyword, and introduces several special properties for convenient code organization — options and init hooks.
 
 
 @example
 
 ```js
-const MyClass = Class.extend({
+class MyClass extends Class {
     initialize(greeter) {
         this.greeter = greeter;
         // class constructor
-    },
+    }
 
     greet(name) {
         alert(this.greeter + ', ' + name)
     }
-});
+}
 
 // create instance of MyClass, passing "Hello" to the constructor
 const a = new MyClass("Hello");
@@ -27,65 +27,29 @@ const a = new MyClass("Hello");
 a.greet("World");
 ```
 
-
-@section Inheritance
-@example
-
-You use Class.extend to define new classes, but you can use the same method on any class to inherit from it:
-
-```js
-const MyChildClass = MyClass.extend({
-    // ... new properties and methods
-});
-```
-
-This will create a class that inherits all methods and properties of the parent class (through a proper prototype chain), adding or overriding the ones you pass to extend. It will also properly react to instanceof:
-
-```js
-const a = new MyChildClass();
-a instanceof MyChildClass; // true
-a instanceof MyClass; // true
-```
-
-You can call parent methods (including constructor) from corresponding child ones (as you do with super calls in other languages) by accessing parent class prototype and using JavaScript's call or apply:
-
-```
-const MyChildClass = MyClass.extend({
-    initialize() {
-        MyClass.prototype.initialize.call(this, "Yo");
-    },
-
-    greet(name) {
-        MyClass.prototype.greet.call(this, 'bro ' + name + '!');
-    }
-});
-
-const a = new MyChildClass();
-a.greet('Jason'); // alerts "Yo, bro Jason!"
-```
-
 @section Options
 @example
 
-`options` is a special property that unlike other objects that you pass
-to `extend` will be merged with the parent one instead of overriding it
-completely, which makes managing configuration of objects and default
-values convenient:
+`options` is a special property that will be merged with the parent class options instead of overriding them completely, which makes managing configuration of objects and default values convenient. Use `setDefaultOptions()` in a static block to configure options:
 
 ```js
-const MyClass = Class.extend({
-    options: {
-        myOption1: 'foo',
-        myOption2: 'bar'
+class MyClass extends Class {
+    static {
+        this.setDefaultOptions({
+            myOption1: 'foo',
+            myOption2: 'bar'
+        });
     }
-});
+}
 
-const MyChildClass = MyClass.extend({
-    options: {
-        myOption1: 'baz',
-        myOption3: 5
+class MyChildClass extends MyClass {
+    static {
+        this.setDefaultOptions({
+            myOption1: 'baz',
+            myOption3: 5
+        });
     }
-});
+}
 
 const a = new MyChildClass();
 a.options.myOption1; // 'baz'
@@ -95,20 +59,22 @@ a.options.myOption3; // 5
 
 There's also [`Util.setOptions`](#util-setoptions), a method for
 conveniently merging options passed to constructor with the defaults
-defines in the class:
+defined in the class:
 
 ```js
-const MyClass = Class.extend({
-    options: {
-        foo: 'bar',
-        bla: 5
-    },
+class MyClass extends Class {
+    static {
+        this.setDefaultOptions({
+            foo: 'bar',
+            bla: 5
+        });
+    }
 
     initialize(options) {
         Util.setOptions(this, options);
         ...
     }
-});
+}
 
 const a = new MyClass({bla: 10});
 a.options; // {foo: 'bar', bla: 10}
@@ -120,10 +86,10 @@ This means you can use the options object to store
 application specific information, as long as you avoid
 keys that are already used by the class in question.
 
-@section Includes
+@section Mixins
 @example
 
-`includes` is a special class property that merges all specified objects into the class (such objects are called mixins).
+You can add methods and properties from other objects using the `include` method (such objects are called mixins):
 
 ```js
 const MyMixin = {
@@ -131,31 +97,12 @@ const MyMixin = {
     bar: 5
 };
 
-const MyClass = Class.extend({
-    includes: MyMixin
-});
+class MyClass extends Class {}
+
+MyClass.include(MyMixin);
 
 const a = new MyClass();
 a.foo();
-```
-
-You can also do such includes in runtime with the `include` method:
-
-```js
-MyClass.include(MyMixin);
-```
-
-`statics` is just a convenience property that injects specified object properties as the static properties of the class, useful for defining constants:
-
-```js
-const MyClass = Class.extend({
-    statics: {
-        FOO: 'bar',
-        BLA: 5
-    }
-});
-
-MyClass.FOO; // 'bar'
 ```
 
 


### PR DESCRIPTION
Removes `Class.extend()` entirely, as it is fundamentally incompatible with regular class constructors (see #9906). This change is a prerequisite to a follow-up PR, which will replace all `initialize()` methods with a proper class constructor. The documentation has also been re-written to reflect the removal of `Class.extend()`.