### PR TITLE
Replace static {} blocks with static defaultOptions for tree-shaking support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ui-event-simulator": "^2.0.0"
   },
   "type": "module",
+  "sideEffects": false,
   "exports": {
     ".": "./dist/leaflet-src.js",
     "./styles.css": "./dist/leaflet.css"

--- a/spec/suites/layer/PopupSpec.js
+++ b/spec/suites/layer/PopupSpec.js
@@ -247,10 +247,10 @@ describe('Popup', () => {
 		const latlng = center;
 		const offset = new Point(20, 30);
 
-		const autoPanBefore = Popup.prototype.options.autoPan;
-		Popup.prototype.options.autoPan = false;
-		const popupAnchorBefore = DefaultIcon.prototype.options.popupAnchor;
-		DefaultIcon.prototype.options.popupAnchor = [0, 0];
+		const autoPanBefore = Popup.defaultOptions.autoPan;
+		Popup.defaultOptions.autoPan = false;
+		const popupAnchorBefore = DefaultIcon.defaultOptions.popupAnchor;
+		DefaultIcon.defaultOptions.popupAnchor = [0, 0];
 
 		const icon = new DivIcon({popupAnchor: offset});
 		const marker1 = new Marker(latlng);
@@ -275,8 +275,8 @@ describe('Popup', () => {
 		expect(offsetLeft - offset.x).to.eql(defaultLeft);
 		expect(offsetTop - offset.y).to.eql(defaultTop);
 
-		Popup.prototype.options.autoPan = autoPanBefore;
-		DefaultIcon.prototype.options.popupAnchor = popupAnchorBefore;
+		Popup.defaultOptions.autoPan = autoPanBefore;
+		DefaultIcon.defaultOptions.popupAnchor = popupAnchorBefore;
 	});
 
 	it('prevents an underlying map click for Layer', () => {

--- a/spec/suites/layer/marker/DefaultIconSpec.js
+++ b/spec/suites/layer/marker/DefaultIconSpec.js
@@ -55,30 +55,30 @@ describe('DefaultIcon', () => {
 	});
 
 	it('don\'t set shadow icon if null', () => {
-		const oldShadowUrl = DefaultIcon.prototype.options.shadowUrl;
-		DefaultIcon.prototype.options.shadowUrl = null;
+		const oldShadowUrl = DefaultIcon.defaultOptions.shadowUrl;
+		DefaultIcon.defaultOptions.shadowUrl = null;
 		const marker = new Marker([0, 0]).addTo(map);
 
 		expect(marker._shadow).to.be.null;
 
 		// This is needed because else other tests will fail
-		DefaultIcon.prototype.options.shadowUrl = oldShadowUrl;
+		DefaultIcon.defaultOptions.shadowUrl = oldShadowUrl;
 	});
 
 	it('don\'t set retina shadow icon if null', () => {
-		const oldShadowRetinaUrl = DefaultIcon.prototype.options.shadowRetinaUrl;
-		const oldShadowUrl = DefaultIcon.prototype.options.shadowUrl;
+		const oldShadowRetinaUrl = DefaultIcon.defaultOptions.shadowRetinaUrl;
+		const oldShadowUrl = DefaultIcon.defaultOptions.shadowUrl;
 		const oldRetinaValue = Browser.retina;
 		Browser.retina = true;
-		DefaultIcon.prototype.options.shadowRetinaUrl = null;
-		DefaultIcon.prototype.options.shadowUrl = null;
+		DefaultIcon.defaultOptions.shadowRetinaUrl = null;
+		DefaultIcon.defaultOptions.shadowUrl = null;
 		const marker = new Marker([0, 0]).addTo(map);
 
 		expect(marker._shadow).to.be.null;
 
 		// This is needed because else other tests will fail
-		DefaultIcon.prototype.options.shadowRetinaUrl = oldShadowRetinaUrl;
-		DefaultIcon.prototype.options.shadowUrl = oldShadowUrl;
+		DefaultIcon.defaultOptions.shadowRetinaUrl = oldShadowRetinaUrl;
+		DefaultIcon.defaultOptions.shadowUrl = oldShadowUrl;
 		Browser.retina = oldRetinaValue;
 	});
 });

--- a/spec/suites/layer/tile/WMSTileLayerSpec.js
+++ b/spec/suites/layer/tile/WMSTileLayerSpec.js
@@ -6,7 +6,7 @@ describe('WMSTileLayer', () => {
 		it('sets wmsParams', () => {
 			const layer = new WMSTileLayer('https://example.com/map', {opacity: 0.5, attribution: 'foo'});
 			expect(layer.wmsParams).to.eql({
-				...layer.defaultWmsParams,
+				...WMSTileLayer.defaultWmsParams,
 				width: 256,
 				height: 256
 			});

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -19,20 +19,19 @@ const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg
 // Creates an attribution control.
 export class AttributionControl extends Control {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka AttributionControl options
-		this.setDefaultOptions({
-			// @option position: String = 'bottomright'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'bottomright',
 
-			// @option prefix: String|false = 'Leaflet'
-			// The HTML text shown before the attributions. Pass `false` to disable.
-			prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
-		});
-	}
+		// @option position: String = 'bottomright'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'bottomright',
+
+		// @option prefix: String|false = 'Leaflet'
+		// The HTML text shown before the attributions. Pass `false` to disable.
+		prefix: `<a target="_blank" href="https://leafletjs.com" title="A JavaScript library for interactive maps">${ukrainianFlag}Leaflet</a>`
+	};
 
 	initialize(options) {
 		super.initialize(options);

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -14,16 +14,15 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 export class Control extends Class {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Control Options
-		this.setDefaultOptions({
-			// @option position: String = 'topright'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'topright'
-		});
-	}
+
+		// @option position: String = 'topright'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'topright'
+	};
 
 
 	initialize(options) {

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -46,44 +46,43 @@ import * as DomUtil from '../dom/DomUtil.js';
 // Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.
 export class LayersControl extends Control {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka LayersControl options
-		this.setDefaultOptions({
-			// @option collapsed: Boolean = true
-			// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
-			collapsed: true,
 
-			// @option collapseDelay: Number = 0
-			// Collapse delay in milliseconds. If greater than 0, the control will remain open longer, making it easier to scroll through long layer lists.
-			collapseDelay: 0,
+		// @option collapsed: Boolean = true
+		// If `true`, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.
+		collapsed: true,
 
-			position: 'topright',
+		// @option collapseDelay: Number = 0
+		// Collapse delay in milliseconds. If greater than 0, the control will remain open longer, making it easier to scroll through long layer lists.
+		collapseDelay: 0,
 
-			// @option autoZIndex: Boolean = true
-			// If `true`, the control will assign zIndexes in increasing order to all of its layers so that the order is preserved when switching them on/off.
-			autoZIndex: true,
+		position: 'topright',
 
-			// @option hideSingleBase: Boolean = false
-			// If `true`, the base layers in the control will be hidden when there is only one.
-			hideSingleBase: false,
+		// @option autoZIndex: Boolean = true
+		// If `true`, the control will assign zIndexes in increasing order to all of its layers so that the order is preserved when switching them on/off.
+		autoZIndex: true,
 
-			// @option sortLayers: Boolean = false
-			// Whether to sort the layers. When `false`, layers will keep the order
-			// in which they were added to the control.
-			sortLayers: false,
+		// @option hideSingleBase: Boolean = false
+		// If `true`, the base layers in the control will be hidden when there is only one.
+		hideSingleBase: false,
 
-			// @option sortFunction: Function = *
-			// A [compare function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
-			// that will be used for sorting the layers, when `sortLayers` is `true`.
-			// The function receives both the `Layer` instances and their names, as in
-			// `sortFunction(layerA, layerB, nameA, nameB)`.
-			// By default, it sorts layers alphabetically by their name.
-			sortFunction(layerA, layerB, nameA, nameB) {
-				return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
-			}
-		});
-	}
+		// @option sortLayers: Boolean = false
+		// Whether to sort the layers. When `false`, layers will keep the order
+		// in which they were added to the control.
+		sortLayers: false,
+
+		// @option sortFunction: Function = *
+		// A [compare function](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort)
+		// that will be used for sorting the layers, when `sortLayers` is `true`.
+		// The function receives both the `Layer` instances and their names, as in
+		// `sortFunction(layerA, layerB, nameA, nameB)`.
+		// By default, it sorts layers alphabetically by their name.
+		sortFunction(layerA, layerB, nameA, nameB) {
+			return nameA < nameB ? -1 : (nameB < nameA ? 1 : 0);
+		}
+	};
 
 	initialize(baseLayers, overlays, options) {
 		super.initialize(options);

--- a/src/control/ScaleControl.js
+++ b/src/control/ScaleControl.js
@@ -19,32 +19,31 @@ import * as DomUtil from '../dom/DomUtil.js';
 // Creates an scale control with the given options.
 export class ScaleControl extends Control {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka ScaleControl options
-		this.setDefaultOptions({
-			// @option position: String = 'bottomleft'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'bottomleft',
 
-			// @option maxWidth: Number = 100
-			// Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).
-			maxWidth: 100,
+		// @option position: String = 'bottomleft'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'bottomleft',
 
-			// @option metric: Boolean = True
-			// Whether to show the metric scale line (m/km).
-			metric: true,
+		// @option maxWidth: Number = 100
+		// Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).
+		maxWidth: 100,
 
-			// @option imperial: Boolean = True
-			// Whether to show the imperial scale line (mi/ft).
-			imperial: true,
+		// @option metric: Boolean = True
+		// Whether to show the metric scale line (m/km).
+		metric: true,
 
-			// @option updateWhenIdle: Boolean = false
-			// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
-			updateWhenIdle: false
-		});
-	}
+		// @option imperial: Boolean = True
+		// Whether to show the imperial scale line (mi/ft).
+		imperial: true,
+
+		// @option updateWhenIdle: Boolean = false
+		// If `true`, the control is updated on [`moveend`](#map-moveend), otherwise it's always up-to-date (updated on [`move`](#map-move)).
+		updateWhenIdle: false
+	};
 
 	onAdd(map) {
 		const className = 'leaflet-control-scale',

--- a/src/control/ZoomControl.js
+++ b/src/control/ZoomControl.js
@@ -16,32 +16,31 @@ import * as DomEvent from '../dom/DomEvent.js';
 // Creates a zoom control
 export class ZoomControl extends Control {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka ZoomControl options
-		this.setDefaultOptions({
-			// @option position: String = 'topleft'
-			// The position of the control (one of the map corners). Possible values are `'topleft'`,
-			// `'topright'`, `'bottomleft'` or `'bottomright'`
-			position: 'topleft',
 
-			// @option zoomInText: String = '<span aria-hidden="true">+</span>'
-			// The text set on the 'zoom in' button.
-			zoomInText: '<span aria-hidden="true">+</span>',
+		// @option position: String = 'topleft'
+		// The position of the control (one of the map corners). Possible values are `'topleft'`,
+		// `'topright'`, `'bottomleft'` or `'bottomright'`
+		position: 'topleft',
 
-			// @option zoomInTitle: String = 'Zoom in'
-			// The title set on the 'zoom in' button.
-			zoomInTitle: 'Zoom in',
+		// @option zoomInText: String = '<span aria-hidden="true">+</span>'
+		// The text set on the 'zoom in' button.
+		zoomInText: '<span aria-hidden="true">+</span>',
 
-			// @option zoomOutText: String = '<span aria-hidden="true">&#x2212;</span>'
-			// The text set on the 'zoom out' button.
-			zoomOutText: '<span aria-hidden="true">&#x2212;</span>',
+		// @option zoomInTitle: String = 'Zoom in'
+		// The title set on the 'zoom in' button.
+		zoomInTitle: 'Zoom in',
 
-			// @option zoomOutTitle: String = 'Zoom out'
-			// The title set on the 'zoom out' button.
-			zoomOutTitle: 'Zoom out'
-		});
-	}
+		// @option zoomOutText: String = '<span aria-hidden="true">&#x2212;</span>'
+		// The text set on the 'zoom out' button.
+		zoomOutText: '<span aria-hidden="true">&#x2212;</span>',
+
+		// @option zoomOutTitle: String = 'Zoom out'
+		// The title set on the 'zoom out' button.
+		zoomOutTitle: 'Zoom out'
+	};
 
 	onAdd(map) {
 		const zoomName = 'leaflet-control-zoom',

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -86,11 +86,48 @@ export function splitWords(str) {
 // Merges the given properties to the `options` of the `obj` object, returning the resulting options. See `Class options`.
 export function setOptions(obj, options) {
 	if (!Object.hasOwn(obj, 'options')) {
-		obj.options = obj.options ? Object.create(obj.options) : {};
+		// Collect static defaultOptions from the prototype chain.
+		// This supports tree-shaking: each class declares only its own defaults as a
+		// static class field (`static defaultOptions = {...}`), and inheritance is
+		// resolved here at construction time rather than at class-definition time.
+		const staticDefaults = [];
+		const protoOptions = [];
+		let proto = obj;
+		while ((proto = Object.getPrototypeOf(proto)) !== null) {
+			const ctor = proto.constructor;
+			if (ctor && Object.hasOwn(ctor, 'defaultOptions')) {
+				staticDefaults.unshift(ctor.defaultOptions);
+			}
+			// Also collect prototype.options set by plugins via mergeOptions/include
+			if (Object.hasOwn(proto, 'options')) {
+				protoOptions.unshift(proto.options);
+			}
+		}
+		if (staticDefaults.length > 0) {
+			// Link each defaultOptions object to its parent via prototype chain (once per pairing).
+			// This creates live inheritance: modifying a class's defaultOptions is immediately
+			// visible to all instances that haven't overridden that property.
+			for (let i = 1; i < staticDefaults.length; i++) {
+				if (Object.getPrototypeOf(staticDefaults[i]) === Object.prototype) {
+					Object.setPrototypeOf(staticDefaults[i], staticDefaults[i - 1]);
+				}
+			}
+			// Instance options inherit directly from the most-derived defaultOptions object
+			obj.options = Object.create(staticDefaults[staticDefaults.length - 1]);
+			// Layer in any plugin-added options (from mergeOptions/include)
+			for (const pluginOpts of protoOptions) {
+				Object.assign(obj.options, pluginOpts);
+			}
+		} else {
+			// Legacy path: options set via setDefaultOptions on the prototype
+			obj.options = obj.options ? Object.create(obj.options) : {};
+		}
 	}
-	for (const i in options) {
-		if (Object.hasOwn(options, i)) {
-			obj.options[i] = options[i];
+	if (options) {
+		for (const i in options) {
+			if (Object.hasOwn(options, i)) {
+				obj.options[i] = options[i];
+			}
 		}
 	}
 	return obj.options;

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -21,16 +21,15 @@ import * as PointerEvents from './DomEvent.PointerEvents.js';
 
 export class Draggable extends Evented {
 
-	static {
-		this.setDefaultOptions({
-			// @section
-			// @aka Draggable options
-			// @option clickTolerance: Number = 3
-			// The max number of pixels a user can shift the pointer during a click
-			// for it to be considered a valid click (as opposed to a pointer drag).
-			clickTolerance: 3
-		});
-	}
+	static defaultOptions = {
+
+		// @section
+		// @aka Draggable options
+		// @option clickTolerance: Number = 3
+		// The max number of pixels a user can shift the pointer during a click
+		// for it to be considered a valid click (as opposed to a pointer drag).
+		clickTolerance: 3
+	};
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -17,23 +17,22 @@ import {Bounds} from '../geometry/Bounds.js';
 
 export class BlanketOverlay extends Layer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka BlanketOverlay options
-		this.setDefaultOptions({
-			// @option padding: Number = 0.1
-			// How much to extend the clip area around the map view (relative to its size)
-			// e.g. 0.1 would be 10% of map view in each direction
-			padding: 0.1,
 
-			// @option continuous: Boolean = false
-			// When `false`, the blanket will update its position only when the
-			// map state settles (*after* a pan/zoom animation). When `true`,
-			// it will update when the map state changes (*during* pan/zoom
-			// animations)
-			continuous: false,
-		});
-	}
+		// @option padding: Number = 0.1
+		// How much to extend the clip area around the map view (relative to its size)
+		// e.g. 0.1 would be 10% of map view in each direction
+		padding: 0.1,
+
+		// @option continuous: Boolean = false
+		// When `false`, the blanket will update its position only when the
+		// map state settles (*after* a pan/zoom animation). When `true`,
+		// it will update when the map state changes (*during* pan/zoom
+		// animations)
+		continuous: false,
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -15,32 +15,31 @@ import * as DomUtil from '../dom/DomUtil.js';
 // @namespace DivOverlay
 export class DivOverlay extends Layer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka DivOverlay options
-		this.setDefaultOptions({
-			// @option interactive: Boolean = false
-			// If true, the popup/tooltip will listen to the pointer events.
-			interactive: false,
 
-			// @option offset: Point = Point(0, 0)
-			// The offset of the overlay position.
-			offset: [0, 0],
+		// @option interactive: Boolean = false
+		// If true, the popup/tooltip will listen to the pointer events.
+		interactive: false,
 
-			// @option className: String = ''
-			// A custom CSS class name to assign to the overlay.
-			className: '',
+		// @option offset: Point = Point(0, 0)
+		// The offset of the overlay position.
+		offset: [0, 0],
 
-			// @option pane: String = undefined
-			// `Map pane` where the overlay will be added.
-			pane: undefined,
+		// @option className: String = ''
+		// A custom CSS class name to assign to the overlay.
+		className: '',
 
-			// @option content: String|HTMLElement|Function = ''
-			// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-			// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
-			content: ''
-		});
-	}
+		// @option pane: String = undefined
+		// `Map pane` where the overlay will be added.
+		pane: undefined,
+
+		// @option content: String|HTMLElement|Function = ''
+		// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
+		// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
+		content: ''
+	};
 
 	initialize(options, source) {
 		if (options instanceof LatLng || Array.isArray(options)) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -24,48 +24,47 @@ import * as DomUtil from '../dom/DomUtil.js';
 // geographical bounds it is tied to.
 export class ImageOverlay extends Layer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka ImageOverlay options
-		this.setDefaultOptions({
-			// @option opacity: Number = 1.0
-			// The opacity of the image overlay.
-			opacity: 1,
 
-			// @option alt: String = ''
-			// Text for the `alt` attribute of the image (useful for accessibility).
-			alt: '',
+		// @option opacity: Number = 1.0
+		// The opacity of the image overlay.
+		opacity: 1,
 
-			// @option interactive: Boolean = false
-			// If `true`, the image overlay will emit [pointer events](#interactive-layer) when clicked or hovered.
-			interactive: false,
+		// @option alt: String = ''
+		// Text for the `alt` attribute of the image (useful for accessibility).
+		alt: '',
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the image.
-			// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false,
+		// @option interactive: Boolean = false
+		// If `true`, the image overlay will emit [pointer events](#interactive-layer) when clicked or hovered.
+		interactive: false,
 
-			// @option errorOverlayUrl: String = ''
-			// URL to the overlay image to show in place of the overlay that failed to load.
-			errorOverlayUrl: '',
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the image.
+		// If a String is provided, the image will have its crossOrigin attribute set to the String provided. This is needed if you want to access image pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false,
 
-			// @option zIndex: Number = 1
-			// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the overlay layer.
-			zIndex: 1,
+		// @option errorOverlayUrl: String = ''
+		// URL to the overlay image to show in place of the overlay that failed to load.
+		errorOverlayUrl: '',
 
-			// @option className: String = ''
-			// A custom class name to assign to the image. Empty by default.
-			className: '',
+		// @option zIndex: Number = 1
+		// The explicit [zIndex](https://developer.mozilla.org/docs/Web/CSS/CSS_Positioning/Understanding_z_index) of the overlay layer.
+		zIndex: 1,
 
-			// @option decoding: String = 'auto'
-			// Tells the browser whether to decode the image in a synchronous fashion,
-			// as per the [`decoding` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
-			// If the image overlay is flickering when being added/removed, set
-			// this option to `'sync'`.
-			decoding: 'auto'
-		});
-	}
+		// @option className: String = ''
+		// A custom class name to assign to the image. Empty by default.
+		className: '',
+
+		// @option decoding: String = 'auto'
+		// Tells the browser whether to decode the image in a synchronous fashion,
+		// as per the [`decoding` HTML attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding).
+		// If the image overlay is flickering when being added/removed, set
+		// this option to `'sync'`.
+		decoding: 'auto'
+	};
 
 	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
 		this._url = url;

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -28,21 +28,20 @@ import * as Util from '../core/Util.js';
 
 export class Layer extends Evented {
 
-	static {
+	static defaultOptions = {
 		// Classes extending `Layer` will inherit the following options:
-		this.setDefaultOptions({
-			// @option pane: String = 'overlayPane'
-			// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
-			// Not effective if the `renderer` option is set (the `renderer` option will override the `pane` option).
-			pane: 'overlayPane',
 
-			// @option attribution: String = null
-			// String to be shown in the attribution control, e.g. "© OpenStreetMap contributors". It describes the layer data and is often a legal obligation towards copyright holders and tile providers.
-			attribution: null,
+		// @option pane: String = 'overlayPane'
+		// By default the layer will be added to the map's [overlay pane](#map-overlaypane). Overriding this option will cause the layer to be placed on another pane by default.
+		// Not effective if the `renderer` option is set (the `renderer` option will override the `pane` option).
+		pane: 'overlayPane',
 
-			bubblingPointerEvents: true
-		});
-	}
+		// @option attribution: String = null
+		// String to be shown in the attribution control, e.g. "© OpenStreetMap contributors". It describes the layer data and is often a legal obligation towards copyright holders and tile providers.
+		attribution: null,
+
+		bubblingPointerEvents: true
+	};
 
 	/* @section
 	 * Classes extending `Layer` will inherit the following methods:

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -47,89 +47,88 @@ import {FeatureGroup} from './FeatureGroup.js';
 // Instantiates a `Popup` object given `latlng` where the popup will open and an optional `options` object that describes its appearance and location.
 export class Popup extends DivOverlay {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Popup options
-		this.setDefaultOptions({
-			// @option pane: String = 'popupPane'
-			// `Map pane` where the popup will be added.
-			pane: 'popupPane',
 
-			// @option offset: Point = Point(0, 7)
-			// The offset of the popup position.
-			offset: [0, 7],
+		// @option pane: String = 'popupPane'
+		// `Map pane` where the popup will be added.
+		pane: 'popupPane',
 
-			// @option maxWidth: Number = 300
-			// Max width of the popup, in pixels.
-			maxWidth: 300,
+		// @option offset: Point = Point(0, 7)
+		// The offset of the popup position.
+		offset: [0, 7],
 
-			// @option minWidth: Number = 50
-			// Min width of the popup, in pixels.
-			minWidth: 50,
+		// @option maxWidth: Number = 300
+		// Max width of the popup, in pixels.
+		maxWidth: 300,
 
-			// @option maxHeight: Number = null
-			// If set, creates a scrollable container of the given height
-			// inside a popup if its content exceeds it.
-			// The scrollable container can be styled using the
-			// `leaflet-popup-scrolled` CSS class selector.
-			maxHeight: null,
+		// @option minWidth: Number = 50
+		// Min width of the popup, in pixels.
+		minWidth: 50,
 
-			// @option autoPan: Boolean = true
-			// Set it to `false` if you don't want the map to do panning animation
-			// to fit the opened popup.
-			autoPan: true,
+		// @option maxHeight: Number = null
+		// If set, creates a scrollable container of the given height
+		// inside a popup if its content exceeds it.
+		// The scrollable container can be styled using the
+		// `leaflet-popup-scrolled` CSS class selector.
+		maxHeight: null,
 
-			// @option autoPanPaddingTopLeft: Point = null
-			// The margin between the popup and the top left corner of the map
-			// view after autopanning was performed.
-			autoPanPaddingTopLeft: null,
+		// @option autoPan: Boolean = true
+		// Set it to `false` if you don't want the map to do panning animation
+		// to fit the opened popup.
+		autoPan: true,
 
-			// @option autoPanPaddingBottomRight: Point = null
-			// The margin between the popup and the bottom right corner of the map
-			// view after autopanning was performed.
-			autoPanPaddingBottomRight: null,
+		// @option autoPanPaddingTopLeft: Point = null
+		// The margin between the popup and the top left corner of the map
+		// view after autopanning was performed.
+		autoPanPaddingTopLeft: null,
 
-			// @option autoPanPadding: Point = Point(5, 5)
-			// Equivalent of setting both top left and bottom right autopan padding to the same value.
-			autoPanPadding: [5, 5],
+		// @option autoPanPaddingBottomRight: Point = null
+		// The margin between the popup and the bottom right corner of the map
+		// view after autopanning was performed.
+		autoPanPaddingBottomRight: null,
 
-			// @option keepInView: Boolean = false
-			// Set it to `true` if you want to prevent users from panning the popup
-			// off of the screen while it is open.
-			keepInView: false,
+		// @option autoPanPadding: Point = Point(5, 5)
+		// Equivalent of setting both top left and bottom right autopan padding to the same value.
+		autoPanPadding: [5, 5],
 
-			// @option closeButton: Boolean = true
-			// Controls the presence of a close button in the popup.
-			closeButton: true,
+		// @option keepInView: Boolean = false
+		// Set it to `true` if you want to prevent users from panning the popup
+		// off of the screen while it is open.
+		keepInView: false,
 
-			// @option closeButtonLabel: String = 'Close popup'
-			// Specifies the 'aria-label' attribute of the close button.
-			closeButtonLabel: 'Close popup',
+		// @option closeButton: Boolean = true
+		// Controls the presence of a close button in the popup.
+		closeButton: true,
 
-			// @option autoClose: Boolean = true
-			// Set it to `false` if you want to override the default behavior of
-			// the popup closing when another popup is opened.
-			autoClose: true,
+		// @option closeButtonLabel: String = 'Close popup'
+		// Specifies the 'aria-label' attribute of the close button.
+		closeButtonLabel: 'Close popup',
 
-			// @option closeOnEscapeKey: Boolean = true
-			// Set it to `false` if you want to override the default behavior of
-			// the ESC key for closing of the popup.
-			closeOnEscapeKey: true,
+		// @option autoClose: Boolean = true
+		// Set it to `false` if you want to override the default behavior of
+		// the popup closing when another popup is opened.
+		autoClose: true,
 
-			// @option closeOnClick: Boolean = *
-			// Set it if you want to override the default behavior of the popup closing when user clicks
-			// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
+		// @option closeOnEscapeKey: Boolean = true
+		// Set it to `false` if you want to override the default behavior of
+		// the ESC key for closing of the popup.
+		closeOnEscapeKey: true,
 
-			// @option className: String = ''
-			// A custom CSS class name to assign to the popup.
-			className: '',
+		// @option closeOnClick: Boolean = *
+		// Set it if you want to override the default behavior of the popup closing when user clicks
+		// on the map. Defaults to the map's [`closePopupOnClick`](#map-closepopuponclick) option.
 
-			// @option trackResize: Boolean = true
-			// Whether the popup shall react to changes in the size of its contents
-			// (e.g. when an image inside the popup loads) and reposition itself.
-			trackResize: true,
-		});
-	}
+		// @option className: String = ''
+		// A custom CSS class name to assign to the popup.
+		className: '',
+
+		// @option trackResize: Boolean = true
+		// Whether the popup shall react to changes in the size of its contents
+		// (e.g. when an image inside the popup loads) and reposition itself.
+		trackResize: true,
+	};
 
 	// @namespace Popup
 	// @method openOn(map: LeafletMap): this

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -53,38 +53,37 @@ import {FeatureGroup} from './FeatureGroup.js';
 // Instantiates a `Tooltip` object given `latlng` where the tooltip will open and an optional `options` object that describes its appearance and location.
 export class Tooltip extends DivOverlay {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Tooltip options
-		this.setDefaultOptions({
-			// @option pane: String = 'tooltipPane'
-			// `Map pane` where the tooltip will be added.
-			pane: 'tooltipPane',
 
-			// @option offset: Point = Point(0, 0)
-			// Optional offset of the tooltip position.
-			offset: [0, 0],
+		// @option pane: String = 'tooltipPane'
+		// `Map pane` where the tooltip will be added.
+		pane: 'tooltipPane',
 
-			// @option direction: String = 'auto'
-			// Direction where to open the tooltip. Possible values are: `right`, `left`,
-			// `top`, `bottom`, `center`, `auto`.
-			// `auto` will dynamically switch between `right` and `left` according to the tooltip
-			// position on the map.
-			direction: 'auto',
+		// @option offset: Point = Point(0, 0)
+		// Optional offset of the tooltip position.
+		offset: [0, 0],
 
-			// @option permanent: Boolean = false
-			// Whether to open the tooltip permanently or only on pointerover.
-			permanent: false,
+		// @option direction: String = 'auto'
+		// Direction where to open the tooltip. Possible values are: `right`, `left`,
+		// `top`, `bottom`, `center`, `auto`.
+		// `auto` will dynamically switch between `right` and `left` according to the tooltip
+		// position on the map.
+		direction: 'auto',
 
-			// @option sticky: Boolean = false
-			// If true, the tooltip will follow the pointer instead of being fixed at the feature center.
-			sticky: false,
+		// @option permanent: Boolean = false
+		// Whether to open the tooltip permanently or only on pointerover.
+		permanent: false,
 
-			// @option opacity: Number = 0.9
-			// Tooltip container opacity.
-			opacity: 0.9
-		});
-	}
+		// @option sticky: Boolean = false
+		// If true, the tooltip will follow the pointer instead of being fixed at the feature center.
+		sticky: false,
+
+		// @option opacity: Number = 0.9
+		// Tooltip container opacity.
+		opacity: 0.9
+	};
 
 	onAdd(map) {
 		super.onAdd(map);

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -26,36 +26,35 @@ import * as Util from '../core/Util.js';
 // geographical bounds it is tied to.
 export class VideoOverlay extends ImageOverlay {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka VideoOverlay options
-		this.setDefaultOptions({
-			// @option autoplay: Boolean = true
-			// Whether the video starts playing automatically when loaded.
-			// On some browsers autoplay will only work with `muted: true`
-			autoplay: true,
 
-			// @option controls: Boolean = false
-			// Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
-			controls: false,
+		// @option autoplay: Boolean = true
+		// Whether the video starts playing automatically when loaded.
+		// On some browsers autoplay will only work with `muted: true`
+		autoplay: true,
 
-			// @option loop: Boolean = true
-			// Whether the video will loop back to the beginning when played.
-			loop: true,
+		// @option controls: Boolean = false
+		// Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
+		controls: false,
 
-			// @option keepAspectRatio: Boolean = true
-			// Whether the video will save aspect ratio after the projection.
-			keepAspectRatio: true,
+		// @option loop: Boolean = true
+		// Whether the video will loop back to the beginning when played.
+		loop: true,
 
-			// @option muted: Boolean = false
-			// Whether the video starts on mute when loaded.
-			muted: false,
+		// @option keepAspectRatio: Boolean = true
+		// Whether the video will save aspect ratio after the projection.
+		keepAspectRatio: true,
 
-			// @option playsInline: Boolean = true
-			// Mobile browsers will play the video right where it is instead of open it up in fullscreen mode.
-			playsInline: true
-		});
-	}
+		// @option muted: Boolean = false
+		// Whether the video starts on mute when loaded.
+		muted: false,
+
+		// @option playsInline: Boolean = true
+		// Mobile browsers will play the video right where it is instead of open it up in fullscreen mode.
+		playsInline: true
+	};
 
 	_initImage() {
 		const wasElementSupplied = this._url.tagName === 'VIDEO';

--- a/src/layer/marker/DefaultIcon.js
+++ b/src/layer/marker/DefaultIcon.js
@@ -9,27 +9,26 @@ import * as DomUtil from '../../dom/DomUtil.js';
  * no icon is specified. Points to the blue marker image distributed with Leaflet
  * releases.
  *
- * In order to customize the default icon, just change the properties of `DefaultIcon.prototype.options`
+ * In order to customize the default icon, just change the properties of `DefaultIcon.defaultOptions`
  * (which is a set of `Icon options`).
  *
- * If you want to _completely_ replace the default icon, override the
- * `Marker.prototype.options.icon` with your own icon instead.
+ * If you want to _completely_ replace the default icon, set the `icon` property in
+ * `Marker.defaultOptions` or pass a custom icon via the `icon` option when creating a `Marker`.
  */
 
 export class DefaultIcon extends Icon {
 
-	static {
-		this.setDefaultOptions({
-			iconUrl:       'marker-icon.svg',
-			iconRetinaUrl: 'marker-icon.svg',
-			shadowUrl:     'marker-shadow.svg',
-			iconSize:    [25, 41],
-			iconAnchor:  [12, 41],
-			popupAnchor: [1, -34],
-			tooltipAnchor: [16, -28],
-			shadowSize:  [41, 41]
-		});
-	}
+	static defaultOptions = {
+
+		iconUrl:       'marker-icon.svg',
+		iconRetinaUrl: 'marker-icon.svg',
+		shadowUrl:     'marker-shadow.svg',
+		iconSize:    [25, 41],
+		iconAnchor:  [12, 41],
+		popupAnchor: [1, -34],
+		tooltipAnchor: [16, -28],
+		shadowSize:  [41, 41]
+	};
 
 	_getIconUrl(name) {
 		// only detect once

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -23,27 +23,26 @@ import {Point} from '../../geometry/Point.js';
 // Creates a `DivIcon` instance with the given options.
 export class DivIcon extends Icon {
 
-	static {
-		this.setDefaultOptions({
-			// @section
-			// @aka DivIcon options
-			iconSize: [12, 12], // also can be set through CSS
+	static defaultOptions = {
 
-			// iconAnchor: (Point),
-			// popupAnchor: (Point),
+		// @section
+		// @aka DivIcon options
+		iconSize: [12, 12], // also can be set through CSS
 
-			// @option html: String|HTMLElement = ''
-			// Custom HTML code to put inside the div element, empty by default. Alternatively,
-			// an instance of `HTMLElement`.
-			html: false,
+		// iconAnchor: (Point),
+		// popupAnchor: (Point),
 
-			// @option bgPos: Point = [0, 0]
-			// Optional relative position of the background, in pixels
-			bgPos: null,
+		// @option html: String|HTMLElement = ''
+		// Custom HTML code to put inside the div element, empty by default. Alternatively,
+		// an instance of `HTMLElement`.
+		html: false,
 
-			className: 'leaflet-div-icon'
-		});
-	}
+		// @option bgPos: Point = [0, 0]
+		// Optional relative position of the background, in pixels
+		bgPos: null,
+
+		className: 'leaflet-div-icon'
+	};
 
 	createIcon(oldIcon) {
 		const div = (oldIcon && oldIcon.tagName === 'DIV') ? oldIcon : document.createElement('div'),

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -34,7 +34,7 @@ import Browser from '../../core/Browser.js';
 // Creates an icon instance with the given options.
 export class Icon extends Class {
 
-	static {
+	static defaultOptions = {
 		/* @section
 		 * @aka Icon options
 		 *
@@ -74,17 +74,16 @@ export class Icon extends Class {
 		 * @option className: String = ''
 		 * A custom class name to assign to both icon and shadow images. Empty by default.
 		 */
-		this.setDefaultOptions({
-			popupAnchor: [0, 0],
-			tooltipAnchor: [0, 0],
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false
-		});
-	}
+		popupAnchor: [0, 0],
+		tooltipAnchor: [0, 0],
+
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false
+	};
 
 	initialize(options) {
 		setOptions(this, options);

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -23,87 +23,86 @@ import {MarkerDrag} from './Marker.Drag.js';
 // Instantiates a Marker object given a geographical point and optionally an options object.
 export class Marker extends Layer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Marker options
-		this.setDefaultOptions({
-			// @option icon: Icon = *
-			// Icon instance to use for rendering the marker.
-			// See [Icon documentation](#Icon) for details on how to customize the marker icon.
-			// If not specified, a common instance of `DefaultIcon` is used.
-			icon: new DefaultIcon(),
 
-			// Option inherited from "Interactive layer" abstract class
-			interactive: true,
+		// @option icon: Icon = *
+		// Icon instance to use for rendering the marker.
+		// See [Icon documentation](#Icon) for details on how to customize the marker icon.
+		// If not specified, a common instance of `DefaultIcon` is used.
+		icon: new DefaultIcon(),
 
-			// @option keyboard: Boolean = true
-			// Whether the marker can be tabbed to with a keyboard and clicked by pressing enter.
-			keyboard: true,
+		// Option inherited from "Interactive layer" abstract class
+		interactive: true,
 
-			// @option title: String = ''
-			// Text for the browser tooltip that appear on marker hover (no tooltip by default).
-			// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
-			title: '',
+		// @option keyboard: Boolean = true
+		// Whether the marker can be tabbed to with a keyboard and clicked by pressing enter.
+		keyboard: true,
 
-			// @option alt: String = 'Marker'
-			// Text for the `alt` attribute of the icon image.
-			// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
-			alt: 'Marker',
+		// @option title: String = ''
+		// Text for the browser tooltip that appear on marker hover (no tooltip by default).
+		// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
+		title: '',
 
-			// @option zIndexOffset: Number = 0
-			// By default, marker images zIndex is set automatically based on its latitude. Use this option if you want to put the marker on top of all others (or below), specifying a high value like `1000` (or high negative value, respectively).
-			zIndexOffset: 0,
+		// @option alt: String = 'Marker'
+		// Text for the `alt` attribute of the icon image.
+		// [Useful for accessibility](https://leafletjs.com/examples/accessibility/#markers-must-be-labelled).
+		alt: 'Marker',
 
-			// @option opacity: Number = 1.0
-			// The opacity of the marker.
-			opacity: 1,
+		// @option zIndexOffset: Number = 0
+		// By default, marker images zIndex is set automatically based on its latitude. Use this option if you want to put the marker on top of all others (or below), specifying a high value like `1000` (or high negative value, respectively).
+		zIndexOffset: 0,
 
-			// @option riseOnHover: Boolean = false
-			// If `true`, the marker will get on top of others when you hover the pointer over it.
-			riseOnHover: false,
+		// @option opacity: Number = 1.0
+		// The opacity of the marker.
+		opacity: 1,
 
-			// @option riseOffset: Number = 250
-			// The z-index offset used for the `riseOnHover` feature.
-			riseOffset: 250,
+		// @option riseOnHover: Boolean = false
+		// If `true`, the marker will get on top of others when you hover the pointer over it.
+		riseOnHover: false,
 
-			// @option pane: String = 'markerPane'
-			// `Map pane` where the markers icon will be added.
-			pane: 'markerPane',
+		// @option riseOffset: Number = 250
+		// The z-index offset used for the `riseOnHover` feature.
+		riseOffset: 250,
 
-			// @option shadowPane: String = 'shadowPane'
-			// `Map pane` where the markers shadow will be added.
-			shadowPane: 'shadowPane',
+		// @option pane: String = 'markerPane'
+		// `Map pane` where the markers icon will be added.
+		pane: 'markerPane',
 
-			// @option bubblingPointerEvents: Boolean = false
-			// When `true`, a pointer event on this marker will trigger the same event on the map
-			// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-			bubblingPointerEvents: false,
+		// @option shadowPane: String = 'shadowPane'
+		// `Map pane` where the markers shadow will be added.
+		shadowPane: 'shadowPane',
 
-			// @option autoPanOnFocus: Boolean = true
-			// When `true`, the map will pan whenever the marker is focused (via
-			// e.g. pressing `tab` on the keyboard) to ensure the marker is
-			// visible within the map's bounds
-			autoPanOnFocus: true,
+		// @option bubblingPointerEvents: Boolean = false
+		// When `true`, a pointer event on this marker will trigger the same event on the map
+		// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingPointerEvents: false,
 
-			// @section Draggable marker options
-			// @option draggable: Boolean = false
-			// Whether the marker is draggable with pointer or not.
-			draggable: false,
+		// @option autoPanOnFocus: Boolean = true
+		// When `true`, the map will pan whenever the marker is focused (via
+		// e.g. pressing `tab` on the keyboard) to ensure the marker is
+		// visible within the map's bounds
+		autoPanOnFocus: true,
 
-			// @option autoPan: Boolean = false
-			// Whether to pan the map when dragging this marker near its edge or not.
-			autoPan: false,
+		// @section Draggable marker options
+		// @option draggable: Boolean = false
+		// Whether the marker is draggable with pointer or not.
+		draggable: false,
 
-			// @option autoPanPadding: Point = Point(50, 50)
-			// Distance (in pixels to the left/right and to the top/bottom) of the
-			// map edge to start panning the map.
-			autoPanPadding: [50, 50],
+		// @option autoPan: Boolean = false
+		// Whether to pan the map when dragging this marker near its edge or not.
+		autoPan: false,
 
-			// @option autoPanSpeed: Number = 10
-			// Number of pixels the map should pan by.
-			autoPanSpeed: 10
-		});
-	}
+		// @option autoPanPadding: Point = Point(50, 50)
+		// Distance (in pixels to the left/right and to the top/bottom) of the
+		// map edge to start panning the map.
+		autoPanPadding: [50, 50],
+
+		// @option autoPanSpeed: Number = 10
+		// Number of pixels the map should pan by.
+		autoPanSpeed: 10
+	};
 
 	/* @section
 	 *

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -75,82 +75,81 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
 // Creates a new instance of GridLayer with the supplied options.
 export class GridLayer extends Layer {
 
-	static {
+	static defaultOptions = {
 	// @section
 	// @aka GridLayer options
-		this.setDefaultOptions({
-			// @option tileSize: Number|Point = 256
-			// Width and height of tiles in the grid. Use a number if width and height are equal, or `Point(width, height)` otherwise.
-			tileSize: 256,
 
-			// @option opacity: Number = 1.0
-			// Opacity of the tiles. Can be used in the `createTile()` function.
-			opacity: 1,
+		// @option tileSize: Number|Point = 256
+		// Width and height of tiles in the grid. Use a number if width and height are equal, or `Point(width, height)` otherwise.
+		tileSize: 256,
 
-			// @option updateWhenIdle: Boolean = (depends)
-			// Load new tiles only when panning ends.
-			// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
-			// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
-			// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
-			updateWhenIdle: Browser.mobile,
+		// @option opacity: Number = 1.0
+		// Opacity of the tiles. Can be used in the `createTile()` function.
+		opacity: 1,
 
-			// @option updateWhenZooming: Boolean = true
-			// By default, a smooth zoom animation (during a [pinch zoom](#map-pinchzoom) or a [`flyTo()`](#map-flyto)) will update grid layers every integer zoom level. Setting this option to `false` will update the grid layer only when the smooth animation ends.
-			updateWhenZooming: true,
+		// @option updateWhenIdle: Boolean = (depends)
+		// Load new tiles only when panning ends.
+		// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
+		// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
+		// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
+		updateWhenIdle: Browser.mobile,
 
-			// @option updateInterval: Number = 200
-			// Tiles will not update more than once every `updateInterval` milliseconds when panning.
-			updateInterval: 200,
+		// @option updateWhenZooming: Boolean = true
+		// By default, a smooth zoom animation (during a [pinch zoom](#map-pinchzoom) or a [`flyTo()`](#map-flyto)) will update grid layers every integer zoom level. Setting this option to `false` will update the grid layer only when the smooth animation ends.
+		updateWhenZooming: true,
 
-			// @option zIndex: Number = 1
-			// The explicit zIndex of the tile layer.
-			zIndex: 1,
+		// @option updateInterval: Number = 200
+		// Tiles will not update more than once every `updateInterval` milliseconds when panning.
+		updateInterval: 200,
 
-			// @option bounds: LatLngBounds = undefined
-			// If set, tiles will only be loaded inside the set `LatLngBounds`.
-			bounds: null,
+		// @option zIndex: Number = 1
+		// The explicit zIndex of the tile layer.
+		zIndex: 1,
 
-			// @option minZoom: Number = 0
-			// The minimum zoom level down to which this layer will be displayed (inclusive).
-			minZoom: 0,
+		// @option bounds: LatLngBounds = undefined
+		// If set, tiles will only be loaded inside the set `LatLngBounds`.
+		bounds: null,
 
-			// @option maxZoom: Number = undefined
-			// The maximum zoom level up to which this layer will be displayed (inclusive).
-			maxZoom: undefined,
+		// @option minZoom: Number = 0
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
+		minZoom: 0,
 
-			// @option maxNativeZoom: Number = undefined
-			// Maximum zoom number the tile source has available. If it is specified,
-			// the tiles on all zoom levels higher than `maxNativeZoom` will be loaded
-			// from `maxNativeZoom` level and auto-scaled.
-			maxNativeZoom: undefined,
+		// @option maxZoom: Number = undefined
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
+		maxZoom: undefined,
 
-			// @option minNativeZoom: Number = undefined
-			// Minimum zoom number the tile source has available. If it is specified,
-			// the tiles on all zoom levels lower than `minNativeZoom` will be loaded
-			// from `minNativeZoom` level and auto-scaled.
-			minNativeZoom: undefined,
+		// @option maxNativeZoom: Number = undefined
+		// Maximum zoom number the tile source has available. If it is specified,
+		// the tiles on all zoom levels higher than `maxNativeZoom` will be loaded
+		// from `maxNativeZoom` level and auto-scaled.
+		maxNativeZoom: undefined,
 
-			// @option noWrap: Boolean = false
-			// Whether the layer is wrapped around the antimeridian. If `true`, the
-			// GridLayer will only be displayed once at low zoom levels. Has no
-			// effect when the [map CRS](#map-crs) doesn't wrap around. Can be used
-			// in combination with [`bounds`](#gridlayer-bounds) to prevent requesting
-			// tiles outside the CRS limits.
-			noWrap: false,
+		// @option minNativeZoom: Number = undefined
+		// Minimum zoom number the tile source has available. If it is specified,
+		// the tiles on all zoom levels lower than `minNativeZoom` will be loaded
+		// from `minNativeZoom` level and auto-scaled.
+		minNativeZoom: undefined,
 
-			// @option pane: String = 'tilePane'
-			// `Map pane` where the grid layer will be added.
-			pane: 'tilePane',
+		// @option noWrap: Boolean = false
+		// Whether the layer is wrapped around the antimeridian. If `true`, the
+		// GridLayer will only be displayed once at low zoom levels. Has no
+		// effect when the [map CRS](#map-crs) doesn't wrap around. Can be used
+		// in combination with [`bounds`](#gridlayer-bounds) to prevent requesting
+		// tiles outside the CRS limits.
+		noWrap: false,
 
-			// @option className: String = ''
-			// A custom class name to assign to the tile layer. Empty by default.
-			className: '',
+		// @option pane: String = 'tilePane'
+		// `Map pane` where the grid layer will be added.
+		pane: 'tilePane',
 
-			// @option keepBuffer: Number = 2
-			// When panning the map, keep this many rows and columns of tiles before unloading them.
-			keepBuffer: 2
-		});
-	}
+		// @option className: String = ''
+		// A custom class name to assign to the tile layer. Empty by default.
+		className: '',
+
+		// @option keepBuffer: Number = 2
+		// When panning the map, keep this many rows and columns of tiles before unloading them.
+		keepBuffer: 2
+	};
 
 	initialize(options) {
 		Util.setOptions(this, options);

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -36,57 +36,56 @@ import * as DomEvent from '../../dom/DomEvent.js';
 // Instantiates a tile layer object given a `URL template` and optionally an options object.
 export class TileLayer extends GridLayer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka TileLayer options
-		this.setDefaultOptions({
-			// @option minZoom: Number = 0
-			// The minimum zoom level down to which this layer will be displayed (inclusive).
-			minZoom: 0,
 
-			// @option maxZoom: Number = 18
-			// The maximum zoom level up to which this layer will be displayed (inclusive).
-			maxZoom: 18,
+		// @option minZoom: Number = 0
+		// The minimum zoom level down to which this layer will be displayed (inclusive).
+		minZoom: 0,
 
-			// @option subdomains: String|String[] = 'abc'
-			// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.
-			subdomains: 'abc',
+		// @option maxZoom: Number = 18
+		// The maximum zoom level up to which this layer will be displayed (inclusive).
+		maxZoom: 18,
 
-			// @option errorTileUrl: String = ''
-			// URL to the tile image to show in place of the tile that failed to load.
-			errorTileUrl: '',
+		// @option subdomains: String|String[] = 'abc'
+		// Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.
+		subdomains: 'abc',
 
-			// @option zoomOffset: Number = 0
-			// The zoom number used in tile URLs will be offset with this value.
-			zoomOffset: 0,
+		// @option errorTileUrl: String = ''
+		// URL to the tile image to show in place of the tile that failed to load.
+		errorTileUrl: '',
 
-			// @option tms: Boolean = false
-			// If `true`, inverses Y axis numbering for tiles (turn this on for [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) services).
-			tms: false,
+		// @option zoomOffset: Number = 0
+		// The zoom number used in tile URLs will be offset with this value.
+		zoomOffset: 0,
 
-			// @option zoomReverse: Boolean = false
-			// If set to true, the zoom number used in tile URLs will be reversed (`maxZoom - zoom` instead of `zoom`)
-			zoomReverse: false,
+		// @option tms: Boolean = false
+		// If `true`, inverses Y axis numbering for tiles (turn this on for [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) services).
+		tms: false,
 
-			// @option detectRetina: Boolean = false
-			// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
-			detectRetina: false,
+		// @option zoomReverse: Boolean = false
+		// If set to true, the zoom number used in tile URLs will be reversed (`maxZoom - zoom` instead of `zoom`)
+		zoomReverse: false,
 
-			// @option crossOrigin: Boolean|String = false
-			// Whether the crossOrigin attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
-			// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
-			crossOrigin: false,
+		// @option detectRetina: Boolean = false
+		// If `true` and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.
+		detectRetina: false,
 
-			// @option referrerPolicy: Boolean|String = false
-			// Whether the referrerPolicy attribute will be added to the tiles.
-			// If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
-			// This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
-			// (e.g. to validate an API token).
-			// Refer to [HTMLImageElement.referrerPolicy](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy) for valid String values.
-			referrerPolicy: false
-		});
-	}
+		// @option crossOrigin: Boolean|String = false
+		// Whether the crossOrigin attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
+		// Refer to [CORS Settings](https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes) for valid String values.
+		crossOrigin: false,
+
+		// @option referrerPolicy: Boolean|String = false
+		// Whether the referrerPolicy attribute will be added to the tiles.
+		// If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
+		// This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
+		// (e.g. to validate an API token).
+		// Refer to [HTMLImageElement.referrerPolicy](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy) for valid String values.
+		referrerPolicy: false
+	};
 
 	initialize(url, options) {
 		super.initialize(options);

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -24,57 +24,58 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Instantiates a WMS tile layer object given a base URL of the WMS service and a WMS parameters/options object.
 export class WMSTileLayer extends TileLayer {
 
-	static {
-		// @section
-		// @aka WMSTileLayer options
-		// If any custom options not documented here are used, they will be sent to the
-		// WMS server as extra parameters in each request URL. This can be useful for
-		// [non-standard vendor WMS parameters](https://docs.geoserver.org/stable/en/user/services/wms/vendor.html).
-		this.prototype.defaultWmsParams = {
-			service: 'WMS',
-			request: 'GetMap',
+	// @section
+	// @aka WMSTileLayer options
+	// If any custom options not documented here are used, they will be sent to the
+	// WMS server as extra parameters in each request URL. This can be useful for
+	// [non-standard vendor WMS parameters](https://docs.geoserver.org/stable/en/user/services/wms/vendor.html).
 
-			// @option layers: String = ''
-			// **(required)** Comma-separated list of WMS layers to show.
-			layers: '',
+	// Default WMS request parameters. Subclasses may override by defining their own
+	// `static defaultWmsParams` field.
+	static defaultWmsParams = {
+		service: 'WMS',
+		request: 'GetMap',
 
-			// @option styles: String = ''
-			// Comma-separated list of WMS styles.
-			styles: '',
+		// @option layers: String = ''
+		// **(required)** Comma-separated list of WMS layers to show.
+		layers: '',
 
-			// @option format: String = 'image/jpeg'
-			// WMS image format (use `'image/png'` for layers with transparency).
-			format: 'image/jpeg',
+		// @option styles: String = ''
+		// Comma-separated list of WMS styles.
+		styles: '',
 
-			// @option transparent: Boolean = false
-			// If `true`, the WMS service will return images with transparency.
-			transparent: false,
+		// @option format: String = 'image/jpeg'
+		// WMS image format (use `'image/png'` for layers with transparency).
+		format: 'image/jpeg',
 
-			// @option version: String = '1.1.1'
-			// Version of the WMS service to use
-			version: '1.1.1'
-		};
+		// @option transparent: Boolean = false
+		// If `true`, the WMS service will return images with transparency.
+		transparent: false,
 
-		this.setDefaultOptions({
-			// @option crs: CRS = null
-			// Coordinate Reference System to use for the WMS requests, defaults to
-			// map CRS. Don't change this if you're not sure what it means.
-			crs: null,
+		// @option version: String = '1.1.1'
+		// Version of the WMS service to use
+		version: '1.1.1'
+	};
 
-			// @option uppercase: Boolean = false
-			// If `true`, WMS request parameter keys will be uppercase.
-			uppercase: false
-		});
-	}
+	static defaultOptions = {
+		// @option crs: CRS = null
+		// Coordinate Reference System to use for the WMS requests, defaults to
+		// map CRS. Don't change this if you're not sure what it means.
+		crs: null,
+
+		// @option uppercase: Boolean = false
+		// If `true`, WMS request parameter keys will be uppercase.
+		uppercase: false
+	};
 
 	initialize(url, options) {
 		super.initialize(url, options);
 
-		const wmsParams = {...this.defaultWmsParams};
+		const wmsParams = {...this.constructor.defaultWmsParams};
 
 		// Options that are unknown in the prototype chain are considered WMS params.
 		for (const [key, value] of Object.entries(options)) {
-			if (!(key in WMSTileLayer.prototype.options)) {
+			if (!(key in this.options)) {
 				wmsParams[key] = value;
 			}
 		}

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -34,15 +34,14 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Creates a Canvas renderer with the given options.
 export class Canvas extends Renderer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Canvas options
-		this.setDefaultOptions({
-			// @option tolerance: Number = 0
-			// How much to extend the click tolerance around a path/object on the map.
-			tolerance: 0
-		});
-	}
+
+		// @option tolerance: Number = 0
+		// How much to extend the click tolerance around a path/object on the map.
+		tolerance: 0
+	};
 
 	getEvents() {
 		const events = super.getEvents();

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -15,17 +15,16 @@ import {Bounds} from '../../geometry/Bounds.js';
 // Instantiates a circle marker object given a geographical point, and an optional options object.
 export class CircleMarker extends Path {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka CircleMarker options
-		this.setDefaultOptions({
-			fill: true,
 
-			// @option radius: Number = 10
-			// Radius of the circle marker, in pixels
-			radius: 10
-		});
-	}
+		fill: true,
+
+		// @option radius: Number = 10
+		// Radius of the circle marker, in pixels
+		radius: 10
+	};
 
 	initialize(latlng, options) {
 		Util.setOptions(this, options);

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -11,69 +11,68 @@ import * as Util from '../../core/Util.js';
 
 export class Path extends Layer {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Path options
-		this.setDefaultOptions({
-			// @option stroke: Boolean = true
-			// Whether to draw stroke along the path. Set it to `false` to disable borders on polygons or circles.
-			stroke: true,
 
-			// @option color: String = '#3388ff'
-			// Stroke color
-			color: '#3388ff',
+		// @option stroke: Boolean = true
+		// Whether to draw stroke along the path. Set it to `false` to disable borders on polygons or circles.
+		stroke: true,
 
-			// @option weight: Number = 3
-			// Stroke width in pixels
-			weight: 3,
+		// @option color: String = '#3388ff'
+		// Stroke color
+		color: '#3388ff',
 
-			// @option opacity: Number = 1.0
-			// Stroke opacity
-			opacity: 1,
+		// @option weight: Number = 3
+		// Stroke width in pixels
+		weight: 3,
 
-			// @option lineCap: String= 'round'
-			// A string that defines [shape to be used at the end](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) of the stroke.
-			lineCap: 'round',
+		// @option opacity: Number = 1.0
+		// Stroke opacity
+		opacity: 1,
 
-			// @option lineJoin: String = 'round'
-			// A string that defines [shape to be used at the corners](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linejoin) of the stroke.
-			lineJoin: 'round',
+		// @option lineCap: String= 'round'
+		// A string that defines [shape to be used at the end](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linecap) of the stroke.
+		lineCap: 'round',
 
-			// @option dashArray: String = null
-			// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray).
-			dashArray: null,
+		// @option lineJoin: String = 'round'
+		// A string that defines [shape to be used at the corners](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-linejoin) of the stroke.
+		lineJoin: 'round',
 
-			// @option dashOffset: String = null
-			// A string that defines the [distance into the dash pattern to start the dash](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dashoffset).
-			dashOffset: null,
+		// @option dashArray: String = null
+		// A string that defines the stroke [dash pattern](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dasharray).
+		dashArray: null,
 
-			// @option fill: Boolean = depends
-			// Whether to fill the path with color. Set it to `false` to disable filling on polygons or circles.
-			fill: false,
+		// @option dashOffset: String = null
+		// A string that defines the [distance into the dash pattern to start the dash](https://developer.mozilla.org/docs/Web/SVG/Attribute/stroke-dashoffset).
+		dashOffset: null,
 
-			// @option fillColor: String = *
-			// Fill color. Defaults to the value of the [`color`](#path-color) option
-			fillColor: null,
+		// @option fill: Boolean = depends
+		// Whether to fill the path with color. Set it to `false` to disable filling on polygons or circles.
+		fill: false,
 
-			// @option fillOpacity: Number = 0.2
-			// Fill opacity.
-			fillOpacity: 0.2,
+		// @option fillColor: String = *
+		// Fill color. Defaults to the value of the [`color`](#path-color) option
+		fillColor: null,
 
-			// @option fillRule: String = 'evenodd'
-			// A string that defines [how the inside of a shape](https://developer.mozilla.org/docs/Web/SVG/Attribute/fill-rule) is determined.
-			fillRule: 'evenodd',
+		// @option fillOpacity: Number = 0.2
+		// Fill opacity.
+		fillOpacity: 0.2,
 
-			// className: '',
+		// @option fillRule: String = 'evenodd'
+		// A string that defines [how the inside of a shape](https://developer.mozilla.org/docs/Web/SVG/Attribute/fill-rule) is determined.
+		fillRule: 'evenodd',
 
-			// Option inherited from "Interactive layer" abstract class
-			interactive: true,
+		// className: '',
 
-			// @option bubblingPointerEvents: Boolean = true
-			// When `true`, a pointer event on this path will trigger the same event on the map
-			// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
-			bubblingPointerEvents: true
-		});
-	}
+		// Option inherited from "Interactive layer" abstract class
+		interactive: true,
+
+		// @option bubblingPointerEvents: Boolean = true
+		// When `true`, a pointer event on this path will trigger the same event on the map
+		// (unless [`DomEvent.stopPropagation`](#domevent-stoppropagation) is used).
+		bubblingPointerEvents: true
+	};
 
 	beforeAdd(map) {
 		// Renderer is set here because we need to call renderer.getEvents

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -53,11 +53,10 @@ import * as PolyUtil from '../../geometry/PolyUtil.js';
 // @constructor Polygon(latlngs: LatLng[], options?: Polyline options)
 export class Polygon extends Polyline {
 
-	static {
-		this.setDefaultOptions({
-			fill: true
-		});
-	}
+	static defaultOptions = {
+
+		fill: true
+	};
 
 	isEmpty() {
 		return !this._latlngs.length || !this._latlngs[0].length;

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -50,21 +50,20 @@ import {Point} from '../../geometry/Point.js';
 // of geographic points.
 export class Polyline extends Path {
 
-	static {
+	static defaultOptions = {
 		// @section
 		// @aka Polyline options
-		this.setDefaultOptions({
-			// @option smoothFactor: Number = 0.5
-			// How much to simplify the polyline on each zoom level (Douglas–Peucker
-			// epsilon, in pixels). Higher values mean faster rendering but less
-			// accuracy; lower values mean more accuracy but slower rendering.
-			smoothFactor: 0.5,
 
-			// @option noClip: Boolean = false
-			// Disable polyline clipping.
-			noClip: false
-		});
-	}
+		// @option smoothFactor: Number = 0.5
+		// How much to simplify the polyline on each zoom level (Douglas–Peucker
+		// epsilon, in pixels). Higher values mean faster rendering but less
+		// accuracy; lower values mean more accuracy but slower rendering.
+		smoothFactor: 0.5,
+
+		// @option noClip: Boolean = false
+		// Disable polyline clipping.
+		noClip: false
+	};
 
 	initialize(latlngs, options) {
 		Util.setOptions(this, options);

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -50,99 +50,98 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // and optionally an object literal with `Map options`.
 export class LeafletMap extends Evented {
 
-	static {
-		this.setDefaultOptions({
-			// @section Map State Options
-			// @option crs: CRS = EPSG3857
-			// The [Coordinate Reference System](#crs) to use. Don't change this if you're not
-			// sure what it means.
-			crs: EPSG3857,
+	static defaultOptions = {
 
-			// @option center: LatLng = undefined
-			// Initial geographic center of the map
-			center: undefined,
+		// @section Map State Options
+		// @option crs: CRS = EPSG3857
+		// The [Coordinate Reference System](#crs) to use. Don't change this if you're not
+		// sure what it means.
+		crs: EPSG3857,
 
-			// @option zoom: Number = undefined
-			// Initial map zoom level
-			zoom: undefined,
+		// @option center: LatLng = undefined
+		// Initial geographic center of the map
+		center: undefined,
 
-			// @option minZoom: Number = *
-			// Minimum zoom level of the map.
-			// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
-			// the lowest of their `minZoom` options will be used instead.
-			minZoom: undefined,
+		// @option zoom: Number = undefined
+		// Initial map zoom level
+		zoom: undefined,
 
-			// @option maxZoom: Number = *
-			// Maximum zoom level of the map.
-			// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
-			// the highest of their `maxZoom` options will be used instead.
-			maxZoom: undefined,
+		// @option minZoom: Number = *
+		// Minimum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the lowest of their `minZoom` options will be used instead.
+		minZoom: undefined,
 
-			// @option layers: Layer[] = []
-			// Array of layers that will be added to the map initially
-			layers: [],
+		// @option maxZoom: Number = *
+		// Maximum zoom level of the map.
+		// If not specified and at least one `GridLayer` or `TileLayer` is in the map,
+		// the highest of their `maxZoom` options will be used instead.
+		maxZoom: undefined,
 
-			// @option maxBounds: LatLngBounds = null
-			// When this option is set, the map restricts the view to the given
-			// geographical bounds, bouncing the user back if the user tries to pan
-			// outside the view. To set the restriction dynamically, use
-			// [`setMaxBounds`](#map-setmaxbounds) method.
-			maxBounds: undefined,
+		// @option layers: Layer[] = []
+		// Array of layers that will be added to the map initially
+		layers: [],
 
-			// @option renderer: Renderer = *
-			// The default method for drawing vector layers on the map. `SVG`
-			// or `Canvas` by default depending on browser support.
-			renderer: undefined,
+		// @option maxBounds: LatLngBounds = null
+		// When this option is set, the map restricts the view to the given
+		// geographical bounds, bouncing the user back if the user tries to pan
+		// outside the view. To set the restriction dynamically, use
+		// [`setMaxBounds`](#map-setmaxbounds) method.
+		maxBounds: undefined,
+
+		// @option renderer: Renderer = *
+		// The default method for drawing vector layers on the map. `SVG`
+		// or `Canvas` by default depending on browser support.
+		renderer: undefined,
 
 
-			// @section Animation Options
-			// @option zoomAnimation: Boolean = true
-			// Whether the map zoom animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
-			zoomAnimation: true,
+		// @section Animation Options
+		// @option zoomAnimation: Boolean = true
+		// Whether the map zoom animation is enabled. By default it's enabled
+		// in all browsers that support CSS Transitions except Android.
+		zoomAnimation: true,
 
-			// @option zoomAnimationThreshold: Number = 4
-			// Won't animate zoom if the zoom difference exceeds this value.
-			zoomAnimationThreshold: 4,
+		// @option zoomAnimationThreshold: Number = 4
+		// Won't animate zoom if the zoom difference exceeds this value.
+		zoomAnimationThreshold: 4,
 
-			// @option fadeAnimation: Boolean = true
-			// Whether the tile fade animation is enabled. By default it's enabled
-			// in all browsers that support CSS Transitions except Android.
-			fadeAnimation: true,
+		// @option fadeAnimation: Boolean = true
+		// Whether the tile fade animation is enabled. By default it's enabled
+		// in all browsers that support CSS Transitions except Android.
+		fadeAnimation: true,
 
-			// @option markerZoomAnimation: Boolean = true
-			// Whether markers animate their zoom with the zoom animation, if disabled
-			// they will disappear for the length of the animation. By default it's
-			// enabled in all browsers that support CSS Transitions except Android.
-			markerZoomAnimation: true,
+		// @option markerZoomAnimation: Boolean = true
+		// Whether markers animate their zoom with the zoom animation, if disabled
+		// they will disappear for the length of the animation. By default it's
+		// enabled in all browsers that support CSS Transitions except Android.
+		markerZoomAnimation: true,
 
-			// @option transform3DLimit: Number = 2^23
-			// Defines the maximum size of a CSS translation transform. The default
-			// value should not be changed unless a web browser positions layers in
-			// the wrong place after doing a large `panBy`.
-			transform3DLimit: 8388608, // Precision limit of a 32-bit float
+		// @option transform3DLimit: Number = 2^23
+		// Defines the maximum size of a CSS translation transform. The default
+		// value should not be changed unless a web browser positions layers in
+		// the wrong place after doing a large `panBy`.
+		transform3DLimit: 8388608, // Precision limit of a 32-bit float
 
-			// @section Interaction Options
-			// @option zoomSnap: Number = 1
-			// Forces the map's zoom level to always be a multiple of this, particularly
-			// right after a [`fitBounds()`](#map-fitbounds) or a pinch-zoom.
-			// By default, the zoom level snaps to the nearest integer; lower values
-			// (e.g. `0.5` or `0.1`) allow for greater granularity. A value of `0`
-			// means the zoom level will not be snapped after `fitBounds` or a pinch-zoom.
-			zoomSnap: 1,
+		// @section Interaction Options
+		// @option zoomSnap: Number = 1
+		// Forces the map's zoom level to always be a multiple of this, particularly
+		// right after a [`fitBounds()`](#map-fitbounds) or a pinch-zoom.
+		// By default, the zoom level snaps to the nearest integer; lower values
+		// (e.g. `0.5` or `0.1`) allow for greater granularity. A value of `0`
+		// means the zoom level will not be snapped after `fitBounds` or a pinch-zoom.
+		zoomSnap: 1,
 
-			// @option zoomDelta: Number = 1
-			// Controls how much the map's zoom level will change after a
-			// [`zoomIn()`](#map-zoomin), [`zoomOut()`](#map-zoomout), pressing `+`
-			// or `-` on the keyboard, or using the [zoom controls](#control-zoom).
-			// Values smaller than `1` (e.g. `0.5`) allow for greater granularity.
-			zoomDelta: 1,
+		// @option zoomDelta: Number = 1
+		// Controls how much the map's zoom level will change after a
+		// [`zoomIn()`](#map-zoomin), [`zoomOut()`](#map-zoomout), pressing `+`
+		// or `-` on the keyboard, or using the [zoom controls](#control-zoom).
+		// Values smaller than `1` (e.g. `0.5`) allow for greater granularity.
+		zoomDelta: 1,
 
-			// @option trackResize: Boolean = true
-			// Whether the map automatically handles browser window resize to update itself.
-			trackResize: true
-		});
-	}
+		// @option trackResize: Boolean = true
+		// Whether the map automatically handles browser window resize to update itself.
+		trackResize: true
+	};
 
 	initialize(id, options) { // (HTMLElement or String, Object)
 		options = Util.setOptions(this, options);


### PR DESCRIPTION
Fixes #9814.

## Problem

`static {}` class initializer blocks are treated as unconditional side effects by bundlers. Even with `"sideEffects": false`, Rollup cannot tree-shake individual classes because their static blocks mutate prototypes at module-evaluation time. As simon04 demonstrated in the issue, `WMSTileLayer` appears in bundles even when never imported.

## Solution

**Replace all `static { this.setDefaultOptions({...}) }` blocks** (26 files) with `static defaultOptions = {...}` class fields. Class fields that don't call external functions are recognized as side-effect-free, allowing bundlers to eliminate unused classes.

**Update `Util.setOptions`** to resolve options inheritance at construction time rather than at class-definition time:
- Walks the prototype chain collecting each class's `static defaultOptions`
- Uses a lazy `Object.setPrototypeOf` call to link each class's `defaultOptions` to its parent's — this preserves the live-inheritance semantics of the original `Object.create(prototype.options)` system, so modifications to `SomeClass.defaultOptions` are immediately visible in existing instances that haven't overridden that property

**Add `"sideEffects": false` to `package.json`** to enable module-level tree-shaking for consumers importing from Leaflet source.

**WMSTileLayer**: the `prototype.defaultWmsParams` assignment is moved to a `static defaultWmsParams` class field; `initialize` accesses it via `this.constructor.defaultWmsParams` so subclasses can override it.

## Result

Importing only `{ LeafletMap, TileLayer }` from source produces a ~167 kB bundle vs ~390 kB for the full build. `WMSTileLayer` and other unused classes are absent from the output (verified with `rollup --treeshake`).

## Test changes

Three spec files accessed `SomeClass.prototype.options` directly (which is no longer populated at class-definition time). Updated to use `SomeClass.defaultOptions` — the correct public API going forward. Behaviour is equivalent because the new `setOptions` implementation preserves live inheritance from `defaultOptions`.

All existing tests pass (1 pre-existing failure unrelated to this change: `console.warning is not a function` in a third-party test dependency).