### PR TITLE
Add plugin: Leaflet.CityAutocompleteUSA

### DIFF
--- a/docs/_plugins/geocoding/city-autocomplete-usa.md
+++ b/docs/_plugins/geocoding/city-autocomplete-usa.md
@@ -1,0 +1,13 @@
+name: Leaflet.CityAutocompleteUSA
+category: geocoding
+repo: https://github.com/slbarriosdev/leaflet-city-autocomplete-usa
+author: Sergio Barrios
+author-url: https://github.com/slbarriosdev
+demo: https://slbarriosdev.github.io/leaflet-city-autocomplete-usa/demo/
+compatible-v0:
+compatible-v1: true
+compatible-v2: true
+---
+
+A lightweight **Leaflet control** that adds an autocomplete search for all U.S. cities using official **U.S. Census Gazetteer** data.  
+Includes smooth map fly-to, marker display, and popup with city details.


### PR DESCRIPTION
Closes #9965

This PR adds **Leaflet.CityAutocompleteUSA** to the official Leaflet plugins list.

- Category: Geocoding
- Demo: https://slbarriosdev.github.io/leaflet-city-autocomplete-usa/demo/
- GitHub: https://github.com/slbarriosdev/leaflet-city-autocomplete-usa
- NPM: https://www.npmjs.com/package/leaflet-city-autocomplete-usa
- License: MIT
