### PR TITLE
Improve test performance by reducing animation durations

### DIFF
--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -274,7 +274,7 @@ describe('TileLayer', () => {
 					done();
 				});
 
-				map.flyTo(trd, 12, {animate: true});
+				map.flyTo(trd, 12, {animate: true, duration: 0.1});
 
 				// map.on('_frame', function () {
 				// 	console.log('frame', counts);

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -1478,7 +1478,7 @@ describe('Map', () => {
 				done();
 			});
 
-			map.flyTo(center, 11, {animate: true});
+			map.flyTo(center, 11, {animate: true, duration: 0.1});
 		});
 	});
 


### PR DESCRIPTION
Addresses #8483 by adding short duration (0.1s) to flyTo() calls in tests that were using default animation timing.

## Changes
- MapSpec.js: Added duration to flyTo test handling Math.log(sq) edge case
- TileLayerSpec.js: Added duration to MAD-TRD flyTo test with 290 tile loads

## Impact
These tests still validate the same functionality but complete much faster, improving the developer experience. The slowest tests were taking several seconds due to default animation durations; now they complete in ~100ms.

## Testing
- ✅ All existing assertions remain unchanged
- ✅ Tests still verify the same behavior
- ✅ Linting passes