### PR TITLE
Replace `setDefaultOptions` with `static defaultOptions`

### DIFF
--- a/docs/examples/custom-icons/example-one-icon.md
+++ b/docs/examples/custom-icons/example-one-icon.md
@@ -11,16 +11,14 @@ title: Single Custom Icon Example
 	}).addTo(map);
 
 	class LeafIcon extends Icon {
-		static {
-			this.setDefaultOptions({
-				shadowUrl: 'leaf-shadow.png',
-				iconSize:     [38, 95],
-				shadowSize:   [50, 64],
-				iconAnchor:   [22, 94],
-				shadowAnchor: [4, 62],
-				popupAnchor:  [-3, -76]
-			});
-		}
+		static defaultOptions = {
+			shadowUrl: 'leaf-shadow.png',
+			iconSize:     [38, 95],
+			shadowSize:   [50, 64],
+			iconAnchor:   [22, 94],
+			shadowAnchor: [4, 62],
+			popupAnchor:  [-3, -76]
+		};
 	}
 
 	const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'});

--- a/docs/examples/custom-icons/example.md
+++ b/docs/examples/custom-icons/example.md
@@ -11,16 +11,14 @@ title: Custom Icons Example
 	}).addTo(map);
 
 	class LeafIcon extends Icon {
-		static {
-			this.setDefaultOptions({
-				shadowUrl: 'leaf-shadow.png',
-				iconSize:     [38, 95],
-				shadowSize:   [50, 64],
-				iconAnchor:   [22, 94],
-				shadowAnchor: [4, 62],
-				popupAnchor:  [-3, -76]
-			});
-		}
+		static defaultOptions = {
+			shadowUrl: 'leaf-shadow.png',
+			iconSize:     [38, 95],
+			shadowSize:   [50, 64],
+			iconAnchor:   [22, 94],
+			shadowAnchor: [4, 62],
+			popupAnchor:  [-3, -76]
+		};
 	}
 
 	const greenIcon = new LeafIcon({iconUrl: 'leaf-green.png'});

--- a/docs/examples/custom-icons/index.md
+++ b/docs/examples/custom-icons/index.md
@@ -52,16 +52,14 @@ What if we need to create several icons that have lots in common? Let's define o
 
 ```js
 class LeafIcon extends Icon {
-	static {
-		this.setDefaultOptions({
-			shadowUrl: 'leaf-shadow.png',
-			iconSize:     [38, 95],
-			shadowSize:   [50, 64],
-			iconAnchor:   [22, 94],
-			shadowAnchor: [4, 62],
-			popupAnchor:  [-3, -76]
-		});
-	}
+	static defaultOptions = {
+		shadowUrl: 'leaf-shadow.png',
+		iconSize:     [38, 95],
+		shadowSize:   [50, 64],
+		iconAnchor:   [22, 94],
+		shadowAnchor: [4, 62],
+		popupAnchor:  [-3, -76]
+	};
 }
 ```
 

--- a/docs/examples/extending-1-classes/index.md
+++ b/docs/examples/extending-1-classes/index.md
@@ -54,16 +54,14 @@ When creating Leaflet classes, adhere to these conventions:
 
 ### Setting default options
 
-All classes that extend from `L.Class` can be provided with default options by calling `setDefaultOptions()` in a [static initialization block](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks):
+All classes that extend from `L.Class` can be provided with default options by specifying `static defaultOptions = {...}`:
 
 ```js
 class MyBox extends Class {
-	static {
-		this.setDefaultOptions({
-			width: 1,
-			height: 1
-		});
-	}
+	static defaultOptions = {
+		width: 1,
+		height: 1
+	};
 
 	initialize(name, options) {
 		super.initialize(options);
@@ -82,11 +80,9 @@ These options are inherited from parent classes, and merged automatically:
 
 ```js
 class MyCube extends MyBox {
-	static {
-		this.setDefaultOptions({
-			depth: 1
-		});
-	}
+	static defaultOptions = {
+		depth: 1
+	};
 }
 
 const cube = new MyCube('Blue');
