### PR TITLE
Use standard `constructor()` instead of `initialize()`

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -1,8 +1,14 @@
 import {expect} from 'chai';
-import {Class} from 'leaflet';
+import {Class, withInitHooks} from 'leaflet';
 import sinon from 'sinon';
 
 describe('Class', () => {
+	it('sets default options', () => {
+		const instance = new Class();
+		expect(Object.hasOwn(instance, 'options')).to.be.true;
+		expect(instance.options).to.eql({});
+	});
+
 	describe('#extends', () => {
 		it('merges options instead of replacing them', () => {
 			class KlassWithOptions1 extends Class {
@@ -28,37 +34,6 @@ describe('Class', () => {
 			expect(a.options.foo3).to.eql(4);
 		});
 
-		it('inherits constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class2();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.be.true;
-		});
-
-		it('does not call child constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class1();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.eql(false);
-		});
 	});
 
 	describe('#include', () => {
@@ -108,6 +83,152 @@ describe('Class', () => {
 			expect(K.prototype.options).not.to.equal(props.options);
 		});
 	});
+});
 
-	// TODO Class.mergeOptions
+describe('withInitHooks', () => {
+	it('registers and triggers the initialization hooks correctly', () => {
+		const constructASpy = sinon.spy();
+		const initHookASpy = sinon.spy();
+		const constructBSpy = sinon.spy();
+		const initHookBSpy = sinon.spy();
+
+		// Give the spies names so they show up properly in logs.
+		constructASpy.displayName = 'constructA';
+		initHookASpy.displayName = 'initHookA';
+		constructBSpy.displayName = 'constructB';
+		initHookBSpy.displayName = 'initHookB';
+
+		const A = withInitHooks(class A {
+			constructor(argA) {
+				this.constructA = 'constructed A';
+				this.argA = argA;
+				constructASpy(argA);
+			}
+		});
+
+		const hookAReturnValue = A.addInitHook(function () {
+			this.hookedA = 'hooked A';
+			initHookASpy();
+		});
+
+		const B = withInitHooks(class B extends A {
+			constructor(argA, argB) {
+				super(argA);
+				this.constructB = 'constructed B';
+				this.argB = argB;
+				constructBSpy(argB);
+			}
+		});
+
+		const hookBReturnValue = B.addInitHook(function () {
+			this.hookedB = 'hooked B';
+			initHookBSpy();
+		});
+
+		const instance = new B('valueA', 'valueB');
+
+		// Assert that the classes returned by addInitHook are the same as the originals.
+		expect(hookAReturnValue).to.equal(A);
+		expect(hookBReturnValue).to.equal(B);
+
+		// Assert that constructors and hooks were called in the expected order.
+		sinon.assert.callOrder(
+			constructASpy,
+			initHookASpy,
+			constructBSpy,
+			initHookBSpy
+		);
+
+		// Assert that the fields set during construction and hooking are present.
+		expect(instance.constructA).to.eql('constructed A');
+		expect(instance.hookedA).to.eql('hooked A');
+		expect(instance.constructB).to.eql('constructed B');
+		expect(instance.hookedB).to.eql('hooked B');
+
+		// Assert that constructor arguments are properly forwarded.
+		expect(instance.argA).to.eql('valueA');
+		expect(instance.argB).to.eql('valueB');
+		expect(constructASpy.calledWith('valueA')).to.be.true;
+		expect(constructBSpy.calledWith('valueB')).to.be.true;
+	});
+
+	it('triggers hooks registered with method name and arguments', () => {
+		const methodSpy = sinon.spy();
+
+		const TestClass = withInitHooks(class TestClass {
+			testMethod(arg1, arg2, arg3) {
+				methodSpy(arg1, arg2, arg3);
+			}
+		});
+
+		TestClass.addInitHook('testMethod', 'value1', 'value2', 'value3');
+
+		new TestClass();
+
+		expect(methodSpy.calledOnce).to.be.true;
+		expect(methodSpy.calledWith('value1', 'value2', 'value3')).to.be.true;
+	});
+
+	it('throws an error when \'addInitHook()\' is called on an unwrapped named class', () => {
+		const WrappedParent = withInitHooks(class WrappedParent {});
+		class TestClass extends WrappedParent {}
+
+		expect(() => {
+			TestClass.addInitHook(() => {});
+		}).to.throw(Error, 'The \'addInitHook()\' method can only be called on classes wrapped with \'withInitHooks()\'. Try wrapping your class:\n\nconst TestClass = withInitHooks(class TestClass { ... });\n');
+	});
+
+	it('throws an error when \'addInitHook()\' is called on unwrapped anonymous class', () => {
+		const WrappedParent = withInitHooks(class WrappedParent {});
+		// Wrapped with an IIFE to prevent the class from getting the name 'TestClass'.
+		const TestClass = (() => class extends WrappedParent {})();
+
+		expect(() => {
+			TestClass.addInitHook(() => {});
+		}).to.throw(Error, 'The \'addInitHook()\' method can only be called on classes wrapped with \'withInitHooks()\'. Try wrapping your class:\n\nconst (anonymous) = withInitHooks(class (anonymous) { ... });\n');
+	});
+
+	it('supports chaining of addInitHook calls', () => {
+		const spy1 = sinon.spy();
+		const spy2 = sinon.spy();
+
+		const TestClass = withInitHooks(class TestClass {});
+
+		const result = TestClass.addInitHook(spy1).addInitHook(spy2);
+
+		expect(result).to.equal(TestClass);
+
+		new TestClass();
+
+		expect(spy1.calledOnce).to.be.true;
+		expect(spy2.calledOnce).to.be.true;
+	});
+
+	it('preserves class instance', () => {
+		const A = withInitHooks(class A {});
+		const B = withInitHooks(class B extends A {});
+
+		const a = new A();
+		const b = new B();
+
+		expect(a).to.be.instanceOf(A);
+		expect(b).to.be.instanceOf(B);
+		expect(b).to.be.instanceOf(A);
+	});
+
+	it('does not fire parent hooks more than once when constructing a subclass', () => {
+		const parentHook = sinon.spy();
+		const childHook = sinon.spy();
+
+		const Parent = withInitHooks(class Parent {});
+		const Child = withInitHooks(class Child extends Parent {});
+
+		Parent.addInitHook(parentHook);
+		Child.addInitHook(childHook);
+
+		new Child();
+
+		expect(parentHook.calledOnce).to.be.true;
+		expect(childHook.calledOnce).to.be.true;
+	});
 });

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, LeafletMap, Marker, Point} from 'leaflet';
+import {DomUtil, LeafletMap, Marker, Point, withInitHooks} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
 
@@ -19,14 +19,15 @@ describe('Marker.Drag', () => {
 		removeMapContainer(map, container);
 	});
 
