### PR TITLE
Vitest follow-up cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,11 +111,9 @@ jobs:
         include:
           - project: chromium
           - project: firefox
-          - project: firefox-retina
+          - project: chromium-retina
           - project: chromium
             os: windows-latest
-          - project: chromium
-            os: macos-latest
           - project: webkit
             os: macos-latest
     steps:
@@ -141,7 +139,7 @@ jobs:
           key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browser
-        run: npx playwright install ${{ matrix.project == 'firefox-retina' && 'firefox' || matrix.project }}
+        run: npx playwright install ${{ matrix.project == 'chromium-retina' && 'chromium' || matrix.project }}
 
       - name: Run tests on ${{ matrix.project }}
         run: npx vitest --run --project=${{ matrix.project }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,60 +13,45 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
           working-directory: ./docs
 
-      - name: Run jekyll build
-        working-directory: ./docs
+      - working-directory: ./docs
         run: bundle exec jekyll build --strict_front_matter
 
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run lint task
-        run: npm run lint
+      - run: npm ci
+      - run: npm run lint
 
   bundlemon:
     if: github.repository_owner == 'Leaflet'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
-
-      - name: Run bundlemon task
-        run: npm run bundlemon
+      - run: npm ci
+      - run: npm run build
+      - run: npm run bundlemon
         env:
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -74,31 +59,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+      - run: npm ci
+      - run: npm run build
+      - run: node ./spec/ssr/ssr_node.js
 
-      - name: Build project
-        run: npm run build
-
-      - name: Run Node.js SSR script
-        run: node ./spec/ssr/ssr_node.js
-
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
-      - name: Run Deno SSR script
-        run: deno run ./spec/ssr/ssr_deno.js
+      - run: deno run ./spec/ssr/ssr_deno.js
 
   test:
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
@@ -117,20 +93,15 @@ jobs:
           - project: webkit
             os: macos-latest
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
+      - run: npm ci
+      - run: npm run build
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -156,20 +127,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
+      - run: npm ci
+      - run: npm run build
 
       - name: Compress artifacts
         working-directory: dist
@@ -191,21 +157,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
-      - name: Set up Node
-        uses: actions/setup-node@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           registry-url: https://registry.npmjs.org
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
+      - run: npm ci
+      - run: npm run build
 
       - name: Publish to NPM
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,10 +144,10 @@ jobs:
         run: npx playwright install ${{ matrix.project == 'firefox-retina' && 'firefox' || matrix.project }}
 
       - name: Run tests on ${{ matrix.project }}
-        run: npx vitest --run --project=${{ matrix.project }} --reporter=verbose --reporter=hanging-process
+        run: npx vitest --run --project=${{ matrix.project }}
 
       - name: Run tests on ${{ matrix.project }} with touch
-        run: npx vitest --run --project=${{ matrix.project }} --reporter=verbose --reporter=hanging-process
+        run: npx vitest --run --project=${{ matrix.project }}
         env:
           VITE_TOUCH: '1'
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,6 @@ import config from 'eslint-config-mourner';
 import css from '@eslint/css';
 import scriptTags from '@mapbox/eslint-plugin-script-tags';
 import importPlugin from 'eslint-plugin-import-x';
-import globals from 'globals';
 import baselineJs from 'eslint-plugin-baseline-js';
 import e18e from '@e18e/eslint-plugin';
 
@@ -112,7 +111,13 @@ export default [
 	{
 		files: ['spec/**'],
 		languageOptions: {
-			globals: {...globals.mocha}
+			globals: {
+				describe: 'readonly',
+				it: 'readonly',
+				beforeEach: 'readonly',
+				afterEach: 'readonly',
+				expect: 'readonly',
+			}
 		},
 		rules: {
 			'no-unused-expressions': 'off'

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "eslint-config-mourner": "^4.1.0",
         "eslint-plugin-baseline-js": "^0.6.2",
         "eslint-plugin-import-x": "^4.16.2",
-        "globals": "^17.6.0",
         "http-server": "^14.1.1",
         "husky": "^9.1.7",
         "leafdoc": "^2.3.0",
@@ -3243,19 +3242,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
         "@mapbox/eslint-plugin-script-tags": "^1.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-terser": "^1.0.0",
-        "@vitest/browser": "^4.1.5",
-        "@vitest/browser-playwright": "^4.1.5",
-        "@vitest/coverage-v8": "^4.1.5",
-        "@vitest/ui": "^4.1.5",
+        "@vitest/browser": "^4.1.6",
+        "@vitest/browser-playwright": "^4.1.6",
+        "@vitest/coverage-v8": "^4.1.6",
+        "@vitest/ui": "^4.1.6",
         "bundlemon": "^3.1.0",
         "chai": "^6.2.2",
         "eslint": "^10.3.0",
@@ -35,7 +35,7 @@
         "sinon": "^22.0.0",
         "ssri": "^14.0.0",
         "ui-event-simulator": "^2.0.0",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1737,15 +1737,15 @@
       ]
     },
     "node_modules/@vitest/browser": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.5.tgz",
-      "integrity": "sha512-iCDGI8c4yg+xmjUg2VsygdAUSIIB4x5Rht/P68OXy1hPELKXHDkzh87lkuTcdYmemRChDkEpB426MmDjzC0ziA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.6.tgz",
+      "integrity": "sha512-ynsspTubXGSpa58JFJ24xIQt4z4A25epSbugEyaTmmrV1//Wec9EgE/LtoaC6yxUrXi5P7erGHRrkdZIHaVQuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@blazediff/core": "1.9.1",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pngjs": "^7.0.0",
         "sirv": "^3.0.2",
@@ -1756,18 +1756,18 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.5"
+        "vitest": "4.1.6"
       }
     },
     "node_modules/@vitest/browser-playwright": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.5.tgz",