@@ -135,12 +131,10 @@ Use `addInitHook()` to run code after `initialize()` completes. This is useful f
 
 ```js
 class MyBox extends Class {
-	static {
-		this.setDefaultOptions({
-			width: 1,
-			height: 1
-		});
-	}
+	static defaultOptions = {
+		width: 1,
+		height: 1
+	};
 }
 
 MyBox.addInitHook(function() {
@@ -161,11 +155,9 @@ console.log(box.getArea()); // Outputs "50"
 
 ```js
 class MyCube extends MyBox {
-	static {
-		this.setDefaultOptions({
-			depth: 1
-		});
-	}
+	static defaultOptions = {
+		depth: 1
+	};
 
 	_calculateVolume(multiplier/*, arg2, arg3. etc. */) {
 		this._volume = this.options.width * this.options.height * this.options.depth * multiplier;

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -6,20 +6,16 @@ describe('Class', () => {
 	describe('#extends', () => {
 		it('merges options instead of replacing them', () => {
 			class KlassWithOptions1 extends Class {
-				static {
-					this.setDefaultOptions({
-						foo1: 1,
-						foo2: 2
-					});
-				}
+				static defaultOptions = ({
+					foo1: 1,
+					foo2: 2
+				});
 			}
 			class KlassWithOptions2 extends KlassWithOptions1 {
-				static {
-					this.setDefaultOptions({
-						foo2: 3,
-						foo3: 4
-					});
-				}
+				static defaultOptions = ({
+					foo2: 3,
+					foo3: 4
+				});
 			}
 
 			const a = new KlassWithOptions2();
@@ -87,9 +83,7 @@ describe('Class', () => {
 		it('keeps parent options', () => { // #6070
 
 			class Quux extends Class {
-				static {
-					this.setDefaultOptions({foo: 'Foo!'});
-				}
+				static defaultOptions = ({foo: 'Foo!'});
 			}
 
 			Quux.include({

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -6,16 +6,16 @@ describe('Class', () => {
 	describe('#extends', () => {
 		it('merges options instead of replacing them', () => {
 			class KlassWithOptions1 extends Class {
-				static defaultOptions = ({
+				static defaultOptions = {
 					foo1: 1,
 					foo2: 2
-				});
+				};
 			}
 			class KlassWithOptions2 extends KlassWithOptions1 {
-				static defaultOptions = ({
+				static defaultOptions = {
 					foo2: 3,
 					foo3: 4
-				});
+				};
 			}
 
 			const a = new KlassWithOptions2();
@@ -83,7 +83,7 @@ describe('Class', () => {
 		it('keeps parent options', () => { // #6070
 
 			class Quux extends Class {
-				static defaultOptions = ({foo: 'Foo!'});
+				static defaultOptions = {foo: 'Foo!'};
 			}
 
 			Quux.include({
@@ -103,5 +103,15 @@ describe('Class', () => {
 		});
 	});
 
-	// TODO Class.mergeOptions
+	describe('#mergeOptions', () => {
+		it('merges options', () => {
+			class MergingClass extends Class {
+				static defaultOptions = {foo: 'Foo!'};
+			}
+			MergingClass.mergeOptions({bar: 'Bar!'});
+			const k = new MergingClass();
+			expect(k.options.foo).to.eql('Foo!');
+			expect(k.options.bar).to.eql('Bar!');
+		});
+	});
 });

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -460,7 +460,7 @@ describe('TileLayer', () => {
 
 		it('consults options.foo for {foo}', () => {
 			class OSMLayer extends TileLayer {
-				static defaultOptions = ({foo: 'bar'});
+				static defaultOptions = {foo: 'bar'};
 			}
 			const layer = new OSMLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}').addTo(map);
 			map.options.zoomSnap = 0;

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -460,9 +460,7 @@ describe('TileLayer', () => {
 
 		it('consults options.foo for {foo}', () => {
 			class OSMLayer extends TileLayer {
-				static {
-					this.setDefaultOptions({foo: 'bar'});
-				}
+				static defaultOptions = ({foo: 'bar'});
 			}
 			const layer = new OSMLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}').addTo(map);
 			map.options.zoomSnap = 0;

--- a/spec/suites/layer/tile/WMSTileLayerSpec.js
+++ b/spec/suites/layer/tile/WMSTileLayerSpec.js
@@ -6,7 +6,7 @@ describe('WMSTileLayer', () => {
 		it('sets wmsParams', () => {
 			const layer = new WMSTileLayer('https://example.com/map', {opacity: 0.5, attribution: 'foo'});
 			expect(layer.wmsParams).to.eql({
-				...layer.defaultWmsParams,
+				...WMSTileLayer.defaultWmsParams,
 				width: 256,
 				height: 256
 			});

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -21,7 +21,7 @@ export class AttributionControl extends Control {
 
 	// @section
 	// @aka AttributionControl options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option position: String = 'bottomright'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -30,7 +30,7 @@ export class AttributionControl extends Control {
 		// @option prefix: String|false = 'Leaflet'
 		// The HTML text shown before the attributions. Pass `false` to disable.
 		prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
-	});
+	};
 
 	initialize(options) {
 		super.initialize(options);

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -19,20 +19,18 @@ const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg
 // Creates an attribution control.
 export class AttributionControl extends Control {
 
-	static {
-		// @section
-		// @aka AttributionControl options
-		this.setDefaultOptions({
-			// @option position: String = 'bottomright'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'bottomright',
+	// @section
+	// @aka AttributionControl options
+	static defaultOptions = ({
+		// @option position: String = 'bottomright'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'bottomright',
 
-			// @option prefix: String|false = 'Leaflet'
-			// The HTML text shown before the attributions. Pass `false` to disable.
-			prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
-		});
-	}
+		// @option prefix: String|false = 'Leaflet'
+		// The HTML text shown before the attributions. Pass `false` to disable.
+		prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
+	});
 
 	initialize(options) {
 		super.initialize(options);

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -14,16 +14,14 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 export class Control extends Class {
 
-	static {
-		// @section
-		// @aka Control Options
-		this.setDefaultOptions({
-			// @option position: String = 'topright'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'topright'
-		});
-	}
+	// @section
+	// @aka Control Options
+	static defaultOptions = ({
+		// @option position: String = 'topright'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'topright'
+	});
 
 
 	initialize(options) {

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -16,12 +16,12 @@ export class Control extends Class {
 
 	// @section
 	// @aka Control Options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option position: String = 'topright'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
 		position: 'topright'
-	});
+	};
 
 
 	initialize(options) {

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -46,44 +46,42 @@ import * as DomUtil from '../dom/DomUtil.js';
 // Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.
 export class LayersControl extends Control {
 
-	static {
-		// @section
-		// @aka LayersControl options
-		this.setDefaultOptions({
-			// @option collapsed: Boolean = true
-			// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
-			collapsed: true,
+	// @section
+	// @aka LayersControl options
+	static defaultOptions = ({
+		// @option collapsed: Boolean = true
+		// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
+		collapsed: true,
 
-			// @option collapseDelay: Number = 0
-			// Collapse delay in milliseconds. If greater than 0, the control will remain open longer, making it easier to scroll through long layer lists.
-			collapseDelay: 0,
+		// @option collapseDelay: Number = 0
+		// Collapse delay in milliseconds. If greater than 0, the control will remain open longer, making it easier to scroll through long layer lists.
+		collapseDelay: 0,
 
-			position: 'topright',
+		position: 'topright',
 
-			// @option autoZIndex: Boolean = true
-			// If `true`, the control will assign zIndexes in increasing order to all of its layers so that the order is preserved when switching them on/off.
-			autoZIndex: true,
+		// @option autoZIndex: Boolean = true
+		// If `true`, the control will assign zIndexes in increasing order to all of its layers so that the order is preserved when switching them on/off.
+		autoZIndex: true,
 
-			// @option hideSingleBase: Boolean = false
-			// If `true`, the base layers in the control will be hidden when there is only one.
-			hideSingleBase: false,
+		// @option hideSingleBase: Boolean = false
+		// If `true`, the base layers in the control will be hidden when there is only one.
+		hideSingleBase: false,
 
-			// @option sortLayers: Boolean = false
-			// Whether to sort the layers. When `false`, layers will keep the order
-			// in which they were added to the control.
-			sortLayers: false,
+		// @option sortLayers: Boolean = false
+		// Whether to sort the layers. When `false`, layers will keep the order
+		// in which they were added to the control.
+		sortLayers: false,
 
-			// @option sortFunction: Function = *
-			// A [compare function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
-			// that will be used for sorting the layers, when `sortLayers` is `true`.
-			// The function receives both the `Layer` instances and their names, as in
-			// `sortFunction(layerA, layerB, nameA, nameB)`.
-			// By default, it sorts layers alphabetically by their name.
-			sortFunction(layerA, layerB, nameA, nameB) {
-				return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
-			}
-		});
-	}
+		// @option sortFunction: Function = *
+		// A [compare function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+		// that will be used for sorting the layers, when `sortLayers` is `true`.
+		// The function receives both the `Layer` instances and their names, as in
+		// `sortFunction(layerA, layerB, nameA, nameB)`.
+		// By default, it sorts layers alphabetically by their name.
+		sortFunction(layerA, layerB, nameA, nameB) {
+			return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
+		}
+	});
 
 	initialize(baseLayers, overlays, options) {
 		super.initialize(options);

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -48,7 +48,7 @@ export class LayersControl extends Control {
 
 	// @section
 	// @aka LayersControl options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option collapsed: Boolean = true
 		// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
 		collapsed: true,
@@ -81,7 +81,7 @@ export class LayersControl extends Control {
 		sortFunction(layerA, layerB, nameA, nameB) {
 			return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
 		}
-	});
+	};
 
 	initialize(baseLayers, overlays, options) {
 		super.initialize(options);

--- a/src/control/ScaleControl.js
+++ b/src/control/ScaleControl.js
@@ -21,7 +21,7 @@ export class ScaleControl extends Control {
 
 	// @section
 	// @aka ScaleControl options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option position: String = 'bottomleft'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -42,7 +42,7 @@ export class ScaleControl extends Control {
 		// @option updateWhenIdle: Boolean = false
 		// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
 		updateWhenIdle: false
-	});
+	};
 
 	onAdd(map) {
 		const className = 'leaflet-control-scale',

--- a/src/control/ScaleControl.js
+++ b/src/control/ScaleControl.js
@@ -19,32 +19,30 @@ import * as DomUtil from '../dom/DomUtil.js';
 // Creates an scale control with the given options.
 export class ScaleControl extends Control {
 
-	static {
-		// @section
-		// @aka ScaleControl options
-		this.setDefaultOptions({
-			// @option position: String = 'bottomleft'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'bottomleft',
+	// @section
+	// @aka ScaleControl options
+	static defaultOptions = ({
+		// @option position: String = 'bottomleft'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'bottomleft',
 
-			// @option maxWidth: Number = 100
-			// Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).
-			maxWidth: 100,
+		// @option maxWidth: Number = 100
+		// Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).
+		maxWidth: 100,
 
-			// @option metric: Boolean = True
-			// Whether to show the metric scale line (m/km).
-			metric: true,
+		// @option metric: Boolean = True
+		// Whether to show the metric scale line (m/km).
+		metric: true,
 
-			// @option imperial: Boolean = True
-			// Whether to show the imperial scale line (mi/ft).
-			imperial: true,
+		// @option imperial: Boolean = True
+		// Whether to show the imperial scale line (mi/ft).
+		imperial: true,
 
-			// @option updateWhenIdle: Boolean = false
-			// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
-			updateWhenIdle: false
-		});
-	}
+		// @option updateWhenIdle: Boolean = false
+		// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
+		updateWhenIdle: false
+	});
 
 	onAdd(map) {
 		const className = 'leaflet-control-scale',

--- a/src/control/ZoomControl.js
+++ b/src/control/ZoomControl.js
@@ -16,32 +16,30 @@ import * as DomEvent from '../dom/DomEvent.js';
 // Creates a zoom control
 export class ZoomControl extends Control {
 
-	static {
-		// @section
-		// @aka ZoomControl options
-		this.setDefaultOptions({
-			// @option position: String = 'topleft'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'topleft',
+	// @section
+	// @aka ZoomControl options
+	static defaultOptions = ({
+		// @option position: String = 'topleft'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'topleft',
 
-			// @option zoomInText: String = '<span aria-hidden="true">+</span>'
-			// The text set on the 'zoom in' button.
-			zoomInText: '<span aria-hidden="true">+</span>',
+		// @option zoomInText: String = '<span aria-hidden="true">+</span>'
+		// The text set on the 'zoom in' button.
+		zoomInText: '<span aria-hidden="true">+</span>',
 
-			// @option zoomInTitle: String = 'Zoom in'
-			// The title set on the 'zoom in' button.
-			zoomInTitle: 'Zoom in',
+		// @option zoomInTitle: String = 'Zoom in'
+		// The title set on the 'zoom in' button.
+		zoomInTitle: 'Zoom in',
 
-			// @option zoomOutText: String = '<span aria-hidden="true">&#x2212;</span>'
-			// The text set on the 'zoom out' button.
-			zoomOutText: '<span aria-hidden="true">&#x2212;</span>',
+		// @option zoomOutText: String = '<span aria-hidden="true">&#x2212;</span>'
+		// The text set on the 'zoom out' button.
+		zoomOutText: '<span aria-hidden="true">&#x2212;</span>',
 
-			// @option zoomOutTitle: String = 'Zoom out'
-			// The title set on the 'zoom out' button.
-			zoomOutTitle: 'Zoom out'
-		});
-	}
+		// @option zoomOutTitle: String = 'Zoom out'
+		// The title set on the 'zoom out' button.
+		zoomOutTitle: 'Zoom out'
+	});
 
 	onAdd(map) {
 		const zoomName = 'leaflet-control-zoom',

--- a/src/control/ZoomControl.js
+++ b/src/control/ZoomControl.js
@@ -18,7 +18,7 @@ export class ZoomControl extends Control {
 
 	// @section
 	// @aka ZoomControl options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option position: String = 'topleft'
 		// The position of the control (one of the map corners). Possible values are `'topleft'`,
 		// `'topright'`, `'bottomleft'` or `'bottomright'`
@@ -39,7 +39,7 @@ export class ZoomControl extends Control {
 		// @option zoomOutTitle: String = 'Zoom out'
 		// The title set on the 'zoom out' button.
 		zoomOutTitle: 'Zoom out'
-	});
+	};
 
 	onAdd(map) {
 		const zoomName = 'leaflet-control-zoom',

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -59,8 +59,8 @@ export class Class {
 
 	static _initDefaultOptions(proto = this.prototype) {
 		if (!proto) { return; }
-		Class._initDefaultOptions(Object.getPrototypeOf(proto)); // parent
 		if (Object.hasOwn(proto, 'options')) { return; }
+		Class._initDefaultOptions(Object.getPrototypeOf(proto)); // parent
 		const options = proto.constructor.defaultOptions;
 		if (!options) { return; }
 		Util.setOptions(proto, options);

--- a/src/core/Class.leafdoc
+++ b/src/core/Class.leafdoc
@@ -30,25 +30,21 @@ a.greet("World");
 @section Options
 @example
 
-`options` is a special property that will be merged with the parent class options instead of overriding them completely, which makes managing configuration of objects and default values convenient. Use `setDefaultOptions()` in a static block to configure options:
+`options` is a special property that will be merged with the parent class options instead of overriding them completely, which makes managing configuration of objects and default values convenient. Specify `static defaultOptions = {...}`: to configure options:
 
 ```js
 class MyClass extends Class {
-    static {
-        this.setDefaultOptions({
-            myOption1: 'foo',
-            myOption2: 'bar'
-        });
-    }
+    static defaultOptions = {
+        myOption1: 'foo',
+        myOption2: 'bar'
+    };
 }
 
 class MyChildClass extends MyClass {
-    static {
-        this.setDefaultOptions({
-            myOption1: 'baz',
-            myOption3: 5
-        });
-    }
+    static defaultOptions = {
+        myOption1: 'baz',
+        myOption3: 5
+    };
 }
 
 const a = new MyChildClass();
@@ -63,12 +59,10 @@ defined in the class:
 
 ```js
 class MyClass extends Class {
-    static {
-        this.setDefaultOptions({
-            foo: 'bar',
-            bla: 5
-        });
-    }
+    static defaultOptions = {
+        foo: 'bar',
+        bla: 5
+    };
 
     initialize(options) {
         Util.setOptions(this, options);

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -88,7 +88,6 @@ export function setOptions(obj, options) {
 	if (!Object.hasOwn(obj, 'options')) {
 		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
-	Object.assign(obj.options, obj.getDefaultOptions?.() ?? {});
 	for (const i in options) {
 		if (Object.hasOwn(options, i)) {
 			obj.options[i] = options[i];

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -88,6 +88,12 @@ export function setOptions(obj, options) {
 	if (!Object.hasOwn(obj, 'options')) {
 		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
+
+	let proto = obj;
+	while ((proto = Object.getPrototypeOf(proto)) !== null) {
+		Object.assign(obj.options, proto.constructor.defaultOptions);
+	}
+
 	for (const i in options) {
 		if (Object.hasOwn(options, i)) {
 			obj.options[i] = options[i];

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -88,12 +88,7 @@ export function setOptions(obj, options) {
 	if (!Object.hasOwn(obj, 'options')) {
 		obj.options = obj.options ? Object.create(obj.options) : {};
 	}
-
-	let proto = obj;
-	while ((proto = Object.getPrototypeOf(proto)) !== null) {
-		Object.assign(obj.options, proto.constructor.defaultOptions);
-	}
-
+	Object.assign(obj.options, obj.getDefaultOptions?.() ?? {});
 	for (const i in options) {
 		if (Object.hasOwn(options, i)) {
 			obj.options[i] = options[i];

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -21,16 +21,14 @@ import * as PointerEvents from './DomEvent.PointerEvents.js';
 
 export class Draggable extends Evented {
 
-	static {
-		this.setDefaultOptions({
-			// @section
-			// @aka Draggable options
-			// @option clickTolerance: Number = 3
-			// The max number of pixels a user can shift the pointer during a click
-			// for it to be considered a valid click (as opposed to a pointer drag).
-			clickTolerance: 3
-		});
-	}
+	static defaultOptions = ({
+		// @section
+		// @aka Draggable options
+		// @option clickTolerance: Number = 3
+		// The max number of pixels a user can shift the pointer during a click
+		// for it to be considered a valid click (as opposed to a pointer drag).
+		clickTolerance: 3
+	});
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -21,14 +21,14 @@ import * as PointerEvents from './DomEvent.PointerEvents.js';
 
 export class Draggable extends Evented {
 
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @section
 		// @aka Draggable options
 		// @option clickTolerance: Number = 3
 		// The max number of pixels a user can shift the pointer during a click
 		// for it to be considered a valid click (as opposed to a pointer drag).
 		clickTolerance: 3
-	});
+	};
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -17,23 +17,21 @@ import {Bounds} from '../geometry/Bounds.js';
 
 export class BlanketOverlay extends Layer {
 
-	static {
-		// @section
-		// @aka BlanketOverlay options
-		this.setDefaultOptions({
-			// @option padding: Number = 0.1
-			// How much to extend the clip area around the map view (relative to its size)
-			// e.g. 0.1 would be 10% of map view in each direction
-			padding: 0.1,
+	// @section
+	// @aka BlanketOverlay options
+	static defaultOptions = ({
+		// @option padding: Number = 0.1
+		// How much to extend the clip area around the map view (relative to its size)
+		// e.g. 0.1 would be 10% of map view in each direction
+		padding: 0.1,
 
-			// @option continuous: Boolean = false
-			// When `false`, the blanket will update its position only when the
-			// map state settles (*after* a pan/zoom animation). When `true`,
-			// it will update when the map state changes (*during* pan/zoom
-			// animations)
-			continuous: false,
-		});
-	}
+		// @option continuous: Boolean = false
+		// When `false`, the blanket will update its position only when the
+		// map state settles (*after* a pan/zoom animation). When `true`,
+		// it will update when the map state changes (*during* pan/zoom
+		// animations)
+		continuous: false,
+	});
 
 	initialize(options) {
 		Util.setOptions(this, options);

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -19,7 +19,7 @@ export class BlanketOverlay extends Layer {
 
 	// @section
 	// @aka BlanketOverlay options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option padding: Number = 0.1
 		// How much to extend the clip area around the map view (relative to its size)
 		// e.g. 0.1 would be 10% of map view in each direction
@@ -31,7 +31,7 @@ export class BlanketOverlay extends Layer {
 		// it will update when the map state changes (*during* pan/zoom
 		// animations)
 		continuous: false,
-	});
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -17,7 +17,7 @@ export class DivOverlay extends Layer {
 
 	// @section
 	// @aka DivOverlay options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option interactive: Boolean = false
 		// If true, the popup/tooltip will listen to the pointer events.
 		interactive: false,
@@ -38,7 +38,7 @@ export class DivOverlay extends Layer {
 		// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
 		// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
 		content: ''
-	});
+	};
 
 	initialize(options, source) {
 		if (options instanceof LatLng || Array.isArray(options)) {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -15,32 +15,30 @@ import * as DomUtil from '../dom/DomUtil.js';
 // @namespace DivOverlay
 export class DivOverlay extends Layer {
 
-	static {
-		// @section
-		// @aka DivOverlay options
-		this.setDefaultOptions({
-			// @option interactive: Boolean = false
-			// If true, the popup/tooltip will listen to the pointer events.
-			interactive: false,
+	// @section
+	// @aka DivOverlay options
+	static defaultOptions = ({
+		// @option interactive: Boolean = false
+		// If true, the popup/tooltip will listen to the pointer events.
+		interactive: false,
 
-			// @option offset: Point = Point(0, 0)
-			// The offset of the overlay position.
-			offset: [0, 0],
+		// @option offset: Point = Point(0, 0)
+		// The offset of the overlay position.
+		offset: [0, 0],
 
-			// @option className: String = ''
-			// A custom CSS class name to assign to the overlay.
-			className: '',
+		// @option className: String = ''
+		// A custom CSS class name to assign to the overlay.
+		className: '',
 
-			// @option pane: String = undefined
-			// `Map pane` where the overlay will be added.
-			pane: undefined,
+		// @option pane: String = undefined
+		// `Map pane` where the overlay will be added.
+		pane: undefined,
 
-			// @option content: String|HTMLElement|Function = ''
-			// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-			// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
-			content: ''
-		});
-	}
+		// @option content: String|HTMLElement|Function = ''
+		// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
+		// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
+		content: ''
+	});
 
 	initialize(options, source) {
 		if (options instanceof LatLng || Array.isArray(options)) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -26,7 +26,7 @@ export class ImageOverlay extends Layer {
 
 	// @section
 	// @aka ImageOverlay options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option opacity: Number = 1.0
 		// The opacity of the image overlay.
 		opacity: 1,
@@ -63,7 +63,7 @@ export class ImageOverlay extends Layer {
 		// If the image overlay is flickering when being added/removed, set
 		// this option to `'sync'`.
 		decoding: 'auto'
-	});
+	};
 
 	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
 		this._url = url;

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -24,48 +24,46 @@ import * as DomUtil from '../dom/DomUtil.js';
 // geographical bounds it is tied to.
 export class ImageOverlay extends Layer {
 
-	static {
-		// @section
-		// @aka ImageOverlay options
-		this.setDefaultOptions({
-			// @option opacity: Number = 1.0
-			// The opacity of the image overlay.
-			opacity: 1,
+	// @section
+	// @aka ImageOverlay options
+	static defaultOptions = ({
+		// @option opacity: Number = 1.0
+		// The opacity of the image overlay.
+		opacity: 1,
 
-			// @option alt: String = ''
-			// Text for the `alt` attribute of the image (useful for accessibility).
-			alt: '',
+		// @option alt: String = ''
+		// Text for the `alt` attribute of the image (useful for accessibility).
+		alt: '',
 
-			// @option interactive: Boolean = false
-			// If `true`, the image overlay will emit [pointer events](#interactive-layer) when clicked or hovered.
-			interactive: false,
+		// @option interactive: Boolean = false
+		// If `true`, the image overlay will emit [pointer events](#interactive-layer) when clicked or hovered.
+		interactive: false,
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the image.
-			// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false,
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the image.
+		// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false,
 
-			// @option errorOverlayUrl: String = ''
-			// URL to the overlay image to show in place of the overlay that failed to load.
-			errorOverlayUrl: '',
+		// @option errorOverlayUrl: String = ''
+		// URL to the overlay image to show in place of the overlay that failed to load.
+		errorOverlayUrl: '',
 
-			// @option zIndex: Number = 1
-			// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the overlay layer.
-			zIndex: 1,
+		// @option zIndex: Number = 1
+		// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the overlay layer.
+		zIndex: 1,
 
-			// @option className: String = ''
-			// A custom class name to assign to the image. Empty by default.
-			className: '',
+		// @option className: String = ''
+		// A custom class name to assign to the image. Empty by default.
+		className: '',
 
-			// @option decoding: String = 'auto'
-			// Tells the browser whether to decode the image in a synchronous fashion,
-			// as per the [`decoding` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
-			// If the image overlay is flickering when being added/removed, set
-			// this option to `'sync'`.
-			decoding: 'auto'
-		});
-	}
+		// @option decoding: String = 'auto'
+		// Tells the browser whether to decode the image in a synchronous fashion,
+		// as per the [`decoding` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
+		// If the image overlay is flickering when being added/removed, set
+		// this option to `'sync'`.
+		decoding: 'auto'
+	});
 
 	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
 		this._url = url;

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -28,21 +28,19 @@ import * as Util from '../core/Util.js';
 
 export class Layer extends Evented {
 
-	static {
-		// Classes extending `Layer` will inherit the following options:
-		this.setDefaultOptions({
-			// @option pane: String = 'overlayPane'
-			// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
-			// Not effective if the `renderer` option is set (the `renderer` option will override the `pane` option).
-			pane: 'overlayPane',
+	// Classes extending `Layer` will inherit the following options:
+	static defaultOptions = {
+		// @option pane: String = 'overlayPane'
+		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
+		// Not effective if the `renderer` option is set (the `renderer` option will override the `pane` option).
+		pane: 'overlayPane',
 
-			// @option attribution: String = null
-			// String to be shown in the attribution control, e.g. "© OpenStreetMap contributors". It describes the layer data and is often a legal obligation towards copyright holders and tile providers.
-			attribution: null,
+		// @option attribution: String = null
+		// String to be shown in the attribution control, e.g. "© OpenStreetMap contributors". It describes the layer data and is often a legal obligation towards copyright holders and tile providers.
+		attribution: null,
 
-			bubblingPointerEvents: true
-		});
-	}
+		bubblingPointerEvents: true
+	};
 
 	/* @section
 	 * Classes extending `Layer` will inherit the following methods:

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -47,89 +47,87 @@ import {FeatureGroup} from './FeatureGroup.js';
 // Instantiates a `Popup` object given `latlng` where the popup will open and an optional `options` object that describes its appearance and location.
 export class Popup extends DivOverlay {
 
-	static {
-		// @section
-		// @aka Popup options
-		this.setDefaultOptions({
-			// @option pane: String = 'popupPane'
-			// `Map pane` where the popup will be added.
-			pane: 'popupPane',
+	// @section
+	// @aka Popup options
+	static defaultOptions = ({
+		// @option pane: String = 'popupPane'
+		// `Map pane` where the popup will be added.
+		pane: 'popupPane',
 
-			// @option offset: Point = Point(0, 7)
-			// The offset of the popup position.
-			offset: [0, 7],
+		// @option offset: Point = Point(0, 7)
+		// The offset of the popup position.
+		offset: [0, 7],
 
-			// @option maxWidth: Number = 300
-			// Max width of the popup, in pixels.
-			maxWidth: 300,
+		// @option maxWidth: Number = 300
+		// Max width of the popup, in pixels.
+		maxWidth: 300,
 
-			// @option minWidth: Number = 50
-			// Min width of the popup, in pixels.
-			minWidth: 50,
+		// @option minWidth: Number = 50
+		// Min width of the popup, in pixels.
+		minWidth: 50,
 
-			// @option maxHeight: Number = null
-			// If set, creates a scrollable container of the given height
-			// inside a popup if its content exceeds it.
-			// The scrollable container can be styled using the
-			// `leaflet-popup-scrolled` CSS class selector.
-			maxHeight: null,
+		// @option maxHeight: Number = null
+		// If set, creates a scrollable container of the given height
+		// inside a popup if its content exceeds it.
+		// The scrollable container can be styled using the
+		// `leaflet-popup-scrolled` CSS class selector.
+		maxHeight: null,
 
-			// @option autoPan: Boolean = true
-			// Set it to `false` if you don't want the map to do panning animation
-			// to fit the opened popup.
-			autoPan: true,
+		// @option autoPan: Boolean = true
+		// Set it to `false` if you don't want the map to do panning animation
+		// to fit the opened popup.
+		autoPan: true,
 
-			// @option autoPanPaddingTopLeft: Point = null
-			// The margin between the popup and the top left corner of the map
-			// view after autopanning was performed.
-			autoPanPaddingTopLeft: null,
+		// @option autoPanPaddingTopLeft: Point = null
+		// The margin between the popup and the top left corner of the map
+		// view after autopanning was performed.
+		autoPanPaddingTopLeft: null,
 
-			// @option autoPanPaddingBottomRight: Point = null
-			// The margin between the popup and the bottom right corner of the map
-			// view after autopanning was performed.
-			autoPanPaddingBottomRight: null,
+		// @option autoPanPaddingBottomRight: Point = null
+		// The margin between the popup and the bottom right corner of the map
+		// view after autopanning was performed.
+		autoPanPaddingBottomRight: null,
 
-			// @option autoPanPadding: Point = Point(5, 5)
-			// Equivalent of setting both top left and bottom right autopan padding to the same value.
-			autoPanPadding: [5, 5],
+		// @option autoPanPadding: Point = Point(5, 5)
+		// Equivalent of setting both top left and bottom right autopan padding to the same value.
+		autoPanPadding: [5, 5],
 
-			// @option keepInView: Boolean = false
-			// Set it to `true` if you want to prevent users from panning the popup
-			// off of the screen while it is open.
-			keepInView: false,
+		// @option keepInView: Boolean = false
+		// Set it to `true` if you want to prevent users from panning the popup
+		// off of the screen while it is open.
+		keepInView: false,
 
-			// @option closeButton: Boolean = true
-			// Controls the presence of a close button in the popup.
-			closeButton: true,
+		// @option closeButton: Boolean = true
+		// Controls the presence of a close button in the popup.
+		closeButton: true,
 
-			// @option closeButtonLabel: String = 'Close popup'
-			// Specifies the 'aria-label' attribute of the close button.
-			closeButtonLabel: 'Close popup',
+		// @option closeButtonLabel: String = 'Close popup'
+		// Specifies the 'aria-label' attribute of the close button.
+		closeButtonLabel: 'Close popup',
 
-			// @option autoClose: Boolean = true
-			// Set it to `false` if you want to override the default behavior of
-			// the popup closing when another popup is opened.
-			autoClose: true,
+		// @option autoClose: Boolean = true
+		// Set it to `false` if you want to override the default behavior of
+		// the popup closing when another popup is opened.
+		autoClose: true,
 
-			// @option closeOnEscapeKey: Boolean = true
-			// Set it to `false` if you want to override the default behavior of
-			// the ESC key for closing of the popup.
-			closeOnEscapeKey: true,
+		// @option closeOnEscapeKey: Boolean = true
+		// Set it to `false` if you want to override the default behavior of
+		// the ESC key for closing of the popup.
+		closeOnEscapeKey: true,
 
-			// @option closeOnClick: Boolean = *
-			// Set it if you want to override the default behavior of the popup closing when user clicks
-			// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
+		// @option closeOnClick: Boolean = *
+		// Set it if you want to override the default behavior of the popup closing when user clicks
+		// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
 
-			// @option className: String = ''
-			// A custom CSS class name to assign to the popup.
-			className: '',
+		// @option className: String = ''
+		// A custom CSS class name to assign to the popup.
+		className: '',
 
-			// @option trackResize: Boolean = true
-			// Whether the popup shall react to changes in the size of its contents
-			// (e.g. when an image inside the popup loads) and reposition itself.
-			trackResize: true,
-		});
-	}
+		// @option trackResize: Boolean = true
+		// Whether the popup shall react to changes in the size of its contents
+		// (e.g. when an image inside the popup loads) and reposition itself.
+		trackResize: true,
+	});
 
 	// @namespace Popup
 	// @method openOn(map: LeafletMap): this

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -49,7 +49,7 @@ export class Popup extends DivOverlay {
 
 	// @section
 	// @aka Popup options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option pane: String = 'popupPane'
 		// `Map pane` where the popup will be added.
 		pane: 'popupPane',
@@ -127,7 +127,7 @@ export class Popup extends DivOverlay {
 		// Whether the popup shall react to changes in the size of its contents
 		// (e.g. when an image inside the popup loads) and reposition itself.
 		trackResize: true,
-	});
+	};
 
 	// @namespace Popup
 	// @method openOn(map: LeafletMap): this

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -55,7 +55,7 @@ export class Tooltip extends DivOverlay {
 
 	// @section
 	// @aka Tooltip options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option pane: String = 'tooltipPane'
 		// `Map pane` where the tooltip will be added.
 		pane: 'tooltipPane',
@@ -82,7 +82,7 @@ export class Tooltip extends DivOverlay {
 		// @option opacity: Number = 0.9
 		// Tooltip container opacity.
 		opacity: 0.9
-	});
+	};
 
 	onAdd(map) {
 		super.onAdd(map);

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -53,38 +53,36 @@ import {FeatureGroup} from './FeatureGroup.js';
 // Instantiates a `Tooltip` object given `latlng` where the tooltip will open and an optional `options` object that describes its appearance and location.
 export class Tooltip extends DivOverlay {
 
-	static {
-		// @section
-		// @aka Tooltip options
-		this.setDefaultOptions({
-			// @option pane: String = 'tooltipPane'
-			// `Map pane` where the tooltip will be added.
-			pane: 'tooltipPane',
+	// @section
+	// @aka Tooltip options
+	static defaultOptions = ({
+		// @option pane: String = 'tooltipPane'
+		// `Map pane` where the tooltip will be added.
+		pane: 'tooltipPane',
 
-			// @option offset: Point = Point(0, 0)
-			// Optional offset of the tooltip position.
-			offset: [0, 0],
+		// @option offset: Point = Point(0, 0)
+		// Optional offset of the tooltip position.
+		offset: [0, 0],
 
-			// @option direction: String = 'auto'
-			// Direction where to open the tooltip. Possible values are: `right`, `left`,
-			// `top`, `bottom`, `center`, `auto`.
-			// `auto` will dynamically switch between `right` and `left` according to the tooltip
-			// position on the map.
-			direction: 'auto',
+		// @option direction: String = 'auto'
+		// Direction where to open the tooltip. Possible values are: `right`, `left`,
+		// `top`, `bottom`, `center`, `auto`.
+		// `auto` will dynamically switch between `right` and `left` according to the tooltip
+		// position on the map.
+		direction: 'auto',
 
-			// @option permanent: Boolean = false
-			// Whether to open the tooltip permanently or only on pointerover.
-			permanent: false,
+		// @option permanent: Boolean = false
+		// Whether to open the tooltip permanently or only on pointerover.
+		permanent: false,
 
-			// @option sticky: Boolean = false
-			// If true, the tooltip will follow the pointer instead of being fixed at the feature center.
-			sticky: false,
+		// @option sticky: Boolean = false
+		// If true, the tooltip will follow the pointer instead of being fixed at the feature center.
+		sticky: false,
 
-			// @option opacity: Number = 0.9
-			// Tooltip container opacity.
-			opacity: 0.9
-		});
-	}
+		// @option opacity: Number = 0.9
+		// Tooltip container opacity.
+		opacity: 0.9
+	});
 
 	onAdd(map) {
 		super.onAdd(map);

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -26,36 +26,34 @@ import * as Util from '../core/Util.js';
 // geographical bounds it is tied to.
 export class VideoOverlay extends ImageOverlay {
 
-	static {
-		// @section
-		// @aka VideoOverlay options
-		this.setDefaultOptions({
-			// @option autoplay: Boolean = true
-			// Whether the video starts playing automatically when loaded.
-			// On some browsers autoplay will only work with `muted: true`
-			autoplay: true,
+	// @section
+	// @aka VideoOverlay options
+	static defaultOptions = ({
+		// @option autoplay: Boolean = true
+		// Whether the video starts playing automatically when loaded.
+		// On some browsers autoplay will only work with `muted: true`
+		autoplay: true,
 
-			// @option controls: Boolean = false
-			// Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
-			controls: false,
+		// @option controls: Boolean = false
+		// Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
+		controls: false,
 
-			// @option loop: Boolean = true
-			// Whether the video will loop back to the beginning when played.
-			loop: true,
+		// @option loop: Boolean = true
+		// Whether the video will loop back to the beginning when played.
+		loop: true,
 
-			// @option keepAspectRatio: Boolean = true
-			// Whether the video will save aspect ratio after the projection.
-			keepAspectRatio: true,
+		// @option keepAspectRatio: Boolean = true
+		// Whether the video will save aspect ratio after the projection.
+		keepAspectRatio: true,
 
-			// @option muted: Boolean = false
-			// Whether the video starts on mute when loaded.
-			muted: false,
+		// @option muted: Boolean = false
+		// Whether the video starts on mute when loaded.
+		muted: false,
 
-			// @option playsInline: Boolean = true
-			// Mobile browsers will play the video right where it is instead of open it up in fullscreen mode.
-			playsInline: true
-		});
-	}
+		// @option playsInline: Boolean = true
+		// Mobile browsers will play the video right where it is instead of open it up in fullscreen mode.
+		playsInline: true
+	});
 
 	_initImage() {
 		const wasElementSupplied = this._url.tagName === 'VIDEO';

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -28,7 +28,7 @@ export class VideoOverlay extends ImageOverlay {
 
 	// @section
 	// @aka VideoOverlay options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option autoplay: Boolean = true
 		// Whether the video starts playing automatically when loaded.
 		// On some browsers autoplay will only work with `muted: true`
@@ -53,7 +53,7 @@ export class VideoOverlay extends ImageOverlay {
 		// @option playsInline: Boolean = true
 		// Mobile browsers will play the video right where it is instead of open it up in fullscreen mode.
 		playsInline: true
-	});
+	};
 
 	_initImage() {
 		const wasElementSupplied = this._url.tagName === 'VIDEO';

--- a/src/layer/marker/DefaultIcon.js
+++ b/src/layer/marker/DefaultIcon.js
@@ -18,7 +18,7 @@ import * as DomUtil from '../../dom/DomUtil.js';
 
 export class DefaultIcon extends Icon {
 
-	static defaultOptions = ({
+	static defaultOptions = {
 		iconUrl:       'marker-icon.svg',
 		iconRetinaUrl: 'marker-icon.svg',
 		shadowUrl:     'marker-shadow.svg',
@@ -27,7 +27,7 @@ export class DefaultIcon extends Icon {
 		popupAnchor: [1, -34],
 		tooltipAnchor: [16, -28],
 		shadowSize:  [41, 41]
-	});
+	};
 
 	_getIconUrl(name) {
 		// only detect once

--- a/src/layer/marker/DefaultIcon.js
+++ b/src/layer/marker/DefaultIcon.js
@@ -18,18 +18,16 @@ import * as DomUtil from '../../dom/DomUtil.js';
 
 export class DefaultIcon extends Icon {
 
-	static {
-		this.setDefaultOptions({
-			iconUrl:       'marker-icon.svg',
-			iconRetinaUrl: 'marker-icon.svg',
-			shadowUrl:     'marker-shadow.svg',
-			iconSize:    [25, 41],
-			iconAnchor:  [12, 41],
-			popupAnchor: [1, -34],
-			tooltipAnchor: [16, -28],
-			shadowSize:  [41, 41]
-		});
-	}
+	static defaultOptions = ({
+		iconUrl:       'marker-icon.svg',
+		iconRetinaUrl: 'marker-icon.svg',
+		shadowUrl:     'marker-shadow.svg',
+		iconSize:    [25, 41],
+		iconAnchor:  [12, 41],
+		popupAnchor: [1, -34],
+		tooltipAnchor: [16, -28],
+		shadowSize:  [41, 41]
+	});
 
 	_getIconUrl(name) {
 		// only detect once

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -23,27 +23,25 @@ import {Point} from '../../geometry/Point.js';
 // Creates a `DivIcon` instance with the given options.
 export class DivIcon extends Icon {
 
-	static {
-		this.setDefaultOptions({
-			// @section
-			// @aka DivIcon options
-			iconSize: [12, 12], // also can be set through CSS
+	static defaultOptions = ({
+		// @section
+		// @aka DivIcon options
+		iconSize: [12, 12], // also can be set through CSS
 
-			// iconAnchor: (Point),
-			// popupAnchor: (Point),
+		// iconAnchor: (Point),
+		// popupAnchor: (Point),
 
-			// @option html: String|HTMLElement = ''
-			// Custom HTML code to put inside the div element, empty by default. Alternatively,
-			// an instance of `HTMLElement`.
-			html: false,
+		// @option html: String|HTMLElement = ''
+		// Custom HTML code to put inside the div element, empty by default. Alternatively,
+		// an instance of `HTMLElement`.
+		html: false,
 
-			// @option bgPos: Point = [0, 0]
-			// Optional relative position of the background, in pixels
-			bgPos: null,
+		// @option bgPos: Point = [0, 0]
+		// Optional relative position of the background, in pixels
+		bgPos: null,
 
-			className: 'leaflet-div-icon'
-		});
-	}
+		className: 'leaflet-div-icon'
+	});
 
 	createIcon(oldIcon) {
 		const div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -23,7 +23,7 @@ import {Point} from '../../geometry/Point.js';
 // Creates a `DivIcon` instance with the given options.
 export class DivIcon extends Icon {
 
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @section
 		// @aka DivIcon options
 		iconSize: [12, 12], // also can be set through CSS
@@ -41,7 +41,7 @@ export class DivIcon extends Icon {
 		bgPos: null,
 
 		className: 'leaflet-div-icon'
-	});
+	};
 
 	createIcon(oldIcon) {
 		const div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -73,7 +73,7 @@ export class Icon extends Class {
 		 * @option className: String = ''
 		 * A custom class name to assign to both icon and shadow images. Empty by default.
 		 */
-	static defaultOptions = ({
+	static defaultOptions = {
 		popupAnchor: [0, 0],
 		tooltipAnchor: [0, 0],
 
@@ -82,7 +82,7 @@ export class Icon extends Class {
 		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
 		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
 		crossOrigin: false
-	});
+	};
 
 	initialize(options) {
 		setOptions(this, options);

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -34,8 +34,7 @@ import Browser from '../../core/Browser.js';
 // Creates an icon instance with the given options.
 export class Icon extends Class {
 
-	static {
-		/* @section
+	/* @section
 		 * @aka Icon options
 		 *
 		 * @option iconUrl: String = null
@@ -74,17 +73,16 @@ export class Icon extends Class {
 		 * @option className: String = ''
 		 * A custom class name to assign to both icon and shadow images. Empty by default.
 		 */
-		this.setDefaultOptions({
-			popupAnchor: [0, 0],
-			tooltipAnchor: [0, 0],
+	static defaultOptions = ({
+		popupAnchor: [0, 0],
+		tooltipAnchor: [0, 0],
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false
-		});
-	}
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false
+	});
 
 	initialize(options) {
 		setOptions(this, options);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -25,7 +25,7 @@ export class Marker extends Layer {
 
 	// @section
 	// @aka Marker options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option icon: Icon = *
 		// Icon instance to use for rendering the marker.
 		// See [Icon documentation](#Icon) for details on how to customize the marker icon.
@@ -101,7 +101,7 @@ export class Marker extends Layer {
 		// @option autoPanSpeed: Number = 10
 		// Number of pixels the map should pan by.
 		autoPanSpeed: 10
-	});
+	};
 
 	/* @section
 	 *

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -23,87 +23,85 @@ import {MarkerDrag} from './Marker.Drag.js';
 // Instantiates a Marker object given a geographical point and optionally an options object.
 export class Marker extends Layer {
 
-	static {
-		// @section
-		// @aka Marker options
-		this.setDefaultOptions({
-			// @option icon: Icon = *
-			// Icon instance to use for rendering the marker.
-			// See [Icon documentation](#Icon) for details on how to customize the marker icon.
-			// If not specified, a common instance of `DefaultIcon` is used.
-			icon: new DefaultIcon(),
+	// @section
+	// @aka Marker options
+	static defaultOptions = ({
+		// @option icon: Icon = *
+		// Icon instance to use for rendering the marker.
+		// See [Icon documentation](#Icon) for details on how to customize the marker icon.
+		// If not specified, a common instance of `DefaultIcon` is used.
+		icon: new DefaultIcon(),
 
-			// Option inherited from "Interactive layer" abstract class
-			interactive: true,
+		// Option inherited from "Interactive layer" abstract class
+		interactive: true,
 
-			// @option keyboard: Boolean = true
-			// Whether the marker can be tabbed to with a keyboard and clicked by pressing enter.
-			keyboard: true,
+		// @option keyboard: Boolean = true
+		// Whether the marker can be tabbed to with a keyboard and clicked by pressing enter.
+		keyboard: true,
 
-			// @option title: String = ''
-			// Text for the browser tooltip that appear on marker hover (no tooltip by default).
-			// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
-			title: '',
+		// @option title: String = ''
+		// Text for the browser tooltip that appear on marker hover (no tooltip by default).
+		// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
+		title: '',
 
-			// @option alt: String = 'Marker'
-			// Text for the `alt` attribute of the icon image.
-			// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
-			alt: 'Marker',
+		// @option alt: String = 'Marker'
+		// Text for the `alt` attribute of the icon image.
+		// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
+		alt: 'Marker',
 
-			// @option zIndexOffset: Number = 0
-			// By default, marker images zIndex is set automatically based on its latitude. Use this option if you want to put the marker on top of all others (or below), specifying a high value like `1000` (or high negative value, respectively).
-			zIndexOffset: 0,
+		// @option zIndexOffset: Number = 0
+		// By default, marker images zIndex is set automatically based on its latitude. Use this option if you want to put the marker on top of all others (or below), specifying a high value like `1000` (or high negative value, respectively).
+		zIndexOffset: 0,
 
-			// @option opacity: Number = 1.0
-			// The opacity of the marker.
-			opacity: 1,
+		// @option opacity: Number = 1.0
+		// The opacity of the marker.
+		opacity: 1,
 
-			// @option riseOnHover: Boolean = false
-			// If `true`, the marker will get on top of others when you hover the pointer over it.
-			riseOnHover: false,
+		// @option riseOnHover: Boolean = false
+		// If `true`, the marker will get on top of others when you hover the pointer over it.
+		riseOnHover: false,
 
-			// @option riseOffset: Number = 250
-			// The z-index offset used for the `riseOnHover` feature.
-			riseOffset: 250,
+		// @option riseOffset: Number = 250
+		// The z-index offset used for the `riseOnHover` feature.
+		riseOffset: 250,
 
-			// @option pane: String = 'markerPane'
-			// `Map pane` where the markers icon will be added.
-			pane: 'markerPane',
+		// @option pane: String = 'markerPane'
+		// `Map pane` where the markers icon will be added.
+		pane: 'markerPane',
 
-			// @option shadowPane: String = 'shadowPane'
-			// `Map pane` where the markers shadow will be added.
-			shadowPane: 'shadowPane',
+		// @option shadowPane: String = 'shadowPane'
+		// `Map pane` where the markers shadow will be added.
+		shadowPane: 'shadowPane',
 
-			// @option bubblingPointerEvents: Boolean = false
-			// When `true`, a pointer event on this marker will trigger the same event on the map
-			// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-			bubblingPointerEvents: false,
+		// @option bubblingPointerEvents: Boolean = false
+		// When `true`, a pointer event on this marker will trigger the same event on the map
+		// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingPointerEvents: false,
 
-			// @option autoPanOnFocus: Boolean = true
-			// When `true`, the map will pan whenever the marker is focused (via
-			// e.g. pressing `tab` on the keyboard) to ensure the marker is
-			// visible within the map's bounds
-			autoPanOnFocus: true,
+		// @option autoPanOnFocus: Boolean = true
+		// When `true`, the map will pan whenever the marker is focused (via
+		// e.g. pressing `tab` on the keyboard) to ensure the marker is
+		// visible within the map's bounds
+		autoPanOnFocus: true,
 
-			// @section Draggable marker options
-			// @option draggable: Boolean = false
-			// Whether the marker is draggable with pointer or not.
-			draggable: false,
+		// @section Draggable marker options
+		// @option draggable: Boolean = false
+		// Whether the marker is draggable with pointer or not.
+		draggable: false,
 
-			// @option autoPan: Boolean = false
-			// Whether to pan the map when dragging this marker near its edge or not.
-			autoPan: false,
+		// @option autoPan: Boolean = false
+		// Whether to pan the map when dragging this marker near its edge or not.
+		autoPan: false,
 
-			// @option autoPanPadding: Point = Point(50, 50)
-			// Distance (in pixels to the left/right and to the top/bottom) of the
-			// map edge to start panning the map.
-			autoPanPadding: [50, 50],
+		// @option autoPanPadding: Point = Point(50, 50)
+		// Distance (in pixels to the left/right and to the top/bottom) of the
+		// map edge to start panning the map.
+		autoPanPadding: [50, 50],
 
-			// @option autoPanSpeed: Number = 10
-			// Number of pixels the map should pan by.
-			autoPanSpeed: 10
-		});
-	}
+		// @option autoPanSpeed: Number = 10
+		// Number of pixels the map should pan by.
+		autoPanSpeed: 10
+	});
 
 	/* @section
 	 *

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -75,82 +75,80 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
 // Creates a new instance of GridLayer with the supplied options.
 export class GridLayer extends Layer {
 
-	static {
 	// @section
 	// @aka GridLayer options
-		this.setDefaultOptions({
-			// @option tileSize: Number|Point = 256
-			// Width and height of tiles in the grid. Use a number if width and height are equal, or `Point(width, height)` otherwise.
-			tileSize: 256,
+	static defaultOptions = {
+		// @option tileSize: Number|Point = 256
+		// Width and height of tiles in the grid. Use a number if width and height are equal, or `Point(width, height)` otherwise.
+		tileSize: 256,
 
-			// @option opacity: Number = 1.0
-			// Opacity of the tiles. Can be used in the `createTile()` function.
-			opacity: 1,
+		// @option opacity: Number = 1.0
+		// Opacity of the tiles. Can be used in the `createTile()` function.
+		opacity: 1,
 
-			// @option updateWhenIdle: Boolean = (depends)
-			// Load new tiles only when panning ends.
-			// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
-			// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
-			// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
-			updateWhenIdle: Browser.mobile,
+		// @option updateWhenIdle: Boolean = (depends)
+		// Load new tiles only when panning ends.
+		// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
+		// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
+		// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
+		updateWhenIdle: Browser.mobile,
 
-			// @option updateWhenZooming: Boolean = true
-			// By default, a smooth zoom animation (during a [pinch zoom](#map-pinchzoom) or a [`flyTo()`](#map-flyto)) will update grid layers every integer zoom level. Setting this option to `false` will update the grid layer only when the smooth animation ends.
-			updateWhenZooming: true,
+		// @option updateWhenZooming: Boolean = true
+		// By default, a smooth zoom animation (during a [pinch zoom](#map-pinchzoom) or a [`flyTo()`](#map-flyto)) will update grid layers every integer zoom level. Setting this option to `false` will update the grid layer only when the smooth animation ends.
+		updateWhenZooming: true,
 
-			// @option updateInterval: Number = 200
-			// Tiles will not update more than once every `updateInterval` milliseconds when panning.
-			updateInterval: 200,
+		// @option updateInterval: Number = 200
+		// Tiles will not update more than once every `updateInterval` milliseconds when panning.
+		updateInterval: 200,
 
-			// @option zIndex: Number = 1
-			// The explicit zIndex of the tile layer.
-			zIndex: 1,
+		// @option zIndex: Number = 1
+		// The explicit zIndex of the tile layer.
+		zIndex: 1,
 
-			// @option bounds: LatLngBounds = undefined
-			// If set, tiles will only be loaded inside the set `LatLngBounds`.
-			bounds: null,
+		// @option bounds: LatLngBounds = undefined
+		// If set, tiles will only be loaded inside the set `LatLngBounds`.
+		bounds: null,
 
-			// @option minZoom: Number = 0
-			// The minimum zoom level down to which this layer will be displayed (inclusive).
-			minZoom: 0,
+		// @option minZoom: Number = 0
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
+		minZoom: 0,
 
-			// @option maxZoom: Number = undefined
-			// The maximum zoom level up to which this layer will be displayed (inclusive).
-			maxZoom: undefined,
+		// @option maxZoom: Number = undefined
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
+		maxZoom: undefined,
 
-			// @option maxNativeZoom: Number = undefined
-			// Maximum zoom number the tile source has available. If it is specified,
-			// the tiles on all zoom levels higher than `maxNativeZoom` will be loaded
-			// from `maxNativeZoom` level and auto-scaled.
-			maxNativeZoom: undefined,
+		// @option maxNativeZoom: Number = undefined
+		// Maximum zoom number the tile source has available. If it is specified,
+		// the tiles on all zoom levels higher than `maxNativeZoom` will be loaded
+		// from `maxNativeZoom` level and auto-scaled.
+		maxNativeZoom: undefined,
 
-			// @option minNativeZoom: Number = undefined
-			// Minimum zoom number the tile source has available. If it is specified,
-			// the tiles on all zoom levels lower than `minNativeZoom` will be loaded
-			// from `minNativeZoom` level and auto-scaled.
-			minNativeZoom: undefined,
+		// @option minNativeZoom: Number = undefined
+		// Minimum zoom number the tile source has available. If it is specified,
+		// the tiles on all zoom levels lower than `minNativeZoom` will be loaded
+		// from `minNativeZoom` level and auto-scaled.
+		minNativeZoom: undefined,
 
-			// @option noWrap: Boolean = false
-			// Whether the layer is wrapped around the antimeridian. If `true`, the
-			// GridLayer will only be displayed once at low zoom levels. Has no
-			// effect when the [map CRS](#map-crs) doesn't wrap around. Can be used
-			// in combination with [`bounds`](#gridlayer-bounds) to prevent requesting
-			// tiles outside the CRS limits.
-			noWrap: false,
+		// @option noWrap: Boolean = false
+		// Whether the layer is wrapped around the antimeridian. If `true`, the
+		// GridLayer will only be displayed once at low zoom levels. Has no
+		// effect when the [map CRS](#map-crs) doesn't wrap around. Can be used
+		// in combination with [`bounds`](#gridlayer-bounds) to prevent requesting
+		// tiles outside the CRS limits.
+		noWrap: false,
 
-			// @option pane: String = 'tilePane'
-			// `Map pane` where the grid layer will be added.
-			pane: 'tilePane',
+		// @option pane: String = 'tilePane'
+		// `Map pane` where the grid layer will be added.
+		pane: 'tilePane',
 
-			// @option className: String = ''
-			// A custom class name to assign to the tile layer. Empty by default.
-			className: '',
+		// @option className: String = ''
+		// A custom class name to assign to the tile layer. Empty by default.
+		className: '',
 
-			// @option keepBuffer: Number = 2
-			// When panning the map, keep this many rows and columns of tiles before unloading them.
-			keepBuffer: 2
-		});
-	}
+		// @option keepBuffer: Number = 2
+		// When panning the map, keep this many rows and columns of tiles before unloading them.
+		keepBuffer: 2
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -36,57 +36,55 @@ import * as DomEvent from '../../dom/DomEvent.js';
 // Instantiates a tile layer object given a `URL template` and optionally an options object.
 export class TileLayer extends GridLayer {
 
-	static {
-		// @section
-		// @aka TileLayer options
-		this.setDefaultOptions({
-			// @option minZoom: Number = 0
-			// The minimum zoom level down to which this layer will be displayed (inclusive).
-			minZoom: 0,
+	// @section
+	// @aka TileLayer options
+	static defaultOptions = {
+		// @option minZoom: Number = 0
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
+		minZoom: 0,
 
-			// @option maxZoom: Number = 18
-			// The maximum zoom level up to which this layer will be displayed (inclusive).
-			maxZoom: 18,
+		// @option maxZoom: Number = 18
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
+		maxZoom: 18,
 
-			// @option subdomains: String|String[] = 'abc'
-			// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.
-			subdomains: 'abc',
+		// @option subdomains: String|String[] = 'abc'
+		// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.
+		subdomains: 'abc',
 
-			// @option errorTileUrl: String = ''
-			// URL to the tile image to show in place of the tile that failed to load.
-			errorTileUrl: '',
+		// @option errorTileUrl: String = ''
+		// URL to the tile image to show in place of the tile that failed to load.
+		errorTileUrl: '',
 
-			// @option zoomOffset: Number = 0
-			// The zoom number used in tile URLs will be offset with this value.
-			zoomOffset: 0,
+		// @option zoomOffset: Number = 0
+		// The zoom number used in tile URLs will be offset with this value.
+		zoomOffset: 0,
 
-			// @option tms: Boolean = false
-			// If `true`, inverses Y axis numbering for tiles (turn this on for [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) services).
-			tms: false,
+		// @option tms: Boolean = false
+		// If `true`, inverses Y axis numbering for tiles (turn this on for [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) services).
+		tms: false,
 
-			// @option zoomReverse: Boolean = false
-			// If set to true, the zoom number used in tile URLs will be reversed (`maxZoom - zoom` instead of `zoom`)
-			zoomReverse: false,
+		// @option zoomReverse: Boolean = false
+		// If set to true, the zoom number used in tile URLs will be reversed (`maxZoom - zoom` instead of `zoom`)
+		zoomReverse: false,
 
-			// @option detectRetina: Boolean = false
-			// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
-			detectRetina: false,
+		// @option detectRetina: Boolean = false
+		// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
+		detectRetina: false,
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false,
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false,
 
-			// @option referrerPolicy: Boolean|String = false
-			// Whether the referrerPolicy attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
-			// This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
-			// (e.g. to validate an API token).
-			// Refer to [HTMLImageElement.referrerPolicy](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy) for valid String values.
-			referrerPolicy: false
-		});
-	}
+		// @option referrerPolicy: Boolean|String = false
+		// Whether the referrerPolicy attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
+		// This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
+		// (e.g. to validate an API token).
+		// Refer to [HTMLImageElement.referrerPolicy](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy) for valid String values.
+		referrerPolicy: false
+	};
 
 	initialize(url, options) {
 		super.initialize(options);

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -72,7 +72,7 @@ export class WMSTileLayer extends TileLayer {
 
 		// Options that are unknown in the prototype chain are considered WMS params.
 		for (const [key, value] of Object.entries(options)) {
-			if (!(key in this.getDefaultOptions())) {
+			if (!(key in WMSTileLayer.prototype.options)) {
 				wmsParams[key] = value;
 			}
 		}

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -72,7 +72,7 @@ export class WMSTileLayer extends TileLayer {
 
 		// Options that are unknown in the prototype chain are considered WMS params.
 		for (const [key, value] of Object.entries(options)) {
-			if (!(key in WMSTileLayer.prototype.options)) {
+			if (!(key in this.getDefaultOptions())) {
 				wmsParams[key] = value;
 			}
 		}

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -24,53 +24,51 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Instantiates a WMS tile layer object given a base URL of the WMS service and a WMS parameters/options object.
 export class WMSTileLayer extends TileLayer {
 
-	static {
-		// @section
-		// @aka WMSTileLayer options
-		// If any custom options not documented here are used, they will be sent to the
-		// WMS server as extra parameters in each request URL. This can be useful for
-		// [non-standard vendor WMS parameters](https://docs.geoserver.org/stable/en/user/services/wms/vendor.html).
-		this.prototype.defaultWmsParams = {
-			service: 'WMS',
-			request: 'GetMap',
+	// @section
+	// @aka WMSTileLayer options
+	// If any custom options not documented here are used, they will be sent to the
+	// WMS server as extra parameters in each request URL. This can be useful for
+	// [non-standard vendor WMS parameters](https://docs.geoserver.org/stable/en/user/services/wms/vendor.html).
+	static defaultWmsParams = {
+		service: 'WMS',
+		request: 'GetMap',
 
-			// @option layers: String = ''
-			// **(required)** Comma-separated list of WMS layers to show.
-			layers: '',
+		// @option layers: String = ''
+		// **(required)** Comma-separated list of WMS layers to show.
+		layers: '',
 
-			// @option styles: String = ''
-			// Comma-separated list of WMS styles.
-			styles: '',
+		// @option styles: String = ''
+		// Comma-separated list of WMS styles.
+		styles: '',
 
-			// @option format: String = 'image/jpeg'
-			// WMS image format (use `'image/png'` for layers with transparency).
-			format: 'image/jpeg',
+		// @option format: String = 'image/jpeg'
+		// WMS image format (use `'image/png'` for layers with transparency).
+		format: 'image/jpeg',
 
-			// @option transparent: Boolean = false
-			// If `true`, the WMS service will return images with transparency.
-			transparent: false,
+		// @option transparent: Boolean = false
+		// If `true`, the WMS service will return images with transparency.
+		transparent: false,
 
-			// @option version: String = '1.1.1'
-			// Version of the WMS service to use
-			version: '1.1.1'
-		};
+		// @option version: String = '1.1.1'
+		// Version of the WMS service to use
+		version: '1.1.1'
+	};
 
-		this.setDefaultOptions({
-			// @option crs: CRS = null
-			// Coordinate Reference System to use for the WMS requests, defaults to
-			// map CRS. Don't change this if you're not sure what it means.
-			crs: null,
+	static defaultOptions = {
+		// @option crs: CRS = null
+		// Coordinate Reference System to use for the WMS requests, defaults to
+		// map CRS. Don't change this if you're not sure what it means.
+		crs: null,
 
-			// @option uppercase: Boolean = false
-			// If `true`, WMS request parameter keys will be uppercase.
-			uppercase: false
-		});
-	}
+		// @option uppercase: Boolean = false
+		// If `true`, WMS request parameter keys will be uppercase.
+		uppercase: false
+	};
 
 	initialize(url, options) {
 		super.initialize(url, options);
 
-		const wmsParams = {...this.defaultWmsParams};
+		const wmsParams = {...WMSTileLayer.defaultWmsParams};
 
 		// Options that are unknown in the prototype chain are considered WMS params.
 		for (const [key, value] of Object.entries(options)) {

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -36,11 +36,11 @@ export class Canvas extends Renderer {
 
 	// @section
 	// @aka Canvas options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option tolerance: Number = 0
 		// How much to extend the click tolerance around a path/object on the map.
 		tolerance: 0
-	});
+	};
 
 	getEvents() {
 		const events = super.getEvents();

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -34,15 +34,13 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Creates a Canvas renderer with the given options.
 export class Canvas extends Renderer {
 
-	static {
-		// @section
-		// @aka Canvas options
-		this.setDefaultOptions({
-			// @option tolerance: Number = 0
-			// How much to extend the click tolerance around a path/object on the map.
-			tolerance: 0
-		});
-	}
+	// @section
+	// @aka Canvas options
+	static defaultOptions = ({
+		// @option tolerance: Number = 0
+		// How much to extend the click tolerance around a path/object on the map.
+		tolerance: 0
+	});
 
 	getEvents() {
 		const events = super.getEvents();

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -15,17 +15,15 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Instantiates a circle marker object given a geographical point, and an optional options object.
 export class CircleMarker extends Path {
 
-	static {
-		// @section
-		// @aka CircleMarker options
-		this.setDefaultOptions({
-			fill: true,
+	// @section
+	// @aka CircleMarker options
+	static defaultOptions = ({
+		fill: true,
 
-			// @option radius: Number = 10
-			// Radius of the circle marker, in pixels
-			radius: 10
-		});
-	}
+		// @option radius: Number = 10
+		// Radius of the circle marker, in pixels
+		radius: 10
+	});
 
 	initialize(latlng, options) {
 		Util.setOptions(this, options);

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -17,13 +17,13 @@ export class CircleMarker extends Path {
 
 	// @section
 	// @aka CircleMarker options
-	static defaultOptions = ({
+	static defaultOptions = {
 		fill: true,
 
 		// @option radius: Number = 10
 		// Radius of the circle marker, in pixels
 		radius: 10
-	});
+	};
 
 	initialize(latlng, options) {
 		Util.setOptions(this, options);

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -11,69 +11,67 @@ import * as Util from '../../core/Util.js';
 
 export class Path extends Layer {
 
-	static {
-		// @section
-		// @aka Path options
-		this.setDefaultOptions({
-			// @option stroke: Boolean = true
-			// Whether to draw stroke along the path. Set it to `false` to disable borders on polygons or circles.
-			stroke: true,
+	// @section
+	// @aka Path options
+	static defaultOptions = ({
+		// @option stroke: Boolean = true
+		// Whether to draw stroke along the path. Set it to `false` to disable borders on polygons or circles.
+		stroke: true,
 
-			// @option color: String = '#3388ff'
-			// Stroke color
-			color: '#3388ff',
+		// @option color: String = '#3388ff'
+		// Stroke color
+		color: '#3388ff',
 
-			// @option weight: Number = 3
-			// Stroke width in pixels
-			weight: 3,
+		// @option weight: Number = 3
+		// Stroke width in pixels
+		weight: 3,
 
-			// @option opacity: Number = 1.0
-			// Stroke opacity
-			opacity: 1,
+		// @option opacity: Number = 1.0
+		// Stroke opacity
+		opacity: 1,
 
-			// @option lineCap: String= 'round'
-			// A string that defines [shape to be used at the end](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) of the stroke.
-			lineCap: 'round',
+		// @option lineCap: String= 'round'
+		// A string that defines [shape to be used at the end](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) of the stroke.
+		lineCap: 'round',
 
-			// @option lineJoin: String = 'round'
-			// A string that defines [shape to be used at the corners](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linejoin) of the stroke.
-			lineJoin: 'round',
+		// @option lineJoin: String = 'round'
+		// A string that defines [shape to be used at the corners](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linejoin) of the stroke.
+		lineJoin: 'round',
 
-			// @option dashArray: String = null
-			// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray).
-			dashArray: null,
+		// @option dashArray: String = null
+		// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray).
+		dashArray: null,
 
-			// @option dashOffset: String = null
-			// A string that defines the [distance into the dash pattern to start the dash](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dashoffset).
-			dashOffset: null,
+		// @option dashOffset: String = null
+		// A string that defines the [distance into the dash pattern to start the dash](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dashoffset).
+		dashOffset: null,
 
-			// @option fill: Boolean = depends
-			// Whether to fill the path with color. Set it to `false` to disable filling on polygons or circles.
-			fill: false,
+		// @option fill: Boolean = depends
+		// Whether to fill the path with color. Set it to `false` to disable filling on polygons or circles.
+		fill: false,
 
-			// @option fillColor: String = *
-			// Fill color. Defaults to the value of the [`color`](#path-color) option
-			fillColor: null,
+		// @option fillColor: String = *
+		// Fill color. Defaults to the value of the [`color`](#path-color) option
+		fillColor: null,
 
-			// @option fillOpacity: Number = 0.2
-			// Fill opacity.
-			fillOpacity: 0.2,
+		// @option fillOpacity: Number = 0.2
+		// Fill opacity.
+		fillOpacity: 0.2,
 
-			// @option fillRule: String = 'evenodd'
-			// A string that defines [how the inside of a shape](https://developer.mozilla.org/docs/Web/SVG/Attribute/fill-rule) is determined.
-			fillRule: 'evenodd',
+		// @option fillRule: String = 'evenodd'
+		// A string that defines [how the inside of a shape](https://developer.mozilla.org/docs/Web/SVG/Attribute/fill-rule) is determined.
+		fillRule: 'evenodd',
 
-			// className: '',
+		// className: '',
 
-			// Option inherited from "Interactive layer" abstract class
-			interactive: true,
+		// Option inherited from "Interactive layer" abstract class
+		interactive: true,
 
-			// @option bubblingPointerEvents: Boolean = true
-			// When `true`, a pointer event on this path will trigger the same event on the map
-			// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-			bubblingPointerEvents: true
-		});
-	}
+		// @option bubblingPointerEvents: Boolean = true
+		// When `true`, a pointer event on this path will trigger the same event on the map
+		// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingPointerEvents: true
+	});
 
 	beforeAdd(map) {
 		// Renderer is set here because we need to call renderer.getEvents

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -13,7 +13,7 @@ export class Path extends Layer {
 
 	// @section
 	// @aka Path options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option stroke: Boolean = true
 		// Whether to draw stroke along the path. Set it to `false` to disable borders on polygons or circles.
 		stroke: true,
@@ -71,7 +71,7 @@ export class Path extends Layer {
 		// When `true`, a pointer event on this path will trigger the same event on the map
 		// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
 		bubblingPointerEvents: true
-	});
+	};
 
 	beforeAdd(map) {
 		// Renderer is set here because we need to call renderer.getEvents

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -53,11 +53,9 @@ import * as PolyUtil from '../../geometry/PolyUtil.js';
 // @constructor Polygon(latlngs: LatLng[], options?: Polyline options)
 export class Polygon extends Polyline {
 
-	static {
-		this.setDefaultOptions({
-			fill: true
-		});
-	}
+	static defaultOptions = ({
+		fill: true
+	});
 
 	isEmpty() {
 		return !this._latlngs.length || !this._latlngs[0].length;

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -53,9 +53,9 @@ import * as PolyUtil from '../../geometry/PolyUtil.js';
 // @constructor Polygon(latlngs: LatLng[], options?: Polyline options)
 export class Polygon extends Polyline {
 
-	static defaultOptions = ({
+	static defaultOptions = {
 		fill: true
-	});
+	};
 
 	isEmpty() {
 		return !this._latlngs.length || !this._latlngs[0].length;

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -50,20 +50,18 @@ import {Point} from '../../geometry/Point.js';
 // of geographic points.
 export class Polyline extends Path {
 
-	static {
-		// @section
-		// @aka Polyline options
-		this.setDefaultOptions({
-			// @option smoothFactor: Number = 1.0
-			// How much to simplify the polyline on each zoom level. More means
-			// better performance and smoother look, and less means more accurate representation.
-			smoothFactor: 1.0,
+	// @section
+	// @aka Polyline options
+	static defaultOptions = ({
+		// @option smoothFactor: Number = 1.0
+		// How much to simplify the polyline on each zoom level. More means
+		// better performance and smoother look, and less means more accurate representation.
+		smoothFactor: 1.0,
 
-			// @option noClip: Boolean = false
-			// Disable polyline clipping.
-			noClip: false
-		});
-	}
+		// @option noClip: Boolean = false
+		// Disable polyline clipping.
+		noClip: false
+	});
 
 	initialize(latlngs, options) {
 		Util.setOptions(this, options);

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -52,7 +52,7 @@ export class Polyline extends Path {
 
 	// @section
 	// @aka Polyline options
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @option smoothFactor: Number = 1.0
 		// How much to simplify the polyline on each zoom level. More means
 		// better performance and smoother look, and less means more accurate representation.
@@ -61,7 +61,7 @@ export class Polyline extends Path {
 		// @option noClip: Boolean = false
 		// Disable polyline clipping.
 		noClip: false
-	});
+	};
 
 	initialize(latlngs, options) {
 		Util.setOptions(this, options);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -50,7 +50,7 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // and optionally an object literal with `Map options`.
 export class LeafletMap extends Evented {
 
-	static defaultOptions = ({
+	static defaultOptions = {
 		// @section Map State Options
 		// @option crs: CRS = EPSG3857
 		// The [Coordinate Reference System](#crs) to use. Don't change this if you're not
@@ -140,7 +140,7 @@ export class LeafletMap extends Evented {
 		// @option trackResize: Boolean = true
 		// Whether the map automatically handles browser window resize to update itself.
 		trackResize: true
-	});
+	};
 
 	initialize(id, options) { // (HTMLElement or String, Object)
 		options = Util.setOptions(this, options);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -50,99 +50,97 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // and optionally an object literal with `Map options`.
 export class LeafletMap extends Evented {
 
-	static {
-		this.setDefaultOptions({
-			// @section Map State Options
-			// @option crs: CRS = EPSG3857
-			// The [Coordinate Reference System](#crs) to use. Don't change this if you're not
-			// sure what it means.
-			crs: EPSG3857,
+	static defaultOptions = ({
+		// @section Map State Options
+		// @option crs: CRS = EPSG3857
+		// The [Coordinate Reference System](#crs) to use. Don't change this if you're not
+		// sure what it means.
+		crs: EPSG3857,
 
-			// @option center: LatLng = undefined
-			// Initial geographic center of the map
-			center: undefined,
+		// @option center: LatLng = undefined
+		// Initial geographic center of the map
+		center: undefined,
 
-			// @option zoom: Number = undefined
-			// Initial map zoom level
-			zoom: undefined,
+		// @option zoom: Number = undefined
+		// Initial map zoom level
+		zoom: undefined,
 
-			// @option minZoom: Number = *
-			// Minimum zoom level of the map.
-			// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
-			// the lowest of their `minZoom` options will be used instead.
-			minZoom: undefined,
+		// @option minZoom: Number = *
+		// Minimum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the lowest of their `minZoom` options will be used instead.
+		minZoom: undefined,
 
-			// @option maxZoom: Number = *
-			// Maximum zoom level of the map.
-			// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
-			// the highest of their `maxZoom` options will be used instead.
-			maxZoom: undefined,
+		// @option maxZoom: Number = *
+		// Maximum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the highest of their `maxZoom` options will be used instead.
+		maxZoom: undefined,
 
-			// @option layers: Layer[] = []
-			// Array of layers that will be added to the map initially
-			layers: [],
+		// @option layers: Layer[] = []
+		// Array of layers that will be added to the map initially
+		layers: [],
 
-			// @option maxBounds: LatLngBounds = null
-			// When this option is set, the map restricts the view to the given
-			// geographical bounds, bouncing the user back if the user tries to pan
-			// outside the view. To set the restriction dynamically, use
-			// [`setMaxBounds`](#map-setmaxbounds) method.
-			maxBounds: undefined,
+		// @option maxBounds: LatLngBounds = null
+		// When this option is set, the map restricts the view to the given
+		// geographical bounds, bouncing the user back if the user tries to pan
+		// outside the view. To set the restriction dynamically, use
+		// [`setMaxBounds`](#map-setmaxbounds) method.
+		maxBounds: undefined,
 
-			// @option renderer: Renderer = *
-			// The default method for drawing vector layers on the map. `SVG`
-			// or `Canvas` by default depending on browser support.
-			renderer: undefined,
+		// @option renderer: Renderer = *
+		// The default method for drawing vector layers on the map. `SVG`
+		// or `Canvas` by default depending on browser support.
+		renderer: undefined,
 
 
-			// @section Animation Options
-			// @option zoomAnimation: Boolean = true
-			// Whether the map zoom animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
-			zoomAnimation: true,
+		// @section Animation Options
+		// @option zoomAnimation: Boolean = true
+		// Whether the map zoom animation is enabled. By default it's enabled
+		// in all browsers that support CSS Transitions except Android.
+		zoomAnimation: true,
 
-			// @option zoomAnimationThreshold: Number = 4
-			// Won't animate zoom if the zoom difference exceeds this value.
-			zoomAnimationThreshold: 4,
+		// @option zoomAnimationThreshold: Number = 4
+		// Won't animate zoom if the zoom difference exceeds this value.
+		zoomAnimationThreshold: 4,
 
-			// @option fadeAnimation: Boolean = true
-			// Whether the tile fade animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
-			fadeAnimation: true,
+		// @option fadeAnimation: Boolean = true
+		// Whether the tile fade animation is enabled. By default it's enabled
+		// in all browsers that support CSS Transitions except Android.
+		fadeAnimation: true,
 
-			// @option markerZoomAnimation: Boolean = true
-			// Whether markers animate their zoom with the zoom animation, if disabled
-			// they will disappear for the length of the animation. By default it's
-			// enabled in all browsers that support CSS Transitions except Android.
-			markerZoomAnimation: true,
+		// @option markerZoomAnimation: Boolean = true
+		// Whether markers animate their zoom with the zoom animation, if disabled
+		// they will disappear for the length of the animation. By default it's
+		// enabled in all browsers that support CSS Transitions except Android.
+		markerZoomAnimation: true,
 
-			// @option transform3DLimit: Number = 2^23
-			// Defines the maximum size of a CSS translation transform. The default
-			// value should not be changed unless a web browser positions layers in
-			// the wrong place after doing a large `panBy`.
-			transform3DLimit: 8388608, // Precision limit of a 32-bit float
+		// @option transform3DLimit: Number = 2^23
+		// Defines the maximum size of a CSS translation transform. The default
+		// value should not be changed unless a web browser positions layers in
+		// the wrong place after doing a large `panBy`.
+		transform3DLimit: 8388608, // Precision limit of a 32-bit float
 
-			// @section Interaction Options
-			// @option zoomSnap: Number = 1
-			// Forces the map's zoom level to always be a multiple of this, particularly
-			// right after a [`fitBounds()`](#map-fitbounds) or a pinch-zoom.
-			// By default, the zoom level snaps to the nearest integer; lower values
-			// (e.g. `0.5` or `0.1`) allow for greater granularity. A value of `0`
-			// means the zoom level will not be snapped after `fitBounds` or a pinch-zoom.
-			zoomSnap: 1,
+		// @section Interaction Options
+		// @option zoomSnap: Number = 1
+		// Forces the map's zoom level to always be a multiple of this, particularly
+		// right after a [`fitBounds()`](#map-fitbounds) or a pinch-zoom.
+		// By default, the zoom level snaps to the nearest integer; lower values
+		// (e.g. `0.5` or `0.1`) allow for greater granularity. A value of `0`
+		// means the zoom level will not be snapped after `fitBounds` or a pinch-zoom.
+		zoomSnap: 1,
 
-			// @option zoomDelta: Number = 1
-			// Controls how much the map's zoom level will change after a
-			// [`zoomIn()`](#map-zoomin), [`zoomOut()`](#map-zoomout), pressing `+`
-			// or `-` on the keyboard, or using the [zoom controls](#control-zoom).
-			// Values smaller than `1` (e.g. `0.5`) allow for greater granularity.
-			zoomDelta: 1,
+		// @option zoomDelta: Number = 1
+		// Controls how much the map's zoom level will change after a
+		// [`zoomIn()`](#map-zoomin), [`zoomOut()`](#map-zoomout), pressing `+`
+		// or `-` on the keyboard, or using the [zoom controls](#control-zoom).
+		// Values smaller than `1` (e.g. `0.5`) allow for greater granularity.
+		zoomDelta: 1,
 
-			// @option trackResize: Boolean = true
-			// Whether the map automatically handles browser window resize to update itself.
-			trackResize: true
-		});
-	}
+		// @option trackResize: Boolean = true
+		// Whether the map automatically handles browser window resize to update itself.
+		trackResize: true
+	});
 
 	initialize(id, options) { // (HTMLElement or String, Object)
 		options = Util.setOptions(this, options);


### PR DESCRIPTION
An attempt to tackle https://github.com/Leaflet/Leaflet/issues/9814.

Quoting from https://github.com/Leaflet/Leaflet/issues/9814#issuecomment-3730229170

> It seems that the [static init block](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Static_initialization_blocks) of `class WMSTileLayer` `static { this.prototype.defaultWmsParams... this.setDefaultOptions... }` is preventing tree-shaking. Commenting out this block, removes the entire `class WMSTileLayer` from the bundle.