### PR TITLE
Fix scale overlapping with attributions on mobile devices

### DIFF
--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -192,6 +192,14 @@
 	}
 }
 
+@media screen and (max-width: 520px){
+	.leaflet-bottom {
+		.leaflet-left{
+			bottom: 34px;
+		}
+	}
+}
+
 
 /* zoom and fade animations */
 


### PR DESCRIPTION
This pr fixes https://github.com/openstreetmap/openstreetmap-website/issues/6705 by shifting the scale up by `34px` on mobile devices (width less than `520px`).