### PR TITLE
Update maptiler-geocoding-control support for v2

### DIFF
--- a/docs/_plugins/geocoding/geocoding-maptiler.md
+++ b/docs/_plugins/geocoding/geocoding-maptiler.md
@@ -2,12 +2,12 @@
 name: Geocoding from MapTiler 
 category: geocoding
 repo: https://github.com/maptiler/maptiler-geocoding-control
-author: M. Ždila | MapTiler
+author: MapTiler Team
 author-url: https://github.com/maptiler
 demo: https://docs.maptiler.com/leaflet/geocoding-control/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 A geocoding and reverse geocoding plugin for Leaflet utilizing the [MapTiler Geocoding API](https://docs.maptiler.com/cloud/api/geocoding/), which includes identification of states, cities, streets, down to the addresses and POIs level. It supports search results in various languages, per-country limiting, fuzzy matching, autocomplete, etc.


### PR DESCRIPTION
As of v3.0.0, `@maptiler/geocoding-control` also supports Leaflet v2 (as per DefinitelyTyped/DefinitelyTyped#73485 version).

Resolves maptiler/maptiler-geocoding-control#98.