### PR TITLE
fix: replace deprecated navigator.platform with userAgent checks

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -42,10 +42,10 @@ const touch = touchNative || pointer;
 const retina = typeof window === 'undefined' || typeof window.devicePixelRatio === 'undefined' ? false : window.devicePixelRatio > 1;
 
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
-const mac = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Mac');
+const mac = userAgentContains('mac');
 
 // @property linux: Boolean; `true` when the browser is running in a Linux platform
-const linux = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Linux');
+const linux = userAgentContains('linux');
 
 function userAgentContains(str) {
 	if (typeof navigator === 'undefined' || typeof navigator.userAgent === 'undefined') {


### PR DESCRIPTION
## Summary

Replace the deprecated `navigator.platform` API with `userAgent` string checks for Mac and Linux detection in `Browser.js`.

## Motivation

`navigator.platform` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform) and may be removed from browsers in the future. The existing `userAgentContains()` utility is already used in the same file for Chrome and Safari detection, making this a consistent approach.

## Changes

- `Browser.mac`: Changed from `navigator.platform.startsWith('Mac')` to `userAgentContains('mac')`
  - Matches `macintosh` in the lowercase UA string (e.g., `mozilla/5.0 (macintosh; ...)`)
- `Browser.linux`: Changed from `navigator.platform.startsWith('Linux')` to `userAgentContains('linux')`
  - Matches `linux` in the lowercase UA string (e.g., `mozilla/5.0 (x11; linux x86_64)`)

Both properties are used in `DomEvent.js` for scroll wheel delta calculation and continue to work identically.

Partial fix for #9710.