### PR TITLE
fix: prevent exception when removing map during GridLayer load event

### DIFF
--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -836,7 +836,7 @@ export class GridLayer extends Layer {
 		if (!tile) { return; }
 
 		tile.loaded = +new Date();
-		if (this._map._fadeAnimated) {
+		if (this._map && this._map._fadeAnimated) {
 			tile.el.style.opacity = 0;
 			cancelAnimationFrame(this._fadeFrame);
 			this._fadeFrame = requestAnimationFrame(this._updateOpacity.bind(this));
@@ -861,6 +861,9 @@ export class GridLayer extends Layer {
 			// @event load: Event
 			// Fired when the grid layer loaded all visible tiles.
 			this.fire('load');
+
+			// Check if map still exists (it could be removed in load event handler)
+			if (!this._map) { return; }
 
 			if (!this._map._fadeAnimated) {
 				requestAnimationFrame(this._pruneTiles.bind(this));


### PR DESCRIPTION
Fixes #7116

**Problem:**
When `map.remove()` was called inside a GridLayer `'load'` event handler, subsequent code would throw:
```
TypeError: Cannot read property '_fadeAnimated' of null
```

This happened because:
1. The `load` event fires in `_tileReady()`
2. An event handler calls `map.remove()`, setting `this._map = null`
3. Code after the event tries to access `this._map._fadeAnimated` → exception

**Solution:**
- Add null check for `this._map` before accessing `_fadeAnimated` (line 839)
- Add early return after `load` event if `this._map` is null (line 865)

This allows the layer to gracefully handle map removal during the load event without throwing exceptions.

**Testing:**
The fix prevents the exceptions described in the original issue when calling `map.remove()` in a GridLayer load event handler.