### PR TITLE
Accessibility / WCAG 1.4.1: Increase color contrast

### DIFF
--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -291,7 +291,7 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	outline-offset: 1px;
 
 	a {
-		color: #0078a8;
+		color: #0284B7;
 	}
 }
 


### PR DESCRIPTION
## Problem description

The text and links within the attribution container (CSS selector `.leaflet-control-attribution`) only get differentiated by `color`, which doesn't fit the necessary contrast ratio of at least 3:1, according to [WCAG Success Criteria 1.4.1](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html).

Further information on the topic are included in the [WCAG Technique G183: Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on hover for links or controls where color alone is used to identify them](https://www.w3.org/WAI/WCAG22/Techniques/general/G183)

## Steps to reproduce

- Open https://leafletjs.com/ and go an included map that even also includes contents in the attribution container
- Get the `color` CSS property values for both the text and links in this area. Text `color` is `#333333`, link `color` is `#0078A8`
- The calculation shows that these values measure at a ratio of 2.55823:1, which is less than the required 3:1

<img width="426" height="120" alt="image" src="https://github.com/user-attachments/assets/9602cb6b-29eb-41c3-9bee-46919e90db81" />

## Solution

Implemented another color that get's suggested by the following online tool (please don't get confused by their labels "background" and "foreground" color, we're essentially measuring two text CSS property `color` values): https://app.contrast-finder.org/result.html?foreground=%23333333&background=%230078a8&ratio=3&isBackgroundTested=true&algo=Rgb&lang=de
