### PR TITLE
Use latest LTS version of Node.js (v24)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 permissions:
   contents: read
 env:
-  NODE_VERSION: 18
+  NODE_VERSION: 24
 jobs:
   setup:
     runs-on: ${{ matrix.os }}

--- a/build/integrity.js
+++ b/build/integrity.js
@@ -3,13 +3,10 @@
 import {readFileSync, writeFileSync} from 'node:fs';
 import https from 'node:https';
 import ssri from 'ssri';
-
-// TODO: Replace this with a regular import when ESLint adds support for import assertions.
-// See: https://rollupjs.org/guide/en/#importing-packagejson
-const {version} = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
+import pkg from '../package.json' with {type: 'json'};
 
 const getIntegrity = path => new Promise((resolve) => {
-	https.get(`https://cdn.jsdelivr.net/npm/leaflet@${version}/dist/${path}`, (res) => {
+	https.get(`https://cdn.jsdelivr.net/npm/leaflet@${pkg.version}/dist/${path}`, (res) => {
 		ssri.fromStream(res, {algorithms: ['sha256']}).then(integrity => resolve(integrity.toString()));
 	});
 });
@@ -20,7 +17,7 @@ const integrityUglifiedGlobal = await getIntegrity('leaflet-global.js');
 const integritySrcGlobal = await getIntegrity('leaflet-global-src.js');
 const integrityCss = await getIntegrity('leaflet.css');
 
-console.log(`Integrity hashes for ${version}:`);
+console.log(`Integrity hashes for ${pkg.version}:`);
 console.log(`dist/leaflet.js:            ${integrityUglified}`);
 console.log(`dist/leaflet-src.js:        ${integritySrc}`);
 console.log(`dist/leaflet-global.js:     ${integrityUglifiedGlobal}`);
@@ -30,7 +27,7 @@ console.log(`dist/leaflet.css:           ${integrityCss}`);
 let docConfig = readFileSync('docs/_config.yml', 'utf8');
 
 docConfig = docConfig
-	.replace(/latest_leaflet_version:.*/,  `latest_leaflet_version: ${version}`)
+	.replace(/latest_leaflet_version:.*/,  `latest_leaflet_version: ${pkg.version}`)
 	.replace(/integrity_hash_source:.*/,   `integrity_hash_source: "${integritySrc}"`)
 	.replace(/integrity_hash_uglified:.*/, `integrity_hash_uglified: "${integrityUglified}"`)
 	.replace(/integrity_hash_global_source:.*/,   `integrity_hash_global_source: "${integritySrcGlobal}"`)

--- a/build/rollup-config.js
+++ b/build/rollup-config.js
@@ -2,10 +2,8 @@ import json from '@rollup/plugin-json';
 import {readFileSync} from 'node:fs';
 import rollupGitVersion from 'rollup-plugin-git-version';
 import {simpleGit} from 'simple-git';
+import pkg from '../package.json' with {type: 'json'};
 
-// TODO: Replace this with a regular import when ESLint adds support for import assertions.
-// See: https://rollupjs.org/guide/en/#importing-packagejson
-const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
 const release = process.env.NODE_ENV === 'release';
 const version = await getVersion();
 const banner = createBanner(version);

--- a/build/version.js
+++ b/build/version.js
@@ -1,8 +1,5 @@
 import {readFileSync, writeFileSync} from 'node:fs';
-
-// TODO: Replace this with a regular import when ESLint adds support for import assertions.
-// See: https://rollupjs.org/guide/en/#importing-packagejson
-const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url)));
+import pkg from '../package.json' with {type: 'json'};
 
 const fileContent = readFileSync(new URL('../src/Leaflet.js', import.meta.url), 'utf8');
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,11 +11,6 @@ export default [
 		files: ['**/*.js', '**/*.cjs'],
 	})),
 	{
-		languageOptions: {
-			ecmaVersion: 'latest',
-		},
-	},
-	{
 		ignores: [
 			'dist/*.js',
 			'docs/docs/highlight',
@@ -109,14 +104,6 @@ export default [
 		},
 		rules: {
 			'no-unused-expressions': 'off'
-		}
-	},
-	{
-		files: ['build/**'],
-		languageOptions: {
-			parserOptions: {
-				ecmaVersion: 2022
-			}
 		}
 	},
 	{


### PR DESCRIPTION
Upgrades the CI to use the latest LTS version of Node.js (v24). Additionally, this PR replaces manual JSON parsing with regular imports, and defaults all linting to the latest ECMAScript version.