-      "integrity": "sha512-CWy0lBQJq97nionyJJdnaU4961IXTl43a7UCu5nHy51IoKxAt6PVIJLo+76rVl7KOOgcWHNkG4kbJu/pW7knvA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/browser-playwright/-/browser-playwright-4.1.6.tgz",
+      "integrity": "sha512-4csoeyl/qwHyxU2zNL0++WaoDr8YJDXOQPwWPNJoTZ+QzcdO3INYKgF5Zfz730Io7zbkuv914aZmfQ+QE+1Hvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/browser": "4.1.5",
-        "@vitest/mocker": "4.1.5",
+        "@vitest/browser": "4.1.6",
+        "@vitest/mocker": "4.1.6",
         "tinyrainbow": "^3.1.0"
       },
       "funding": {
@@ -1775,7 +1775,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "4.1.5"
+        "vitest": "4.1.6"
       },
       "peerDependenciesMeta": {
         "playwright": {
@@ -1783,37 +1783,15 @@
         }
       }
     },
-    "node_modules/@vitest/browser/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
-      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1827,8 +1805,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.5",
-        "vitest": "4.1.5"
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1837,16 +1815,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
-      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1855,13 +1833,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
-      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.5",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1892,9 +1870,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
-      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1905,13 +1883,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
-      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1919,14 +1897,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
-      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1935,9 +1913,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
-      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1945,13 +1923,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
-      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.6.tgz",
+      "integrity": "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.5",
+        "@vitest/utils": "4.1.6",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -1963,17 +1941,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.5"
+        "vitest": "4.1.6"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
-      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.5",
+        "@vitest/pretty-format": "4.1.6",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5743,19 +5721,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
-      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.5",
-        "@vitest/mocker": "4.1.5",
-        "@vitest/pretty-format": "4.1.5",
-        "@vitest/runner": "4.1.5",
-        "@vitest/snapshot": "4.1.5",
-        "@vitest/spy": "4.1.5",
-        "@vitest/utils": "4.1.5",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -5783,12 +5761,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.5",
-        "@vitest/browser-preview": "4.1.5",
-        "@vitest/browser-webdriverio": "4.1.5",
-        "@vitest/coverage-istanbul": "4.1.5",
-        "@vitest/coverage-v8": "4.1.5",
-        "@vitest/ui": "4.1.5",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -5967,6 +5945,28 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xregexp": {

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "@mapbox/eslint-plugin-script-tags": "^1.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-terser": "^1.0.0",
-    "@vitest/browser": "^4.1.5",
-    "@vitest/browser-playwright": "^4.1.5",
-    "@vitest/coverage-v8": "^4.1.5",
-    "@vitest/ui": "^4.1.5",
+    "@vitest/browser": "^4.1.6",
+    "@vitest/browser-playwright": "^4.1.6",
+    "@vitest/coverage-v8": "^4.1.6",
+    "@vitest/ui": "^4.1.6",
     "bundlemon": "^3.1.0",
     "chai": "^6.2.2",
     "eslint": "^10.3.0",
@@ -30,7 +30,7 @@
     "sinon": "^22.0.0",
     "ssri": "^14.0.0",
     "ui-event-simulator": "^2.0.0",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.6"
   },
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "eslint-config-mourner": "^4.1.0",
     "eslint-plugin-baseline-js": "^0.6.2",
     "eslint-plugin-import-x": "^4.16.2",
-    "globals": "^17.6.0",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "leafdoc": "^2.3.0",

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,5 +1,6 @@
 import {Assertion, util} from 'chai';
 import {DefaultIcon, LatLng, Point} from 'leaflet';