-	class MyMarker extends Marker {
+	const MyMarker = withInitHooks(class MyMarker extends Marker {
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
 		}
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
 		}
-	}
+	});
+
 	MyMarker.addInitHook('on', 'add', function () {
 		this._initialPos = this._getPosition();
 	});

--- a/spec/suites/map/handler/DragHandlerSpec.js
+++ b/spec/suites/map/handler/DragHandlerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, LatLng, LeafletMap, Marker, Point} from 'leaflet';
+import {DomUtil, LatLng, LeafletMap, Marker, Point, withInitHooks} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
@@ -53,14 +53,15 @@ describe('DragHandler', () => {
 		});
 	});
 
-	class MyMap extends LeafletMap {
+	const MyMap = withInitHooks(class MyMap extends LeafletMap {
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
 		}
 		getOffset() {
 			return this._getPosition().subtract(this._initialPos);
 		}
-	}
+	});
+
 	MyMap.addInitHook('on', 'load', function () {
 		this._initialPos = this._getPosition();
 	});

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control.js';
 import {LeafletMap} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
@@ -17,7 +18,7 @@ const ukrainianFlag = '<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg
 // @namespace AttributionControl
 // @constructor AttributionControl(options: AttributionControl options)
 // Creates an attribution control.
-export class AttributionControl extends Control {
+export const AttributionControl = withInitHooks(class AttributionControl extends Control {
 
 	static {
 		// @section
@@ -34,8 +35,8 @@ export class AttributionControl extends Control {
 		});
 	}
 
-	initialize(options) {
-		super.initialize(options);
+	constructor(options) {
+		super(options);
 
 		this._attributions = {};
 	}
@@ -122,7 +123,7 @@ export class AttributionControl extends Control {
 
 		this._container.innerHTML = prefixAndAttribs.join(' <span aria-hidden="true">|</span> ');
 	}
-}
+});
 
 // @namespace LeafletMap
 // @section Control options

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -1,5 +1,4 @@
-
-import {Class} from '../core/Class.js';
+import {Class, withInitHooks} from '../core/Class.js';
 import {LeafletMap} from '../map/Map.js';
 import * as Util from '../core/Util.js';
 import * as DomUtil from '../dom/DomUtil.js';
@@ -12,7 +11,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  * All other controls extend from this class.
  */
 
-export class Control extends Class {
+export const Control = withInitHooks(class Control extends Class {
 
 	static {
 		// @section
@@ -26,7 +25,8 @@ export class Control extends Class {
 	}
 
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -109,7 +109,7 @@ export class Control extends Class {
 			this._map.getContainer().focus();
 		}
 	}
-}
+});
 
 /* @section Extension methods
  * @uninheritable

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -1,5 +1,6 @@
 
 import {Control} from './Control.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
@@ -44,7 +45,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor LayersControl(baselayers?: Object, overlays?: Object, options?: LayersControl options)
 // Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.
-export class LayersControl extends Control {
+export const LayersControl = withInitHooks(class LayersControl extends Control {
 
 	static {
 		// @section
@@ -85,8 +86,8 @@ export class LayersControl extends Control {
 		});
 	}
 
-	initialize(baseLayers, overlays, options) {
-		super.initialize(options);
+	constructor(baseLayers, overlays, options) {
+		super(options);
 
 		this._layerControlInputs = [];
 		this._layers = [];
@@ -438,4 +439,4 @@ export class LayersControl extends Control {
 		});
 	}
 
-}
+});

--- a/src/control/ScaleControl.js
+++ b/src/control/ScaleControl.js
@@ -1,5 +1,6 @@
 
 import {Control} from './Control.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
 /*
@@ -17,7 +18,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 
 // @constructor ScaleControl(options?: ScaleControl options)
 // Creates an scale control with the given options.
-export class ScaleControl extends Control {
+export const ScaleControl = withInitHooks(class ScaleControl extends Control {
 
 	static {
 		// @section
@@ -130,4 +131,4 @@ export class ScaleControl extends Control {
 
 		return pow10 * d;
 	}
-}
+});

--- a/src/control/ZoomControl.js
+++ b/src/control/ZoomControl.js
@@ -1,6 +1,7 @@
 
 import {Control} from './Control.js';
 import {LeafletMap} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
 
@@ -14,7 +15,7 @@ import * as DomEvent from '../dom/DomEvent.js';
 // @namespace ZoomControl
 // @constructor ZoomControl(options: ZoomControl options)
 // Creates a zoom control
-export class ZoomControl extends Control {
+export const ZoomControl = withInitHooks(class ZoomControl extends Control {
 
 	static {
 		// @section
@@ -125,7 +126,7 @@ export class ZoomControl extends Control {
 			this._zoomInButton.setAttribute('aria-disabled', 'true');
 		}
 	}
-}
+});
 
 // @namespace LeafletMap
 // @section Control options

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -7,7 +7,7 @@ import * as Util from './Util.js';
 
 // Thanks to John Resig and Dean Edwards for inspiration!
 
-export class Class {
+export const Class = withInitHooks(class Class {
 	// @function include(properties: Object): this
 	// [Includes a mixin](#class-includes) into the current class.
 	static include(props) {
@@ -50,55 +50,47 @@ export class Class {
 
 	// @function addInitHook(fn: Function): this
 	// Adds a [constructor hook](#class-constructor-hooks) to the class.
-	static addInitHook(fn, ...args) { // (Function) || (String, args...)
+
+	constructor() {
+		Util.setOptions(this);
+	}
+});
+
+// @function withInitHooks(Object TargetClass): Function
+// Decorates a class to be able to use [constructor hooks](#class-constructor-hooks) functionality.
+/**
+ * @template T
+ * @param {T} TargetClass
+ * @returns {T}
+ */
+export function withInitHooks(TargetClass) {
+	const hooks = [];
+	const proxy = new Proxy(TargetClass, {
+		construct(target, args, newTarget) {
+			const instance = Reflect.construct(target, args, newTarget);
+
+			for (const hook of hooks) {
+				hook.call(instance);
+			}
+
+			return instance;
+		}
+	});
+
+	TargetClass.addInitHook = function addInitHook(fn, ...args) {
+		if (this !== proxy) {
+			const className = this.name || '(anonymous)';
+			throw new Error(`The 'addInitHook()' method can only be called on classes wrapped with 'withInitHooks()'. Try wrapping your class:\n\nconst ${className} = withInitHooks(class ${className} { ... });\n`);
+		}
+
 		const init = typeof fn === 'function' ? fn : function () {
 			this[fn].apply(this, args);
 		};
 
-		if (!Object.hasOwn(this.prototype, '_initHooks')) { // do not use ??= here
-			this.prototype._initHooks = [];
-		}
-		this.prototype._initHooks.push(init);
+		hooks.push(init);
+
 		return this;
-	}
+	};
 
