### PR TITLE
Add tonghohin/shadcn-map plugin to docs

### DIFF
--- a/docs/_plugins/frameworks-build-systems/shadcn-map.md
+++ b/docs/_plugins/frameworks-build-systems/shadcn-map.md
@@ -1,0 +1,13 @@
+---
+name: \@shadcn-map/map
+category: frameworks-build-systems
+repo: https://github.com/tonghohin/shadcn-map
+author: Hin Tong
+author-url: https://tonghohin.vercel.app/
+demo: https://shadcn-map.vercel.app/
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+A map component integrated with [shadcn/ui](https://ui.shadcn.com/), built with Leaflet and React Leaflet.


### PR DESCRIPTION
A map component integrated with [shadcn/ui](https://ui.shadcn.com/), built with Leaflet and React Leaflet.

Demo: https://shadcn-map.vercel.app/


