### PR TITLE
Document handling untrusted HTML in popups/tooltips

### DIFF
--- a/docs/examples/geojson/index.md
+++ b/docs/examples/geojson/index.md
@@ -168,6 +168,12 @@ new GeoJSON(geojsonFeature, {
 	onEachFeature: onEachFeature
 }).addTo(map);</code></pre>
 
+<p><strong>Security note.</strong> <code>bindPopup</code> renders its string argument as HTML. If your GeoJSON comes from untrusted sources (user uploads, third-party APIs, etc.), sanitize <code>popupContent</code> with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element via <code>textContent</code> and bind that instead:</p>
+
+<pre><code>const el = document.createElement('div');
+el.textContent = feature.properties.popupContent;
+layer.bindPopup(el);</code></pre>
+
 <h4>filter</h4>
 
 <p>The <code>filter</code> option can be used to control the visibility of GeoJSON features. To accomplish this we pass a function as the <code>filter</code> option. This function gets called for each feature in your GeoJSON layer, and gets passed the <code>feature</code> and the <code>layer</code>. You can then utilise the values in the feature's properties to control the visibility by returning <code>true</code> or <code>false</code>.</p>

--- a/docs/examples/quick-start/index.md
+++ b/docs/examples/quick-start/index.md
@@ -134,6 +134,8 @@ polygon.bindPopup("I am a polygon.");
 
 Try clicking on our objects. The `bindPopup` method attaches a popup with the specified HTML content to your marker so the popup appears when you click on the object, and the `openPopup` method (for markers only) immediately opens the attached popup.
 
