### PR TITLE
fix: scope disableTextSelection to specific element instead of document

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -80,12 +80,21 @@ const documentStyle = typeof document === 'undefined' ? {} : document.documentEl
 // Safari still needs a vendor prefix, we need to detect with property name is supported.
 const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
 let prevUserSelect;
+let prevUserSelectEl;
 
-// @function disableTextSelection()
-// Prevents the user from selecting text in the document. Used internally
-// by Leaflet to override the behaviour of any click-and-drag interaction on
-// the map. Affects drag interactions on the whole document.
-export function disableTextSelection() {
+// @function disableTextSelection(el?: HTMLElement)
+// Prevents the user from generating `selectstart` DOM events, usually
+// generated when the user starts dragging. When an element is provided,
+// only disables text selection within that element. Otherwise falls back
+// to disabling text selection on the whole document.
+export function disableTextSelection(el) {
+	if (el) {
+		const style = el.style;
+		prevUserSelectEl = style[userSelectProp];
+		style[userSelectProp] = 'none';
+		return;
+	}
+
 	const value = documentStyle[userSelectProp];
 
 	if (value === 'none') {
@@ -96,9 +105,18 @@ export function disableTextSelection() {
 	documentStyle[userSelectProp] = 'none';
 }
 
-// @function enableTextSelection()
+// @function enableTextSelection(el?: HTMLElement)
 // Cancels the effects of a previous [`DomUtil.disableTextSelection`](#domutil-disabletextselection).
-export function enableTextSelection() {
+export function enableTextSelection(el) {
+	if (el) {
+		if (typeof prevUserSelectEl === 'undefined') {
+			return;
+		}
+		el.style[userSelectProp] = prevUserSelectEl;
+		prevUserSelectEl = undefined;
+		return;
+	}
+
 	if (typeof prevUserSelect === 'undefined') {
 		return;
 	}

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -90,7 +90,7 @@ export class Draggable extends Evented {
 		}
 
 		DomUtil.disableImageDrag();
-		DomUtil.disableTextSelection();
+		DomUtil.disableTextSelection(this._element);
 
 		if (this._moving) { return; }
 
@@ -181,7 +181,7 @@ export class Draggable extends Evented {
 		DomEvent.off(this._dragStartTarget, 'pointerup pointercancel', this._onUp, this);
 
 		DomUtil.enableImageDrag();
-		DomUtil.enableTextSelection();
+		DomUtil.enableTextSelection(this._element);
 
 		const fireDragend = this._moved && this._moving;
 

--- a/src/map/handler/BoxZoomHandler.js
+++ b/src/map/handler/BoxZoomHandler.js
@@ -65,7 +65,7 @@ export class BoxZoomHandler extends Handler {
 		this._clearDeferredResetState();
 		this._resetState();
 
-		DomUtil.disableTextSelection();
+		DomUtil.disableTextSelection(this._container);
 		DomUtil.disableImageDrag();
 
 		this._startPoint = this._map.pointerEventToContainerPoint(e);
@@ -106,7 +106,7 @@ export class BoxZoomHandler extends Handler {
 			this._container.classList.remove('leaflet-crosshair');
 		}
 
-		DomUtil.enableTextSelection();
+		DomUtil.enableTextSelection(this._container);
 		DomUtil.enableImageDrag();
 
 		DomEvent.off(this._container, {


### PR DESCRIPTION
## Summary

Fixes #9259

`L.DomUtil.disableTextSelection()` currently disables text selection on the entire document via `document.documentElement.style.userSelect = "none"`. This prevents text selection in other elements on the page (e.g. content-editable divs, search bars) that are outside the map container, even though text selection should only be prevented within the map during drag/zoom interactions.

## Root Cause

In `src/dom/DomUtil.js:88`, the `disableTextSelection()` function unconditionally sets `user-select: none` on `document.documentElement.style`. This is a global side effect that affects the entire page, not just the map.

The callers in `Draggable.js:93` and `BoxZoomHandler.js:68` call this function without passing any element reference.

## Fix

Added an optional `el` parameter to both `disableTextSelection()` and `enableTextSelection()`:

- When an element is provided, `user-select: none` is applied only to that element's style
- When no element is provided, falls back to existing document-wide behavior (backward compatible)
- Updated `Draggable.js` to pass `this._element` 
- Updated `BoxZoomHandler.js` to pass `this._container` (the map container)
- Both `disableTextSelection()` and `enableTextSelection()` are updated symmetrically

## Changes

- `src/dom/DomUtil.js`: Added element-scoped text selection disable/enable (`+27 -9`)
- `src/dom/Draggable.js`: Pass element to disable/enable calls (`+2 -2`)
- `src/map/handler/BoxZoomHandler.js`: Pass container to disable/enable calls (`+2 -2`)

## Testing

- Map drag: text selection disabled only on the dragged element, not the whole document ✅
- Box zoom: text selection disabled only on the map container ✅
- External content-editable elements: text selection works normally during map interactions ✅
- Backward compatibility: calling `disableTextSelection()` without arguments still works (document-wide) ✅
- Symmetric enable: calling `enableTextSelection(el)` with the same element restores the previous value ✅