### PR TITLE
Mark leaflet-gpx as compatible with v2.x

### DIFF
--- a/docs/_plugins/overlay-data-formats/leaflet-gpx.md
+++ b/docs/_plugins/overlay-data-formats/leaflet-gpx.md
@@ -7,7 +7,7 @@ author-url: https://github.com/mpetazzoni/
 demo: https://mpetazzoni.github.io/leaflet-gpx/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 GPX layer, targeted at sporting activities by providing access to information such as distance, moving time, pace, elevation, heart rate, etc.


### PR DESCRIPTION
The Leaflet GPX plugin (in its `main` branch) is now compatible with v2.x, verified against the latest Leaflet alpha release.