### PR TITLE
docs: add missing JSDoc annotations for public methods

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -78,11 +78,16 @@ export class Layer extends Evented {
 		return this._map.getPane(name ? (this.options[name] || name) : this.options.pane);
 	}
 
+	// @method addInteractiveTarget(targetEl: HTMLElement): this
+	// Registers a DOM element as an interactive target for this layer.
+	// Used internally to handle events on layer elements.
 	addInteractiveTarget(targetEl) {
 		this._map._targets[Util.stamp(targetEl)] = this;
 		return this;
 	}
 
+	// @method removeInteractiveTarget(targetEl: HTMLElement): this
+	// Unregisters a DOM element as an interactive target for this layer.
 	removeInteractiveTarget(targetEl) {
 		delete this._map._targets[Util.stamp(targetEl)];
 		return this;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -204,6 +204,8 @@ export class Tooltip extends DivOverlay {
 		this._setPosition(pos);
 	}
 
+	// @method setOpacity(opacity: Number): this
+	// Sets the opacity of the tooltip.
 	setOpacity(opacity) {
 		this.options.opacity = opacity;
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -204,6 +204,9 @@ export class Marker extends Layer {
 		return this._icon;
 	}
 
+	// @method update(): this
+	// Updates the marker position based on the current geographical coordinates.
+	// Useful for updating marker position after programmatically changing coordinates.
 	update() {
 
 		if (this._icon && this._map) {

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -58,6 +58,8 @@ export class Circle extends CircleMarker {
 			this._map.layerPointToLatLng(this._point.add(half)));
 	}
 
+	// @method setStyle(options: Path options): this
+	// Sets the style of the circle. Also updates the circle radius if the `radius` option is specified.
 	setStyle(options) {
 		Path.prototype.setStyle.call(this, options);
 		if (options?.radius !== undefined) {


### PR DESCRIPTION
Adds `@method` JSDoc annotations for public methods that previously lacked proper API documentation.

**Methods documented:**

### Layer.js
- `addInteractiveTarget(targetEl)` — registers a DOM element as an interactive target
- `removeInteractiveTarget(targetEl)` — unregisters an interactive target

These methods are used by custom layer implementations to handle events on layer elements.

### Marker.js
- `update()` — updates marker position based on current coordinates

Useful when programmatically changing marker coordinates.

### Tooltip.js
- `setOpacity(opacity)` — sets the tooltip opacity

Public API method for controlling tooltip visibility.

### Circle.js
- `setStyle(options)` — overridden to also handle radius updates

Important to document this override behavior so developers know `radius` can be set via `setStyle()`.

---

These methods were all functional but lacked proper JSDoc annotations, making them difficult to discover in the API documentation. This PR improves API discoverability without changing any functionality.