### PR TITLE
Add Leaflet WMS Crop plugin

### DIFF
--- a/docs/_plugins/tile-image-display/leaflet-wms-crop.md
+++ b/docs/_plugins/tile-image-display/leaflet-wms-crop.md
@@ -1,13 +1,13 @@
 ---
 name: Leaflet WMS Crop
-category: basemap-providers
+category: tile-image-display
 repo: https://github.com/amanchry/leaflet-wms-crop
 author: Aman Chaudhary
 author-url: https://github.com/amanchry
 demo: https://amanchry.github.io/leaflet-wms-crop/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Client-side clipping for Leaflet WMS layers using GeoJSON/polygon boundaries.


### PR DESCRIPTION
A plugin for Client-side clipping for Leaflet WMS layers using GeoJSON/polygon boundaries.
