### PR TITLE
Add test for Canvas#_containsPoint()

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -297,7 +297,8 @@ describe('Canvas', () => {
 			requestAnimationFrame(() => { done(); });
 		});
 	});
-	describe('Canvas _containsPoint', () => {
+	
+	describe('#_containsPoint', () => {
 		it('detects point inside polygon', () => {
 			const polygon = new Polygon([
 				[0, 0],


### PR DESCRIPTION
This PR adds test coverage for Canvas `_containsPoint`, including points inside and outside polygons.

Fixes https://github.com/Leaflet/Leaflet/issues/5165
