### PR TITLE
fix: default icon imagePath was treated as undefined if empty

### DIFF
--- a/src/layer/marker/DefaultIcon.js
+++ b/src/layer/marker/DefaultIcon.js
@@ -46,7 +46,7 @@ export class DefaultIcon extends Icon {
 		// `DefaultIcon` will try to auto-detect the location of the
 		// blue icon images. If you are placing these images in a non-standard
 		// way, set this option to point to the right path.
-		return (this.options.imagePath || DefaultIcon.imagePath) + url;
+		return (this.options.imagePath ?? DefaultIcon.imagePath) + url;
 	}
 
 	_stripUrl(path) {	// separate function to use in tests


### PR DESCRIPTION
I'm in a situation where I want to set the default `iconUrl` to some full URL, and have `imagePath` set to an empty string.

However, doing so results in leaflet trying to auto-detect a path instead of simply using the empty string.

I don't know if this behavior was intended, but if it wasn't, a simple fix would be to have `IconDefault` checking if `imagePath` is nullish and not falsly.