-	constructor(...args) {
-		this._initHooksCalled = false;
-
-		Util.setOptions(this);
-
-		// call the constructor
-		if (this.initialize) {
-			this.initialize(...args);
-		}
-
-		// call all constructor hooks
-		this.callInitHooks();
-	}
-
-	callInitHooks() {
-		if (this._initHooksCalled) {
-			return;
-		}
-
-		// collect all prototypes in chain
-		const prototypes = [];
-		let current = this;
-
-		while ((current = Object.getPrototypeOf(current)) !== null) {
-			prototypes.push(current);
-		}
-
-		// reverse so the parent prototype is first
-		prototypes.reverse();
-
-		// call init hooks on each prototype
-		for (const proto of prototypes) {
-			for (const hook of proto._initHooks ?? []) {
-				hook.call(this);
-			}
-		}
-
-		this._initHooksCalled = true;
-	}
+	return proxy;
 }

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -1,4 +1,4 @@
-import {Class} from './Class.js';
+import {Class, withInitHooks} from './Class.js';
 import * as Util from './Util.js';
 
 /*
@@ -25,7 +25,7 @@ import * as Util from './Util.js';
  * ```
  */
 
-export class Evented extends Class {
+export const Evented = withInitHooks(class Evented extends Class {
 	/* @method on(type: String, fn: Function, context?: Object): this
 	 * Adds a listener function (`fn`) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. `'click dblclick'`).
 	 *
@@ -307,4 +307,4 @@ export class Evented extends Class {
 			}, true);
 		}
 	}
-};
+});

--- a/src/core/Handler.js
+++ b/src/core/Handler.js
@@ -1,4 +1,4 @@
-import {Class} from './Class.js';
+import {Class, withInitHooks} from './Class.js';
 
 /*
 	Handler is a base class for handler classes that are used internally to inject
@@ -8,8 +8,9 @@ import {Class} from './Class.js';
 // @class Handler
 // Abstract class for map interaction handlers
 
-export class Handler extends Class {
-	initialize(map) {
+export const Handler = withInitHooks(class Handler extends Class {
+	constructor(map) {
+		super();
 		this._map = map;
 	}
 
@@ -45,7 +46,7 @@ export class Handler extends Class {
 	// Called when the handler is enabled, should add event hooks.
 	// @method removeHooks()
 	// Called when the handler is disabled, should remove the event hooks added previously.
-}
+});
 
 // @section There is static function which can be called without instantiating Handler:
 // @function addTo(map: LeafletMap, name: String): this

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,5 +1,5 @@
 export {default as Browser} from './Browser.js';
-export {Class} from './Class.js';
+export {Class, withInitHooks} from './Class.js';
 export {Evented} from './Events.js';
 export {Handler} from './Handler.js';
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../core/Class.js';
 import {Evented} from '../core/Events.js';
 import * as DomEvent from './DomEvent.js';
 import * as DomUtil from './DomUtil.js';
@@ -19,7 +20,7 @@ import * as PointerEvents from './DomEvent.PointerEvents.js';
  * ```
  */
 
-export class Draggable extends Evented {
+export const Draggable = withInitHooks(class Draggable extends Evented {
 
 	static {
 		this.setDefaultOptions({
@@ -34,7 +35,8 @@ export class Draggable extends Evented {
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).
-	initialize(element, dragStartTarget, preventOutline, options) {
+	constructor(element, dragStartTarget, preventOutline, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._element = element;
@@ -198,4 +200,4 @@ export class Draggable extends Evented {
 		}
 	}
 
-}
+});

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -1,4 +1,5 @@
 import {Evented} from '../core/Events.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomUtil from '../dom/DomUtil.js';
 
 
@@ -31,7 +32,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  *
  */
 
-export class PosAnimation extends Evented {
+export const PosAnimation = withInitHooks(class PosAnimation extends Evented {
 
 	// @method run(el: HTMLElement, newPos: Point, duration?: Number, easeLinearity?: Number)
 	// Run an animation of a given element to a new position, optionally setting
@@ -108,4 +109,4 @@ export class PosAnimation extends Evented {
 	_easeOut(t) {
 		return 1 - (1 - t) ** this._easeOutPower;
 	}
-}
+});

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -1,5 +1,6 @@
 import {Layer} from './Layer.js';
 import * as DomUtil from '../dom/DomUtil.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import {Bounds} from '../geometry/Bounds.js';
@@ -15,7 +16,7 @@ import {Bounds} from '../geometry/Bounds.js';
  * that rely on one single HTML element
  */
 
-export class BlanketOverlay extends Layer {
+export const BlanketOverlay = withInitHooks(class BlanketOverlay extends Layer {
 
 	static {
 		// @section
@@ -35,7 +36,8 @@ export class BlanketOverlay extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -165,4 +167,4 @@ export class BlanketOverlay extends Layer {
 	_onZoomEnd() {}
 	_onViewReset() {}
 	_onSettled() {}
-}
+});

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -1,6 +1,7 @@
 import {LeafletMap} from '../map/Map.js';
 import {Layer} from './Layer.js';
 import {FeatureGroup} from './FeatureGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {LatLng} from '../geo/LatLng.js';
 import {Point} from '../geometry/Point.js';
@@ -13,7 +14,7 @@ import * as DomUtil from '../dom/DomUtil.js';
  */
 
 // @namespace DivOverlay
-export class DivOverlay extends Layer {
+export const DivOverlay = withInitHooks(class DivOverlay extends Layer {
 
 	static {
 		// @section
@@ -42,7 +43,9 @@ export class DivOverlay extends Layer {
 		});
 	}
 
-	initialize(options, source) {
+	constructor(options, source) {
+		super();
+
 		if (options instanceof LatLng || Array.isArray(options)) {
 			this._latlng = new LatLng(options);
 			Util.setOptions(this, source);
@@ -315,7 +318,7 @@ export class DivOverlay extends Layer {
 		return [0, 0];
 	}
 
-}
+});
 
 LeafletMap.include({
 	_initOverlay(OverlayClass, content, latlng, options) {

--- a/src/layer/FeatureGroup.js
+++ b/src/layer/FeatureGroup.js
@@ -1,4 +1,5 @@
 import {LayerGroup} from './LayerGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import {LatLngBounds} from '../geo/LatLngBounds.js';
 
 /*
@@ -24,7 +25,7 @@ import {LatLngBounds} from '../geo/LatLngBounds.js';
 
 // @constructor FeatureGroup(layers?: Layer[], options?: Object)
 // Create a feature group, optionally given an initial set of layers and an `options` object.
-export class FeatureGroup extends LayerGroup {
+export const FeatureGroup = withInitHooks(class FeatureGroup extends LayerGroup {
 
 	addLayer(layer) {
 		if (this.hasLayer(layer)) {
@@ -85,4 +86,4 @@ export class FeatureGroup extends LayerGroup {
 		}
 		return bounds;
 	}
-}
+});

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -1,5 +1,6 @@
 import {LayerGroup} from './LayerGroup.js';
 import {FeatureGroup} from './FeatureGroup.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {Marker} from './marker/Marker.js';
 import {Circle} from './vector/Circle.js';
@@ -35,7 +36,7 @@ import * as LineUtil from '../geometry/LineUtil.js';
 // Creates a GeoJSON layer. Optionally accepts an object in
 // [GeoJSON format](https://tools.ietf.org/html/rfc7946) to display on the map
 // (you can alternatively add it later with `addData` method) and an `options` object.
-export class GeoJSON extends FeatureGroup {
+export const GeoJSON = withInitHooks(class GeoJSON extends FeatureGroup {
 
 	/* @section
 	 * @aka GeoJSON options
@@ -89,8 +90,8 @@ export class GeoJSON extends FeatureGroup {
 	 * Whether default Markers for "Point" type Features inherit from group options.
 	 */
 
-	initialize(geojson, options) {
-		super.initialize(undefined, options);
+	constructor(geojson, options) {
+		super(undefined, options);
 
 		if (geojson) {
 			this.addData(geojson);
@@ -303,7 +304,7 @@ export class GeoJSON extends FeatureGroup {
 		};
 	}
 
-}
+});
 
 const PointToGeoJSON = {
 	toGeoJSON(precision) {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -1,4 +1,5 @@
 import {Layer} from './Layer.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {LatLngBounds} from '../geo/LatLngBounds.js';
 import {Bounds} from '../geometry/Bounds.js';
@@ -22,7 +23,7 @@ import * as DomUtil from '../dom/DomUtil.js';
 // @constructor ImageOverlay(imageUrl: String, bounds: LatLngBounds, options?: ImageOverlay options)
 // Instantiates an image overlay object given the URL of the image and the
 // geographical bounds it is tied to.
-export class ImageOverlay extends Layer {
+export const ImageOverlay = withInitHooks(class ImageOverlay extends Layer {
 
 	static {
 		// @section
@@ -67,7 +68,9 @@ export class ImageOverlay extends Layer {
 		});
 	}
 
-	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
+	constructor(url, bounds, options) { // (String, LatLngBounds, Object)
+		super();
+
 		this._url = url;
 		this._bounds = new LatLngBounds(bounds);
 
@@ -273,4 +276,4 @@ export class ImageOverlay extends Layer {
 	getCenter() {
 		return this._bounds.getCenter();
 	}
-}
+});

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -1,5 +1,6 @@
 import {Evented} from '../core/Events.js';
 import {LeafletMap} from '../map/Map.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -26,7 +27,7 @@ import * as Util from '../core/Util.js';
  */
 
 
-export class Layer extends Evented {
+export const Layer = withInitHooks(class Layer extends Evented {
 
 	static {
 		// Classes extending `Layer` will inherit the following options:
@@ -114,7 +115,7 @@ export class Layer extends Evented {
 		this.fire('add');
 		map.fire('layeradd', {layer: this});
 	}
-}
+});
 
 /* @section Extension methods
  * @uninheritable

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -1,5 +1,6 @@
 
 import {Layer} from './Layer.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -21,9 +22,11 @@ import * as Util from '../core/Util.js';
 
 // @constructor LayerGroup(layers?: Layer[], options?: Object)
 // Create a layer group, optionally given an initial set of layers and an `options` object.
-export class LayerGroup extends Layer {
+export const LayerGroup = withInitHooks(class LayerGroup extends Layer {
 
-	initialize(layers, options) { // for compatibility of code using `LayerGroup.extend`
+	constructor(layers, options) {
+		super();
+
 		Util.setOptions(this, options);
 
 		this._layers = {};
@@ -123,4 +126,4 @@ export class LayerGroup extends Layer {
 	getLayerId(layer) {
 		return Util.stamp(layer);
 	}
-}
+});

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -1,4 +1,5 @@
 import {DivOverlay} from './DivOverlay.js';
+import {withInitHooks} from '../core/Class.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import {Point} from '../geometry/Point.js';
@@ -45,7 +46,7 @@ import {FeatureGroup} from './FeatureGroup.js';
 // @alternative
 // @constructor Popup(latlng: LatLng, options?: Popup options)
 // Instantiates a `Popup` object given `latlng` where the popup will open and an optional `options` object that describes its appearance and location.
-export class Popup extends DivOverlay {
+export const Popup = withInitHooks(class Popup extends DivOverlay {
 
 	static {
 		// @section
@@ -337,7 +338,7 @@ export class Popup extends DivOverlay {
 		return new Point(this._source?._getPopupAnchor ? this._source._getPopupAnchor() : [0, 0]);
 	}
 
-}
+});
 
 
 /* @namespace LeafletMap

--- a/src/layer/SVGOverlay.js
+++ b/src/layer/SVGOverlay.js
@@ -1,4 +1,5 @@
 import {ImageOverlay} from './ImageOverlay.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -24,7 +25,7 @@ import * as Util from '../core/Util.js';
 // @constructor SVGOverlay(svg: String|SVGElement, bounds: LatLngBounds, options?: SVGOverlay options)
 // Instantiates an image overlay object given an SVG element and the geographical bounds it is tied to.
 // A viewBox attribute is required on the SVG element to zoom in and out properly.
-export class SVGOverlay extends ImageOverlay {
+export const SVGOverlay = withInitHooks(class SVGOverlay extends ImageOverlay {
 	_initImage() {
 		const el = this._image = this._url;
 
@@ -39,4 +40,4 @@ export class SVGOverlay extends ImageOverlay {
 	// @method getElement(): SVGElement
 	// Returns the instance of [`SVGElement`](https://developer.mozilla.org/docs/Web/API/SVGElement)
 	// used by this overlay.
-}
+});

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -4,6 +4,7 @@ import {LeafletMap} from '../map/Map.js';
 import {Layer} from './Layer.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {FeatureGroup} from './FeatureGroup.js';
 
@@ -51,7 +52,7 @@ import {FeatureGroup} from './FeatureGroup.js';
 // @alternative
 // @constructor Tooltip(latlng: LatLng, options?: Tooltip options)
 // Instantiates a `Tooltip` object given `latlng` where the tooltip will open and an optional `options` object that describes its appearance and location.
-export class Tooltip extends DivOverlay {
+export const Tooltip = withInitHooks(class Tooltip extends DivOverlay {
 
 	static {
 		// @section
@@ -222,7 +223,7 @@ export class Tooltip extends DivOverlay {
 		return new Point(this._source?._getTooltipAnchor && !this.options.sticky ? this._source._getTooltipAnchor() : [0, 0]);
 	}
 
-}
+});
 
 // @namespace LeafletMap
 // @section Methods for Layers and Controls

--- a/src/layer/VideoOverlay.js
+++ b/src/layer/VideoOverlay.js
@@ -1,6 +1,7 @@
 import {ImageOverlay} from './ImageOverlay.js';
 import * as DomUtil from '../dom/DomUtil.js';
 import * as DomEvent from '../dom/DomEvent.js';
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 
 /*
@@ -24,7 +25,7 @@ import * as Util from '../core/Util.js';
 // @constructor VideoOverlay(video: String|Array|HTMLVideoElement, bounds: LatLngBounds, options?: VideoOverlay options)
 // Instantiates an image overlay object given the URL of the video (or array of URLs, or even a video element) and the
 // geographical bounds it is tied to.
-export class VideoOverlay extends ImageOverlay {
+export const VideoOverlay = withInitHooks(class VideoOverlay extends ImageOverlay {
 
 	static {
 		// @section
@@ -103,4 +104,4 @@ export class VideoOverlay extends ImageOverlay {
 	// @method getElement(): HTMLVideoElement
 	// Returns the instance of [`HTMLVideoElement`](https://developer.mozilla.org/docs/Web/API/HTMLVideoElement)
 	// used by this overlay.
-}
+});

--- a/src/layer/marker/DefaultIcon.js
+++ b/src/layer/marker/DefaultIcon.js
@@ -1,4 +1,5 @@
 import {Icon} from './Icon.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 
 /*
@@ -16,7 +17,7 @@ import * as DomUtil from '../../dom/DomUtil.js';
  * `Marker.prototype.options.icon` with your own icon instead.
  */
 
-export class DefaultIcon extends Icon {
+export const DefaultIcon = withInitHooks(class DefaultIcon extends Icon {
 
 	static {
 		this.setDefaultOptions({
@@ -68,4 +69,4 @@ export class DefaultIcon extends Icon {
 		if (!link) { return ''; }
 		return link.href.substring(0, link.href.length - 'leaflet.css'.length - 1);
 	}
-}
+});

--- a/src/layer/marker/DivIcon.js
+++ b/src/layer/marker/DivIcon.js
@@ -1,4 +1,5 @@
 import {Icon} from './Icon.js';
+import {withInitHooks} from '../../core/Class.js';
 import {Point} from '../../geometry/Point.js';
 
 /*
@@ -21,7 +22,7 @@ import {Point} from '../../geometry/Point.js';
 
 // @constructor DivIcon(options: DivIcon options)
 // Creates a `DivIcon` instance with the given options.
-export class DivIcon extends Icon {
+export const DivIcon = withInitHooks(class DivIcon extends Icon {
 
 	static {
 		this.setDefaultOptions({
@@ -68,4 +69,4 @@ export class DivIcon extends Icon {
 	createShadow() {
 		return null;
 	}
-}
+});

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -1,4 +1,4 @@
-import {Class} from '../../core/Class.js';
+import {Class, withInitHooks} from '../../core/Class.js';
 import {setOptions} from '../../core/Util.js';
 import {Point} from '../../geometry/Point.js';
 import Browser from '../../core/Browser.js';
@@ -32,7 +32,7 @@ import Browser from '../../core/Browser.js';
 
 // @constructor Icon(options: Icon options)
 // Creates an icon instance with the given options.
-export class Icon extends Class {
+export const Icon = withInitHooks(class Icon extends Class {
 
 	static {
 		/* @section
@@ -86,7 +86,8 @@ export class Icon extends Class {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		setOptions(this, options);
 	}
 
@@ -158,4 +159,4 @@ export class Icon extends Class {
 	_getIconUrl(name) {
 		return Browser.retina && this.options[`${name}RetinaUrl`] || this.options[`${name}Url`];
 	}
-}
+});

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../../core/Class.js';
 import {Handler} from '../../core/Handler.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import {Draggable} from '../../dom/Draggable.js';
@@ -22,9 +23,10 @@ import {Point} from '../../geometry/Point.js';
  * Marker dragging handler. Only valid when the marker is on the map (Otherwise set [`marker.options.draggable`](#marker-draggable)).
  */
 
-export class MarkerDrag extends Handler {
-	initialize(marker) {
-		super.initialize(marker._map);
+export const MarkerDrag = withInitHooks(class MarkerDrag extends Handler {
+	constructor(marker) {
+		super(marker._map);
+
 		this._marker = marker;
 	}
 
@@ -156,4 +158,4 @@ export class MarkerDrag extends Handler {
 			.fire('moveend')
 			.fire('dragend', e);
 	}
-}
+});

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -1,5 +1,6 @@
 import {Layer} from '../Layer.js';
 import {DefaultIcon} from './DefaultIcon.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Point} from '../../geometry/Point.js';
@@ -21,7 +22,7 @@ import {MarkerDrag} from './Marker.Drag.js';
 
 // @constructor Marker(latlng: LatLng, options? : Marker options)
 // Instantiates a Marker object given a geographical point and optionally an options object.
-export class Marker extends Layer {
+export const Marker = withInitHooks(class Marker extends Layer {
 
 	static {
 		// @section
@@ -110,7 +111,8 @@ export class Marker extends Layer {
 	 * In addition to [shared layer methods](#Layer) like `addTo()` and `remove()` and [popup methods](#Popup) like bindPopup() you can also use the following methods:
 	 */
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 	}
@@ -411,4 +413,4 @@ export class Marker extends Layer {
 	_getTooltipAnchor() {
 		return this.options.icon.options.tooltipAnchor;
 	}
-}
+});

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -1,4 +1,5 @@
 import {Layer} from '../Layer.js';
+import {withInitHooks} from '../../core/Class.js';
 import Browser from '../../core/Browser.js';
 import * as Util from '../../core/Util.js';
 import * as DomUtil from '../../dom/DomUtil.js';
@@ -73,7 +74,7 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
 
 // @constructor GridLayer(options?: GridLayer options)
 // Creates a new instance of GridLayer with the supplied options.
-export class GridLayer extends Layer {
+export const GridLayer = withInitHooks(class GridLayer extends Layer {
 
 	static {
 	// @section
@@ -152,7 +153,8 @@ export class GridLayer extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 
@@ -894,4 +896,4 @@ export class GridLayer extends Layer {
 	_noTilesToLoad() {
 		return Object.values(this._tiles).every(t => t.loaded);
 	}
-}
+});

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -1,4 +1,5 @@
 import {GridLayer} from './GridLayer.js';
+import {withInitHooks} from '../../core/Class.js';
 import Browser from '../../core/Browser.js';
 import * as Util from '../../core/Util.js';
 import * as DomEvent from '../../dom/DomEvent.js';
@@ -34,7 +35,7 @@ import * as DomEvent from '../../dom/DomEvent.js';
 
 // @constructor TileLayer(urlTemplate: String, options?: TileLayer options)
 // Instantiates a tile layer object given a `URL template` and optionally an options object.
-export class TileLayer extends GridLayer {
+export const TileLayer = withInitHooks(class TileLayer extends GridLayer {
 
 	static {
 		// @section
@@ -88,8 +89,8 @@ export class TileLayer extends GridLayer {
 		});
 	}
 
-	initialize(url, options) {
-		super.initialize(options);
+	constructor(url, options) {
+		super(options);
 
 		this._url = url;
 
@@ -288,4 +289,4 @@ export class TileLayer extends GridLayer {
 	_clampZoom(zoom) {
 		return Math.round(super._clampZoom(zoom));
 	}
-}
+});

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -1,4 +1,5 @@
 import {TileLayer} from './TileLayer.js';
+import {withInitHooks} from '../../core/Class.js';
 import Browser from '../../core/Browser.js';
 import {EPSG4326} from '../../geo/crs/EPSG4326.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -22,7 +23,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor WMSTileLayer(baseUrl: String, options: WMSTileLayer options)
 // Instantiates a WMS tile layer object given a base URL of the WMS service and a WMS parameters/options object.
-export class WMSTileLayer extends TileLayer {
+export const WMSTileLayer = withInitHooks(class WMSTileLayer extends TileLayer {
 
 	static {
 		// @section
@@ -67,8 +68,8 @@ export class WMSTileLayer extends TileLayer {
 		});
 	}
 
-	initialize(url, options) {
-		super.initialize(url, options);
+	constructor(url, options) {
+		super(url, options);
 
 		const wmsParams = {...this.defaultWmsParams};
 
@@ -128,4 +129,4 @@ export class WMSTileLayer extends TileLayer {
 
 		return this;
 	}
-}
+});

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -1,5 +1,6 @@
 import {Renderer} from './Renderer.js';
 import * as DomEvent from '../../dom/DomEvent.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
@@ -32,7 +33,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor Canvas(options?: Renderer options)
 // Creates a Canvas renderer with the given options.
-export class Canvas extends Renderer {
+export const Canvas = withInitHooks(class Canvas extends Renderer {
 
 	static {
 		// @section
@@ -471,4 +472,4 @@ export class Canvas extends Renderer {
 
 		this._requestRedraw(layer);
 	}
-}
+});

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -1,4 +1,5 @@
 import {CircleMarker} from './CircleMarker.js';
+import {withInitHooks} from '../../core/Class.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
 import {EarthCRS} from '../../geo/crs/EarthCRS.js';
 
@@ -21,10 +22,10 @@ import {EarthCRS} from '../../geo/crs/EarthCRS.js';
 // @constructor Circle(latlng: LatLng, options?: Circle options)
 // Instantiates a circle object given a geographical point, and an options object
 // which contains the circle radius.
-export class Circle extends CircleMarker {
+export const Circle = withInitHooks(class Circle extends CircleMarker {
 
-	initialize(latlng, options) {
-		super.initialize(latlng, options);
+	constructor(latlng, options) {
+		super(latlng, options);
 
 		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 
@@ -82,4 +83,4 @@ export class Circle extends CircleMarker {
 
 		this._updateBounds();
 	}
-}
+});

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -1,4 +1,5 @@
 import {Path} from './Path.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -13,7 +14,7 @@ import {Bounds} from '../../geometry/Bounds.js';
 
 // @constructor CircleMarker(latlng: LatLng, options?: CircleMarker options)
 // Instantiates a circle marker object given a geographical point, and an optional options object.
-export class CircleMarker extends Path {
+export const CircleMarker = withInitHooks(class CircleMarker extends Path {
 
 	static {
 		// @section
@@ -27,7 +28,8 @@ export class CircleMarker extends Path {
 		});
 	}
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 		this._radius = this.options.radius;
@@ -104,4 +106,4 @@ export class CircleMarker extends Path {
 	_containsPoint(p) {
 		return p.distanceTo(this._point) <= this._pxRadius + this._clickTolerance();
 	}
-}
+});

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -1,4 +1,5 @@
 import {Layer} from '../Layer.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 
 /*
@@ -9,7 +10,7 @@ import * as Util from '../../core/Util.js';
  * overlays (Polygon, Polyline, Circle). Do not use it directly. Extends `Layer`.
  */
 
-export class Path extends Layer {
+export const Path = withInitHooks(class Path extends Layer {
 
 	static {
 		// @section
@@ -142,4 +143,4 @@ export class Path extends Layer {
 		return (this.options.stroke ? this.options.weight / 2 : 0) +
 		  (this._renderer.options.tolerance || 0);
 	}
-}
+});

--- a/src/layer/vector/Polygon.js
+++ b/src/layer/vector/Polygon.js
@@ -4,6 +4,7 @@ import * as LineUtil from '../../geometry/LineUtil.js';
 import {Point} from '../../geometry/Point.js';
 import {Bounds} from '../../geometry/Bounds.js';
 import * as PolyUtil from '../../geometry/PolyUtil.js';
+import {withInitHooks} from '../../core/Class.js';
 
 /*
  * @class Polygon
@@ -51,7 +52,7 @@ import * as PolyUtil from '../../geometry/PolyUtil.js';
  */
 
 // @constructor Polygon(latlngs: LatLng[], options?: Polyline options)
-export class Polygon extends Polyline {
+export const Polygon = withInitHooks(class Polygon extends Polyline {
 
 	static {
 		this.setDefaultOptions({
@@ -152,4 +153,4 @@ export class Polygon extends Polyline {
 		return inside || super._containsPoint(p, true);
 	}
 
-}
+});

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -1,4 +1,5 @@
 import {Path} from './Path.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 import * as LineUtil from '../../geometry/LineUtil.js';
 import {LatLng} from '../../geo/LatLng.js';
@@ -48,7 +49,7 @@ import {Point} from '../../geometry/Point.js';
 // optionally an options object. You can create a `Polyline` object with
 // multiple separate lines (`MultiPolyline`) by passing an array of arrays
 // of geographic points.
-export class Polyline extends Path {
+export const Polyline = withInitHooks(class Polyline extends Path {
 
 	static {
 		// @section
@@ -66,7 +67,8 @@ export class Polyline extends Path {
 		});
 	}
 
-	initialize(latlngs, options) {
+	constructor(latlngs, options) {
+		super();
 		Util.setOptions(this, options);
 		this._setLatLngs(latlngs);
 	}
@@ -290,4 +292,4 @@ export class Polyline extends Path {
 		}
 		return false;
 	}
-}
+});

--- a/src/layer/vector/Rectangle.js
+++ b/src/layer/vector/Rectangle.js
@@ -1,5 +1,6 @@
 import {Polygon} from './Polygon.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
+import {withInitHooks} from '../../core/Class.js';
 
 /*
  * Rectangle extends Polygon and creates a rectangle when passed a LatLngBounds object.
@@ -27,18 +28,18 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
  */
 
 // @constructor Rectangle(latLngBounds: LatLngBounds, options?: Polyline options)
-export class Rectangle extends Polygon {
-	initialize(latLngBounds, options) {
-		super.initialize(this._boundsToLatLngs(latLngBounds), options);
+export const Rectangle = withInitHooks(class Rectangle extends Polygon {
+	constructor(latLngBounds, options) {
+		super(Rectangle.#boundsToLatLngs(latLngBounds), options);
 	}
 
 	// @method setBounds(latLngBounds: LatLngBounds): this
 	// Redraws the rectangle with the passed bounds.
 	setBounds(latLngBounds) {
-		return this.setLatLngs(this._boundsToLatLngs(latLngBounds));
+		return this.setLatLngs(Rectangle.#boundsToLatLngs(latLngBounds));
 	}
 
-	_boundsToLatLngs(latLngBounds) {
+	static #boundsToLatLngs(latLngBounds) {
 		latLngBounds = new LatLngBounds(latLngBounds);
 		return [
 			latLngBounds.getSouthWest(),
@@ -47,4 +48,4 @@ export class Rectangle extends Polygon {
 			latLngBounds.getSouthEast()
 		];
 	}
-}
+});

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -1,4 +1,5 @@
 import {BlanketOverlay} from '../BlanketOverlay.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as Util from '../../core/Util.js';
 
 /*
@@ -23,10 +24,10 @@ import * as Util from '../../core/Util.js';
  * its map has moved
  */
 
-export class Renderer extends BlanketOverlay {
+export const Renderer = withInitHooks(class Renderer extends BlanketOverlay {
 
-	initialize(options) {
-		super.initialize({...options, continuous: false});
+	constructor(options) {
+		super({...options, continuous: false});
 		Util.stamp(this);
 		this._layers ??= {};
 	}
@@ -70,4 +71,4 @@ export class Renderer extends BlanketOverlay {
 	// the 'update' event whenever appropriate (before/after rendering).
 	_update() {}
 
-}
+});

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -1,4 +1,5 @@
 import {Renderer} from './Renderer.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import {splitWords, stamp} from '../../core/Util.js';
 
@@ -32,7 +33,7 @@ import {splitWords, stamp} from '../../core/Util.js';
 // @namespace SVG
 // @constructor SVG(options?: Renderer options)
 // Creates a SVG renderer with the given options.
-export class SVG extends Renderer {
+export const SVG = withInitHooks(class SVG extends Renderer {
 
 	_initContainer() {
 		this._container = SVG.create('svg');
@@ -208,4 +209,4 @@ export class SVG extends Renderer {
 		return str || 'M0 0';
 	}
 
-}
+});

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1,3 +1,4 @@
+import {withInitHooks} from '../core/Class.js';
 import * as Util from '../core/Util.js';
 import {Evented} from '../core/Events.js';
 import {EPSG3857} from '../geo/crs/EPSG3857.js';
@@ -48,7 +49,7 @@ import * as PointerEvents from '../dom/DomEvent.PointerEvents.js';
 // @constructor Map(el: HTMLElement, options?: Map options)
 // Instantiates a map object given an instance of a `<div>` HTML element
 // and optionally an object literal with `Map options`.
-export class LeafletMap extends Evented {
+export const LeafletMap = withInitHooks(class LeafletMap extends Evented {
 
 	static {
 		this.setDefaultOptions({
@@ -141,7 +142,8 @@ export class LeafletMap extends Evented {
 		});
 	}
 
-	initialize(id, options) { // (HTMLElement or String, Object)
+	constructor(id, options) { // (HTMLElement or String, Object)
+		super();
 		options = Util.setOptions(this, options);
 
 		// Make sure to assign internal flags at the beginning,
@@ -167,8 +169,6 @@ export class LeafletMap extends Evented {
 		if (options.center && options.zoom !== undefined) {
 			this.setView(new LatLng(options.center), options.zoom, {reset: true});
 		}
-
-		this.callInitHooks();
 
 		// don't animate on browsers without hardware-accelerated transitions or old Android
 		this._zoomAnimated = this.options.zoomAnimation;
@@ -1763,6 +1763,6 @@ export class LeafletMap extends Evented {
 
 		this._moveEnd(true);
 	}
-}
+});
 
 export const Map = LeafletMap;

--- a/src/map/handler/BoxZoomHandler.js
+++ b/src/map/handler/BoxZoomHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomUtil from '../../dom/DomUtil.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
@@ -19,9 +20,9 @@ LeafletMap.mergeOptions({
 	boxZoom: true
 });
 
-export class BoxZoomHandler extends Handler {
-	initialize(map) {
-		super.initialize(map);
+export const BoxZoomHandler = withInitHooks(class BoxZoomHandler extends Handler {
+	constructor(map) {
+		super(map);
 		this._container = map._container;
 		this._pane = map._panes.overlayPane;
 		this._resetStateTimeout = 0;
@@ -144,7 +145,7 @@ export class BoxZoomHandler extends Handler {
 			this._resetState();
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property boxZoom: Handler

--- a/src/map/handler/DoubleClickZoomHandler.js
+++ b/src/map/handler/DoubleClickZoomHandler.js
@@ -1,4 +1,5 @@
 import {LeafletMap} from '../Map.js';
+import {withInitHooks} from '../../core/Class.js';
 import {Handler} from '../../core/Handler.js';
 
 /*
@@ -17,7 +18,7 @@ LeafletMap.mergeOptions({
 	doubleClickZoom: true
 });
 
-export class DoubleClickZoomHandler extends Handler {
+export const DoubleClickZoomHandler = withInitHooks(class DoubleClickZoomHandler extends Handler {
 	addHooks() {
 		this._map.on('dblclick', this._onDoubleClick, this);
 	}
@@ -38,7 +39,7 @@ export class DoubleClickZoomHandler extends Handler {
 			map.setZoomAround(e.containerPoint, zoom);
 		}
 	}
-}
+});
 
 // @section Handlers
 //

--- a/src/map/handler/DragHandler.js
+++ b/src/map/handler/DragHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import {Draggable} from '../../dom/Draggable.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
 import {Bounds} from '../../geometry/Bounds.js';
@@ -50,7 +51,7 @@ LeafletMap.mergeOptions({
 	maxBoundsViscosity: 0.0
 });
 
-export class DragHandler extends Handler {
+export const DragHandler = withInitHooks(class DragHandler extends Handler {
 	addHooks() {
 		if (!this._draggable) {
 			const map = this._map;
@@ -224,7 +225,7 @@ export class DragHandler extends Handler {
 			}
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property dragging: Handler

--- a/src/map/handler/KeyboardHandler.js
+++ b/src/map/handler/KeyboardHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import {on, off, stop} from '../../dom/DomEvent.js';
 import {Point} from '../../geometry/Point.js';
 
@@ -21,7 +22,7 @@ LeafletMap.mergeOptions({
 	keyboardPanDelta: 80
 });
 
-export class KeyboardHandler extends Handler {
+export const KeyboardHandler = withInitHooks(class KeyboardHandler extends Handler {
 
 	static keyCodes = {
 		left:    ['ArrowLeft'],
@@ -32,8 +33,8 @@ export class KeyboardHandler extends Handler {
 		zoomOut: ['Minus', 'NumpadSubtract', 'Digit6', 'Slash']
 	};
 
-	initialize(map) {
-		super.initialize(map);
+	constructor(map) {
+		super(map);
 
 		this._setPanDelta(map.options.keyboardPanDelta);
 		this._setZoomDelta(map.options.zoomDelta);
@@ -176,7 +177,7 @@ export class KeyboardHandler extends Handler {
 
 		stop(e);
 	}
-}
+});
 
 // @section Handlers
 // @section Handlers

--- a/src/map/handler/PinchZoomHandler.js
+++ b/src/map/handler/PinchZoomHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import * as PointerEvents from '../../dom/DomEvent.PointerEvents.js';
 
@@ -24,7 +25,7 @@ LeafletMap.mergeOptions({
 	bounceAtZoomLimits: true
 });
 
-export class PinchZoomHandler extends Handler {
+export const PinchZoomHandler = withInitHooks(class PinchZoomHandler extends Handler {
 	addHooks() {
 		this._map._container.classList.add('leaflet-touch-zoom');
 		DomEvent.on(this._map._container, 'pointerdown', this._onPointerStart, this);
@@ -123,7 +124,7 @@ export class PinchZoomHandler extends Handler {
 			this._map._resetView(this._center, this._map._limitZoom(this._zoom));
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property pinchZoom: Handler

--- a/src/map/handler/ScrollWheelZoomHandler.js
+++ b/src/map/handler/ScrollWheelZoomHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 
 /*
@@ -27,7 +28,7 @@ LeafletMap.mergeOptions({
 	wheelPxPerZoomLevel: 60
 });
 
-export class ScrollWheelZoomHandler extends Handler {
+export const ScrollWheelZoomHandler = withInitHooks(class ScrollWheelZoomHandler extends Handler {
 	addHooks() {
 		DomEvent.on(this._map._container, 'wheel', this._onWheelScroll, this);
 
@@ -83,7 +84,7 @@ export class ScrollWheelZoomHandler extends Handler {
 			map.setZoomAround(this._lastMousePos, zoom + delta);
 		}
 	}
-}
+});
 
 // @section Handlers
 // @property scrollWheelZoom: Handler

--- a/src/map/handler/TapHoldHandler.js
+++ b/src/map/handler/TapHoldHandler.js
@@ -1,5 +1,6 @@
 import {LeafletMap} from '../Map.js';
 import {Handler} from '../../core/Handler.js';
+import {withInitHooks} from '../../core/Class.js';
 import * as DomEvent from '../../dom/DomEvent.js';
 import {Point} from '../../geometry/Point.js';
 import Browser from '../../core/Browser.js';
@@ -26,7 +27,7 @@ LeafletMap.mergeOptions({
 	tapTolerance: 15
 });
 
-export class TapHoldHandler extends Handler {
+export const TapHoldHandler = withInitHooks(class TapHoldHandler extends Handler {
 	addHooks() {
 		DomEvent.on(this._map._container, 'pointerdown', this._onDown, this);
 	}
@@ -95,7 +96,7 @@ export class TapHoldHandler extends Handler {
 
 		e.target.dispatchEvent(simulatedEvent);
 	}
-}
+});
 
 // @section Handlers
 // @property tapHold: Handler


### PR DESCRIPTION
Replaces all `initialize()` methods with standard JavaScript `constructor()` across all built-in Leaflet classes.

A new `withInitHooks()` decorator using a `Proxy` is introduced to preserve `addInitHook()` functionality.

Previously, the `constructor()` of `Class` was responsible for calling `initialize()`, followed by walking the prototype chain to trigger init hooks. This was fundamentally incompatible with standard JavaScript constructors, as `super()` must be called before accessing `this`, meaning hooks could not access properties set after `super()` (see #9889 for detailed analysis).

The new approach wraps each class with `withInitHooks()`, which uses a `Proxy` to intercept construction via `Reflect.construct()`. Hooks registered with `addInitHook()` are triggered after each level's constructor completes, preserving the original execution order.

Given the following class hierarchy where both classes are wrapped and have hooks registered:

```js
const A = withInitHooks(class A {
  constructor() { console.log('1. A constructor'); }
});
A.addInitHook(function () { console.log('2. A hook'); });

const B = withInitHooks(class B extends A {
  constructor() { super(); console.log('3. B constructor'); }
});
B.addInitHook(function () { console.log('4. B hook'); });

new B();
// 1. A constructor
// 2. A hook
// 3. B constructor
// 4. B hook
```

The following diagram illustrates the construction order when calling `new B()`:

```mermaid
sequenceDiagram
    participant User
    participant B_Proxy
    participant B_Constructor
    participant A_Proxy
    participant A_Constructor
    participant A_Hooks
    participant B_Hooks

    User->>B_Proxy: new B(args)
    B_Proxy->>B_Constructor: Reflect.construct()
    B_Constructor->>A_Proxy: super(args)
    A_Proxy->>A_Constructor: Reflect.construct()
    A_Constructor-->>A_Proxy: instance
    A_Proxy->>A_Hooks: hook.call(instance)
    A_Hooks-->>B_Constructor: return
    B_Constructor-->>B_Proxy: instance
    B_Proxy->>B_Hooks: hook.call(instance)
    B_Hooks-->>User: instance
```

## Breaking changes

- **`initialize()` is removed from all built-in classes.** Subclasses that override `initialize()` and call `ParentClass.prototype.initialize.call(this, ...)` must migrate to `constructor()` with `super(...)`.
- **Classes using `addInitHook()` must be wrapped with `withInitHooks()`.** Built-in classes are wrapped by default. Plugin authors extending Leaflet classes who wish to register init hooks on their own class must wrap it:
  ```js
  import { Layer, withInitHooks } from 'leaflet';

  const MyLayer = withInitHooks(class MyLayer extends Layer {
    constructor(options) {
      super(options);
    }
  });

  MyLayer.addInitHook(function () { /* ... */ });
  ```

## Migration guide

```js
// Before
class MyMarker extends Marker {
  initialize(latlng, options) {
    Marker.prototype.initialize.call(this, latlng, options);
    this.custom = true;
  }
}

// After
class MyMarker extends Marker {
  constructor(latlng, options) {
    super(latlng, options);
    this.custom = true;
  }
}
```

Closes #9889