### PR TITLE
Consistently call super class `initialize()` method

### DIFF
--- a/src/control/Control.Attribution.js
+++ b/src/control/Control.Attribution.js
@@ -1,7 +1,6 @@
 
 import {Control} from './Control.js';
 import {LeafletMap} from '../map/Map.js';
-import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
@@ -36,7 +35,7 @@ export class Attribution extends Control {
 	}
 
 	initialize(options) {
-		Util.setOptions(this, options);
+		super.initialize(options);
 
 		this._attributions = {};
 	}

--- a/src/control/Control.Layers.js
+++ b/src/control/Control.Layers.js
@@ -86,7 +86,7 @@ export class Layers extends Control {
 	}
 
 	initialize(baseLayers, overlays, options) {
-		Util.setOptions(this, options);
+		super.initialize(options);
 
 		this._layerControlInputs = [];
 		this._layers = [];

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -88,9 +88,7 @@ export class GeoJSON extends FeatureGroup {
 	 */
 
 	initialize(geojson, options) {
-		Util.setOptions(this, options);
-
-		this._layers = {};
+		super.initialize(undefined, options);
 
 		if (geojson) {
 			this.addData(geojson);

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -24,6 +24,7 @@ import {Point} from '../../geometry/Point.js';
 
 export class MarkerDrag extends Handler {
 	initialize(marker) {
+		super.initialize(marker._map);
 		this._marker = marker;
 	}
 

--- a/src/layer/tile/TileLayer.WMS.js
+++ b/src/layer/tile/TileLayer.WMS.js
@@ -1,5 +1,4 @@
 import {TileLayer} from './TileLayer.js';
-import {setOptions} from '../../core/Util.js';
 import Browser from '../../core/Browser.js';
 import {EPSG4326} from '../../geo/crs/CRS.EPSG4326.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -69,22 +68,20 @@ export class TileLayerWMS extends TileLayer {
 	}
 
 	initialize(url, options) {
-
-		this._url = url;
+		super.initialize(url, options);
 
 		const wmsParams = {...this.defaultWmsParams};
 
-		// all keys that are not TileLayer options go to WMS params
-		for (const i of Object.keys(options)) {
-			if (!(i in this.options)) { // do not use Object.keys here, as it excludes options inherited from TileLayer
-				wmsParams[i] = options[i];
+		// Options that are unknown in the prototype chain are considered WMS params.
+		for (const [key, value] of Object.entries(options)) {
+			if (!(key in TileLayerWMS.prototype.options)) {
+				wmsParams[key] = value;
 			}
 		}
 
-		options = setOptions(this, options);
-
-		const realRetina = options.detectRetina && Browser.retina ? 2 : 1;
+		const realRetina = this.options.detectRetina && Browser.retina ? 2 : 1;
 		const tileSize = this.getTileSize();
+
 		wmsParams.width = tileSize.x * realRetina;
 		wmsParams.height = tileSize.y * realRetina;
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -89,46 +89,45 @@ export class TileLayer extends GridLayer {
 	}
 
 	initialize(url, options) {
+		super.initialize(options);
 
 		this._url = url;
 
-		options = Util.setOptions(this, options);
-
 		// in case the attribution hasn't been specified, check for known hosts that require attribution
-		if (options.attribution === null) {
+		if (this.options.attribution === null) {
 			const urlHostname = new URL(url, location.href).hostname;
 
 			// check for Open Street Map hosts
 			const osmHosts = ['tile.openstreetmap.org', 'tile.osm.org'];
 			if (osmHosts.some(host => urlHostname.endsWith(host))) {
-				options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+				this.options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			}
 		}
 
 		// detecting retina displays, adjusting tileSize and zoom levels
-		if (options.detectRetina && Browser.retina && options.maxZoom > 0) {
+		if (this.options.detectRetina && Browser.retina && this.options.maxZoom > 0) {
 
-			options.tileSize = Math.floor(options.tileSize / 2);
+			this.options.tileSize = Math.floor(this.options.tileSize / 2);
 
-			if (!options.zoomReverse) {
-				options.zoomOffset++;
-				options.maxZoom = Math.max(options.minZoom, options.maxZoom - 1);
+			if (!this.options.zoomReverse) {
+				this.options.zoomOffset++;
+				this.options.maxZoom = Math.max(this.options.minZoom, this.options.maxZoom - 1);
 			} else {
-				options.zoomOffset--;
-				options.minZoom = Math.min(options.maxZoom, options.minZoom + 1);
+				this.options.zoomOffset--;
+				this.options.minZoom = Math.min(this.options.maxZoom, this.options.minZoom + 1);
 			}
 
-			options.minZoom = Math.max(0, options.minZoom);
-		} else if (!options.zoomReverse) {
+			this.options.minZoom = Math.max(0, this.options.minZoom);
+		} else if (!this.options.zoomReverse) {
 			// make sure maxZoom is gte minZoom
-			options.maxZoom = Math.max(options.minZoom, options.maxZoom);
+			this.options.maxZoom = Math.max(this.options.minZoom, this.options.maxZoom);
 		} else {
 			// make sure minZoom is lte maxZoom
-			options.minZoom = Math.min(options.maxZoom, options.minZoom);
+			this.options.minZoom = Math.min(this.options.maxZoom, this.options.minZoom);
 		}
 
-		if (typeof options.subdomains === 'string') {
-			options.subdomains = options.subdomains.split('');
+		if (typeof this.options.subdomains === 'string') {
+			this.options.subdomains = this.options.subdomains.split('');
 		}
 
 		this.on('tileunload', this._onTileRemove);

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,7 +1,5 @@
 import {CircleMarker} from './CircleMarker.js';
 import {Path} from './Path.js';
-import * as Util from '../../core/Util.js';
-import {LatLng} from '../../geo/LatLng.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
 import {Earth} from '../../geo/crs/CRS.Earth.js';
 
@@ -27,8 +25,7 @@ import {Earth} from '../../geo/crs/CRS.Earth.js';
 export class Circle extends CircleMarker {
 
 	initialize(latlng, options) {
-		Util.setOptions(this, options);
-		this._latlng = new LatLng(latlng);
+		super.initialize(latlng, options);
 
 		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -26,7 +26,7 @@ import * as Util from '../../core/Util.js';
 export class Renderer extends BlanketOverlay {
 
 	initialize(options) {
-		Util.setOptions(this, {...options, continuous: false});
+		super.initialize({...options, continuous: false});
 		Util.stamp(this);
 		this._layers ??= {};
 	}

--- a/src/map/handler/Map.BoxZoom.js
+++ b/src/map/handler/Map.BoxZoom.js
@@ -21,7 +21,7 @@ LeafletMap.mergeOptions({
 
 export class BoxZoom extends Handler {
 	initialize(map) {
-		this._map = map;
+		super.initialize(map);
 		this._container = map._container;
 		this._pane = map._panes.overlayPane;
 		this._resetStateTimeout = 0;

--- a/src/map/handler/Map.Keyboard.js
+++ b/src/map/handler/Map.Keyboard.js
@@ -33,7 +33,7 @@ export class Keyboard extends Handler {
 	};
 
 	initialize(map) {
-		this._map = map;
+		super.initialize(map);
 
 		this._setPanDelta(map.options.keyboardPanDelta);
 		this._setZoomDelta(map.options.zoomDelta);


### PR DESCRIPTION
As part of landing standard JavaScript class constructors, we must consistently call the constructor of the super class. This is currently not the case with the existing `initialize()` method, so this PR adds these changes first, before migrating fully over to standard constructors. This is to ensure the size of the PR doesn't get too big and its contents remain reviewable.