+Note that popup content is rendered as HTML, so don't pass untrusted user input to it directly.
+
 You can also use popups as layers (when you need something more than attaching a popup to an object):
 
 ```javascript

--- a/docs/reference-2.0.0.html
+++ b/docs/reference-2.0.0.html
@@ -979,7 +979,8 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Creates a popup with the specified content and options and opens it in the given point on a map.</p>
+		<td><p>Creates a popup with the specified content and options and opens it in the given point on a map.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='map-closepopup'>
@@ -997,7 +998,8 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Creates a tooltip with the specified content and options and open it.</p>
+		<td><p>Creates a tooltip with the specified content and options and open it.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='map-closetooltip'>
@@ -2773,8 +2775,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindpopup'>
@@ -2810,7 +2815,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='marker-getpopup'>
@@ -2844,8 +2850,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindtooltip'>
@@ -2881,7 +2890,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='marker-gettooltip'>
@@ -3091,7 +3101,8 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -3391,8 +3402,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='divoverlay-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-getelement'>
@@ -3506,8 +3520,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindpopup'>
@@ -3543,7 +3560,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-getpopup'>
@@ -3577,8 +3595,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindtooltip'>
@@ -3614,7 +3635,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-gettooltip'>
@@ -3775,6 +3797,11 @@ open popups while making sure that only one popup is open at one time
 <p>or</p>
 <pre><code class="language-js">const popup = new Popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;'})
 	.openOn(map);
+</code></pre>
+<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.textContent = untrustedString;
+marker.bindPopup(el);
 </code></pre>
 
 
@@ -3971,7 +3998,8 @@ on the map. Defaults to the map's <a href="#map-closepopuponclick"><code>closePo
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -4299,8 +4327,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='popup-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='popup-getelement'>
@@ -4415,8 +4446,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindpopup'>
@@ -4452,7 +4486,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='popup-getpopup'>
@@ -4486,8 +4521,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindtooltip'>
@@ -4523,7 +4561,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='popup-gettooltip'>
@@ -4683,6 +4722,11 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <pre><code class="language-js">const tooltip = new Tooltip(latlng, {content: 'Hello world!&lt;br /&gt;This is a nice tooltip.'})
 	.addTo(map);
 </code></pre>
+<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.textContent = untrustedString;
+marker.bindTooltip(el);
+</code></pre>
 <p>Note about tooltip offset. Leaflet takes two options in consideration
 for computing tooltip offsetting:</p>
 <ul>
@@ -4819,7 +4863,8 @@ position on the map.</td>
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -5133,8 +5178,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='tooltip-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='tooltip-getelement'>
@@ -5249,8 +5297,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindpopup'>
@@ -5286,7 +5337,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tooltip-getpopup'>
@@ -5320,8 +5372,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindtooltip'>
@@ -5357,7 +5412,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tooltip-gettooltip'>
@@ -6149,8 +6205,11 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindpopup'>
@@ -6186,7 +6245,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-getpopup'>
@@ -6220,8 +6280,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindtooltip'>
@@ -6257,7 +6320,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-gettooltip'>
@@ -7118,8 +7182,11 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-unbindpopup'>
@@ -7155,7 +7222,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-getpopup'>
@@ -7189,8 +7257,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-unbindtooltip'>
@@ -7226,7 +7297,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-gettooltip'>
@@ -7878,8 +7950,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindpopup'>
@@ -7915,7 +7990,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-getpopup'>
@@ -7949,8 +8025,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindtooltip'>
@@ -7986,7 +8065,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-gettooltip'>
@@ -8736,8 +8816,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindpopup'>
@@ -8773,7 +8856,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-getpopup'>
@@ -8807,8 +8891,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindtooltip'>
@@ -8844,7 +8931,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-gettooltip'>
@@ -9535,8 +9623,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindpopup'>
@@ -9572,7 +9663,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svgoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-getpopup'>
@@ -9606,8 +9698,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindtooltip'>
@@ -9643,7 +9738,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svgoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-gettooltip'>
@@ -10236,8 +10332,11 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindpopup'>
@@ -10273,7 +10372,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='path-getpopup'>
@@ -10307,8 +10407,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindtooltip'>
@@ -10344,7 +10447,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='path-gettooltip'>
@@ -11108,8 +11212,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindpopup'>
@@ -11145,7 +11252,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polyline-getpopup'>
@@ -11179,8 +11287,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindtooltip'>
@@ -11216,7 +11327,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polyline-gettooltip'>
@@ -12008,8 +12120,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindpopup'>
@@ -12045,7 +12160,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polygon-getpopup'>
@@ -12079,8 +12195,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindtooltip'>
@@ -12116,7 +12235,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polygon-gettooltip'>
@@ -12918,8 +13038,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindpopup'>
@@ -12955,7 +13078,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='rectangle-getpopup'>
@@ -12989,8 +13113,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindtooltip'>
@@ -13026,7 +13153,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='rectangle-gettooltip'>
@@ -13794,8 +13922,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindpopup'>
@@ -13831,7 +13962,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circle-getpopup'>
@@ -13865,8 +13997,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindtooltip'>
@@ -13902,7 +14037,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circle-gettooltip'>
@@ -14617,8 +14753,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindpopup'>
@@ -14654,7 +14793,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-getpopup'>
@@ -14688,8 +14828,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindtooltip'>
@@ -14725,7 +14868,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-gettooltip'>
@@ -15200,8 +15344,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindpopup'>
@@ -15237,7 +15384,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svg-getpopup'>
@@ -15271,8 +15419,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindtooltip'>
@@ -15308,7 +15459,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svg-gettooltip'>
@@ -15838,8 +15990,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindpopup'>
@@ -15875,7 +16030,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='canvas-getpopup'>
@@ -15909,8 +16065,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindtooltip'>
@@ -15946,7 +16105,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='canvas-gettooltip'>
@@ -16541,8 +16701,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindpopup'>
@@ -16578,7 +16741,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layergroup-getpopup'>
@@ -16612,8 +16776,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindtooltip'>
@@ -16649,7 +16816,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layergroup-gettooltip'>
@@ -17319,8 +17487,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindpopup'>
@@ -17356,7 +17527,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-getpopup'>
@@ -17390,8 +17562,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindtooltip'>
@@ -17427,7 +17602,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-gettooltip'>
@@ -18213,8 +18389,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindpopup'>
@@ -18250,7 +18429,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='geojson-getpopup'>
@@ -18284,8 +18464,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindtooltip'>
@@ -18321,7 +18504,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='geojson-gettooltip'>
@@ -19067,8 +19251,11 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindpopup'>
@@ -19104,7 +19291,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-getpopup'>
@@ -19138,8 +19326,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindtooltip'>
@@ -19175,7 +19366,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-gettooltip'>
@@ -23038,8 +23230,11 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindpopup'>
@@ -23075,7 +23270,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layer-getpopup'>
@@ -23107,8 +23303,11 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindtooltip'>
@@ -23144,7 +23343,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layer-gettooltip'>
@@ -23585,8 +23785,11 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindpopup'>
@@ -23622,7 +23825,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-getpopup'>
@@ -23656,8 +23860,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindtooltip'>
@@ -23693,7 +23900,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-gettooltip'>
@@ -24645,8 +24853,11 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindpopup'>
@@ -24682,7 +24893,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='blanketoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-getpopup'>
@@ -24716,8 +24928,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindtooltip'>
@@ -24753,7 +24968,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='blanketoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-gettooltip'>
@@ -25178,8 +25394,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindpopup'>
@@ -25215,7 +25434,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='renderer-getpopup'>
@@ -25249,8 +25469,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindtooltip'>
@@ -25286,7 +25509,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='renderer-gettooltip'>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -991,7 +991,8 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Creates a popup with the specified content and options and opens it in the given point on a map.</p>
+		<td><p>Creates a popup with the specified content and options and opens it in the given point on a map.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='map-closepopup'>
@@ -1009,7 +1010,8 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Creates a tooltip with the specified content and options and open it.</p>
+		<td><p>Creates a tooltip with the specified content and options and open it.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='map-closetooltip'>
@@ -2860,8 +2862,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindpopup'>
@@ -2897,7 +2902,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='marker-getpopup'>
@@ -2931,8 +2937,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindtooltip'>
@@ -2968,7 +2977,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='marker-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='marker-gettooltip'>
@@ -3142,7 +3152,8 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -3442,8 +3453,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='divoverlay-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-getelement'>
@@ -3557,8 +3571,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindpopup'>
@@ -3594,7 +3611,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-getpopup'>
@@ -3628,8 +3646,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindtooltip'>
@@ -3665,7 +3686,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='divoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-gettooltip'>
@@ -3790,6 +3812,11 @@ open popups while making sure that only one popup is open at one time
 <p>or</p>
 <pre><code class="language-js">const popup = new Popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;'})
 	.openOn(map);
+</code></pre>
+<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.textContent = untrustedString;
+marker.bindPopup(el);
 </code></pre>
 
 
@@ -3986,7 +4013,8 @@ on the map. Defaults to the map's <a href="#map-closepopuponclick"><code>closePo
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -4314,8 +4342,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='popup-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='popup-getelement'>
@@ -4430,8 +4461,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindpopup'>
@@ -4467,7 +4501,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='popup-getpopup'>
@@ -4501,8 +4536,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindtooltip'>
@@ -4538,7 +4576,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='popup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='popup-gettooltip'>
@@ -4661,6 +4700,11 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <p>or</p>
 <pre><code class="language-js">const tooltip = new Tooltip(latlng, {content: 'Hello world!&lt;br /&gt;This is a nice tooltip.'})
 	.addTo(map);
+</code></pre>
+<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.textContent = untrustedString;
+marker.bindTooltip(el);
 </code></pre>
 <p>Note about tooltip offset. Leaflet takes two options in consideration
 for computing tooltip offsetting:</p>
@@ -4798,7 +4842,8 @@ position on the map.</td>
 		<td><code>String|HTMLElement|Function</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
-passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</td>
+passed to the function. The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</td>
 	</tr>
 </tbody></table>
 
@@ -5112,8 +5157,11 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 	<tr id='tooltip-setcontent'>
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-The function should return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
+		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
+HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+passed the source layer will be passed to the function. The function should
+return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
 	</tr>
 	<tr id='tooltip-getelement'>
@@ -5228,8 +5276,11 @@ The function should return a <code>String</code> or <code>HTMLElement</code> to 
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindpopup'>
@@ -5265,7 +5316,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tooltip-getpopup'>
@@ -5299,8 +5351,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindtooltip'>
@@ -5336,7 +5391,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tooltip-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tooltip-gettooltip'>
@@ -6092,8 +6148,11 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindpopup'>
@@ -6129,7 +6188,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-getpopup'>
@@ -6163,8 +6223,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindtooltip'>
@@ -6200,7 +6263,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-gettooltip'>
@@ -7025,8 +7089,11 @@ callback is called when the tile has been loaded.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-unbindpopup'>
@@ -7062,7 +7129,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-getpopup'>
@@ -7096,8 +7164,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-unbindtooltip'>
@@ -7133,7 +7204,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='tilelayer-wms-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-gettooltip'>
@@ -7749,8 +7821,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindpopup'>
@@ -7786,7 +7861,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-getpopup'>
@@ -7820,8 +7896,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindtooltip'>
@@ -7857,7 +7936,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='imageoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-gettooltip'>
@@ -8571,8 +8651,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindpopup'>
@@ -8608,7 +8691,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-getpopup'>
@@ -8642,8 +8726,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindtooltip'>
@@ -8679,7 +8766,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='videooverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-gettooltip'>
@@ -9334,8 +9422,11 @@ used by this overlay.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindpopup'>
@@ -9371,7 +9462,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svgoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-getpopup'>
@@ -9405,8 +9497,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindtooltip'>
@@ -9442,7 +9537,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svgoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-gettooltip'>
@@ -9999,8 +10095,11 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindpopup'>
@@ -10036,7 +10135,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='path-getpopup'>
@@ -10070,8 +10170,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindtooltip'>
@@ -10107,7 +10210,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='path-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='path-gettooltip'>
@@ -10835,8 +10939,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindpopup'>
@@ -10872,7 +10979,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polyline-getpopup'>
@@ -10906,8 +11014,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindtooltip'>
@@ -10943,7 +11054,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polyline-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polyline-gettooltip'>
@@ -11699,8 +11811,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindpopup'>
@@ -11736,7 +11851,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polygon-getpopup'>
@@ -11770,8 +11886,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindtooltip'>
@@ -11807,7 +11926,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='polygon-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='polygon-gettooltip'>
@@ -12573,8 +12693,11 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindpopup'>
@@ -12610,7 +12733,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='rectangle-getpopup'>
@@ -12644,8 +12768,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindtooltip'>
@@ -12681,7 +12808,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='rectangle-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='rectangle-gettooltip'>
@@ -13413,8 +13541,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindpopup'>
@@ -13450,7 +13581,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circle-getpopup'>
@@ -13484,8 +13616,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindtooltip'>
@@ -13521,7 +13656,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circle-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circle-gettooltip'>
@@ -14200,8 +14336,11 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindpopup'>
@@ -14237,7 +14376,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-getpopup'>
@@ -14271,8 +14411,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindtooltip'>
@@ -14308,7 +14451,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='circlemarker-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-gettooltip'>
@@ -14747,8 +14891,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindpopup'>
@@ -14784,7 +14931,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svg-getpopup'>
@@ -14818,8 +14966,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindtooltip'>
@@ -14855,7 +15006,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='svg-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='svg-gettooltip'>
@@ -15349,8 +15501,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindpopup'>
@@ -15386,7 +15541,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='canvas-getpopup'>
@@ -15420,8 +15576,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindtooltip'>
@@ -15457,7 +15616,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='canvas-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='canvas-gettooltip'>
@@ -16016,8 +16176,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindpopup'>
@@ -16053,7 +16216,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layergroup-getpopup'>
@@ -16087,8 +16251,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindtooltip'>
@@ -16124,7 +16291,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layergroup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layergroup-gettooltip'>
@@ -16758,8 +16926,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindpopup'>
@@ -16795,7 +16966,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-getpopup'>
@@ -16829,8 +17001,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindtooltip'>
@@ -16866,7 +17041,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='featuregroup-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-gettooltip'>
@@ -17616,8 +17792,11 @@ implement <code>methodName</code>.</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindpopup'>
@@ -17653,7 +17832,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='geojson-getpopup'>
@@ -17687,8 +17867,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindtooltip'>
@@ -17724,7 +17907,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='geojson-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='geojson-gettooltip'>
@@ -18439,8 +18623,11 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindpopup'>
@@ -18476,7 +18663,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-getpopup'>
@@ -18510,8 +18698,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindtooltip'>
@@ -18547,7 +18738,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='gridlayer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-gettooltip'>
@@ -22271,8 +22463,11 @@ layer.closePopup();
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindpopup'>
@@ -22308,7 +22503,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layer-getpopup'>
@@ -22340,8 +22536,11 @@ layer.closeTooltip();
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindtooltip'>
@@ -22377,7 +22576,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='layer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='layer-gettooltip'>
@@ -22782,8 +22982,11 @@ for a second (also called long press).</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindpopup'>
@@ -22819,7 +23022,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-getpopup'>
@@ -22853,8 +23057,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindtooltip'>
@@ -22890,7 +23097,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='interactive-layer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-gettooltip'>
@@ -23805,8 +24013,11 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindpopup'>
@@ -23842,7 +24053,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='blanketoverlay-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-getpopup'>
@@ -23876,8 +24088,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindtooltip'>
@@ -23913,7 +24128,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='blanketoverlay-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-gettooltip'>
@@ -24302,8 +24518,11 @@ its map has moved</td>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindpopup'>
@@ -24339,7 +24558,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the popup bound to this layer.</p>
+		<td><p>Sets the content of the popup bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='renderer-getpopup'>
@@ -24373,8 +24593,11 @@ the layer as the first argument and should return a <code>String</code> or <code
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
-necessary event listeners. If a <code>Function</code> is passed it will receive
-the layer as the first argument and should return a <code>String</code> or <code>HTMLElement</code>.</p>
+necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
+may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
+it will receive the layer as the first argument and should return a
+<code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindtooltip'>
@@ -24410,7 +24633,8 @@ the layer as the first argument and should return a <code>String</code> or <code
 	<tr id='renderer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the content of the tooltip bound to this layer.</p>
+		<td><p>Sets the content of the tooltip bound to this layer.
+String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
 	<tr id='renderer-gettooltip'>

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -38,6 +38,7 @@ export class DivOverlay extends Layer {
 			// @option content: String|HTMLElement|Function = ''
 			// Sets the HTML content of the overlay while initializing. If a function is passed the source layer will be
 			// passed to the function. The function should return a `String` or `HTMLElement` to be used in the overlay.
+			// String content is rendered as HTML; sanitize untrusted input or pass an `HTMLElement` with safe `textContent` instead.
 			content: ''
 		});
 	}
@@ -162,8 +163,11 @@ export class DivOverlay extends Layer {
 	}
 
 	// @method setContent(htmlContent: String|HTMLElement|Function): this
-	// Sets the HTML content of the overlay. If a function is passed the source layer will be passed to the function.
-	// The function should return a `String` or `HTMLElement` to be used in the overlay.
+	// Sets the HTML content of the overlay. A `String` argument is rendered as
+	// HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+	// or pass an `HTMLElement` with safe `textContent` instead. If a function is
+	// passed the source layer will be passed to the function. The function should
+	// return a `String` or `HTMLElement` to be used in the overlay.
 	setContent(content) {
 		this._content = content;
 		this.update();

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -36,6 +36,17 @@ import {FeatureGroup} from './FeatureGroup.js';
  * const popup = new Popup(latlng, {content: '<p>Hello world!<br />This is a nice popup.</p>'})
  * 	.openOn(map);
  * ```
