### PR TITLE
docs: remove L. global references from example documentation

### DIFF
--- a/docs/examples/crs-simple/index.md
+++ b/docs/examples/crs-simple/index.md
@@ -37,7 +37,7 @@ A Leaflet map has one CRS (and *one* CRS *only*), that can be changed when creat
 		crs: CRS.Simple
 	});
 
-Then we can just add a `L.ImageOverlay` with the starmap image and its *approximate* bounds:
+Then we can just add an `ImageOverlay` with the starmap image and its *approximate* bounds:
 
 	const bounds = [[0,0], [1000,1000]];
 	const image = new ImageOverlay('uqm_map_full.png', bounds).addTo(map);
@@ -64,7 +64,7 @@ In a `CRS.Simple`, one horizontal map unit is mapped to one horizontal pixel, an
 
 ### Pixels vs. Map Units
 
-One common mistake when using `CRS.Simple` is assuming that the map units equal image pixels. In this case, the map covers 1000x1000 units, but the image is 2315x2315 pixels big. Different cases will call for one pixel = one map unit, or 64 pixels = one map unit, or anything. **Think in map units** in a grid, and then add your layers (`L.ImageOverlay`s, `L.Marker`s and so on) accordingly.
+One common mistake when using `CRS.Simple` is assuming that the map units equal image pixels. In this case, the map covers 1000x1000 units, but the image is 2315x2315 pixels big. Different cases will call for one pixel = one map unit, or 64 pixels = one map unit, or anything. **Think in map units** in a grid, and then add your layers (`ImageOverlay`s, `Marker`s and so on) accordingly.
 
 In fact, the image we're using covers more than 1000 map units - there is a sizable margin. Measuring how many pixels there are between the 0 and 1000 coordinates, and extrapolating, we can have the right coordinate bounds for this image:
 
