### PR TITLE
Refactor: Extract initial attribution collection to separate method

### DIFF
--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -45,18 +45,20 @@ export class AttributionControl extends Control {
 		this._container = DomUtil.create('div', 'leaflet-control-attribution');
 		DomEvent.disableClickPropagation(this._container);
 
-		// TODO ugly, refactor
-		for (const layer of Object.values(map._layers)) {
-			if (layer.getAttribution) {
-				this.addAttribution(layer.getAttribution());
-			}
-		}
-
+		this._collectInitialAttributions(map);
 		this._update();
 
 		map.on('layeradd', this._addAttribution, this);
 
 		return this._container;
+	}
+
+	_collectInitialAttributions(map) {
+		for (const layer of Object.values(map._layers)) {
+			if (layer.getAttribution) {
+				this.addAttribution(layer.getAttribution());
+			}
+		}
 	}
 
 	onRemove(map) {


### PR DESCRIPTION
Moved the loop that gathers initial attributions from existing layers into a dedicated `_collectInitialAttributions()` method for better code organization and readability.

This addresses the TODO comment requesting refactoring of the "ugly" inline loop in the `onAdd` method.

**Changes:**
- Extracted the `for...of` loop into `_collectInitialAttributions(map)`
- Maintains identical functionality
- Improves code maintainability