### PR TITLE
fix(TileLayer): handle undefined/empty subdomains option

### DIFF
--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -126,7 +126,9 @@ export class TileLayer extends GridLayer {
 			this.options.minZoom = Math.min(this.options.maxZoom, this.options.minZoom);
 		}
 
-		if (typeof this.options.subdomains === 'string') {
+		if (!this.options.subdomains) {
+			this.options.subdomains = [];
+		} else if (typeof this.options.subdomains === 'string') {
 			this.options.subdomains = this.options.subdomains.split('');
 		}
 
@@ -237,6 +239,9 @@ export class TileLayer extends GridLayer {
 	}
 
 	_getSubdomain(tilePoint) {
+		if (!this.options.subdomains.length) {
+			return '';
+		}
 		const index = Math.abs(tilePoint.x + tilePoint.y) % this.options.subdomains.length;
 		return this.options.subdomains[index];
 	}


### PR DESCRIPTION
## Summary

Prevent errors when `subdomains` option is set to `undefined` or an empty string.

## Problem

```js
new TileLayer('https://a.tile.openstreetmap.org/{z}/{x}/{y}.png', {
  subdomains: undefined
});
// TypeError: Cannot read property 'length' of undefined
```

The `initialize()` method only checks `typeof === 'string'` before calling `.split('')`, but doesn't handle `undefined`, `null`, or other falsy values. Additionally, `_getSubdomain()` doesn't guard against an empty array, which would cause a division by zero (`% 0` returns `NaN`).

## Fix

- Normalize falsy `subdomains` values to an empty array in `initialize()`
- Guard `_getSubdomain()` to return an empty string when `subdomains` is empty

Fixes #7744.