@@ -85,9 +85,9 @@ You'll notice that Sol is at coordinates `[145,175]` instead of `[175,145]`, and
 
 <small>(In technical terms, Leaflet prefers to use [`[northing, easting]`](https://en.wikipedia.org/wiki/Easting_and_northing) over `[easting, northing]` - the first coordinate in a coordinate pair points "north" and the second points "east")</small>
 
-The debate about whether `[lng, lat]` or `[lat, lng]` or `[y, x]` or `[x, y]` [is not new, and there is no clear consensus](http://www.macwright.org/lonlat/). This lack of consensus is why Leaflet has a class named `L.LatLng` instead of the more confusion-prone `L.Coordinate`.
+The debate about whether `[lng, lat]` or `[lat, lng]` or `[y, x]` or `[x, y]` [is not new, and there is no clear consensus](http://www.macwright.org/lonlat/). This lack of consensus is why Leaflet has a class named `LatLng` instead of the more confusion-prone `Coordinate`.
 
-If working with `[y, x]` coordinates with something named `L.LatLng` doesn't make much sense to you, you can easily create wrappers for them:
+If working with `[y, x]` coordinates with something named `LatLng` doesn't make much sense to you, you can easily create wrappers for them:
 
 	const yx = LatLng;
 

--- a/docs/examples/custom-icons/index.md
+++ b/docs/examples/custom-icons/index.md
@@ -24,7 +24,7 @@ Note that the white area in the images is actually transparent.
 
 ### Creating an icon
 
-Marker icons in Leaflet are defined by [L.Icon](/reference.html#icon) objects, which are passed as an option when creating markers. Let's create a green leaf icon:
+Marker icons in Leaflet are defined by [`Icon`](/reference.html#icon) objects, which are passed as an option when creating markers. Let's create a green leaf icon:
 
 ```js
 const greenIcon = new Icon({
@@ -48,7 +48,7 @@ const marker = new Marker([51.5, -0.09], {icon: greenIcon}).addTo(map);
 
 ### Defining an icon class
 
-What if we need to create several icons that have lots in common? Let's define our own icon class containing the shared options, inheriting from `L.Icon`! It's really easy in Leaflet:
+What if we need to create several icons that have lots in common? Let's define our own icon class containing the shared options, inheriting from `Icon`! It's really easy in Leaflet:
 
 ```js
 class LeafIcon extends Icon {
@@ -81,4 +81,4 @@ new Marker([51.495, -0.083], {icon: redIcon}).addTo(map).bindPopup("I am a red l
 new Marker([51.49, -0.1], {icon: orangeIcon}).addTo(map).bindPopup("I am an orange leaf.");
 ```
 
-That's it. Now take a look at the [full example](example.html), the [`L.Icon` docs](/reference.html#icon), or browse [other examples](../../examples.html).
+That's it. Now take a look at the [full example](example.html), the [`Icon` docs](/reference.html#icon), or browse [other examples](../../examples.html).

--- a/docs/examples/map-panes/index.md
+++ b/docs/examples/map-panes/index.md
@@ -57,7 +57,7 @@ If we create a Leaflet map with these two tile layers, any marker or polygon wil
 
 We can use the defaults for the basemap tiles and some overlays like GeoJSON layers, but we have to define a custom pane for the labels, so they show on top of the GeoJSON data.
 
-Custom map panes are created on a per-map basis, so first create an instance of `L.Map` and the pane:
+Custom map panes are created on a per-map basis, so first create an instance of `LeafletMap` and the pane:
 
 
     const map = new LeafletMap('map');

--- a/docs/examples/zoom-levels/index.md
+++ b/docs/examples/zoom-levels/index.md
@@ -146,7 +146,7 @@ the cylindrical projection that Leaflet uses is <i>conformal</i> (preserves shap
 but not <i>equidistant</i> (does not preserve distances), and not <i>equal-area</i>
 (does not preserve areas, as things near the equator appear smaller than they are).
 
-By adding a `L.Control.Scale` to a map, and panning to the equator and to 60° north,
+By adding a `Control.Scale` to a map, and panning to the equator and to 60° north,
 we can see how the scale factor <b>doubles</b>. The following example uses
 [javascript timeouts](https://developer.mozilla.org/docs/Web/API/WindowTimers/setTimeout)
 to  do this automatically:
@@ -162,7 +162,7 @@ to  do this automatically:
 
 {% include frame.html url="example-scale.html" %}
 
-`L.Control.Scale` shows the scale which applies to the center point of the map.
+`Control.Scale` shows the scale which applies to the center point of the map.
 At high zoom levels, the scale changes very little, and is not noticeable.
 
 
@@ -234,7 +234,7 @@ snap the zoom level.
 
 There is another important map option related to `zoomSnap`: [the `zoomDelta` option](/reference.html#map-zoomdelta).
 This controls how many zoom levels to zoom in/out when using the zoom buttons
-(from the default [`L.Control.Zoom`](/reference.html#control-zoom))
+(from the default [`Control.Zoom`](/reference.html#control-zoom))
 or the `+`/`-` keys in your keyboard.
 
 For the mousewheel zoom, the [`wheelPxPerZoomLevel`](/reference.html#map-wheelpxperzoomlevel)


### PR DESCRIPTION
## Summary
Updated documentation to remove references to the `L.` global variable in favor of direct class names, as part of the Leaflet 2.x migration.

## Changes
- `custom-icons/index.md`: `L.Icon` → `Icon`
- `zoom-levels/index.md`: `L.Control.Scale` → `Control.Scale`, `L.Control.Zoom` → `Control.Zoom`
- `map-panes/index.md`: `L.Map` → `LeafletMap`
- `crs-simple/index.md`: `L.ImageOverlay` → `ImageOverlay`, `L.Marker` → `Marker`, `L.LatLng` → `LatLng`

## Context
This is a partial fix for #10036. The `L` global was removed from the ESM distribution in Leaflet 2.x (see #10027), so documentation should use direct class names instead of the `L.` prefix.

This PR focuses on a subset of the example documentation files.

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297