### PR TITLE
fix(css): increase attribution background opacity for better contrast

### DIFF
--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -470,7 +470,7 @@ path.leaflet-interactive:focus:not(:focus-visible) {
 
 .leaflet-container .leaflet-control-attribution {
 	background: #fff;
-	background: rgba(255, 255, 255, 0.8);
+	background: rgba(255, 255, 255, 0.9);
 	margin: 0;
 }
 


### PR DESCRIPTION
## Summary

Increase the attribution control background opacity from 0.8 to 0.9 to improve text readability.

## Motivation

The attribution text (`#333`) can be hard to read over dark map tiles when the background is only 80% opaque (#7538). This is especially impactful for users with visual impairments.

## Change

`rgba(255, 255, 255, 0.8)` → `rgba(255, 255, 255, 0.9)`

This keeps the semi-transparent appearance while providing better contrast against dark backgrounds, helping meet WCAG 2.1 SC 1.4.3 (Contrast Minimum).

Fixes #7538.