+ *
+ * **Security note.** Popup string content is rendered as HTML. If your content
+ * may include untrusted input (e.g. data from users or external APIs), sanitize
+ * it with a library like [DOMPurify](https://github.com/cure53/DOMPurify), or
+ * build a DOM element using `textContent` to render it as plain text:
+ *
+ * ```js
+ * const el = document.createElement('div');
+ * el.textContent = untrustedString;
+ * marker.bindPopup(el);
+ * ```
  */
 
 
@@ -358,6 +369,7 @@ LeafletMap.include({
 	// @alternative
 	// @method openPopup(content: String|HTMLElement, latlng: LatLng, options?: Popup options): this
 	// Creates a popup with the specified content and options and opens it in the given point on a map.
+	// String content is rendered as HTML; sanitize untrusted input or pass an `HTMLElement` with safe `textContent` instead.
 	openPopup(popup, latlng, options) {
 		this._initOverlay(Popup, popup, latlng, options)
 			.openOn(this);
@@ -394,8 +406,11 @@ Layer.include({
 
 	// @method bindPopup(content: String|HTMLElement|Function|Popup, options?: Popup options): this
 	// Binds a popup to the layer with the passed `content` and sets up the
-	// necessary event listeners. If a `Function` is passed it will receive
-	// the layer as the first argument and should return a `String` or `HTMLElement`.
+	// necessary event listeners. A `String` argument is rendered as HTML; if it
+	// may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+	// `HTMLElement` with safe `textContent` instead. If a `Function` is passed
+	// it will receive the layer as the first argument and should return a
+	// `String` or `HTMLElement`.
 	bindPopup(content, options) {
 		this._popup = this._initOverlay(Popup, this._popup, content, options);
 		if (!this._popupHandlersAdded) {
@@ -464,6 +479,7 @@ Layer.include({
 
 	// @method setPopupContent(content: String|HTMLElement|Popup): this
 	// Sets the content of the popup bound to this layer.
+	// String content is rendered as HTML; sanitize untrusted input or pass an `HTMLElement` with safe `textContent` instead.
 	setPopupContent(content) {
 		this._popup?.setContent(content);
 		return this;

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -34,6 +34,16 @@ import {FeatureGroup} from './FeatureGroup.js';
  * 	.addTo(map);
  * ```
  *
+ * **Security note.** Tooltip string content is rendered as HTML. If your content
+ * may include untrusted input (e.g. data from users or external APIs), sanitize
+ * it with a library like [DOMPurify](https://github.com/cure53/DOMPurify), or
+ * build a DOM element using `textContent` to render it as plain text:
+ *
+ * ```js
+ * const el = document.createElement('div');
+ * el.textContent = untrustedString;
+ * marker.bindTooltip(el);
+ * ```
  *
  * Note about tooltip offset. Leaflet takes two options in consideration
  * for computing tooltip offsetting:
@@ -233,6 +243,7 @@ LeafletMap.include({
 	// @alternative
 	// @method openTooltip(content: String|HTMLElement, latlng: LatLng, options?: Tooltip options): this
 	// Creates a tooltip with the specified content and options and open it.
+	// String content is rendered as HTML; sanitize untrusted input or pass an `HTMLElement` with safe `textContent` instead.
 	openTooltip(tooltip, latlng, options) {
 		this._initOverlay(Tooltip, tooltip, latlng, options)
 			.openOn(this);
@@ -267,8 +278,11 @@ Layer.include({
 
 	// @method bindTooltip(content: String|HTMLElement|Function|Tooltip, options?: Tooltip options): this
 	// Binds a tooltip to the layer with the passed `content` and sets up the
-	// necessary event listeners. If a `Function` is passed it will receive
-	// the layer as the first argument and should return a `String` or `HTMLElement`.
+	// necessary event listeners. A `String` argument is rendered as HTML; if it
+	// may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+	// `HTMLElement` with safe `textContent` instead. If a `Function` is passed
+	// it will receive the layer as the first argument and should return a
+	// `String` or `HTMLElement`.
 	bindTooltip(content, options) {
 
 		if (this._tooltip && this.isTooltipOpen()) {
@@ -366,6 +380,7 @@ Layer.include({
 
 	// @method setTooltipContent(content: String|HTMLElement|Tooltip): this
 	// Sets the content of the tooltip bound to this layer.
+	// String content is rendered as HTML; sanitize untrusted input or pass an `HTMLElement` with safe `textContent` instead.
 	setTooltipContent(content) {
 		this._tooltip?.setContent(content);
 		return this;


### PR DESCRIPTION
We're getting hounded about this CVE https://www.cve.org/CVERecord?id=CVE-2025-69993, which is in it's essence not a valid vulnerability issue since `bindPopup` and similar methods accept HTML input **by design**, and not passing untrusted user input to it or sanitizing it is the responsibility of application developers rather than a JS library (with many similar precedents existing for jQuery, React, etc.).

However, we could do a better job of documenting that aspect in relevant sections. This PR makes a pass at updating the docs — both the source and the generated files, just so that we can update it everywhere with one PR merge for now.

Related: #9773 