### PR TITLE
refactor: replace +new Date() with Date.now()

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -315,7 +315,7 @@ export class GridLayer extends Layer {
 
 		this._container.style.opacity = this.options.opacity;
 
-		const now = +new Date();
+		const now = Date.now();
 		let nextFrame = false,
 		willPrune = false;
 
@@ -835,7 +835,7 @@ export class GridLayer extends Layer {
 		tile = this._tiles[key];
 		if (!tile) { return; }
 
-		tile.loaded = +new Date();
+		tile.loaded = Date.now();
 		if (this._map._fadeAnimated) {
 			tile.el.style.opacity = 0;
 			cancelAnimationFrame(this._fadeFrame);

--- a/src/map/handler/DragHandler.js
+++ b/src/map/handler/DragHandler.js
@@ -119,7 +119,7 @@ export class DragHandler extends Handler {
 
 	_onDrag(e) {
 		if (this._map.options.inertia) {
-			const time = this._lastTime = +new Date(),
+			const time = this._lastTime = Date.now(),
 			pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
 
 			this._positions.push(pos);
@@ -192,7 +192,7 @@ export class DragHandler extends Handler {
 			map.fire('moveend');
 
 		} else {
-			this._prunePositions(+new Date());
+			this._prunePositions(Date.now());
 
 			const direction = this._lastPos.subtract(this._positions[0]),
 			duration = (this._lastTime - this._times[0]) / 1000,

--- a/src/map/handler/ScrollWheelZoomHandler.js
+++ b/src/map/handler/ScrollWheelZoomHandler.js
@@ -48,10 +48,10 @@ export class ScrollWheelZoomHandler extends Handler {
 		this._lastMousePos = this._map.pointerEventToContainerPoint(e);
 
 		if (!this._startTime) {
-			this._startTime = +new Date();
+			this._startTime = Date.now();
 		}
 
-		const left = Math.max(debounce - (+new Date() - this._startTime), 0);
+		const left = Math.max(debounce - (Date.now() - this._startTime), 0);
 
 		clearTimeout(this._timer);
 		this._timer = setTimeout(this._performZoom.bind(this), left);


### PR DESCRIPTION
Replace the `+new Date()` idiom with the more readable `Date.now()` across the codebase.

Both return the same millisecond timestamp, but `Date.now()` is the modern standard — more explicit and avoids the implicit type coercion.

**Files changed:**
- `src/map/handler/ScrollWheelZoomHandler.js` (2 occurrences)
- `src/map/handler/DragHandler.js` (2 occurrences)  
- `src/layer/tile/GridLayer.js` (1 occurrence — another was already `Date.now()`)