### PR TITLE
Docs: Add documentation for move and zoom event properties

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1243,6 +1243,8 @@ export class LeafletMap extends Evented {
 			// @event zoom: Event
 			// Fired repeatedly during any change in zoom level,
 			// including zoom and fly animations.
+			// The event object may contain a `pinch` property (boolean) indicating
+			// whether the zoom originated from a pinch gesture.
 			if (zoomChanged || (data?.pinch)) {	// Always fire 'zoom' if pinching because #3530
 				this.fire('zoom', data);
 			}
@@ -1250,6 +1252,9 @@ export class LeafletMap extends Evented {
 			// @event move: Event
 			// Fired repeatedly during any movement of the map,
 			// including pan and fly animations.
+			// The event object contains a `flyTo` property (boolean) indicating
+			// whether the move is part of a flyTo animation, and may contain
+			// a `pinch` property (boolean) for pinch-related moves.
 			this.fire('move', data);
 		} else if (data?.pinch) {	// Always fire 'zoom' if pinching because #3530
 			this.fire('zoom', data);


### PR DESCRIPTION
Added documentation for the properties included in `move` and `zoom` events:

**move event:**
- `flyTo`: boolean - indicates whether the move is part of a flyTo animation
- `pinch`: boolean (optional) - indicates pinch-related moves

**zoom event:**
- `pinch`: boolean (optional) - indicates whether the zoom originated from a pinch gesture

This improves API documentation by making it clear what data is available in these commonly-used events, helping developers understand what properties they can access when listening to these events.