### PR TITLE
docs: clarify `L.geoJSON` `onEachFeature` arguments

### DIFF
--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -63,6 +63,8 @@ export class GeoJSON extends FeatureGroup {
 	 * @option onEachFeature: Function = *
 	 * A `Function` that will be called once for each created `Feature`, after it has
 	 * been created and styled. Useful for attaching events and popups to features.
+	 * It will receive the `feature` as the first argument and its corresponding
+	 * spawned `layer` from [`asFeature`](#geojson-asFeature) as the second.
 	 * The default is to do nothing with the newly created layers:
 	 * ```js
 	 * function (feature, layer) {}


### PR DESCRIPTION
A small addition to the documentation for https://leafletjs.com/reference.html#geojson-oneachfeature to clarify that the second argument, `layer`, is spawned layer (and how it was created), rather than potentially the top-level `L.geoJSON` layer itself. 

I ended up inspecting the `layer` argument and Leaflet's source to ensure I understood the behaviour of how this generated, which isn't really obvious, even when carefully reading the information about the default behaviour.