### PR TITLE
refactor: remove deprecated window.event fallbacks

### DIFF
--- a/src/dom/DomEvent.js
+++ b/src/dom/DomEvent.js
@@ -103,7 +103,7 @@ function addOne(obj, type, fn, context) {
 	if (obj[eventsKey] && obj[eventsKey][id]) { return this; }
 
 	let handler = function (e) {
-		return fn.call(context || obj, e || window.event);
+		return fn.call(context || obj, e);
 	};
 
 	const originalHandler = handler;
@@ -117,7 +117,6 @@ function addOne(obj, type, fn, context) {
 			obj.addEventListener(pointerSubst[type] || type, handler, {passive: false});
 		} else if (type === 'pointerenter' || type === 'pointerleave') {
 			handler = function (e) {
-				e ??= window.event;
 				if (isExternalTarget(obj, e)) {
 					originalHandler(e);
 				}


### PR DESCRIPTION
Remove the `e || window.event` and `e ??= window.event` fallbacks in `DomEvent.js`.

These were IE-era workarounds for browsers that did not pass the event object to `addEventListener` callbacks. All modern browsers (and all browsers targeted by Leaflet 2.x) pass the event as the first parameter, making [`window.event`](https://developer.mozilla.org/en-US/docs/Web/API/Window/event) unnecessary.

`window.event` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Window/event) and should not be relied upon.