+import '../dist/leaflet.css';
 
 util.addMethod(Assertion.prototype, 'near', function (expected, delta = 1) {
 	expected = new Point(expected);
@@ -27,18 +28,6 @@ util.addMethod(Assertion.prototype, 'eqlLatLng', function (expected) {
 const runAsTouchBrowser = import.meta.env.VITE_TOUCH === '1';
 it.skipIfNotTouch = runAsTouchBrowser ? it : it.skip;
 it.skipIfTouch = runAsTouchBrowser ? it.skip : it;
-
-// Load leaflet.css as a real <link> (not a Vite-injected <style>) so the
-// DefaultIcon path autodetection can find it via document.querySelector.
-const link = document.createElement('link');
-link.rel = 'stylesheet';
-link.href = '/dist/leaflet.css';
-const cssLoaded = new Promise((resolve, reject) => {
-	link.addEventListener('load', resolve);
-	link.addEventListener('error', () => reject(new Error('Failed to load /dist/leaflet.css')));
-});
-document.head.appendChild(link);
-await cssLoaded;
 
 DefaultIcon.imagePath = '/dist/images/';
 

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -25,10 +25,6 @@ util.addMethod(Assertion.prototype, 'eqlLatLng', function (expected) {
 	new Assertion(this._obj.alt).to.eql(expected.alt);
 });
 
-const runAsTouchBrowser = import.meta.env.VITE_TOUCH === '1';
-it.skipIfNotTouch = runAsTouchBrowser ? it : it.skip;
-it.skipIfTouch = runAsTouchBrowser ? it.skip : it;
-
 DefaultIcon.imagePath = '/dist/images/';
 
 // Shim Mocha-style `done` callback on top of Vitest's promise-based runner.
@@ -67,3 +63,9 @@ if (globalThis.it) {
 	patch(globalThis.it, 'only');
 	patch(globalThis.it, 'skip');
 }
+
+// Assigned AFTER patching so these reference the wrapped `it`/`it.skip` —
+// otherwise Vitest schedules differently and timing-sensitive specs flake.
+const runAsTouchBrowser = import.meta.env.VITE_TOUCH === '1';
+it.skipIfNotTouch = runAsTouchBrowser ? it : it.skip;
+it.skipIfTouch = runAsTouchBrowser ? it.skip : it;

--- a/spec/setup.js
+++ b/spec/setup.js
@@ -1,4 +1,32 @@
-import {DefaultIcon} from 'leaflet';
+import {Assertion, util} from 'chai';
+import {DefaultIcon, LatLng, Point} from 'leaflet';
+
+util.addMethod(Assertion.prototype, 'near', function (expected, delta = 1) {
+	expected = new Point(expected);
+
+	new Assertion(this._obj.x).to.be.within(expected.x - delta, expected.x + delta);
+	new Assertion(this._obj.y).to.be.within(expected.y - delta, expected.y + delta);
+});
+
+util.addMethod(Assertion.prototype, 'nearLatLng', function (expected, delta = 1e-4) {
+	expected = new LatLng(expected);
+
+	new Assertion(this._obj.lat).to.be.within(expected.lat - delta, expected.lat + delta);
+	new Assertion(this._obj.lng).to.be.within(expected.lng - delta, expected.lng + delta);
+	new Assertion(this._obj.alt).to.eql(expected.alt);
+});
+
+util.addMethod(Assertion.prototype, 'eqlLatLng', function (expected) {
+	expected = new LatLng(expected);
+
+	new Assertion(this._obj.lat).to.eql(expected.lat);
+	new Assertion(this._obj.lng).to.eql(expected.lng);
+	new Assertion(this._obj.alt).to.eql(expected.alt);
+});
+
+const runAsTouchBrowser = import.meta.env.VITE_TOUCH === '1';
+it.skipIfNotTouch = runAsTouchBrowser ? it : it.skip;
+it.skipIfTouch = runAsTouchBrowser ? it.skip : it;
 
 // Load leaflet.css as a real <link> (not a Vite-injected <style>) so the
 // DefaultIcon path autodetection can find it via document.querySelector.

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -14,7 +14,6 @@ export function createContainer(width, height) {
 	container.style.left = '0px';
 	container.style.height = height;
 	container.style.width = width;
-	container.style.opacity = '0.4';
 	document.body.appendChild(container);
 
 	return container;

--- a/spec/suites/SpecHelper.js
+++ b/spec/suites/SpecHelper.js
@@ -1,34 +1,6 @@
-import {Assertion, util} from 'chai';
-import {LatLng, Point, DomEvent} from 'leaflet';
-
-util.addMethod(Assertion.prototype, 'near', function (expected, delta = 1) {
-	expected = new Point(expected);
-
-	new Assertion(this._obj.x).to.be.within(expected.x - delta, expected.x + delta);
-	new Assertion(this._obj.y).to.be.within(expected.y - delta, expected.y + delta);
-});
-
-util.addMethod(Assertion.prototype, 'nearLatLng', function (expected, delta = 1e-4) {
-	expected = new LatLng(expected);
-
-	new Assertion(this._obj.lat).to.be.within(expected.lat - delta, expected.lat + delta);
-	new Assertion(this._obj.lng).to.be.within(expected.lng - delta, expected.lng + delta);
-	new Assertion(this._obj.alt).to.eql(expected.alt);
-});
-
-util.addMethod(Assertion.prototype, 'eqlLatLng', function (expected) {
-	expected = new LatLng(expected);
-
-	new Assertion(this._obj.lat).to.eql(expected.lat);
-	new Assertion(this._obj.lng).to.eql(expected.lng);
-	new Assertion(this._obj.alt).to.eql(expected.alt);
-});
+import {DomEvent} from 'leaflet';
 
 const runAsTouchBrowser = import.meta.env.VITE_TOUCH === '1';
-
-// A couple of tests need the browser to be touch-capable
-it.skipIfNotTouch = runAsTouchBrowser ? it : it.skip;
-it.skipIfTouch = runAsTouchBrowser ? it.skip : it;
 
 export const pointerType = runAsTouchBrowser ? 'touch' : 'mouse';
 export const pointerEventType = ['pointer', {pointerType}];
@@ -56,4 +28,3 @@ export function removeMapContainer(map, container) {
 
 	DomEvent.PointerEvents.cleanupPointers();
 }
-

--- a/spec/suites/geo/crs/CRSSpec.js
+++ b/spec/suites/geo/crs/CRSSpec.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {CRS, EPSG3395, EPSG3857, EPSG4326, EarthCRS, SimpleCRS, Util, LatLng, LatLngBounds, Point} from 'leaflet';
-import '../../SpecHelper.js';
 
 describe('EPSG3857', () => {
 	const crs = EPSG3857;

--- a/spec/suites/geo/projection/ProjectionSpec.js
+++ b/spec/suites/geo/projection/ProjectionSpec.js
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import {Projection, LatLng, Point} from 'leaflet';
-import '../../SpecHelper.js';
 
 describe('Projection.Mercator', () => {
 	const p = Projection.Mercator;

--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import {Bounds, LineUtil, LeafletMap, LatLng, Point, Polyline} from 'leaflet';
 import sinon from 'sinon';
-import '../SpecHelper.js';
 
 describe('LineUtil', () => {
 	describe('#clipSegment', () => {

--- a/spec/suites/geometry/PolyUtilSpec.js
+++ b/spec/suites/geometry/PolyUtilSpec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
 import {Bounds, LeafletMap, Point, PolyUtil, Polygon} from 'leaflet';
 import sinon from 'sinon';
-import '../SpecHelper.js';
 
 describe('PolyUtil', () => {
 	describe('#clipPolygon', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -34,8 +34,8 @@ export default defineConfig({
 				{browser: 'firefox'},
 				{browser: 'webkit'},
 				{
-					browser: 'firefox',
-					name: 'firefox-retina',
+					browser: 'chromium',
+					name: 'chromium-retina',
 					provider: playwright({contextOptions: {hasTouch: touch, deviceScaleFactor: 2}}),
 				},
 			],


### PR DESCRIPTION
### Test infrastructure
- **Consolidated test setup into `spec/setup.js`.** Custom chai assertions (`near`, `nearLatLng`, `eqlLatLng`) and the `it.skipIfTouch`/`skipIfNotTouch` helpers moved out of `SpecHelper.js` into the global setup file. Putting them in the setup file (which runs once per worker) makes them globally available and removes the need for per-spec imports.
- **Switched CSS loading** from a manually-injected `<link>` (with a load-promise) to a plain `import '../dist/leaflet.css'` in setup. Simpler, no race condition handling needed.
- **Dropped opacity hack** (`container.style.opacity = '0.4'`) from `createContainer` — leftover that's no longer needed.

### Dependencies
- **Bumped Vitest** and `@vitest/*` packages from 4.1.5 → 4.1.6.
- **Dropped `globals` dev dependency.** ESLint config now defines the five test globals (`describe`, `it`, `beforeEach`, `afterEach`, `expect`) inline instead of pulling in `globals.mocha`. Saves a dep for ~5 strings.

### CI
- **Removed macOS+Chromium job** from the test matrix. Redundant — Chromium is already covered on Linux and Windows; macOS coverage is provided by the WebKit job.
- **Switched the retina job from Firefox to Chromium.** Chromium handles `deviceScaleFactor: 2` more reliably.
- **Stripped redundant `name:` tags** from workflow steps where the `uses:`/`run:` line is self-explanatory. Pure noise reduction.
- **Dropped `--reporter=verbose --reporter=hanging-process`** from test runs — the default reporter is fine now that the underlying hangs are resolved.