### PR TITLE
Fix move event to always include flyTo property

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -361,7 +361,7 @@ export class LeafletMap extends Evented {
 			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
 		} else {
 			this._rawPanBy(offset);
-			this.fire('move').fire('moveend');
+			this.fire('move', {flyTo: false}).fire('moveend');
 		}
 
 		return this;
@@ -597,7 +597,7 @@ export class LeafletMap extends Evented {
 				this._rawPanBy(offset);
 			}
 
-			this.fire('move');
+			this.fire('move', {flyTo: false});
 
 			if (options.debounceMoveend) {
 				clearTimeout(this._sizeTimer);
@@ -1606,7 +1606,7 @@ export class LeafletMap extends Evented {
 	}
 
 	_onPanTransitionStep() {
-		this.fire('move');
+		this.fire('move', {flyTo: false});
 	}
 
 	_onPanTransitionEnd() {
@@ -1760,7 +1760,7 @@ export class LeafletMap extends Evented {
 		}
 		delete this._tempFireZoomEvent;
 
-		this.fire('move');
+		this.fire('move', {flyTo: false});
 
 		this._moveEnd(true);
 	}


### PR DESCRIPTION
The `move` event now consistently includes the `flyTo` property in all cases.

Previously, the `flyTo` property was only included during flyTo animations, but was missing in other move events (pan, zoom, etc.).

This change adds `flyTo: false` to all move event firings that don't explicitly set it, ensuring consistent event data for consumers.

Fixes #9775