### PR TITLE
Add leaflet.regions, leaflet.us-states, and leaflet.countries plugins

### DIFF
--- a/docs/_plugins/markers-renderers/leaflet.countries.md
+++ b/docs/_plugins/markers-renderers/leaflet.countries.md
@@ -1,0 +1,12 @@
+---
+name: leaflet.countries
+category: markers-renderers
+repo: https://github.com/EricDalnas/leaflet.countries
+author: Eric Dalnas
+author-url: https://github.com/EricDalnas
+demo: https://ericdalnas.github.io/leaflet.countries/demo/index.html
+compatible-v1: true
+compatible-v2: false
+---
+
+Extends [leaflet.regions](https://github.com/EricDalnas/leaflet.regions) to render world country boundaries using ISO 3166-1 alpha-2 keys. Supports per-country color, permanent labels, click/hover popups, and custom label positions for countries with non-centered centroids. Handles Natural Earth's ISO_A2 `-99` fallback automatically. Use `defaultVisible: false` to highlight only specific countries.

--- a/docs/_plugins/markers-renderers/leaflet.regions.md
+++ b/docs/_plugins/markers-renderers/leaflet.regions.md
@@ -1,0 +1,12 @@
+---
+name: leaflet.regions
+category: markers-renderers
+repo: https://github.com/EricDalnas/leaflet.regions
+author: Eric Dalnas
+author-url: https://github.com/EricDalnas
+demo: https://ericdalnas.github.io/leaflet.regions/demo/index.html
+compatible-v1: true
+compatible-v2: false
+---
+
+Base plugin for rendering GeoJSON regions (polygons) with per-feature color, permanent labels, and click/hover popups. Supports data binding via a simple key→object map, `defaultVisible: false` for focused single-region displays, and live re-render via `refresh()`. Extended by [leaflet.us-states](https://github.com/EricDalnas/leaflet.us-states) and [leaflet.countries](https://github.com/EricDalnas/leaflet.countries).

--- a/docs/_plugins/markers-renderers/leaflet.us-states.md
+++ b/docs/_plugins/markers-renderers/leaflet.us-states.md
@@ -1,0 +1,12 @@
+---
+name: leaflet.us-states
+category: markers-renderers
+repo: https://github.com/EricDalnas/leaflet.us-states
+author: Eric Dalnas
+author-url: https://github.com/EricDalnas
+demo: https://ericdalnas.github.io/leaflet.us-states/demo/index.html
+compatible-v1: true
+compatible-v2: false
+---
+
+Extends [leaflet.regions](https://github.com/EricDalnas/leaflet.regions) to render US state boundaries from GeoJSON with per-state color, permanent labels (with zoom-based abbreviation), and click/hover popups. Supports data binding via a `states` key→object map, choropleth coloring, and `defaultVisible: false` to show only specific states with minimal code.


### PR DESCRIPTION
leaflet.regions loads and displays regional boundary layers with custom data overlays.
leaflet.countries displays country polygons and  optional country‑level data.
leaflet.us‑states displays U.S. state polygons with optional state-level overlays.
