### PR TITLE
docs: update mobile example to use viewport units

### DIFF
--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -6,7 +6,7 @@ css: "body {
 		margin: 0;
 	}
 	#map {
-		height: 100%;
+		height: 100vh;
 		width: 100vw;
 	}"
 ---

--- a/docs/examples/mobile/index.md
+++ b/docs/examples/mobile/index.md
@@ -11,7 +11,7 @@ In this example, you'll learn how to create a fullscreen map tuned for mobile de
 
 ### Preparing the page
 
-First we'll take a look at the HTML &amp; CSS code of the page. To make our map `div` element stretch to all available space (fullscreen), we can use the following CSS code (note: In this example we use percentage for height. While vh is arguably better, due to a bug with Google Chrome on mobile.):
+First we'll take a look at the HTML &amp; CSS code of the page. To make our map `div` element stretch to all available space (fullscreen), we can use the following CSS code:
 
 {: .css}
 	body {
@@ -19,7 +19,7 @@ First we'll take a look at the HTML &amp; CSS code of the page. To make our map 
 		margin: 0;
 	}
 	html, body, #map {
-		height: 100%;
+		height: 100vh;
 		width: 100vw;
 	}
 


### PR DESCRIPTION
Update the mobile tutorial example to use `100vh` instead of `100%` for the map height.

The Chrome mobile bug that previously prevented using `vh` units was fixed years ago. Using `100vh` is more reliable for fullscreen maps as it doesn't depend on parent elements having explicit heights.

Also removes the parenthetical note about the workaround from the tutorial text.

Fixes #7342.