### PR TITLE
fix: correct typo 'supressEvent' to 'suppressEvent' in Map._move()

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1229,7 +1229,7 @@ export class LeafletMap extends Evented {
 		return this;
 	}
 
-	_move(center, zoom, data, supressEvent) {
+	_move(center, zoom, data, suppressEvent) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -1239,7 +1239,7 @@ export class LeafletMap extends Evented {
 		this._lastCenter = center;
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
-		if (!supressEvent) {
+		if (!suppressEvent) {
 			// @event zoom: Event
 			// Fired repeatedly during any change in zoom level,
 			// including zoom and fly animations.


### PR DESCRIPTION
Fix typo in the private `_move()` method parameter name: `supressEvent` → `suppressEvent` (missing 'p').