### PR TITLE
feat(css): respect prefers-reduced-motion for animations

### DIFF
--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -708,6 +708,20 @@ path.leaflet-interactive:focus:not(:focus-visible) {
 	}
 }
 
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+	.leaflet-fade-anim .leaflet-popup {
+		transition: none;
+	}
+	.leaflet-fade-anim .leaflet-map-pane .leaflet-tile {
+		transition: none;
+	}
+	.leaflet-zoom-anim .leaflet-zoom-animated {
+		transition: none;
+	}
+}
+
 /* Printing */
 
 @media print {


### PR DESCRIPTION
## Summary

Add a `prefers-reduced-motion` media query to disable CSS transitions for users who have requested reduced motion in their OS settings.

## Motivation

Users with vestibular disorders or motion sensitivity can enable "Reduce motion" in their OS accessibility settings. Web applications should respect this preference per [WCAG 2.3.3 (Animation from Interactions)](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions.html).

Currently, Leaflet's tile fade-in, popup fade, and zoom animations play regardless of the user's motion preferences.

## Changes

Added a `@media (prefers-reduced-motion: reduce)` block that sets `transition: none` on:
- `.leaflet-fade-anim .leaflet-popup` — popup fade transitions
- `.leaflet-fade-anim .leaflet-map-pane .leaflet-tile` — tile fade-in transitions  
- `.leaflet-zoom-anim .leaflet-zoom-animated` — zoom animations

This is CSS-only and has no impact on users without the reduced motion preference.