### PR TITLE
fix(TileLayer): adjust maxNativeZoom when detectRetina is enabled

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -118,6 +118,15 @@ export class TileLayer extends GridLayer {
 			}
 
 			this.options.minZoom = Math.max(0, this.options.minZoom);
+
+			// Also adjust maxNativeZoom/minNativeZoom to prevent requesting
+			// tiles beyond the tile server's native zoom range (#8850)
+			if (this.options.maxNativeZoom !== undefined) {
+				this.options.maxNativeZoom--;
+			}
+			if (this.options.minNativeZoom !== undefined) {
+				this.options.minNativeZoom = Math.max(0, this.options.minNativeZoom - 1);
+			}
 		} else if (!this.options.zoomReverse) {
 			// make sure maxZoom is gte minZoom
 			this.options.maxZoom = Math.max(this.options.minZoom, this.options.maxZoom);


### PR DESCRIPTION
## Summary

Fix tile requests going beyond the server's native zoom range when `detectRetina` is used together with `maxNativeZoom`.

## Problem

When `detectRetina` is enabled on a retina display, `TileLayer` adjusts `zoomOffset` (+1) and `maxZoom` (-1), but does not adjust `maxNativeZoom`. This causes `_getZoomForUrl()` to return a zoom level beyond the server's native range.

**Example** with `maxNativeZoom: 18` and `detectRetina: true`:
1. `zoomOffset` becomes 1, `maxZoom` becomes 17
2. At display zoom 18, `_tileZoom` is clamped to 18 by `maxNativeZoom`
3. `_getZoomForUrl()` returns `18 + 1 = 19` — requests non-existent tiles

## Fix

Also adjust `maxNativeZoom` (and `minNativeZoom` if set) when `detectRetina` modifies zoom parameters. This ensures `_tileZoom` is correctly clamped, and tile URLs stay within the server's native zoom range.

Fixes #8850.