### PR TITLE
docs: remove outdated browser compatibility references

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -161,7 +161,7 @@ export function getSizedParentNode(element) {
 // Returns an object with `x` and `y` members as horizontal and vertical scales respectively,
 // and `boundingClientRect` as the result of [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 export function getScale(element) {
-	const rect = element.getBoundingClientRect(); // Read-only in old browsers.
+	const rect = element.getBoundingClientRect();
 
 	return {
 		x: rect.width / element.offsetWidth || 1,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -97,8 +97,7 @@ export class LeafletMap extends Evented {
 
 			// @section Animation Options
 			// @option zoomAnimation: Boolean = true
-			// Whether the map zoom animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
+			// Whether the map zoom animation is enabled.
 			zoomAnimation: true,
 
 			// @option zoomAnimationThreshold: Number = 4
@@ -106,14 +105,12 @@ export class LeafletMap extends Evented {
 			zoomAnimationThreshold: 4,
 
 			// @option fadeAnimation: Boolean = true
-			// Whether the tile fade animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
+			// Whether the tile fade animation is enabled.
 			fadeAnimation: true,
 
 			// @option markerZoomAnimation: Boolean = true
 			// Whether markers animate their zoom with the zoom animation, if disabled
-			// they will disappear for the length of the animation. By default it's
-			// enabled in all browsers that support CSS Transitions except Android.
+			// they will disappear for the length of the animation.
 			markerZoomAnimation: true,
 
 			// @option transform3DLimit: Number = 2^23


### PR DESCRIPTION
## Summary

Remove outdated browser compatibility references from source code documentation.

## Changes

- **Map.js**: Remove "except Android" from `zoomAnimation`, `fadeAnimation`, and `markerZoomAnimation` option descriptions. CSS Transitions have been universally supported across all modern browsers (including Android) for many years.
- **DomUtil.js**: Remove "Read-only in old browsers" comment from `getBoundingClientRect()` call. The return value is a `DOMRect` and has always been read-only per spec.

Partial fix for #8477.