### PR TITLE
Add Leaflet.LatLng.Grid plugin to Synthetic overlays

### DIFF
--- a/docs/_plugins/synthetic-overlays/leaflet-latlng-grid.md
+++ b/docs/_plugins/synthetic-overlays/leaflet-latlng-grid.md
@@ -1,0 +1,13 @@
+---
+name: Leaflet.LatLng.Grid
+category: synthetic-overlays
+repo: https://github.com/latlng-work/leaflet-latlng-grid
+author: latlng-work
+author-url: https://www.latlng.work
+demo: https://www.latlng.work/leaflet-plugin/demo
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+Canvas-rendered auto-scaling lat/lng graticule grid with live coordinate display, one-click copy to clipboard, and latlng.work deep-link integration.


### PR DESCRIPTION
Adds leaflet-latlng-grid to the Synthetic overlays section.

Canvas-rendered auto-scaling lat/lng graticule grid with live 
coordinate display, one-click copy to clipboard, and latlng.work 
deep-link integration. Zero dependencies beyond Leaflet.

- npm: https://www.npmjs.com/package/leaflet-latlng-grid
- Demo: https://www.latlng.work/leaflet-plugin/demo
