### PR TITLE
Add Leaflet.WorldWrap to plugin list

### DIFF
--- a/docs/_plugins/geoprocessing/leaflet.WorldWrap.md
+++ b/docs/_plugins/geoprocessing/leaflet.WorldWrap.md
@@ -1,0 +1,15 @@
+---
+name: Leaflet.WorldWrap
+category: geoprocessing
+repo: https://github.com/EricDalnas/leaflet.worldwrap
+author: Eric Dalnas
+author-url: https://github.com/EricDalnas
+demo: https://ericdalnas.github.io/leaflet.worldwrap/demo.html
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+Seamlessly wraps vector layers (polylines, polygons, circles, markers, GeoJSON)
+across the antimeridian without splitting them. Coordinates are normalised and
+shadow copies are duplicated into every visible world copy in real time.


### PR DESCRIPTION
leaflet.world wrap renders vector layers across the antimeridian without splitting and clones copies for each worldview.