### PR TITLE
Fix: Correct spelling of suppressEvent parameter

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1229,7 +1229,7 @@ export class LeafletMap extends Evented {
 		return this;
 	}
 
-	_move(center, zoom, data, supressEvent) {
+	_move(center, zoom, data, suppressEvent) {
 		if (zoom === undefined) {
 			zoom = this._zoom;
 		}
@@ -1239,7 +1239,7 @@ export class LeafletMap extends Evented {
 		this._lastCenter = center;
 		this._pixelOrigin = this._getNewPixelOrigin(center);
 
-		if (!supressEvent) {
+		if (!suppressEvent) {
 			// @event zoom: Event
 			// Fired repeatedly during any change in zoom level,
 			// including zoom and fly animations.


### PR DESCRIPTION
Fixed typo in `_move` method parameter name from `supressEvent` to `suppressEvent` (suppress has double 'p').

**Changes:**
- Renamed parameter from `supressEvent` to `suppressEvent`
- Updated the conditional check to use the corrected parameter name

This is a private method so there are no breaking changes.