### PR TITLE
Recommend Sanitizer API instead of DOMPurify

### DIFF
--- a/docs/examples/geojson/index.md
+++ b/docs/examples/geojson/index.md
@@ -168,7 +168,7 @@ new GeoJSON(geojsonFeature, {
 	onEachFeature: onEachFeature
 }).addTo(map);</code></pre>
 
-<p><strong>Security note.</strong> <code>bindPopup</code> renders its string argument as HTML. If your GeoJSON comes from untrusted sources (user uploads, third-party APIs, etc.), sanitize <code>popupContent</code> with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element via <code>textContent</code> and bind that instead:</p>
+<p><strong>Security note.</strong> <code>bindPopup</code> renders its string argument as HTML. If your GeoJSON comes from untrusted sources (user uploads, third-party APIs, etc.), sanitize <code>popupContent</code> before passing it to Leaflet, or build a DOM element via <code>textContent</code> to render it as plain text:</p>
 
 <pre><code>const el = document.createElement('div');
 el.textContent = feature.properties.popupContent;

--- a/docs/reference-2.0.0.html
+++ b/docs/reference-2.0.0.html
@@ -2776,7 +2776,8 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -2851,7 +2852,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -3403,7 +3405,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+HTML; if it may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>)
 or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
@@ -3521,7 +3524,8 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -3596,7 +3600,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -3798,7 +3803,12 @@ open popups while making sure that only one popup is open at one time
 <pre><code class="language-js">const popup = new Popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;'})
 	.openOn(map);
 </code></pre>
-<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with the browser's built-in <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a> (with a fallback for unsupported browsers):</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.setHTML(untrustedString);
+marker.bindPopup(el);
+</code></pre>
+<p>Or build a DOM element using <code>textContent</code> to render it as plain text:</p>
 <pre><code class="language-js">const el = document.createElement('div');
 el.textContent = untrustedString;
 marker.bindPopup(el);
@@ -4328,7 +4338,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+HTML; if it may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>)
 or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
@@ -4447,7 +4458,8 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -4522,7 +4534,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -4722,7 +4735,12 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <pre><code class="language-js">const tooltip = new Tooltip(latlng, {content: 'Hello world!&lt;br /&gt;This is a nice tooltip.'})
 	.addTo(map);
 </code></pre>
-<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with the browser's built-in <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a> (with a fallback for unsupported browsers):</p>
+<pre><code class="language-js">const el = document.createElement('div');
+el.setHTML(untrustedString);
+marker.bindTooltip(el);
+</code></pre>
+<p>Or build a DOM element using <code>textContent</code> to render it as plain text:</p>
 <pre><code class="language-js">const el = document.createElement('div');
 el.textContent = untrustedString;
 marker.bindTooltip(el);
@@ -5179,7 +5197,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
+HTML; if it may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>)
 or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
@@ -5298,7 +5317,8 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -5373,7 +5393,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -6206,7 +6227,8 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -6281,7 +6303,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -7183,7 +7206,8 @@ callback is called when the tile has been loaded.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -7258,7 +7282,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -7951,7 +7976,8 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -8026,7 +8052,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -8817,7 +8844,8 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -8892,7 +8920,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -9624,7 +9653,8 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -9699,7 +9729,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -10333,7 +10364,8 @@ for a second (also called long press).</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -10408,7 +10440,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -11213,7 +11246,8 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -11288,7 +11322,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -12121,7 +12156,8 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -12196,7 +12232,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -13039,7 +13076,8 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -13114,7 +13152,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -13923,7 +13962,8 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -13998,7 +14038,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -14754,7 +14795,8 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -14829,7 +14871,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -15345,7 +15388,8 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -15420,7 +15464,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -15991,7 +16036,8 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -16066,7 +16112,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -16702,7 +16749,8 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -16777,7 +16825,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -17488,7 +17537,8 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -17563,7 +17613,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -18390,7 +18441,8 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -18465,7 +18517,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -19252,7 +19305,8 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -19327,7 +19381,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -23231,7 +23286,8 @@ layer.closePopup();
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -23304,7 +23360,8 @@ layer.closeTooltip();
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -23786,7 +23843,8 @@ for a second (also called long press).</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -23861,7 +23919,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -24854,7 +24913,8 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -24929,7 +24989,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -25395,7 +25456,8 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>
@@ -25470,7 +25532,8 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
+may contain untrusted input, sanitize it (e.g. with the browser's built-in
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API">Sanitizer API</a>) or pass an
 <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
 it will receive the layer as the first argument and should return a
 <code>String</code> or <code>HTMLElement</code>.</p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -8,10 +8,6 @@ bodyclass: api-page
 
 <p>This reference reflects <strong>Leaflet {{site.latest_leaflet_version}}</strong>. Check <a href='reference-versions.html'>this list</a> if you are using a different version of Leaflet.</p>
 
-<div class="announcement">For the new <strong>Leaflet 2.0.0-alpha.1</strong> references go to <a href="reference-2.0.0.html">Leaflet 2.0.0-alpha.1</a></div>
-
-<br>
-
 <div id="toc" class="clearfix">
 	<div class="toc-col map-col">
 		<h4>Map</h4>
@@ -46,7 +42,7 @@ bodyclass: api-page
 		<h4>Raster Layers</h4>
 		<ul>
 			<li><a href="#tilelayer">TileLayer</a></li>
-			<li><a href="#tilelayer-wms">TileLayer.WMS</a></li>
+			<li><a href="#wmstilelayer">WMSTileLayer</a></li>
 			<li><a href="#imageoverlay">ImageOverlay</a></li>
 			<li><a href="#videooverlay">VideoOverlay</a></li>
 			<li><a href="#svgoverlay">SVGOverlay</a></li>
@@ -128,10 +124,10 @@ bodyclass: api-page
 	</div>
 </div>
 
-<h2 id='map'>Map</h2><p>The central class of the API — it is used to create a map on a page and manipulate it.</p>
+<h2 id='leafletmap'>LeafletMap</h2><p>The central class of the API — it is used to create a map on a page and manipulate it.</p>
 
 <section>
-<h3 id='map-example'>Usage example</h3>
+<h3 id='leafletmap-example'>Usage example</h3>
 
 <section >
 
@@ -140,7 +136,7 @@ bodyclass: api-page
 
 
 <pre><code class="language-js">// initialize the map on the &quot;map&quot; div with a given center and zoom
-const map = new Map('map', {
+const map = new LeafletMap('map', {
 	center: [51.505, -0.09],
 	zoom: 13
 });
@@ -152,7 +148,7 @@ const map = new Map('map', {
 
 
 </section><section>
-<h3 id='map-constructor'>Constructor</h3>
+<h3 id='leafletmap-constructor'>Constructor</h3>
 
 <section >
 
@@ -165,25 +161,25 @@ const map = new Map('map', {
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-map'>
-		<td><code><b>new Map</b>(<nobr>&lt;String&gt;</nobr> <i>id</i>, <nobr>&lt;Map options&gt;</nobr> <i>options?</i>)</code></td>
-		<td>Instantiates a map object given the DOM ID of a <code>&lt;div&gt;</code> element
-and optionally an object literal with <code>Map options</code>.</td>
-	</tr>
-	<tr id='map-map'>
-		<td><code><b>new Map</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;Map options&gt;</nobr> <i>options?</i>)</code></td>
-		<td>Instantiates a map object given an instance of a <code>&lt;div&gt;</code> HTML element
-and optionally an object literal with <code>Map options</code>.</td>
-	</tr>
-	<tr id='map-leafletmap'>
+	<tr id='leafletmap-leafletmap'>
 		<td><code><b>new LeafletMap</b>(<nobr>&lt;String&gt;</nobr> <i>id</i>, <nobr>&lt;LeafletMap options&gt;</nobr> <i>options?</i>)</code></td>
 		<td>Instantiates a map object given the DOM ID of a <code>&lt;div&gt;</code> element
 and optionally an object literal with <code>LeafletMap options</code>.</td>
 	</tr>
-	<tr id='map-leafletmap'>
+	<tr id='leafletmap-leafletmap'>
 		<td><code><b>new LeafletMap</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;LeafletMap options&gt;</nobr> <i>options?</i>)</code></td>
 		<td>Instantiates a map object given an instance of a <code>&lt;div&gt;</code> HTML element
 and optionally an object literal with <code>LeafletMap options</code>.</td>
+	</tr>
+	<tr id='leafletmap-map'>
+		<td><code><b>new Map</b>(<nobr>&lt;String&gt;</nobr> <i>id</i>, <nobr>&lt;Map options&gt;</nobr> <i>options?</i>)</code></td>
+		<td>Instantiates a map object given the DOM ID of a <code>&lt;div&gt;</code> element
+and optionally an object literal with <code>Map options</code>.</td>
+	</tr>
+	<tr id='leafletmap-map'>
+		<td><code><b>new Map</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>, <nobr>&lt;Map options&gt;</nobr> <i>options?</i>)</code></td>
+		<td>Instantiates a map object given an instance of a <code>&lt;div&gt;</code> HTML element
+and optionally an object literal with <code>Map options</code>.</td>
 	</tr>
 </tbody></table>
 
@@ -192,7 +188,7 @@ and optionally an object literal with <code>LeafletMap options</code>.</td>
 
 
 </section><section>
-<h3 id='map-option'>Options</h3>
+<h3 id='leafletmap-option'>Options</h3>
 
 <section >
 
@@ -207,7 +203,7 @@ and optionally an object literal with <code>LeafletMap options</code>.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-prefercanvas'>
+	<tr id='leafletmap-prefercanvas'>
 		<td><code><b>preferCanvas</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
@@ -218,7 +214,7 @@ By default, all <a href="#path"><code>Path</code></a>s are rendered in a <a href
 
 </section><section class='collapsable'>
 
-<h4 id='map-control-options'>Control options</h4>
+<h4 id='leafletmap-control-options'>Control options</h4>
 
 
 <table><thead>
@@ -229,13 +225,13 @@ By default, all <a href="#path"><code>Path</code></a>s are rendered in a <a href
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-attributioncontrol'>
+	<tr id='leafletmap-attributioncontrol'>
 		<td><code><b>attributionControl</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>Whether a <a href="#control-attribution">attribution control</a> is added to the map by default.</td>
 	</tr>
-	<tr id='map-zoomcontrol'>
+	<tr id='leafletmap-zoomcontrol'>
 		<td><code><b>zoomControl</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
@@ -245,7 +241,7 @@ By default, all <a href="#path"><code>Path</code></a>s are rendered in a <a href
 
 </section><section class='collapsable'>
 
-<h4 id='map-interaction-options'>Interaction Options</h4>
+<h4 id='leafletmap-interaction-options'>Interaction Options</h4>
 
 
 <table><thead>
@@ -256,35 +252,13 @@ By default, all <a href="#path"><code>Path</code></a>s are rendered in a <a href
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-closepopuponclick'>
+	<tr id='leafletmap-closepopuponclick'>
 		<td><code><b>closePopupOnClick</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>Set it to <code>false</code> if you don't want popups to close when user clicks the map.</td>
 	</tr>
-	<tr id='map-boxzoom'>
-		<td><code><b>boxZoom</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>true</code></td>
-		<td>Whether the map can be zoomed to a rectangular area specified by
-dragging the pointer while pressing the shift key.</td>
-	</tr>
-	<tr id='map-doubleclickzoom'>
-		<td><code><b>doubleClickZoom</b></code></td>
-		<td><code>Boolean|String</code></td>
-		<td><code>true</code></td>
-		<td>Whether the map can be zoomed in by double clicking on it and
-zoomed out by double clicking while holding shift. If passed
-<code>'center'</code>, double-click zoom will zoom to the center of the
-view regardless of where the pointer was.</td>
-	</tr>
-	<tr id='map-dragging'>
-		<td><code><b>dragging</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>true</code></td>
-		<td>Whether the map is draggable with pointer or not.</td>
-	</tr>
-	<tr id='map-zoomsnap'>
+	<tr id='leafletmap-zoomsnap'>
 		<td><code><b>zoomSnap</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>1</code></td>
@@ -294,7 +268,7 @@ By default, the zoom level snaps to the nearest integer; lower values
 (e.g. <code>0.5</code> or <code>0.1</code>) allow for greater granularity. A value of <code>0</code>
 means the zoom level will not be snapped after <code>fitBounds</code> or a pinch-zoom.</td>
 	</tr>
-	<tr id='map-zoomdelta'>
+	<tr id='leafletmap-zoomdelta'>
 		<td><code><b>zoomDelta</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>1</code></td>
@@ -303,17 +277,39 @@ means the zoom level will not be snapped after <code>fitBounds</code> or a pinch
 or <code>-</code> on the keyboard, or using the <a href="#control-zoom">zoom controls</a>.
 Values smaller than <code>1</code> (e.g. <code>0.5</code>) allow for greater granularity.</td>
 	</tr>
-	<tr id='map-trackresize'>
+	<tr id='leafletmap-trackresize'>
 		<td><code><b>trackResize</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>Whether the map automatically handles browser window resize to update itself.</td>
 	</tr>
+	<tr id='leafletmap-boxzoom'>
+		<td><code><b>boxZoom</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>true</code></td>
+		<td>Whether the map can be zoomed to a rectangular area specified by
+dragging the pointer while pressing the shift key.</td>
+	</tr>
+	<tr id='leafletmap-doubleclickzoom'>
+		<td><code><b>doubleClickZoom</b></code></td>
+		<td><code>Boolean|String</code></td>
+		<td><code>true</code></td>
+		<td>Whether the map can be zoomed in by double clicking on it and
+zoomed out by double clicking while holding shift. If passed
+<code>'center'</code>, double-click zoom will zoom to the center of the
+view regardless of where the pointer was.</td>
+	</tr>
+	<tr id='leafletmap-dragging'>
+		<td><code><b>dragging</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>true</code></td>
+		<td>Whether the map is draggable with pointer or not.</td>
+	</tr>
 </tbody></table>
 
 </section><section class='collapsable'>
 
-<h4 id='map-panning-inertia-options'>Panning Inertia Options</h4>
+<h4 id='leafletmap-map-state-options'>Map State Options</h4>
 
 
 <table><thead>
@@ -324,7 +320,127 @@ Values smaller than <code>1</code> (e.g. <code>0.5</code>) allow for greater gra
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-inertia'>
+	<tr id='leafletmap-crs'>
+		<td><code><b>crs</b></code></td>
+		<td><code><a href='#crs'>CRS</a></code></td>
+		<td><code>EPSG3857</code></td>
+		<td>The <a href="#crs">Coordinate Reference System</a> to use. Don't change this if you're not
+sure what it means.</td>
+	</tr>
+	<tr id='leafletmap-center'>
+		<td><code><b>center</b></code></td>
+		<td><code><a href='#latlng'>LatLng</a></code></td>
+		<td><code>undefined</code></td>
+		<td>Initial geographic center of the map</td>
+	</tr>
+	<tr id='leafletmap-zoom'>
+		<td><code><b>zoom</b></code></td>
+		<td><code>Number</code></td>
+		<td><code>undefined</code></td>
+		<td>Initial map zoom level</td>
+	</tr>
+	<tr id='leafletmap-minzoom'>
+		<td><code><b>minZoom</b></code></td>
+		<td><code>Number</code></td>
+		<td><code>*</code></td>
+		<td>Minimum zoom level of the map.
+If not specified and at least one <a href="#gridlayer"><code>GridLayer</code></a> or <a href="#tilelayer"><code>TileLayer</code></a> is in the map,
+the lowest of their <code>minZoom</code> options will be used instead.</td>
+	</tr>
+	<tr id='leafletmap-maxzoom'>
+		<td><code><b>maxZoom</b></code></td>
+		<td><code>Number</code></td>
+		<td><code>*</code></td>
+		<td>Maximum zoom level of the map.
+If not specified and at least one <a href="#gridlayer"><code>GridLayer</code></a> or <a href="#tilelayer"><code>TileLayer</code></a> is in the map,
+the highest of their <code>maxZoom</code> options will be used instead.</td>
+	</tr>
+	<tr id='leafletmap-layers'>
+		<td><code><b>layers</b></code></td>
+		<td><code>Layer[]</code></td>
+		<td><code>[]</code></td>
+		<td>Array of layers that will be added to the map initially</td>
+	</tr>
+	<tr id='leafletmap-maxbounds'>
+		<td><code><b>maxBounds</b></code></td>
+		<td><code><a href='#latlngbounds'>LatLngBounds</a></code></td>
+		<td><code>null</code></td>
+		<td>When this option is set, the map restricts the view to the given
+geographical bounds, bouncing the user back if the user tries to pan
+outside the view. To set the restriction dynamically, use
+<a href="#map-setmaxbounds"><code>setMaxBounds</code></a> method.</td>
+	</tr>
+	<tr id='leafletmap-renderer'>
+		<td><code><b>renderer</b></code></td>
+		<td><code><a href='#renderer'>Renderer</a></code></td>
+		<td><code>*</code></td>
+		<td>The default method for drawing vector layers on the map. <a href="#svg"><code>SVG</code></a>
+or <a href="#canvas"><code>Canvas</code></a> by default depending on browser support.</td>
+	</tr>
+</tbody></table>
+
+</section><section class='collapsable'>
+
+<h4 id='leafletmap-animation-options'>Animation Options</h4>
+
+
+<table><thead>
+	<tr>
+		<th>Option</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='leafletmap-zoomanimation'>
+		<td><code><b>zoomAnimation</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>true</code></td>
+		<td>Whether the map zoom animation is enabled.</td>
+	</tr>
+	<tr id='leafletmap-zoomanimationthreshold'>
+		<td><code><b>zoomAnimationThreshold</b></code></td>
+		<td><code>Number</code></td>
+		<td><code>4</code></td>
+		<td>Won't animate zoom if the zoom difference exceeds this value.</td>
+	</tr>
+	<tr id='leafletmap-fadeanimation'>
+		<td><code><b>fadeAnimation</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>true</code></td>
+		<td>Whether the tile fade animation is enabled.</td>
+	</tr>
+	<tr id='leafletmap-markerzoomanimation'>
+		<td><code><b>markerZoomAnimation</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>true</code></td>
+		<td>Whether markers animate their zoom with the zoom animation, if disabled
+they will disappear for the length of the animation.</td>
+	</tr>
+	<tr id='leafletmap-transform3dlimit'>
+		<td><code><b>transform3DLimit</b></code></td>
+		<td><code>Number</code></td>
+		<td><code>2^23</code></td>
+		<td>Defines the maximum size of a CSS translation transform. The default
+value should not be changed unless a web browser positions layers in
+the wrong place after doing a large <code>panBy</code>.</td>
+	</tr>
+</tbody></table>
+
+</section><section class='collapsable'>
+
+<h4 id='leafletmap-panning-inertia-options'>Panning Inertia Options</h4>
+
+
+<table><thead>
+	<tr>
+		<th>Option</th>
+		<th>Type</th>
+		<th>Default</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='leafletmap-inertia'>
 		<td><code><b>inertia</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>*</code></td>
@@ -333,25 +449,25 @@ the map builds momentum while dragging and continues moving in
 the same direction for some time. Feels especially nice on touch
 devices. Enabled by default.</td>
 	</tr>
-	<tr id='map-inertiadeceleration'>
+	<tr id='leafletmap-inertiadeceleration'>
 		<td><code><b>inertiaDeceleration</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>3000</code></td>
 		<td>The rate with which the inertial movement slows down, in pixels/second².</td>
 	</tr>
-	<tr id='map-inertiamaxspeed'>
+	<tr id='leafletmap-inertiamaxspeed'>
 		<td><code><b>inertiaMaxSpeed</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>Infinity</code></td>
 		<td>Max speed of the inertial movement, in pixels/second.</td>
 	</tr>
-	<tr id='map-easelinearity'>
+	<tr id='leafletmap-easelinearity'>
 		<td><code><b>easeLinearity</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0.2</code></td>
 		<td></td>
 	</tr>
-	<tr id='map-worldcopyjump'>
+	<tr id='leafletmap-worldcopyjump'>
 		<td><code><b>worldCopyJump</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
@@ -359,7 +475,7 @@ devices. Enabled by default.</td>
 of the world and seamlessly jumps to the original one so that all overlays
 like markers and vector layers are still visible.</td>
 	</tr>
-	<tr id='map-maxboundsviscosity'>
+	<tr id='leafletmap-maxboundsviscosity'>
 		<td><code><b>maxBoundsViscosity</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0.0</code></td>
@@ -373,7 +489,7 @@ solid, preventing the user from dragging outside the bounds.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-keyboard-navigation-options'>Keyboard Navigation Options</h4>
+<h4 id='leafletmap-keyboard-navigation-options'>Keyboard Navigation Options</h4>
 
 
 <table><thead>
@@ -384,14 +500,14 @@ solid, preventing the user from dragging outside the bounds.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-keyboard'>
+	<tr id='leafletmap-keyboard'>
 		<td><code><b>keyboard</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>Makes the map focusable and allows users to navigate the map with keyboard
 arrows and <code>+</code>/<code>-</code> keys.</td>
 	</tr>
-	<tr id='map-keyboardpandelta'>
+	<tr id='leafletmap-keyboardpandelta'>
 		<td><code><b>keyboardPanDelta</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>80</code></td>
@@ -401,7 +517,7 @@ arrows and <code>+</code>/<code>-</code> keys.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-touch-interaction-options'>Touch interaction options</h4>
+<h4 id='leafletmap-touch-interaction-options'>Touch interaction options</h4>
 
 
 <table><thead>
@@ -412,7 +528,7 @@ arrows and <code>+</code>/<code>-</code> keys.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-pinchzoom'>
+	<tr id='leafletmap-pinchzoom'>
 		<td><code><b>pinchZoom</b></code></td>
 		<td><code>Boolean|String</code></td>
 		<td><code>*</code></td>
@@ -421,20 +537,20 @@ passed <code>'center'</code>, it will zoom to the center of the view regardless 
 where the touch events (fingers) were. Enabled for touch-capable web
 browsers.</td>
 	</tr>
-	<tr id='map-bounceatzoomlimits'>
+	<tr id='leafletmap-bounceatzoomlimits'>
 		<td><code><b>bounceAtZoomLimits</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>Set it to false if you don't want the map to zoom beyond min/max zoom
 and then bounce back when pinch-zooming.</td>
 	</tr>
-	<tr id='map-taphold'>
+	<tr id='leafletmap-taphold'>
 		<td><code><b>tapHold</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code></code></td>
 		<td>Enables simulation of <code>contextmenu</code> event, default is <code>true</code> for mobile Safari.</td>
 	</tr>
-	<tr id='map-taptolerance'>
+	<tr id='leafletmap-taptolerance'>
 		<td><code><b>tapTolerance</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>15</code></td>
@@ -445,7 +561,7 @@ for it to be considered a valid tap.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-mouse-wheel-options'>Mouse wheel options</h4>
+<h4 id='leafletmap-mouse-wheel-options'>Mouse wheel options</h4>
 
 
 <table><thead>
@@ -456,21 +572,21 @@ for it to be considered a valid tap.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-scrollwheelzoom'>
+	<tr id='leafletmap-scrollwheelzoom'>
 		<td><code><b>scrollWheelZoom</b></code></td>
 		<td><code>Boolean|String</code></td>
 		<td><code>true</code></td>
 		<td>Whether the map can be zoomed by using the mouse wheel. If passed <code>'center'</code>,
 it will zoom to the center of the view regardless of where the pointer was.</td>
 	</tr>
-	<tr id='map-wheeldebouncetime'>
+	<tr id='leafletmap-wheeldebouncetime'>
 		<td><code><b>wheelDebounceTime</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>40</code></td>
 		<td>Limits the rate at which a wheel can fire (in milliseconds). By default, the
 user can't zoom via wheel more often than once per 40 ms.</td>
 	</tr>
-	<tr id='map-wheelpxperzoomlevel'>
+	<tr id='leafletmap-wheelpxperzoomlevel'>
 		<td><code><b>wheelPxPerZoomLevel</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>60</code></td>
@@ -480,138 +596,15 @@ faster (and vice versa).</td>
 	</tr>
 </tbody></table>
 
-</section><section class='collapsable'>
-
-<h4 id='map-map-state-options'>Map State Options</h4>
-
-
-<table><thead>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='map-crs'>
-		<td><code><b>crs</b></code></td>
-		<td><code><a href='#crs'>CRS</a></code></td>
-		<td><code>CRS.EPSG3857</code></td>
-		<td>The <a href="#crs">Coordinate Reference System</a> to use. Don't change this if you're not
-sure what it means.</td>
-	</tr>
-	<tr id='map-center'>
-		<td><code><b>center</b></code></td>
-		<td><code><a href='#latlng'>LatLng</a></code></td>
-		<td><code>undefined</code></td>
-		<td>Initial geographic center of the map</td>
-	</tr>
-	<tr id='map-zoom'>
-		<td><code><b>zoom</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>undefined</code></td>
-		<td>Initial map zoom level</td>
-	</tr>
-	<tr id='map-minzoom'>
-		<td><code><b>minZoom</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>*</code></td>
-		<td>Minimum zoom level of the map.
-If not specified and at least one <a href="#gridlayer"><code>GridLayer</code></a> or <a href="#tilelayer"><code>TileLayer</code></a> is in the map,
-the lowest of their <code>minZoom</code> options will be used instead.</td>
-	</tr>
-	<tr id='map-maxzoom'>
-		<td><code><b>maxZoom</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>*</code></td>
-		<td>Maximum zoom level of the map.
-If not specified and at least one <a href="#gridlayer"><code>GridLayer</code></a> or <a href="#tilelayer"><code>TileLayer</code></a> is in the map,
-the highest of their <code>maxZoom</code> options will be used instead.</td>
-	</tr>
-	<tr id='map-layers'>
-		<td><code><b>layers</b></code></td>
-		<td><code>Layer[]</code></td>
-		<td><code>[]</code></td>
-		<td>Array of layers that will be added to the map initially</td>
-	</tr>
-	<tr id='map-maxbounds'>
-		<td><code><b>maxBounds</b></code></td>
-		<td><code><a href='#latlngbounds'>LatLngBounds</a></code></td>
-		<td><code>null</code></td>
-		<td>When this option is set, the map restricts the view to the given
-geographical bounds, bouncing the user back if the user tries to pan
-outside the view. To set the restriction dynamically, use
-<a href="#map-setmaxbounds"><code>setMaxBounds</code></a> method.</td>
-	</tr>
-	<tr id='map-renderer'>
-		<td><code><b>renderer</b></code></td>
-		<td><code><a href='#renderer'>Renderer</a></code></td>
-		<td><code>*</code></td>
-		<td>The default method for drawing vector layers on the map. <a href="#svg"><code>SVG</code></a>
-or <a href="#canvas"><code>Canvas</code></a> by default depending on browser support.</td>
-	</tr>
-</tbody></table>
-
-</section><section class='collapsable'>
-
-<h4 id='map-animation-options'>Animation Options</h4>
-
-
-<table><thead>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='map-zoomanimation'>
-		<td><code><b>zoomAnimation</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>true</code></td>
-		<td>Whether the map zoom animation is enabled. By default it's enabled
-in all browsers that support CSS Transitions except Android.</td>
-	</tr>
-	<tr id='map-zoomanimationthreshold'>
-		<td><code><b>zoomAnimationThreshold</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>4</code></td>
-		<td>Won't animate zoom if the zoom difference exceeds this value.</td>
-	</tr>
-	<tr id='map-fadeanimation'>
-		<td><code><b>fadeAnimation</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>true</code></td>
-		<td>Whether the tile fade animation is enabled. By default it's enabled
-in all browsers that support CSS Transitions except Android.</td>
-	</tr>
-	<tr id='map-markerzoomanimation'>
-		<td><code><b>markerZoomAnimation</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>true</code></td>
-		<td>Whether markers animate their zoom with the zoom animation, if disabled
-they will disappear for the length of the animation. By default it's
-enabled in all browsers that support CSS Transitions except Android.</td>
-	</tr>
-	<tr id='map-transform3dlimit'>
-		<td><code><b>transform3DLimit</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>2^23</code></td>
-		<td>Defines the maximum size of a CSS translation transform. The default
-value should not be changed unless a web browser positions layers in
-the wrong place after doing a large <code>panBy</code>.</td>
-	</tr>
-</tbody></table>
-
 </section>
 
 
 </section><section>
-<h3 id='map-event'>Events</h3>
+<h3 id='leafletmap-event'>Events</h3>
 
 <section class='collapsable'>
 
-<h4 id='map-layer-events'>Layer events</h4>
+<h4 id='leafletmap-layer-events'>Layer events</h4>
 
 
 <table><thead>
@@ -621,27 +614,27 @@ the wrong place after doing a large <code>panBy</code>.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-baselayerchange'>
+	<tr id='leafletmap-baselayerchange'>
 		<td><code><b>baselayerchange</b></code></td>
 		<td><code><a href='#layerscontrolevent'>LayersControlEvent</a></code></td>
 		<td>Fired when the base layer is changed through the <a href="#control-layers">layers control</a>.</td>
 	</tr>
-	<tr id='map-overlayadd'>
+	<tr id='leafletmap-overlayadd'>
 		<td><code><b>overlayadd</b></code></td>
 		<td><code><a href='#layerscontrolevent'>LayersControlEvent</a></code></td>
 		<td>Fired when an overlay is selected through the <a href="#control-layers">layers control</a>.</td>
 	</tr>
-	<tr id='map-overlayremove'>
+	<tr id='leafletmap-overlayremove'>
 		<td><code><b>overlayremove</b></code></td>
 		<td><code><a href='#layerscontrolevent'>LayersControlEvent</a></code></td>
 		<td>Fired when an overlay is deselected through the <a href="#control-layers">layers control</a>.</td>
 	</tr>
-	<tr id='map-layeradd'>
+	<tr id='leafletmap-layeradd'>
 		<td><code><b>layeradd</b></code></td>
 		<td><code><a href='#layerevent'>LayerEvent</a></code></td>
 		<td>Fired when a new layer is added to the map.</td>
 	</tr>
-	<tr id='map-layerremove'>
+	<tr id='leafletmap-layerremove'>
 		<td><code><b>layerremove</b></code></td>
 		<td><code><a href='#layerevent'>LayerEvent</a></code></td>
 		<td>Fired when some layer is removed from the map</td>
@@ -650,7 +643,7 @@ the wrong place after doing a large <code>panBy</code>.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-map-state-change-events'>Map state change events</h4>
+<h4 id='leafletmap-map-state-change-events'>Map state change events</h4>
 
 <div class='section-comments'></div>
 
@@ -661,62 +654,62 @@ the wrong place after doing a large <code>panBy</code>.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-zoomlevelschange'>
+	<tr id='leafletmap-zoomlevelschange'>
 		<td><code><b>zoomlevelschange</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the number of zoomlevels on the map is changed due
 to adding or removing a layer.</td>
 	</tr>
-	<tr id='map-resize'>
+	<tr id='leafletmap-resize'>
 		<td><code><b>resize</b></code></td>
 		<td><code><a href='#resizeevent'>ResizeEvent</a></code></td>
 		<td>Fired when the map is resized.</td>
 	</tr>
-	<tr id='map-unload'>
+	<tr id='leafletmap-unload'>
 		<td><code><b>unload</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map is destroyed with <a href="#map-remove">remove</a> method.</td>
 	</tr>
-	<tr id='map-viewreset'>
+	<tr id='leafletmap-viewreset'>
 		<td><code><b>viewreset</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map needs to redraw its content (this usually happens
 on map zoom or load). Very useful for creating custom overlays.</td>
 	</tr>
-	<tr id='map-load'>
+	<tr id='leafletmap-load'>
 		<td><code><b>load</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map is initialized (when its center and zoom are set
 for the first time).</td>
 	</tr>
-	<tr id='map-zoomstart'>
+	<tr id='leafletmap-zoomstart'>
 		<td><code><b>zoomstart</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map zoom is about to change (e.g. before zoom animation).</td>
 	</tr>
-	<tr id='map-movestart'>
+	<tr id='leafletmap-movestart'>
 		<td><code><b>movestart</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the view of the map starts changing (e.g. user starts dragging the map).</td>
 	</tr>
-	<tr id='map-zoom'>
+	<tr id='leafletmap-zoom'>
 		<td><code><b>zoom</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired repeatedly during any change in zoom level,
 including zoom and fly animations.</td>
 	</tr>
-	<tr id='map-move'>
+	<tr id='leafletmap-move'>
 		<td><code><b>move</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired repeatedly during any movement of the map,
 including pan and fly animations.</td>
 	</tr>
-	<tr id='map-zoomend'>
+	<tr id='leafletmap-zoomend'>
 		<td><code><b>zoomend</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map zoom changed, after any animations.</td>
 	</tr>
-	<tr id='map-moveend'>
+	<tr id='leafletmap-moveend'>
 		<td><code><b>moveend</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the center of the map stops changing
@@ -726,7 +719,7 @@ including pan and fly animations.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-popup-events'>Popup events</h4>
+<h4 id='leafletmap-popup-events'>Popup events</h4>
 
 
 <table><thead>
@@ -736,17 +729,17 @@ including pan and fly animations.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-popupopen'>
+	<tr id='leafletmap-popupopen'>
 		<td><code><b>popupopen</b></code></td>
 		<td><code><a href='#popupevent'>PopupEvent</a></code></td>
 		<td>Fired when a popup is opened in the map</td>
 	</tr>
-	<tr id='map-popupclose'>
+	<tr id='leafletmap-popupclose'>
 		<td><code><b>popupclose</b></code></td>
 		<td><code><a href='#popupevent'>PopupEvent</a></code></td>
 		<td>Fired when a popup in the map is closed</td>
 	</tr>
-	<tr id='map-autopanstart'>
+	<tr id='leafletmap-autopanstart'>
 		<td><code><b>autopanstart</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the map starts autopanning when opening a popup.</td>
@@ -755,7 +748,7 @@ including pan and fly animations.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-tooltip-events'>Tooltip events</h4>
+<h4 id='leafletmap-tooltip-events'>Tooltip events</h4>
 
 
 <table><thead>
@@ -765,12 +758,12 @@ including pan and fly animations.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-tooltipopen'>
+	<tr id='leafletmap-tooltipopen'>
 		<td><code><b>tooltipopen</b></code></td>
 		<td><code><a href='#tooltipevent'>TooltipEvent</a></code></td>
 		<td>Fired when a tooltip is opened in the map.</td>
 	</tr>
-	<tr id='map-tooltipclose'>
+	<tr id='leafletmap-tooltipclose'>
 		<td><code><b>tooltipclose</b></code></td>
 		<td><code><a href='#tooltipevent'>TooltipEvent</a></code></td>
 		<td>Fired when a tooltip in the map is closed.</td>
@@ -779,7 +772,7 @@ including pan and fly animations.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-location-events'>Location events</h4>
+<h4 id='leafletmap-location-events'>Location events</h4>
 
 
 <table><thead>
@@ -789,12 +782,12 @@ including pan and fly animations.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-locationerror'>
+	<tr id='leafletmap-locationerror'>
 		<td><code><b>locationerror</b></code></td>
 		<td><code><a href='#errorevent'>ErrorEvent</a></code></td>
 		<td>Fired when geolocation (using the <a href="#map-locate"><code>locate</code></a> method) failed.</td>
 	</tr>
-	<tr id='map-locationfound'>
+	<tr id='leafletmap-locationfound'>
 		<td><code><b>locationfound</b></code></td>
 		<td><code><a href='#locationevent'>LocationEvent</a></code></td>
 		<td>Fired when geolocation (using the <a href="#map-locate"><code>locate</code></a> method)
@@ -804,7 +797,7 @@ went successfully.</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-interaction-events'>Interaction events</h4>
+<h4 id='leafletmap-interaction-events'>Interaction events</h4>
 
 
 <table><thead>
@@ -814,42 +807,42 @@ went successfully.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-click'>
+	<tr id='leafletmap-click'>
 		<td><code><b>click</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the user clicks (or taps) the map.</td>
 	</tr>
-	<tr id='map-dblclick'>
+	<tr id='leafletmap-dblclick'>
 		<td><code><b>dblclick</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the user double-clicks (or double-taps) the map.</td>
 	</tr>
-	<tr id='map-pointerdown'>
+	<tr id='leafletmap-pointerdown'>
 		<td><code><b>pointerdown</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the user pushes the pointer on the map.</td>
 	</tr>
-	<tr id='map-pointerup'>
+	<tr id='leafletmap-pointerup'>
 		<td><code><b>pointerup</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the user releases the pointer on the map.</td>
 	</tr>
-	<tr id='map-pointerover'>
+	<tr id='leafletmap-pointerover'>
 		<td><code><b>pointerover</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the pointer enters the map.</td>
 	</tr>
-	<tr id='map-pointerout'>
+	<tr id='leafletmap-pointerout'>
 		<td><code><b>pointerout</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the pointer leaves the map.</td>
 	</tr>
-	<tr id='map-pointermove'>
+	<tr id='leafletmap-pointermove'>
 		<td><code><b>pointermove</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired while the pointer moves over the map.</td>
 	</tr>
-	<tr id='map-contextmenu'>
+	<tr id='leafletmap-contextmenu'>
 		<td><code><b>contextmenu</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired when the user pushes the right mouse button on the map, prevents
@@ -857,24 +850,24 @@ default browser context menu from showing if there are listeners on
 this event. Also fired on mobile when the user holds a single touch
 for a second (also called long press).</td>
 	</tr>
-	<tr id='map-keypress'>
+	<tr id='leafletmap-keypress'>
 		<td><code><b>keypress</b></code></td>
 		<td><code><a href='#keyboardevent'>KeyboardEvent</a></code></td>
 		<td>Fired when the user presses a key from the keyboard that produces a character value while the map is focused.</td>
 	</tr>
-	<tr id='map-keydown'>
+	<tr id='leafletmap-keydown'>
 		<td><code><b>keydown</b></code></td>
 		<td><code><a href='#keyboardevent'>KeyboardEvent</a></code></td>
 		<td>Fired when the user presses a key from the keyboard while the map is focused. Unlike the <code>keypress</code> event,
 the <code>keydown</code> event is fired for keys that produce a character value and for keys
 that do not produce a character value.</td>
 	</tr>
-	<tr id='map-keyup'>
+	<tr id='leafletmap-keyup'>
 		<td><code><b>keyup</b></code></td>
 		<td><code><a href='#keyboardevent'>KeyboardEvent</a></code></td>
 		<td>Fired when the user releases a key from the keyboard while the map is focused.</td>
 	</tr>
-	<tr id='map-preclick'>
+	<tr id='leafletmap-preclick'>
 		<td><code><b>preclick</b></code></td>
 		<td><code><a href='#pointerevent'>PointerEvent</a></code></td>
 		<td>Fired before pointer click on the map (sometimes useful when you
@@ -885,7 +878,7 @@ handlers start running).</td>
 
 </section><section class='collapsable'>
 
-<h4 id='map-other-events'>Other Events</h4>
+<h4 id='leafletmap-other-events'>Other Events</h4>
 
 
 <table><thead>
@@ -895,7 +888,7 @@ handlers start running).</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-zoomanim'>
+	<tr id='leafletmap-zoomanim'>
 		<td><code><b>zoomanim</b></code></td>
 		<td><code><a href='#zoomanimevent'>ZoomAnimEvent</a></code></td>
 		<td>Fired at least once per zoom animation. For continuous zoom, like pinch zooming, fired once per frame during zoom.</td>
@@ -906,7 +899,7 @@ handlers start running).</td>
 
 
 </section><section>
-<h3 id='map-method'>Methods</h3>
+<h3 id='leafletmap-method'>Methods</h3>
 
 <section >
 
@@ -920,7 +913,7 @@ handlers start running).</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-getrenderer'>
+	<tr id='leafletmap-getrenderer'>
 		<td><code><b>getRenderer</b>(<nobr>&lt;<a href='#path'>Path</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code><a href='#renderer'>Renderer</a></code></td>
 		<td><p>Returns the instance of <a href="#renderer"><code>Renderer</code></a> that should be used to render the given
@@ -932,7 +925,7 @@ are respected, and that the renderers do exist on the map.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-layers-and-controls'>Methods for Layers and Controls</h4>
+<h4 id='leafletmap-methods-for-layers-and-controls'>Methods for Layers and Controls</h4>
 
 
 <table><thead>
@@ -942,37 +935,37 @@ are respected, and that the renderers do exist on the map.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-addcontrol'>
+	<tr id='leafletmap-addcontrol'>
 		<td><code><b>addControl</b>(<nobr>&lt;<a href='#control'>Control</a>&gt;</nobr> <i>control</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the given control to the map</p>
 </td>
 	</tr>
-	<tr id='map-removecontrol'>
+	<tr id='leafletmap-removecontrol'>
 		<td><code><b>removeControl</b>(<nobr>&lt;<a href='#control'>Control</a>&gt;</nobr> <i>control</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the given control from the map</p>
 </td>
 	</tr>
-	<tr id='map-addlayer'>
+	<tr id='leafletmap-addlayer'>
 		<td><code><b>addLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the given layer to the map</p>
 </td>
 	</tr>
-	<tr id='map-removelayer'>
+	<tr id='leafletmap-removelayer'>
 		<td><code><b>removeLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the given layer from the map.</p>
 </td>
 	</tr>
-	<tr id='map-haslayer'>
+	<tr id='leafletmap-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
 		<td><p>Returns <code>true</code> if the given layer is currently added to the map</p>
 </td>
 	</tr>
-	<tr id='map-eachlayer'>
+	<tr id='leafletmap-eachlayer'>
 		<td><code><b>eachLayer</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Iterates over the layers of the map, optionally specifying context of the iterator function.</p>
@@ -982,39 +975,39 @@ are respected, and that the renderers do exist on the map.</p>
 </code></pre>
 </td>
 	</tr>
-	<tr id='map-openpopup'>
+	<tr id='leafletmap-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#popup'>Popup</a>&gt;</nobr> <i>popup</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens the specified popup while closing the previously opened (to make sure only one is opened at one time for usability).</p>
 </td>
 	</tr>
-	<tr id='map-openpopup'>
+	<tr id='leafletmap-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Creates a popup with the specified content and options and opens it in the given point on a map.
 String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
-	<tr id='map-closepopup'>
+	<tr id='leafletmap-closepopup'>
 		<td><code><b>closePopup</b>(<nobr>&lt;<a href='#popup'>Popup</a>&gt;</nobr> <i>popup?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Closes the popup previously opened with <a href="#map-openpopup">openPopup</a> (or the given one).</p>
 </td>
 	</tr>
-	<tr id='map-opentooltip'>
+	<tr id='leafletmap-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#tooltip'>Tooltip</a>&gt;</nobr> <i>tooltip</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens the specified tooltip.</p>
 </td>
 	</tr>
-	<tr id='map-opentooltip'>
+	<tr id='leafletmap-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Creates a tooltip with the specified content and options and open it.
 String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
-	<tr id='map-closetooltip'>
+	<tr id='leafletmap-closetooltip'>
 		<td><code><b>closeTooltip</b>(<nobr>&lt;<a href='#tooltip'>Tooltip</a>&gt;</nobr> <i>tooltip</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Closes the tooltip given as parameter.</p>
@@ -1024,7 +1017,7 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-modifying-map-state'>Methods for modifying map state</h4>
+<h4 id='leafletmap-methods-for-modifying-map-state'>Methods for modifying map state</h4>
 
 
 <table><thead>
@@ -1034,109 +1027,109 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-setview'>
+	<tr id='leafletmap-setview'>
 		<td><code><b>setView</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>center</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom?</i>, <nobr>&lt;<a href='#zoom/pan-options'>Zoom/pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the view of the map (geographical center and zoom) with the given
 animation options.</p>
 </td>
 	</tr>
-	<tr id='map-setzoom'>
+	<tr id='leafletmap-setzoom'>
 		<td><code><b>setZoom</b>(<nobr>&lt;Number&gt;</nobr> <i>zoom</i>, <nobr>&lt;<a href='#zoom/pan-options'>Zoom/pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the zoom of the map.</p>
 </td>
 	</tr>
-	<tr id='map-zoomin'>
+	<tr id='leafletmap-zoomin'>
 		<td><code><b>zoomIn</b>(<nobr>&lt;Number&gt;</nobr> <i>delta?</i>, <nobr>&lt;<a href='#zoom-options'>Zoom options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Increases the zoom of the map by <code>delta</code> (<a href="#map-zoomdelta"><code>zoomDelta</code></a> by default).</p>
 </td>
 	</tr>
-	<tr id='map-zoomout'>
+	<tr id='leafletmap-zoomout'>
 		<td><code><b>zoomOut</b>(<nobr>&lt;Number&gt;</nobr> <i>delta?</i>, <nobr>&lt;<a href='#zoom-options'>Zoom options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Decreases the zoom of the map by <code>delta</code> (<a href="#map-zoomdelta"><code>zoomDelta</code></a> by default).</p>
 </td>
 	</tr>
-	<tr id='map-setzoomaround'>
+	<tr id='leafletmap-setzoomaround'>
 		<td><code><b>setZoomAround</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom</i>, <nobr>&lt;<a href='#zoom-options'>Zoom options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Zooms the map while keeping a specified geographical point on the map
 stationary (e.g. used internally for scroll zoom and double-click zoom).</p>
 </td>
 	</tr>
-	<tr id='map-setzoomaround'>
+	<tr id='leafletmap-setzoomaround'>
 		<td><code><b>setZoomAround</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>offset</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom</i>, <nobr>&lt;<a href='#zoom-options'>Zoom options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Zooms the map while keeping a specified pixel on the map (relative to the top-left corner) stationary.</p>
 </td>
 	</tr>
-	<tr id='map-fitbounds'>
+	<tr id='leafletmap-fitbounds'>
 		<td><code><b>fitBounds</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>, <nobr>&lt;<a href='#fitbounds-options'>fitBounds options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets a map view that contains the given geographical bounds with the
 maximum zoom level possible.</p>
 </td>
 	</tr>
-	<tr id='map-fitworld'>
+	<tr id='leafletmap-fitworld'>
 		<td><code><b>fitWorld</b>(<nobr>&lt;<a href='#fitbounds-options'>fitBounds options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets a map view that mostly contains the whole world with the maximum
 zoom level possible.</p>
 </td>
 	</tr>
-	<tr id='map-panto'>
+	<tr id='leafletmap-panto'>
 		<td><code><b>panTo</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#pan-options'>Pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Pans the map to a given center.</p>
 </td>
 	</tr>
-	<tr id='map-panby'>
+	<tr id='leafletmap-panby'>
 		<td><code><b>panBy</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>offset</i>, <nobr>&lt;<a href='#pan-options'>Pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Pans the map by a given number of pixels (animated).</p>
 </td>
 	</tr>
-	<tr id='map-flyto'>
+	<tr id='leafletmap-flyto'>
 		<td><code><b>flyTo</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom?</i>, <nobr>&lt;<a href='#zoom/pan-options'>Zoom/pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the view of the map (geographical center and zoom) performing a smooth
 pan-zoom animation.</p>
 </td>
 	</tr>
-	<tr id='map-flytobounds'>
+	<tr id='leafletmap-flytobounds'>
 		<td><code><b>flyToBounds</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>, <nobr>&lt;<a href='#fitbounds-options'>fitBounds options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the view of the map with a smooth animation like <a href="#map-flyto"><code>flyTo</code></a>,
 but takes a bounds parameter like <a href="#map-fitbounds"><code>fitBounds</code></a>.</p>
 </td>
 	</tr>
-	<tr id='map-setmaxbounds'>
+	<tr id='leafletmap-setmaxbounds'>
 		<td><code><b>setMaxBounds</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Restricts the map view to the given bounds (see the <a href="#map-maxbounds">maxBounds</a> option).</p>
 </td>
 	</tr>
-	<tr id='map-setminzoom'>
+	<tr id='leafletmap-setminzoom'>
 		<td><code><b>setMinZoom</b>(<nobr>&lt;Number&gt;</nobr> <i>zoom</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the lower limit for the available zoom levels (see the <a href="#map-minzoom">minZoom</a> option).</p>
 </td>
 	</tr>
-	<tr id='map-setmaxzoom'>
+	<tr id='leafletmap-setmaxzoom'>
 		<td><code><b>setMaxZoom</b>(<nobr>&lt;Number&gt;</nobr> <i>zoom</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the upper limit for the available zoom levels (see the <a href="#map-maxzoom">maxZoom</a> option).</p>
 </td>
 	</tr>
-	<tr id='map-paninsidebounds'>
+	<tr id='leafletmap-paninsidebounds'>
 		<td><code><b>panInsideBounds</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>, <nobr>&lt;<a href='#pan-options'>Pan options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Pans the map to the closest view that would lie inside the given bounds (if it's not already), controlling the animation using the options specific, if any.</p>
 </td>
 	</tr>
-	<tr id='map-paninside'>
+	<tr id='leafletmap-paninside'>
 		<td><code><b>panInside</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;<a href='#padding-options'>padding options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Pans the map the minimum amount to make the <code>latlng</code> visible. Use
@@ -1145,7 +1138,7 @@ If <code>latlng</code> is already within the (optionally padded) display bounds,
 the map will not be panned.</p>
 </td>
 	</tr>
-	<tr id='map-invalidatesize'>
+	<tr id='leafletmap-invalidatesize'>
 		<td><code><b>invalidateSize</b>(<nobr>&lt;<a href='#invalidatesize-options'>invalidateSize options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Checks if the map container size changed and updates the map if so —
@@ -1156,7 +1149,7 @@ that it doesn't happen often even if the method is called many
 times in a row.</p>
 </td>
 	</tr>
-	<tr id='map-invalidatesize'>
+	<tr id='leafletmap-invalidatesize'>
 		<td><code><b>invalidateSize</b>(<nobr>&lt;Boolean&gt;</nobr> <i>animate</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Checks if the map container size changed and updates the map if so —
@@ -1164,7 +1157,7 @@ call it after you've changed the map size dynamically, also animating
 pan by default.</p>
 </td>
 	</tr>
-	<tr id='map-stop'>
+	<tr id='leafletmap-stop'>
 		<td><code><b>stop</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Stops the currently running <code>panTo</code> or <code>flyTo</code> animation, if any.</p>
@@ -1174,7 +1167,7 @@ pan by default.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-geolocation-methods'>Geolocation methods</h4>
+<h4 id='leafletmap-geolocation-methods'>Geolocation methods</h4>
 
 
 <table><thead>
@@ -1184,7 +1177,7 @@ pan by default.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-locate'>
+	<tr id='leafletmap-locate'>
 		<td><code><b>locate</b>(<nobr>&lt;<a href='#locate-options'>Locate options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Tries to locate the user using the Geolocation API, firing a <a href="#map-locationfound"><code>locationfound</code></a>
@@ -1196,7 +1189,7 @@ modern browsers (<a href="https://sites.google.com/a/chromium.org/dev/Home/chrom
 See <a href="#locate-options"><code>Locate options</code></a> for more details.</p>
 </td>
 	</tr>
-	<tr id='map-stoplocate'>
+	<tr id='leafletmap-stoplocate'>
 		<td><code><b>stopLocate</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Stops watching location previously initiated by <code>map.locate({watch: true})</code>
@@ -1208,7 +1201,7 @@ and aborts resetting the map view if map.locate was called with
 
 </section><section class='collapsable'>
 
-<h4 id='map-other-methods'>Other Methods</h4>
+<h4 id='leafletmap-other-methods'>Other Methods</h4>
 
 
 <table><thead>
@@ -1218,19 +1211,19 @@ and aborts resetting the map view if map.locate was called with
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-addhandler'>
+	<tr id='leafletmap-addhandler'>
 		<td><code><b>addHandler</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>, <nobr>&lt;Function&gt;</nobr> <i>HandlerClass</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a new <a href="#handler"><code>Handler</code></a> to the map, given its name and constructor function.</p>
 </td>
 	</tr>
-	<tr id='map-remove'>
+	<tr id='leafletmap-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Destroys the map and clears all related event listeners.</p>
 </td>
 	</tr>
-	<tr id='map-createpane'>
+	<tr id='leafletmap-createpane'>
 		<td><code><b>createPane</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>, <nobr>&lt;HTMLElement&gt;</nobr> <i>container?</i>)</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Creates a new <a href="#map-pane">map pane</a> with the given name if it doesn't exist already,
@@ -1238,26 +1231,26 @@ then returns it. The pane is created as a child of <code>container</code>, or
 as a child of the main map pane if not set.</p>
 </td>
 	</tr>
-	<tr id='map-getpane'>
+	<tr id='leafletmap-getpane'>
 		<td><code><b>getPane</b>(<nobr>&lt;String|HTMLElement&gt;</nobr> <i>pane</i>)</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns a <a href="#map-pane">map pane</a>, given its name or its HTML element (its identity).</p>
 </td>
 	</tr>
-	<tr id='map-getpanes'>
+	<tr id='leafletmap-getpanes'>
 		<td><code><b>getPanes</b>()</code></td>
 		<td><code>Object</code></td>
 		<td><p>Returns a plain object containing the names of all <a href="#map-pane">panes</a> as keys and
 the panes as values.</p>
 </td>
 	</tr>
-	<tr id='map-getcontainer'>
+	<tr id='leafletmap-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTML element that contains the map.</p>
 </td>
 	</tr>
-	<tr id='map-whenready'>
+	<tr id='leafletmap-whenready'>
 		<td><code><b>whenReady</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Runs the given function <code>fn</code> when the map gets initialized with
@@ -1269,7 +1262,7 @@ if it's already initialized, optionally passing a function context.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-methods-for-getting-map-state'>Methods for Getting Map State</h4>
+<h4 id='leafletmap-methods-for-getting-map-state'>Methods for Getting Map State</h4>
 
 
 <table><thead>
@@ -1279,37 +1272,37 @@ if it's already initialized, optionally passing a function context.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-getcenter'>
+	<tr id='leafletmap-getcenter'>
 		<td><code><b>getCenter</b>()</code></td>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>Returns the geographical center of the map view</p>
 </td>
 	</tr>
-	<tr id='map-getzoom'>
+	<tr id='leafletmap-getzoom'>
 		<td><code><b>getZoom</b>()</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the current zoom level of the map view</p>
 </td>
 	</tr>
-	<tr id='map-getbounds'>
+	<tr id='leafletmap-getbounds'>
 		<td><code><b>getBounds</b>()</code></td>
 		<td><code><a href='#latlngbounds'>LatLngBounds</a></code></td>
 		<td><p>Returns the geographical bounds visible in the current map view</p>
 </td>
 	</tr>
-	<tr id='map-getminzoom'>
+	<tr id='leafletmap-getminzoom'>
 		<td><code><b>getMinZoom</b>()</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the minimum zoom level of the map (if set in the <code>minZoom</code> option of the map or of any layers), or <code>0</code> by default.</p>
 </td>
 	</tr>
-	<tr id='map-getmaxzoom'>
+	<tr id='leafletmap-getmaxzoom'>
 		<td><code><b>getMaxZoom</b>()</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the maximum zoom level of the map (if set in the <code>maxZoom</code> option of the map or of any layers).</p>
 </td>
 	</tr>
-	<tr id='map-getboundszoom'>
+	<tr id='leafletmap-getboundszoom'>
 		<td><code><b>getBoundsZoom</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>, <nobr>&lt;Boolean&gt;</nobr> <i>inside?</i>, <nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>padding?</i>)</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the maximum zoom level on which the given bounds fit to the map
@@ -1318,13 +1311,13 @@ instead returns the minimum zoom level on which the map view fits into
 the given bounds in its entirety.</p>
 </td>
 	</tr>
-	<tr id='map-getsize'>
+	<tr id='leafletmap-getsize'>
 		<td><code><b>getSize</b>()</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Returns the current size of the map container (in pixels).</p>
 </td>
 	</tr>
-	<tr id='map-getpixelbounds'>
+	<tr id='leafletmap-getpixelbounds'>
 		<td><code><b>getPixelBounds</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>center?</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom?</i>)</code></td>
 		<td><code><a href='#bounds'>Bounds</a></code></td>
 		<td><p>Returns the bounds of the current map view in projected pixel
@@ -1332,14 +1325,14 @@ coordinates (sometimes useful in layer and overlay implementations).
 If <code>center</code> and <code>zoom</code> is omitted, the map's current zoom level and center is used.</p>
 </td>
 	</tr>
-	<tr id='map-getpixelorigin'>
+	<tr id='leafletmap-getpixelorigin'>
 		<td><code><b>getPixelOrigin</b>()</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Returns the projected pixel coordinates of the top left point of
 the map layer (useful in custom layer and overlay implementations).</p>
 </td>
 	</tr>
-	<tr id='map-getpixelworldbounds'>
+	<tr id='leafletmap-getpixelworldbounds'>
 		<td><code><b>getPixelWorldBounds</b>(<nobr>&lt;Number&gt;</nobr> <i>zoom?</i>)</code></td>
 		<td><code><a href='#bounds'>Bounds</a></code></td>
 		<td><p>Returns the world's bounds in pixel coordinates for zoom level <code>zoom</code>.
@@ -1350,7 +1343,7 @@ If <code>zoom</code> is omitted, the map's current zoom level is used.</p>
 
 </section><section class='collapsable'>
 
-<h4 id='map-conversion-methods'>Conversion Methods</h4>
+<h4 id='leafletmap-conversion-methods'>Conversion Methods</h4>
 
 
 <table><thead>
@@ -1360,14 +1353,14 @@ If <code>zoom</code> is omitted, the map's current zoom level is used.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-getzoomscale'>
+	<tr id='leafletmap-getzoomscale'>
 		<td><code><b>getZoomScale</b>(<nobr>&lt;Number&gt;</nobr> <i>toZoom</i>, <nobr>&lt;Number&gt;</nobr> <i>fromZoom?</i>)</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the scale factor to be applied to a map transition from zoom level
 <code>fromZoom</code> to <code>toZoom</code>. Used internally to help with zoom animations.</p>
 </td>
 	</tr>
-	<tr id='map-getscalezoom'>
+	<tr id='leafletmap-getscalezoom'>
 		<td><code><b>getScaleZoom</b>(<nobr>&lt;Number&gt;</nobr> <i>scale</i>, <nobr>&lt;Number&gt;</nobr> <i>fromZoom?</i>)</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the zoom level that the map would end up at, if it is at <code>fromZoom</code>
@@ -1375,7 +1368,7 @@ level and everything is scaled by a factor of <code>scale</code>. Inverse of
 <a href="#map-getZoomScale"><code>getZoomScale</code></a>.</p>
 </td>
 	</tr>
-	<tr id='map-project'>
+	<tr id='leafletmap-project'>
 		<td><code><b>project</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom?</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Projects a geographical coordinate <a href="#latlng"><code>LatLng</code></a> according to the projection
@@ -1384,27 +1377,27 @@ of the map's CRS, then scales it according to <code>zoom</code> and the CRS's
 the CRS origin.</p>
 </td>
 	</tr>
-	<tr id='map-unproject'>
+	<tr id='leafletmap-unproject'>
 		<td><code><b>unproject</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>point</i>, <nobr>&lt;Number&gt;</nobr> <i>zoom?</i>)</code></td>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>Inverse of <a href="#map-project"><code>project</code></a>.</p>
 </td>
 	</tr>
-	<tr id='map-layerpointtolatlng'>
+	<tr id='leafletmap-layerpointtolatlng'>
 		<td><code><b>layerPointToLatLng</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>point</i>)</code></td>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>Given a pixel coordinate relative to the <a href="#map-getpixelorigin">origin pixel</a>,
 returns the corresponding geographical coordinate (for the current zoom level).</p>
 </td>
 	</tr>
-	<tr id='map-latlngtolayerpoint'>
+	<tr id='leafletmap-latlngtolayerpoint'>
 		<td><code><b>latLngToLayerPoint</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a geographical coordinate, returns the corresponding pixel coordinate
 relative to the <a href="#map-getpixelorigin">origin pixel</a>.</p>
 </td>
 	</tr>
-	<tr id='map-wraplatlng'>
+	<tr id='leafletmap-wraplatlng'>
 		<td><code><b>wrapLatLng</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>)</code></td>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>Returns a <a href="#latlng"><code>LatLng</code></a> where <code>lat</code> and <code>lng</code> has been wrapped according to the
@@ -1414,7 +1407,7 @@ By default this means longitude is wrapped around the dateline so its
 value is between -180 and +180 degrees.</p>
 </td>
 	</tr>
-	<tr id='map-wraplatlngbounds'>
+	<tr id='leafletmap-wraplatlngbounds'>
 		<td><code><b>wrapLatLngBounds</b>(<nobr>&lt;<a href='#latlngbounds'>LatLngBounds</a>&gt;</nobr> <i>bounds</i>)</code></td>
 		<td><code><a href='#latlngbounds'>LatLngBounds</a></code></td>
 		<td><p>Returns a <a href="#latlngbounds"><code>LatLngBounds</code></a> with the same size as the given one, ensuring that
@@ -1424,54 +1417,59 @@ value is between -180 and +180 degrees, and the majority of the bounds
 overlaps the CRS's bounds.</p>
 </td>
 	</tr>
-	<tr id='map-distance'>
+	<tr id='leafletmap-distance'>
 		<td><code><b>distance</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng1</i>, <nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng2</i>)</code></td>
 		<td><code>Number</code></td>
 		<td><p>Returns the distance between two geographical coordinates according to
 the map's CRS. By default this measures distance in meters.</p>
 </td>
 	</tr>
-	<tr id='map-containerpointtolayerpoint'>
+	<tr id='leafletmap-containerpointtolayerpoint'>
 		<td><code><b>containerPointToLayerPoint</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>point</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a pixel coordinate relative to the map container, returns the corresponding
 pixel coordinate relative to the <a href="#map-getpixelorigin">origin pixel</a>.</p>
 </td>
 	</tr>
-	<tr id='map-layerpointtocontainerpoint'>
+	<tr id='leafletmap-layerpointtocontainerpoint'>
 		<td><code><b>layerPointToContainerPoint</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>point</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a pixel coordinate relative to the <a href="#map-getpixelorigin">origin pixel</a>,
 returns the corresponding pixel coordinate relative to the map container.</p>
 </td>
 	</tr>
-	<tr id='map-containerpointtolatlng'>
+	<tr id='leafletmap-containerpointtolatlng'>
 		<td><code><b>containerPointToLatLng</b>(<nobr>&lt;<a href='#point'>Point</a>&gt;</nobr> <i>point</i>)</code></td>
 		<td><code><a href='#latlng'>LatLng</a></code></td>
 		<td><p>Given a pixel coordinate relative to the map container, returns
 the corresponding geographical coordinate (for the current zoom level).</p>
 </td>
 	</tr>
-	<tr id='map-latlngtocontainerpoint'>
+	<tr id='leafletmap-latlngtocontainerpoint'>
 		<td><code><b>latLngToContainerPoint</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a geographical coordinate, returns the corresponding pixel coordinate
 relative to the map container.</p>
 </td>
 	</tr>
-	<tr id='map-pointereventtocontainerpoint'>
+	<tr id='leafletmap-pointereventtocontainerpoint'>
 		<td><code><b>pointerEventToContainerPoint</b>(<nobr>&lt;<a href='#pointerevent'>PointerEvent</a>&gt;</nobr> <i>ev</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a PointerEvent object, returns the pixel coordinate relative to the
 map container where the event took place.</p>
 </td>
 	</tr>
-	<tr id='map-pointereventtolayerpoint'>
+	<tr id='leafletmap-pointereventtolayerpoint'>
 		<td><code><b>pointerEventToLayerPoint</b>(<nobr>&lt;<a href='#pointerevent'>PointerEvent</a>&gt;</nobr> <i>ev</i>)</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Given a PointerEvent object, returns the pixel coordinate relative to
-the <a href="#map-getpixelorigin">origin pixel</a> where the event took place.
-Given a PointerEvent object, returns geographical coordinate where the
+the <a href="#map-getpixelorigin">origin pixel</a> where the event took place.</p>
+</td>
+	</tr>
+	<tr id='leafletmap-pointereventtolatlng'>
+		<td><code><b>pointerEventToLatLng</b>(<nobr>&lt;<a href='#pointerevent'>PointerEvent</a>&gt;</nobr> <i>ev</i>)</code></td>
+		<td><code><a href='#latlng'>LatLng</a></code></td>
+		<td><p>Given a PointerEvent object, returns geographical coordinate where the
 event took place.</p>
 </td>
 	</tr>
@@ -1495,37 +1493,37 @@ event took place.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-on'>
+	<tr id='leafletmap-on'>
 		<td><code><b>on</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a listener function (<code>fn</code>) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. <code>'click dblclick'</code>).</p>
 </td>
 	</tr>
-	<tr id='map-on'>
+	<tr id='leafletmap-on'>
 		<td><code><b>on</b>(<nobr>&lt;Object&gt;</nobr> <i>eventMap</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a set of type/listener pairs, e.g. <code>{click: onClick, pointermove: onPointerMove}</code></p>
 </td>
 	</tr>
-	<tr id='map-off'>
+	<tr id='leafletmap-off'>
 		<td><code><b>off</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Function&gt;</nobr> <i>fn?</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes a previously added listener function. If no function is specified, it will remove all the listeners of that particular event from the object. Note that if you passed a custom context to <code>on</code>, you must pass the same context to <code>off</code> in order to remove the listener.</p>
 </td>
 	</tr>
-	<tr id='map-off'>
+	<tr id='leafletmap-off'>
 		<td><code><b>off</b>(<nobr>&lt;Object&gt;</nobr> <i>eventMap</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes a set of type/listener pairs.</p>
 </td>
 	</tr>
-	<tr id='map-off'>
+	<tr id='leafletmap-off'>
 		<td><code><b>off</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes all listeners to all events on the object. This includes implicitly attached events.</p>
 </td>
 	</tr>
-	<tr id='map-fire'>
+	<tr id='leafletmap-fire'>
 		<td><code><b>fire</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Object&gt;</nobr> <i>data?</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Fires an event of the specified type. You can optionally provide a data
@@ -1533,26 +1531,26 @@ object — the first argument of the listener function will contain its
 properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
-	<tr id='map-listens'>
+	<tr id='leafletmap-listens'>
 		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
 		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.
 The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
-	<tr id='map-once'>
+	<tr id='leafletmap-once'>
 		<td><code><b>once</b>(<i>…</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Behaves as <a href="#evented-on"><code>on(…)</code></a>, except the listener will only get fired once and then removed.</p>
 </td>
 	</tr>
-	<tr id='map-addeventparent'>
+	<tr id='leafletmap-addeventparent'>
 		<td><code><b>addEventParent</b>(<nobr>&lt;<a href='#evented'>Evented</a>&gt;</nobr> <i>obj</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds an event parent - an <a href="#evented"><code>Evented</code></a> that will receive propagated events</p>
 </td>
 	</tr>
-	<tr id='map-removeeventparent'>
+	<tr id='leafletmap-removeeventparent'>
 		<td><code><b>removeEventParent</b>(<nobr>&lt;<a href='#evented'>Evented</a>&gt;</nobr> <i>obj</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes an event parent, so it will stop receiving propagated events</p>
@@ -1565,11 +1563,11 @@ The verification can optionally be propagated, it will return <code>true</code> 
 </div>
 
 </section><section>
-<h3 id='map-property'>Properties</h3>
+<h3 id='leafletmap-property'>Properties</h3>
 
 <section class='collapsable'>
 
-<h4 id='map-controls'>Controls</h4>
+<h4 id='leafletmap-controls'>Controls</h4>
 
 
 <table><thead>
@@ -1579,9 +1577,9 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-zoomcontrol'>
+	<tr id='leafletmap-zoomcontrol'>
 		<td><code><b>zoomControl</b></code></td>
-		<td><code><a href='#control-zoom'>Control.Zoom</a></code></td>
+		<td><code><a href='#zoomcontrol'>ZoomControl</a></code></td>
 		<td>The default zoom control (only available if the
 <a href="#map-zoomcontrol"><code>zoomControl</code> option</a> was <code>true</code> when creating the map).</td>
 	</tr>
@@ -1589,7 +1587,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 </section><section class='collapsable'>
 
-<h4 id='map-handlers'>Handlers</h4>
+<h4 id='leafletmap-handlers'>Handlers</h4>
 
 
 <table><thead>
@@ -1599,37 +1597,37 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-boxzoom'>
+	<tr id='leafletmap-boxzoom'>
 		<td><code><b>boxZoom</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Box (shift-drag with pointer) zoom handler.</td>
 	</tr>
-	<tr id='map-doubleclickzoom'>
+	<tr id='leafletmap-doubleclickzoom'>
 		<td><code><b>doubleClickZoom</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Double click zoom handler.</td>
 	</tr>
-	<tr id='map-dragging'>
+	<tr id='leafletmap-dragging'>
 		<td><code><b>dragging</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Map dragging handler.</td>
 	</tr>
-	<tr id='map-keyboard'>
+	<tr id='leafletmap-keyboard'>
 		<td><code><b>keyboard</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Keyboard navigation handler.</td>
 	</tr>
-	<tr id='map-pinchzoom'>
+	<tr id='leafletmap-pinchzoom'>
 		<td><code><b>pinchZoom</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Pinch zoom handler.</td>
 	</tr>
-	<tr id='map-scrollwheelzoom'>
+	<tr id='leafletmap-scrollwheelzoom'>
 		<td><code><b>scrollWheelZoom</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Scroll wheel zoom handler.</td>
 	</tr>
-	<tr id='map-taphold'>
+	<tr id='leafletmap-taphold'>
 		<td><code><b>tapHold</b></code></td>
 		<td><code><a href='#handler'>Handler</a></code></td>
 		<td>Long tap handler to simulate <code>contextmenu</code> event (useful in mobile Safari).</td>
@@ -1640,7 +1638,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 </section><section>
-<h3 id='map-pane'>Map panes</h3>
+<h3 id='leafletmap-pane'>Map panes</h3>
 
 <section >
 
@@ -1660,204 +1658,47 @@ can access panes with <a href="#map-getpane"><code>map.getPane</code></a> or
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='map-mappane'>
+	<tr id='leafletmap-mappane'>
 		<td><code><b>mapPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>&#x27;auto&#x27;</code></td>
 		<td>Pane that contains all other map panes</td>
 	</tr>
-	<tr id='map-tilepane'>
+	<tr id='leafletmap-tilepane'>
 		<td><code><b>tilePane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>200</code></td>
 		<td>Pane for <a href="#gridlayer"><code>GridLayer</code></a>s and <a href="#tilelayer"><code>TileLayer</code></a>s</td>
 	</tr>
-	<tr id='map-overlaypane'>
+	<tr id='leafletmap-overlaypane'>
 		<td><code><b>overlayPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>400</code></td>
 		<td>Pane for vectors (<a href="#path"><code>Path</code></a>s, like <a href="#polyline"><code>Polyline</code></a>s and <a href="#polygon"><code>Polygon</code></a>s), <a href="#imageoverlay"><code>ImageOverlay</code></a>s and <a href="#videooverlay"><code>VideoOverlay</code></a>s</td>
 	</tr>
-	<tr id='map-shadowpane'>
+	<tr id='leafletmap-shadowpane'>
 		<td><code><b>shadowPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>500</code></td>
 		<td>Pane for overlay shadows (e.g. <a href="#marker"><code>Marker</code></a> shadows)</td>
 	</tr>
-	<tr id='map-markerpane'>
+	<tr id='leafletmap-markerpane'>
 		<td><code><b>markerPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>600</code></td>
 		<td>Pane for <a href="#icon"><code>Icon</code></a>s of <a href="#marker"><code>Marker</code></a>s</td>
 	</tr>
-	<tr id='map-tooltippane'>
+	<tr id='leafletmap-tooltippane'>
 		<td><code><b>tooltipPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>650</code></td>
 		<td>Pane for <a href="#tooltip"><code>Tooltip</code></a>s.</td>
 	</tr>
-	<tr id='map-popuppane'>
+	<tr id='leafletmap-popuppane'>
 		<td><code><b>popupPane</b></code></td>
 		<td><code>HTMLElement</code></td>
 		<td><code>700</code></td>
 		<td>Pane for <a href="#popup"><code>Popup</code></a>s.</td>
-	</tr>
-</tbody></table>
-
-</section>
-
-
-</section><span id='locate-options'></span>
-
-<section>
-<h3 id='locate-options-option'>Locate options</h3>
-
-<section >
-
-
-
-<div class='section-comments'>Some of the geolocation methods for <a href="#map"><code>Map</code></a> take in an <code>options</code> parameter. This
-is a plain javascript object with the following optional components:</div>
-
-<table><thead>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='locate-options-watch'>
-		<td><code><b>watch</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>false</code></td>
-		<td>If <code>true</code>, starts continuous watching of location changes (instead of detecting it
-once) using W3C <code>watchPosition</code> method. You can later stop watching using
-<code>map.stopLocate()</code> method.</td>
-	</tr>
-	<tr id='locate-options-setview'>
-		<td><code><b>setView</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>false</code></td>
-		<td>If <code>true</code>, automatically sets the map view to the user location with respect to
-detection accuracy, or to world view if geolocation failed.</td>
-	</tr>
-	<tr id='locate-options-maxzoom'>
-		<td><code><b>maxZoom</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>Infinity</code></td>
-		<td>The maximum zoom for automatic view setting when using <code>setView</code> option.</td>
-	</tr>
-	<tr id='locate-options-timeout'>
-		<td><code><b>timeout</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>10000</code></td>
-		<td>Number of milliseconds to wait for a response from geolocation before firing a
-<code>locationerror</code> event.</td>
-	</tr>
-	<tr id='locate-options-maximumage'>
-		<td><code><b>maximumAge</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>0</code></td>
-		<td>Maximum age of detected location. If less than this amount of milliseconds
-passed since last geolocation response, <code>locate</code> will return a cached location.</td>
-	</tr>
-	<tr id='locate-options-enablehighaccuracy'>
-		<td><code><b>enableHighAccuracy</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>false</code></td>
-		<td>Enables high accuracy, see <a href="https://w3c.github.io/geolocation-api/#enablehighaccuracy-member">description in the W3C spec</a>.</td>
-	</tr>
-</tbody></table>
-
-</section>
-
-
-</section><span id='zoom-options'></span>
-
-<section>
-<h3 id='zoom-options-option'>Zoom options</h3>
-
-<section >
-
-
-
-<div class='section-comments'>Some of the <a href="#map"><code>Map</code></a> methods which modify the zoom level take in an <code>options</code>
-parameter. This is a plain javascript object with the following optional
-components:</div>
-
-<table><thead>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='zoom-options-animate'>
-		<td><code><b>animate</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code></code></td>
-		<td>If not specified, zoom animation will happen if the zoom origin is inside the
-current view. If <code>true</code>, the map will attempt animating zoom disregarding where
-zoom origin is. Setting <code>false</code> will make it always reset the view completely
-without animation.</td>
-	</tr>
-</tbody></table>
-
-</section>
-
-
-</section><span id='pan-options'></span>
-
-<section>
-<h3 id='pan-options-option'>Pan options</h3>
-
-<section >
-
-
-
-<div class='section-comments'>Some of the <a href="#map"><code>Map</code></a> methods which modify the center of the map take in an <code>options</code>
-parameter. This is a plain javascript object with the following optional
-components:</div>
-
-<table><thead>
-	<tr>
-		<th>Option</th>
-		<th>Type</th>
-		<th>Default</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='pan-options-animate'>
-		<td><code><b>animate</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code></code></td>
-		<td>If <code>true</code>, panning will always be animated if possible. If <code>false</code>, it will
-not animate panning, either resetting the map view if panning more than a
-screen away, or just setting a new offset for the map pane (except for <code>panBy</code>
-which always does the latter).</td>
-	</tr>
-	<tr id='pan-options-duration'>
-		<td><code><b>duration</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>0.25</code></td>
-		<td>Duration of animated panning, in seconds.</td>
-	</tr>
-	<tr id='pan-options-easelinearity'>
-		<td><code><b>easeLinearity</b></code></td>
-		<td><code>Number</code></td>
-		<td><code>0.25</code></td>
-		<td>The curvature factor of panning animation easing (third parameter of the
-<a href="https://cubic-bezier.com/">Cubic Bezier curve</a>). 1.0 means linear animation,
-and the smaller this number, the more bowed the curve.</td>
-	</tr>
-	<tr id='pan-options-nomovestart'>
-		<td><code><b>noMoveStart</b></code></td>
-		<td><code>Boolean</code></td>
-		<td><code>false</code></td>
-		<td>If <code>true</code>, panning won't fire <code>movestart</code> event on start (used internally for
-panning inertia).</td>
 	</tr>
 </tbody></table>
 
@@ -2311,7 +2152,7 @@ to obscure objects you're zooming to.</td>
 		<td><code>*</code></td>
 		<td>Icon instance to use for rendering the marker.
 See <a href="#icon">Icon documentation</a> for details on how to customize the marker icon.
-If not specified, a common instance of <a href="#icon-default"><code>Icon.Default</code></a> is used.</td>
+If not specified, a common instance of <a href="#defaulticon"><code>DefaultIcon</code></a> is used.</td>
 	</tr>
 	<tr id='marker-keyboard'>
 		<td><code><b>keyboard</b></code></td>
@@ -2802,7 +2643,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	</tr>
 	</thead><tbody>
 	<tr id='marker-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -2814,7 +2655,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 </td>
 	</tr>
 	<tr id='marker-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -2863,10 +2704,10 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindpopup'>
@@ -2938,10 +2779,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='marker-unbindtooltip'>
@@ -3410,7 +3251,7 @@ for a second (also called long press).</td>
 	</tr>
 	</thead><tbody>
 	<tr id='divoverlay-openon'>
-		<td><code><b>openOn</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>openOn</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the overlay to the map.
 Alternative to <code>map.openPopup(popup)</code>/<code>.openTooltip(tooltip)</code>.</p>
@@ -3454,8 +3295,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
-or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+HTML; if it may contain untrusted input, sanitize it before passing it to
+Leaflet, or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
@@ -3511,7 +3352,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	</tr>
 	</thead><tbody>
 	<tr id='divoverlay-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -3523,7 +3364,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 </td>
 	</tr>
 	<tr id='divoverlay-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -3572,10 +3413,10 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindpopup'>
@@ -3647,10 +3488,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-unbindtooltip'>
@@ -3813,7 +3654,10 @@ open popups while making sure that only one popup is open at one time
 <pre><code class="language-js">const popup = new Popup(latlng, {content: '&lt;p&gt;Hello world!&lt;br /&gt;This is a nice popup.&lt;/p&gt;'})
 	.openOn(map);
 </code></pre>
-<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<p><strong>Security note.</strong> Popup string content is rendered as HTML. If your content
+may include untrusted input (e.g. data from users or external APIs), sanitize
+it before passing it to Leaflet, or build a DOM element using <code>textContent</code>
+to render it as plain text:</p>
 <pre><code class="language-js">const el = document.createElement('div');
 el.textContent = untrustedString;
 marker.bindPopup(el);
@@ -4279,7 +4123,7 @@ for a second (also called long press).</td>
 	</tr>
 	</thead><tbody>
 	<tr id='popup-openon'>
-		<td><code><b>openOn</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>openOn</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Alternative to <code>map.openPopup(popup)</code>.
 Adds the popup to the map and closes the previous one.</p>
@@ -4343,8 +4187,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
-or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+HTML; if it may contain untrusted input, sanitize it before passing it to
+Leaflet, or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
@@ -4401,7 +4245,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	</tr>
 	</thead><tbody>
 	<tr id='popup-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -4413,7 +4257,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 </td>
 	</tr>
 	<tr id='popup-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -4462,10 +4306,10 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindpopup'>
@@ -4537,10 +4381,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='popup-unbindtooltip'>
@@ -4701,7 +4545,10 @@ The verification can optionally be propagated, it will return <code>true</code> 
 <pre><code class="language-js">const tooltip = new Tooltip(latlng, {content: 'Hello world!&lt;br /&gt;This is a nice tooltip.'})
 	.addTo(map);
 </code></pre>
-<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content may include untrusted input (e.g. data from users or external APIs), sanitize it with a library like <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, or build a DOM element using <code>textContent</code> to render it as plain text:</p>
+<p><strong>Security note.</strong> Tooltip string content is rendered as HTML. If your content
+may include untrusted input (e.g. data from users or external APIs), sanitize
+it before passing it to Leaflet, or build a DOM element using <code>textContent</code>
+to render it as plain text:</p>
 <pre><code class="language-js">const el = document.createElement('div');
 el.textContent = untrustedString;
 marker.bindTooltip(el);
@@ -5114,7 +4961,7 @@ for a second (also called long press).</td>
 	</tr>
 	</thead><tbody>
 	<tr id='tooltip-openon'>
-		<td><code><b>openOn</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>openOn</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the overlay to the map.
 Alternative to <code>map.openPopup(popup)</code>/<code>.openTooltip(tooltip)</code>.</p>
@@ -5158,8 +5005,8 @@ Alternative to <code>layer.togglePopup()</code>/<code>.toggleTooltip()</code>.</
 		<td><code><b>setContent</b>(<nobr>&lt;String|HTMLElement|Function&gt;</nobr> <i>htmlContent</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the HTML content of the overlay. A <code>String</code> argument is rendered as
-HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
-or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
+HTML; if it may contain untrusted input, sanitize it before passing it to
+Leaflet, or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a function is
 passed the source layer will be passed to the function. The function should
 return a <code>String</code> or <code>HTMLElement</code> to be used in the overlay.</p>
 </td>
@@ -5216,7 +5063,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	</tr>
 	</thead><tbody>
 	<tr id='tooltip-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -5228,7 +5075,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 </td>
 	</tr>
 	<tr id='tooltip-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -5277,10 +5124,10 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindpopup'>
@@ -5352,10 +5199,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tooltip-unbindtooltip'>
@@ -5624,13 +5471,12 @@ Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_setting
 	</tr>
 	<tr id='tilelayer-referrerpolicy'>
 		<td><code><b>referrerPolicy</b></code></td>
-		<td><code>Boolean|String</code></td>
-		<td><code>false</code></td>
-		<td>Whether the referrerPolicy attribute will be added to the tiles.
-If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
-This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
-(e.g. to validate an API token).
-Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy">HTMLImageElement.referrerPolicy</a> for valid String values.</td>
+		<td><code>String</code></td>
+		<td><code>&#x27;strict-origin-when-cross-origin&#x27;</code></td>
+		<td>Sets the tiles' <code>referrerPolicy</code> attribute set to the String provided. See
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy"><code>HTMLImageElement.referrerPolicy</code></a> for possible values.
+<p>Tile providers might require you to use a specific referrer policy (e.g. to verify API tokens or prevent abuse).
+Specifically, if you are using tiles from <code>tile.openstreetmap.org</code> or <code>tile.osm.org</code>, you <a href="https://operations.osmfoundation.org/policies/tiles/">should not change this value</a>.</p></td>
 	</tr>
 </tbody></table>
 
@@ -6088,7 +5934,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 	</tr>
 	</thead><tbody>
 	<tr id='tilelayer-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -6100,7 +5946,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 </td>
 	</tr>
 	<tr id='tilelayer-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -6149,10 +5995,10 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindpopup'>
@@ -6224,10 +6070,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-unbindtooltip'>
@@ -6363,10 +6209,10 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
-</section><h2 id='tilelayer-wms'>TileLayer.WMS</h2><p>Used to display <a href="https://en.wikipedia.org/wiki/Web_Map_Service">WMS</a> services as tile layers on the map. Extends <a href="#tilelayer"><code>TileLayer</code></a>.</p>
+</section><h2 id='wmstilelayer'>WMSTileLayer</h2><p>Used to display <a href="https://en.wikipedia.org/wiki/Web_Map_Service">WMS</a> services as tile layers on the map. Extends <a href="#tilelayer"><code>TileLayer</code></a>.</p>
 
 <section>
-<h3 id='tilelayer-wms-example'>Usage example</h3>
+<h3 id='wmstilelayer-example'>Usage example</h3>
 
 <section >
 
@@ -6374,7 +6220,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 
-<pre><code class="language-js">const nexrad = new TileLayer.wms(&quot;http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi&quot;, {
+<pre><code class="language-js">const nexrad = new WMSTileLayer(&quot;http://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r.cgi&quot;, {
 	layers: 'nexrad-n0r-900913',
 	format: 'image/png',
 	transparent: true,
@@ -6388,7 +6234,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 </section><section>
-<h3 id='tilelayer-wms-constructor'>Constructor</h3>
+<h3 id='wmstilelayer-constructor'>Constructor</h3>
 
 <section >
 
@@ -6401,8 +6247,8 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-tilelayer-wms'>
-		<td><code><b>new TileLayer.WMS</b>(<nobr>&lt;String&gt;</nobr> <i>baseUrl</i>, <nobr>&lt;<a href='#tilelayer-wms-option'>TileLayer.WMS options</a>&gt;</nobr> <i>options</i>)</code></td>
+	<tr id='wmstilelayer-wmstilelayer'>
+		<td><code><b>new WMSTileLayer</b>(<nobr>&lt;String&gt;</nobr> <i>baseUrl</i>, <nobr>&lt;<a href='#wmstilelayer-option'>WMSTileLayer options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td>Instantiates a WMS tile layer object given a base URL of the WMS service and a WMS parameters/options object.</td>
 	</tr>
 </tbody></table>
@@ -6412,7 +6258,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 </section><section>
-<h3 id='tilelayer-wms-option'>Options</h3>
+<h3 id='wmstilelayer-option'>Options</h3>
 
 <section >
 
@@ -6430,44 +6276,44 @@ WMS server as extra parameters in each request URL. This can be useful for
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-layers'>
+	<tr id='wmstilelayer-layers'>
 		<td><code><b>layers</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td><strong>(required)</strong> Comma-separated list of WMS layers to show.</td>
 	</tr>
-	<tr id='tilelayer-wms-styles'>
+	<tr id='wmstilelayer-styles'>
 		<td><code><b>styles</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>Comma-separated list of WMS styles.</td>
 	</tr>
-	<tr id='tilelayer-wms-format'>
+	<tr id='wmstilelayer-format'>
 		<td><code><b>format</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;image/jpeg&#x27;</code></td>
 		<td>WMS image format (use <code>'image/png'</code> for layers with transparency).</td>
 	</tr>
-	<tr id='tilelayer-wms-transparent'>
+	<tr id='wmstilelayer-transparent'>
 		<td><code><b>transparent</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>If <code>true</code>, the WMS service will return images with transparency.</td>
 	</tr>
-	<tr id='tilelayer-wms-version'>
+	<tr id='wmstilelayer-version'>
 		<td><code><b>version</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;1.1.1&#x27;</code></td>
 		<td>Version of the WMS service to use</td>
 	</tr>
-	<tr id='tilelayer-wms-crs'>
+	<tr id='wmstilelayer-crs'>
 		<td><code><b>crs</b></code></td>
 		<td><code><a href='#crs'>CRS</a></code></td>
 		<td><code>null</code></td>
 		<td>Coordinate Reference System to use for the WMS requests, defaults to
 map CRS. Don't change this if you're not sure what it means.</td>
 	</tr>
-	<tr id='tilelayer-wms-uppercase'>
+	<tr id='wmstilelayer-uppercase'>
 		<td><code><b>uppercase</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
@@ -6494,55 +6340,55 @@ map CRS. Don't change this if you're not sure what it means.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-minzoom'>
+	<tr id='wmstilelayer-minzoom'>
 		<td><code><b>minZoom</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0</code></td>
 		<td>The minimum zoom level down to which this layer will be displayed (inclusive).</td>
 	</tr>
-	<tr id='tilelayer-wms-maxzoom'>
+	<tr id='wmstilelayer-maxzoom'>
 		<td><code><b>maxZoom</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>18</code></td>
 		<td>The maximum zoom level up to which this layer will be displayed (inclusive).</td>
 	</tr>
-	<tr id='tilelayer-wms-subdomains'>
+	<tr id='wmstilelayer-subdomains'>
 		<td><code><b>subdomains</b></code></td>
 		<td><code>String|String[]</code></td>
 		<td><code>&#x27;abc&#x27;</code></td>
 		<td>Subdomains of the tile service. Can be passed in the form of one string (where each letter is a subdomain name) or an array of strings.</td>
 	</tr>
-	<tr id='tilelayer-wms-errortileurl'>
+	<tr id='wmstilelayer-errortileurl'>
 		<td><code><b>errorTileUrl</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>URL to the tile image to show in place of the tile that failed to load.</td>
 	</tr>
-	<tr id='tilelayer-wms-zoomoffset'>
+	<tr id='wmstilelayer-zoomoffset'>
 		<td><code><b>zoomOffset</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0</code></td>
 		<td>The zoom number used in tile URLs will be offset with this value.</td>
 	</tr>
-	<tr id='tilelayer-wms-tms'>
+	<tr id='wmstilelayer-tms'>
 		<td><code><b>tms</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>If <code>true</code>, inverses Y axis numbering for tiles (turn this on for <a href="https://en.wikipedia.org/wiki/Tile_Map_Service">TMS</a> services).</td>
 	</tr>
-	<tr id='tilelayer-wms-zoomreverse'>
+	<tr id='wmstilelayer-zoomreverse'>
 		<td><code><b>zoomReverse</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>If set to true, the zoom number used in tile URLs will be reversed (<code>maxZoom - zoom</code> instead of <code>zoom</code>)</td>
 	</tr>
-	<tr id='tilelayer-wms-detectretina'>
+	<tr id='wmstilelayer-detectretina'>
 		<td><code><b>detectRetina</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>If <code>true</code> and user is on a retina display, it will request four tiles of half the specified size and a bigger zoom level in place of one to utilize the high resolution.</td>
 	</tr>
-	<tr id='tilelayer-wms-crossorigin'>
+	<tr id='wmstilelayer-crossorigin'>
 		<td><code><b>crossOrigin</b></code></td>
 		<td><code>Boolean|String</code></td>
 		<td><code>false</code></td>
@@ -6550,15 +6396,14 @@ map CRS. Don't change this if you're not sure what it means.</td>
 If a String is provided, all tiles will have their crossOrigin attribute set to the String provided. This is needed if you want to access tile pixel data.
 Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes">CORS Settings</a> for valid String values.</td>
 	</tr>
-	<tr id='tilelayer-wms-referrerpolicy'>
+	<tr id='wmstilelayer-referrerpolicy'>
 		<td><code><b>referrerPolicy</b></code></td>
-		<td><code>Boolean|String</code></td>
-		<td><code>false</code></td>
-		<td>Whether the referrerPolicy attribute will be added to the tiles.
-If a String is provided, all tiles will have their referrerPolicy attribute set to the String provided.
-This may be needed if your map's rendering context has a strict default but your tile provider expects a valid referrer
-(e.g. to validate an API token).
-Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy">HTMLImageElement.referrerPolicy</a> for valid String values.</td>
+		<td><code>String</code></td>
+		<td><code>&#x27;strict-origin-when-cross-origin&#x27;</code></td>
+		<td>Sets the tiles' <code>referrerPolicy</code> attribute set to the String provided. See
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/referrerPolicy"><code>HTMLImageElement.referrerPolicy</code></a> for possible values.
+<p>Tile providers might require you to use a specific referrer policy (e.g. to verify API tokens or prevent abuse).
+Specifically, if you are using tiles from <code>tile.openstreetmap.org</code> or <code>tile.osm.org</code>, you <a href="https://operations.osmfoundation.org/policies/tiles/">should not change this value</a>.</p></td>
 	</tr>
 </tbody></table>
 
@@ -6582,19 +6427,19 @@ Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElem
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-tilesize'>
+	<tr id='wmstilelayer-tilesize'>
 		<td><code><b>tileSize</b></code></td>
 		<td><code>Number|Point</code></td>
 		<td><code>256</code></td>
 		<td>Width and height of tiles in the grid. Use a number if width and height are equal, or <code>Point(width, height)</code> otherwise.</td>
 	</tr>
-	<tr id='tilelayer-wms-opacity'>
+	<tr id='wmstilelayer-opacity'>
 		<td><code><b>opacity</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>1.0</code></td>
 		<td>Opacity of the tiles. Can be used in the <code>createTile()</code> function.</td>
 	</tr>
-	<tr id='tilelayer-wms-updatewhenidle'>
+	<tr id='wmstilelayer-updatewhenidle'>
 		<td><code><b>updateWhenIdle</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>(depends)</code></td>
@@ -6603,31 +6448,31 @@ Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElem
 <code>false</code> otherwise in order to display new tiles <em>during</em> panning, since it is easy to pan outside the
 <a href="#gridlayer-keepbuffer"><code>keepBuffer</code></a> option in desktop browsers.</td>
 	</tr>
-	<tr id='tilelayer-wms-updatewhenzooming'>
+	<tr id='wmstilelayer-updatewhenzooming'>
 		<td><code><b>updateWhenZooming</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>By default, a smooth zoom animation (during a <a href="#map-pinchzoom">pinch zoom</a> or a <a href="#map-flyto"><code>flyTo()</code></a>) will update grid layers every integer zoom level. Setting this option to <code>false</code> will update the grid layer only when the smooth animation ends.</td>
 	</tr>
-	<tr id='tilelayer-wms-updateinterval'>
+	<tr id='wmstilelayer-updateinterval'>
 		<td><code><b>updateInterval</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>200</code></td>
 		<td>Tiles will not update more than once every <code>updateInterval</code> milliseconds when panning.</td>
 	</tr>
-	<tr id='tilelayer-wms-zindex'>
+	<tr id='wmstilelayer-zindex'>
 		<td><code><b>zIndex</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>1</code></td>
 		<td>The explicit zIndex of the tile layer.</td>
 	</tr>
-	<tr id='tilelayer-wms-bounds'>
+	<tr id='wmstilelayer-bounds'>
 		<td><code><b>bounds</b></code></td>
 		<td><code><a href='#latlngbounds'>LatLngBounds</a></code></td>
 		<td><code>undefined</code></td>
 		<td>If set, tiles will only be loaded inside the set <a href="#latlngbounds"><code>LatLngBounds</code></a>.</td>
 	</tr>
-	<tr id='tilelayer-wms-maxnativezoom'>
+	<tr id='wmstilelayer-maxnativezoom'>
 		<td><code><b>maxNativeZoom</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>undefined</code></td>
@@ -6635,7 +6480,7 @@ Refer to <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElem
 the tiles on all zoom levels higher than <code>maxNativeZoom</code> will be loaded
 from <code>maxNativeZoom</code> level and auto-scaled.</td>
 	</tr>
-	<tr id='tilelayer-wms-minnativezoom'>
+	<tr id='wmstilelayer-minnativezoom'>
 		<td><code><b>minNativeZoom</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>undefined</code></td>
@@ -6643,7 +6488,7 @@ from <code>maxNativeZoom</code> level and auto-scaled.</td>
 the tiles on all zoom levels lower than <code>minNativeZoom</code> will be loaded
 from <code>minNativeZoom</code> level and auto-scaled.</td>
 	</tr>
-	<tr id='tilelayer-wms-nowrap'>
+	<tr id='wmstilelayer-nowrap'>
 		<td><code><b>noWrap</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
@@ -6653,19 +6498,19 @@ effect when the <a href="#map-crs">map CRS</a> doesn't wrap around. Can be used
 in combination with <a href="#gridlayer-bounds"><code>bounds</code></a> to prevent requesting
 tiles outside the CRS limits.</td>
 	</tr>
-	<tr id='tilelayer-wms-pane'>
+	<tr id='wmstilelayer-pane'>
 		<td><code><b>pane</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;tilePane&#x27;</code></td>
 		<td><code>Map pane</code> where the grid layer will be added.</td>
 	</tr>
-	<tr id='tilelayer-wms-classname'>
+	<tr id='wmstilelayer-classname'>
 		<td><code><b>className</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&#x27;</code></td>
 		<td>A custom class name to assign to the tile layer. Empty by default.</td>
 	</tr>
-	<tr id='tilelayer-wms-keepbuffer'>
+	<tr id='wmstilelayer-keepbuffer'>
 		<td><code><b>keepBuffer</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>2</code></td>
@@ -6693,7 +6538,7 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-attribution'>
+	<tr id='wmstilelayer-attribution'>
 		<td><code><b>attribution</b></code></td>
 		<td><code>String</code></td>
 		<td><code>null</code></td>
@@ -6726,7 +6571,7 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-tileabort'>
+	<tr id='wmstilelayer-tileabort'>
 		<td><code><b>tileabort</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
 		<td>Fired when a tile was loading but is now not wanted.</td>
@@ -6752,32 +6597,32 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-loading'>
+	<tr id='wmstilelayer-loading'>
 		<td><code><b>loading</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the grid layer starts loading tiles.</td>
 	</tr>
-	<tr id='tilelayer-wms-tileunload'>
+	<tr id='wmstilelayer-tileunload'>
 		<td><code><b>tileunload</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
 		<td>Fired when a tile is removed (e.g. when a tile goes off the screen).</td>
 	</tr>
-	<tr id='tilelayer-wms-tileloadstart'>
+	<tr id='wmstilelayer-tileloadstart'>
 		<td><code><b>tileloadstart</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
 		<td>Fired when a tile is requested and starts loading.</td>
 	</tr>
-	<tr id='tilelayer-wms-tileerror'>
+	<tr id='wmstilelayer-tileerror'>
 		<td><code><b>tileerror</b></code></td>
 		<td><code><a href='#tileerrorevent'>TileErrorEvent</a></code></td>
 		<td>Fired when there is an error loading a tile.</td>
 	</tr>
-	<tr id='tilelayer-wms-tileload'>
+	<tr id='wmstilelayer-tileload'>
 		<td><code><b>tileload</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
 		<td>Fired when a tile loads.</td>
 	</tr>
-	<tr id='tilelayer-wms-load'>
+	<tr id='wmstilelayer-load'>
 		<td><code><b>load</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired when the grid layer loaded all visible tiles.</td>
@@ -6803,12 +6648,12 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-add'>
+	<tr id='wmstilelayer-add'>
 		<td><code><b>add</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired after the layer is added to a map</td>
 	</tr>
-	<tr id='tilelayer-wms-remove'>
+	<tr id='wmstilelayer-remove'>
 		<td><code><b>remove</b></code></td>
 		<td><code><a href='#event'>Event</a></code></td>
 		<td>Fired after the layer is removed from a map</td>
@@ -6834,12 +6679,12 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-popupopen'>
+	<tr id='wmstilelayer-popupopen'>
 		<td><code><b>popupopen</b></code></td>
 		<td><code><a href='#popupevent'>PopupEvent</a></code></td>
 		<td>Fired when a popup bound to this layer is opened</td>
 	</tr>
-	<tr id='tilelayer-wms-popupclose'>
+	<tr id='wmstilelayer-popupclose'>
 		<td><code><b>popupclose</b></code></td>
 		<td><code><a href='#popupevent'>PopupEvent</a></code></td>
 		<td>Fired when a popup bound to this layer is closed</td>
@@ -6865,12 +6710,12 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-tooltipopen'>
+	<tr id='wmstilelayer-tooltipopen'>
 		<td><code><b>tooltipopen</b></code></td>
 		<td><code><a href='#tooltipevent'>TooltipEvent</a></code></td>
 		<td>Fired when a tooltip bound to this layer is opened.</td>
 	</tr>
-	<tr id='tilelayer-wms-tooltipclose'>
+	<tr id='wmstilelayer-tooltipclose'>
 		<td><code><b>tooltipclose</b></code></td>
 		<td><code><a href='#tooltipevent'>TooltipEvent</a></code></td>
 		<td>Fired when a tooltip bound to this layer is closed.</td>
@@ -6882,7 +6727,7 @@ tiles outside the CRS limits.</td>
 </div>
 
 </section><section>
-<h3 id='tilelayer-wms-method'>Methods</h3>
+<h3 id='wmstilelayer-method'>Methods</h3>
 
 <section >
 
@@ -6896,7 +6741,7 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-setparams'>
+	<tr id='wmstilelayer-setparams'>
 		<td><code><b>setParams</b>(<nobr>&lt;Object&gt;</nobr> <i>params</i>, <nobr>&lt;Boolean&gt;</nobr> <i>noRedraw?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Merges an object with the new parameters and re-requests tiles on the current screen (unless <code>noRedraw</code> was set to true).</p>
@@ -6922,7 +6767,7 @@ tiles outside the CRS limits.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-seturl'>
+	<tr id='wmstilelayer-seturl'>
 		<td><code><b>setUrl</b>(<nobr>&lt;String&gt;</nobr> <i>url</i>, <nobr>&lt;Boolean&gt;</nobr> <i>noRedraw?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Updates the layer's URL template and redraws it (unless <code>noRedraw</code> is set to <code>true</code>).
@@ -6930,7 +6775,7 @@ If the URL does not change, the layer will not be redrawn unless
 the noRedraw parameter is set to false.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-createtile'>
+	<tr id='wmstilelayer-createtile'>
 		<td><code><b>createTile</b>(<nobr>&lt;Object&gt;</nobr> <i>coords</i>, <nobr>&lt;Function&gt;</nobr> <i>done?</i>)</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Called only internally, overrides GridLayer's <a href="#gridlayer-createtile"><code>createTile()</code></a>
@@ -6959,49 +6804,49 @@ callback is called when the tile has been loaded.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-bringtofront'>
+	<tr id='wmstilelayer-bringtofront'>
 		<td><code><b>bringToFront</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Brings the tile layer to the top of all tile layers.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-bringtoback'>
+	<tr id='wmstilelayer-bringtoback'>
 		<td><code><b>bringToBack</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Brings the tile layer to the bottom of all tile layers.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-getcontainer'>
+	<tr id='wmstilelayer-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTML element that contains the tiles for this layer.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-setopacity'>
+	<tr id='wmstilelayer-setopacity'>
 		<td><code><b>setOpacity</b>(<nobr>&lt;Number&gt;</nobr> <i>opacity</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Changes the <a href="#gridlayer-opacity">opacity</a> of the grid layer.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-setzindex'>
+	<tr id='wmstilelayer-setzindex'>
 		<td><code><b>setZIndex</b>(<nobr>&lt;Number&gt;</nobr> <i>zIndex</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Changes the <a href="#gridlayer-zindex">zIndex</a> of the grid layer.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-isloading'>
+	<tr id='wmstilelayer-isloading'>
 		<td><code><b>isLoading</b>()</code></td>
 		<td><code>Boolean</code></td>
 		<td><p>Returns <code>true</code> if any tile in the grid layer has not finished loading.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-redraw'>
+	<tr id='wmstilelayer-redraw'>
 		<td><code><b>redraw</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Causes the layer to clear all the tiles and request them again.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-gettilesize'>
+	<tr id='wmstilelayer-gettilesize'>
 		<td><code><b>getTileSize</b>()</code></td>
 		<td><code><a href='#point'>Point</a></code></td>
 		<td><p>Normalizes the <a href="#gridlayer-tilesize">tileSize option</a> into a point. Used by the <code>createTile()</code> method.</p>
@@ -7028,37 +6873,37 @@ callback is called when the tile has been loaded.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='wmstilelayer-addto'>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-remove'>
+	<tr id='wmstilelayer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the map it is currently active on.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='wmstilelayer-removefrom'>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-removefrom'>
+	<tr id='wmstilelayer-removefrom'>
 		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#layergroup'>LayerGroup</a>&gt;</nobr> <i>group</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given <a href="#layergroup"><code>LayerGroup</code></a></p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-getpane'>
+	<tr id='wmstilelayer-getpane'>
 		<td><code><b>getPane</b>(<nobr>&lt;String&gt;</nobr> <i>name?</i>)</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the <code>HTMLElement</code> representing the named pane on the map. If <code>name</code> is omitted, returns the pane for this layer.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-getattribution'>
+	<tr id='wmstilelayer-getattribution'>
 		<td><code><b>getAttribution</b>()</code></td>
 		<td><code>String</code></td>
 		<td><p>Used by the <code>attribution control</code>, returns the <a href="#gridlayer-attribution">attribution option</a>.</p>
@@ -7085,55 +6930,55 @@ callback is called when the tile has been loaded.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-bindpopup'>
+	<tr id='wmstilelayer-bindpopup'>
 		<td><code><b>bindPopup</b>(<nobr>&lt;String|HTMLElement|Function|Popup&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#popup-option'>Popup options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-unbindpopup'>
+	<tr id='wmstilelayer-unbindpopup'>
 		<td><code><b>unbindPopup</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the popup previously bound with <code>bindPopup</code>.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-openpopup'>
+	<tr id='wmstilelayer-openpopup'>
 		<td><code><b>openPopup</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens the bound popup at the specified <code>latlng</code> or at the default popup anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-closepopup'>
+	<tr id='wmstilelayer-closepopup'>
 		<td><code><b>closePopup</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Closes the popup bound to this layer if it is open.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-togglepopup'>
+	<tr id='wmstilelayer-togglepopup'>
 		<td><code><b>togglePopup</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens or closes the popup bound to this layer depending on its current state.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-ispopupopen'>
+	<tr id='wmstilelayer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
 		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-setpopupcontent'>
+	<tr id='wmstilelayer-setpopupcontent'>
 		<td><code><b>setPopupContent</b>(<nobr>&lt;String|HTMLElement|Popup&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the content of the popup bound to this layer.
 String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-getpopup'>
+	<tr id='wmstilelayer-getpopup'>
 		<td><code><b>getPopup</b>()</code></td>
 		<td><code><a href='#popup'>Popup</a></code></td>
 		<td><p>Returns the popup bound to this layer.</p>
@@ -7160,55 +7005,55 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-bindtooltip'>
+	<tr id='wmstilelayer-bindtooltip'>
 		<td><code><b>bindTooltip</b>(<nobr>&lt;String|HTMLElement|Function|Tooltip&gt;</nobr> <i>content</i>, <nobr>&lt;<a href='#tooltip-option'>Tooltip options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-unbindtooltip'>
+	<tr id='wmstilelayer-unbindtooltip'>
 		<td><code><b>unbindTooltip</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the tooltip previously bound with <code>bindTooltip</code>.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-opentooltip'>
+	<tr id='wmstilelayer-opentooltip'>
 		<td><code><b>openTooltip</b>(<nobr>&lt;<a href='#latlng'>LatLng</a>&gt;</nobr> <i>latlng?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens the bound tooltip at the specified <code>latlng</code> or at the default tooltip anchor if no <code>latlng</code> is passed.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-closetooltip'>
+	<tr id='wmstilelayer-closetooltip'>
 		<td><code><b>closeTooltip</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Closes the tooltip bound to this layer if it is open.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-toggletooltip'>
+	<tr id='wmstilelayer-toggletooltip'>
 		<td><code><b>toggleTooltip</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Opens or closes the tooltip bound to this layer depending on its current state.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-istooltipopen'>
+	<tr id='wmstilelayer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
 		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-settooltipcontent'>
+	<tr id='wmstilelayer-settooltipcontent'>
 		<td><code><b>setTooltipContent</b>(<nobr>&lt;String|HTMLElement|Tooltip&gt;</nobr> <i>content</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the content of the tooltip bound to this layer.
 String content is rendered as HTML; sanitize untrusted input or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-gettooltip'>
+	<tr id='wmstilelayer-gettooltip'>
 		<td><code><b>getTooltip</b>()</code></td>
 		<td><code><a href='#tooltip'>Tooltip</a></code></td>
 		<td><p>Returns the tooltip bound to this layer.</p>
@@ -7235,37 +7080,37 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='tilelayer-wms-on'>
+	<tr id='wmstilelayer-on'>
 		<td><code><b>on</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a listener function (<code>fn</code>) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. <code>'click dblclick'</code>).</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-on'>
+	<tr id='wmstilelayer-on'>
 		<td><code><b>on</b>(<nobr>&lt;Object&gt;</nobr> <i>eventMap</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a set of type/listener pairs, e.g. <code>{click: onClick, pointermove: onPointerMove}</code></p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-off'>
+	<tr id='wmstilelayer-off'>
 		<td><code><b>off</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Function&gt;</nobr> <i>fn?</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes a previously added listener function. If no function is specified, it will remove all the listeners of that particular event from the object. Note that if you passed a custom context to <code>on</code>, you must pass the same context to <code>off</code> in order to remove the listener.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-off'>
+	<tr id='wmstilelayer-off'>
 		<td><code><b>off</b>(<nobr>&lt;Object&gt;</nobr> <i>eventMap</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes a set of type/listener pairs.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-off'>
+	<tr id='wmstilelayer-off'>
 		<td><code><b>off</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes all listeners to all events on the object. This includes implicitly attached events.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-fire'>
+	<tr id='wmstilelayer-fire'>
 		<td><code><b>fire</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Object&gt;</nobr> <i>data?</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Fires an event of the specified type. You can optionally provide a data
@@ -7273,26 +7118,26 @@ object — the first argument of the listener function will contain its
 properties. The event can optionally be propagated to event parents.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-listens'>
+	<tr id='wmstilelayer-listens'>
 		<td><code><b>listens</b>(<nobr>&lt;String&gt;</nobr> <i>type</i>, <nobr>&lt;Boolean&gt;</nobr> <i>propagate?</i>)</code></td>
 		<td><code>Boolean</code></td>
 		<td><p>Returns <code>true</code> if a particular event type has any listeners attached to it.
 The verification can optionally be propagated, it will return <code>true</code> if parents have the listener attached to it.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-once'>
+	<tr id='wmstilelayer-once'>
 		<td><code><b>once</b>(<i>…</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Behaves as <a href="#evented-on"><code>on(…)</code></a>, except the listener will only get fired once and then removed.</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-addeventparent'>
+	<tr id='wmstilelayer-addeventparent'>
 		<td><code><b>addEventParent</b>(<nobr>&lt;<a href='#evented'>Evented</a>&gt;</nobr> <i>obj</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds an event parent - an <a href="#evented"><code>Evented</code></a> that will receive propagated events</p>
 </td>
 	</tr>
-	<tr id='tilelayer-wms-removeeventparent'>
+	<tr id='wmstilelayer-removeeventparent'>
 		<td><code><b>removeEventParent</b>(<nobr>&lt;<a href='#evented'>Evented</a>&gt;</nobr> <i>obj</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes an event parent, so it will stop receiving propagated events</p>
@@ -7761,7 +7606,7 @@ used by this overlay.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='imageoverlay-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -7773,7 +7618,7 @@ used by this overlay.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -7822,10 +7667,10 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindpopup'>
@@ -7897,10 +7742,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-unbindtooltip'>
@@ -8107,12 +7952,17 @@ geographical bounds it is tied to.</td>
 		<td>Whether the video starts playing automatically when loaded.
 On some browsers autoplay will only work with <code>muted: true</code></td>
 	</tr>
+	<tr id='videooverlay-controls'>
+		<td><code><b>controls</b></code></td>
+		<td><code>Boolean</code></td>
+		<td><code>false</code></td>
+		<td>Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.</td>
+	</tr>
 	<tr id='videooverlay-loop'>
 		<td><code><b>loop</b></code></td>
 		<td><code>Boolean</code></td>
-		<td><code>false</code></td>
-		<td>Whether the browser will offer controls to allow the user to control video playback, including volume, seeking, and pause/resume playback.
-Whether the video will loop back to the beginning when played.</td>
+		<td><code>true</code></td>
+		<td>Whether the video will loop back to the beginning when played.</td>
 	</tr>
 	<tr id='videooverlay-keepaspectratio'>
 		<td><code><b>keepAspectRatio</b></code></td>
@@ -8591,7 +8441,7 @@ used by this overlay.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='videooverlay-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -8603,7 +8453,7 @@ used by this overlay.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -8652,10 +8502,10 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindpopup'>
@@ -8727,10 +8577,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-unbindtooltip'>
@@ -9362,7 +9212,7 @@ used by this overlay.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='svgoverlay-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -9374,7 +9224,7 @@ used by this overlay.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -9423,10 +9273,10 @@ used by this overlay.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindpopup'>
@@ -9498,10 +9348,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-unbindtooltip'>
@@ -10035,7 +9885,7 @@ for a second (also called long press).</td>
 	</tr>
 	</thead><tbody>
 	<tr id='path-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -10047,7 +9897,7 @@ for a second (also called long press).</td>
 </td>
 	</tr>
 	<tr id='path-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -10096,10 +9946,10 @@ for a second (also called long press).</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindpopup'>
@@ -10171,10 +10021,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='path-unbindtooltip'>
@@ -10310,6 +10160,39 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
+</section><section>
+<h3 id='path-function'>Functions</h3>
+
+<section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='path-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='path-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section>
+
+
 </section><h2 id='polyline'>Polyline</h2><p>A class for drawing polyline overlays on a map. Extends <a href="#path"><code>Path</code></a>.</p>
 
 <section>
@@ -10396,9 +10279,10 @@ of geographic points.</td>
 	<tr id='polyline-smoothfactor'>
 		<td><code><b>smoothFactor</b></code></td>
 		<td><code>Number</code></td>
-		<td><code>1.0</code></td>
-		<td>How much to simplify the polyline on each zoom level. More means
-better performance and smoother look, and less means more accurate representation.</td>
+		<td><code>0.5</code></td>
+		<td>How much to simplify the polyline on each zoom level (Douglas–Peucker
+epsilon, in pixels). Higher values mean faster rendering but less
+accuracy; lower values mean more accuracy but slower rendering.</td>
 	</tr>
 	<tr id='polyline-noclip'>
 		<td><code><b>noClip</b></code></td>
@@ -10879,7 +10763,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	</tr>
 	</thead><tbody>
 	<tr id='polyline-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -10891,7 +10775,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 </td>
 	</tr>
 	<tr id='polyline-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -10940,10 +10824,10 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindpopup'>
@@ -11015,10 +10899,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polyline-unbindtooltip'>
@@ -11154,6 +11038,46 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
+</section><section>
+<h3 id=''>Functions</h3>
+
+
+
+
+<div class='accordion'>
+	<label><span class='expander'>▶</span> Functions inherited from <a href='#path'>Path</a></label>
+	<div class='accordion-overflow'>
+		<div class='accordion-content'><section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='polyline-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='polyline-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section></div>
+	</div>
+</div>
+
 </section><h2 id='polygon'>Polygon</h2><p>A class for drawing polygon overlays on a map. Extends <a href="#polyline"><code>Polyline</code></a>.</p>
 <p>Note that points you pass when creating a polygon shouldn't have an additional last point equal to the first one — it's better to filter out such points.</p>
 
@@ -11246,9 +11170,10 @@ map.fitBounds(polygon.getBounds());
 	<tr id='polygon-smoothfactor'>
 		<td><code><b>smoothFactor</b></code></td>
 		<td><code>Number</code></td>
-		<td><code>1.0</code></td>
-		<td>How much to simplify the polyline on each zoom level. More means
-better performance and smoother look, and less means more accurate representation.</td>
+		<td><code>0.5</code></td>
+		<td>How much to simplify the polyline on each zoom level (Douglas–Peucker
+epsilon, in pixels). Higher values mean faster rendering but less
+accuracy; lower values mean more accuracy but slower rendering.</td>
 	</tr>
 	<tr id='polygon-noclip'>
 		<td><code><b>noClip</b></code></td>
@@ -11751,7 +11676,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	</tr>
 	</thead><tbody>
 	<tr id='polygon-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -11763,7 +11688,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 </td>
 	</tr>
 	<tr id='polygon-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -11812,10 +11737,10 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindpopup'>
@@ -11887,10 +11812,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='polygon-unbindtooltip'>
@@ -12026,6 +11951,46 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
+</section><section>
+<h3 id=''>Functions</h3>
+
+
+
+
+<div class='accordion'>
+	<label><span class='expander'>▶</span> Functions inherited from <a href='#path'>Path</a></label>
+	<div class='accordion-overflow'>
+		<div class='accordion-content'><section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='polygon-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='polygon-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section></div>
+	</div>
+</div>
+
 </section><h2 id='rectangle'>Rectangle</h2><p>A class for drawing rectangle overlays on a map. Extends <a href="#polygon"><code>Polygon</code></a>.</p>
 
 <section>
@@ -12101,9 +12066,10 @@ map.fitBounds(bounds);
 	<tr id='rectangle-smoothfactor'>
 		<td><code><b>smoothFactor</b></code></td>
 		<td><code>Number</code></td>
-		<td><code>1.0</code></td>
-		<td>How much to simplify the polyline on each zoom level. More means
-better performance and smoother look, and less means more accurate representation.</td>
+		<td><code>0.5</code></td>
+		<td>How much to simplify the polyline on each zoom level (Douglas–Peucker
+epsilon, in pixels). Higher values mean faster rendering but less
+accuracy; lower values mean more accuracy but slower rendering.</td>
 	</tr>
 	<tr id='rectangle-noclip'>
 		<td><code><b>noClip</b></code></td>
@@ -12633,7 +12599,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	</tr>
 	</thead><tbody>
 	<tr id='rectangle-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -12645,7 +12611,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 </td>
 	</tr>
 	<tr id='rectangle-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -12694,10 +12660,10 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindpopup'>
@@ -12769,10 +12735,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='rectangle-unbindtooltip'>
@@ -12908,7 +12874,47 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
-</section><h2 id='circle'>Circle</h2><p>A class for drawing circle overlays on a map. Extends <a href="#circlemarker"><code>CircleMarker</code></a>.</p>
+</section><section>
+<h3 id=''>Functions</h3>
+
+
+
+
+<div class='accordion'>
+	<label><span class='expander'>▶</span> Functions inherited from <a href='#path'>Path</a></label>
+	<div class='accordion-overflow'>
+		<div class='accordion-content'><section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='rectangle-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='rectangle-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section></div>
+	</div>
+</div>
+
+</section><h2 id='circle'>Circle</h2><p>A class for drawing circle overlays on a map with radius specified in meters. Extends <a href="#circlemarker"><code>CircleMarker</code></a>.</p>
 <p>It's an approximation and starts to diverge from a real circle closer to poles (due to projection distortion).</p>
 
 <section>
@@ -13481,7 +13487,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	</tr>
 	</thead><tbody>
 	<tr id='circle-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -13493,7 +13499,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 </td>
 	</tr>
 	<tr id='circle-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -13542,10 +13548,10 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindpopup'>
@@ -13617,10 +13623,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circle-unbindtooltip'>
@@ -13756,7 +13762,47 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
-</section><h2 id='circlemarker'>CircleMarker</h2><p>A circle of a fixed size with radius specified in pixels. Extends <a href="#path"><code>Path</code></a>.</p>
+</section><section>
+<h3 id=''>Functions</h3>
+
+
+
+
+<div class='accordion'>
+	<label><span class='expander'>▶</span> Functions inherited from <a href='#path'>Path</a></label>
+	<div class='accordion-overflow'>
+		<div class='accordion-content'><section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='circle-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='circle-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section></div>
+	</div>
+</div>
+
+</section><h2 id='circlemarker'>CircleMarker</h2><p>A circle of a fixed size with radius specified in CSS pixels. Extends <a href="#path"><code>Path</code></a>.</p>
 
 <section>
 <h3 id='circlemarker-constructor'>Constructor</h3>
@@ -13802,7 +13848,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 		<td><code><b>radius</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>10</code></td>
-		<td>Radius of the circle marker, in pixels</td>
+		<td>Radius of the circle marker, in CSS pixels</td>
 	</tr>
 </tbody></table>
 
@@ -14201,13 +14247,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='circlemarker-setradius'>
 		<td><code><b>setRadius</b>(<nobr>&lt;Number&gt;</nobr> <i>radius</i>)</code></td>
 		<td><code>this</code></td>
-		<td><p>Sets the radius of a circle marker. Units are in pixels.</p>
+		<td><p>Sets the radius of a circle marker. Units are in CSS pixels.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-getradius'>
 		<td><code><b>getRadius</b>()</code></td>
 		<td><code>Number</code></td>
-		<td><p>Returns the current radius of the circle</p>
+		<td><p>Returns the current radius of the circle. Units are in CSS pixels.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -14276,7 +14322,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	</tr>
 	</thead><tbody>
 	<tr id='circlemarker-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -14288,7 +14334,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 </td>
 	</tr>
 	<tr id='circlemarker-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -14337,10 +14383,10 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindpopup'>
@@ -14412,10 +14458,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-unbindtooltip'>
@@ -14551,6 +14597,46 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
+</section><section>
+<h3 id=''>Functions</h3>
+
+
+
+
+<div class='accordion'>
+	<label><span class='expander'>▶</span> Functions inherited from <a href='#path'>Path</a></label>
+	<div class='accordion-overflow'>
+		<div class='accordion-content'><section >
+
+
+
+
+<table><thead>
+	<tr>
+		<th>Function</th>
+		<th>Returns</th>
+		<th>Description</th>
+	</tr>
+	</thead><tbody>
+	<tr id='circlemarker-create'>
+		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code>SVGElement</code></td>
+		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
+corresponding to the class name passed. For example, using 'line' will return
+an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
+	</tr>
+	<tr id='circlemarker-pointstopath'>
+		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
+		<td><code>String</code></td>
+		<td>Generates a SVG path string for multiple rings, with each ring turning
+into &quot;M..L..L..&quot; instructions</td>
+	</tr>
+</tbody></table>
+
+</section></div>
+	</div>
+</div>
+
 </section><h2 id='svg'>SVG</h2><p>Allows vector layers to be displayed with <a href="https://developer.mozilla.org/docs/Web/SVG">SVG</a>.
 Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
@@ -14564,12 +14650,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use SVG by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new SVG()
 });
 </code></pre>
 <p>Use a SVG renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new SVG({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle = new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -14831,7 +14917,7 @@ its map has moved</td>
 	</tr>
 	</thead><tbody>
 	<tr id='svg-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -14843,7 +14929,7 @@ its map has moved</td>
 </td>
 	</tr>
 	<tr id='svg-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -14892,10 +14978,10 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindpopup'>
@@ -14967,10 +15053,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='svg-unbindtooltip'>
@@ -15106,40 +15192,6 @@ The verification can optionally be propagated, it will return <code>true</code> 
 	</div>
 </div>
 
-</section><section>
-<h3 id='svg-function'>Functions</h3>
-
-<section >
-
-
-
-<div class='section-comments'>There are several static functions which can be called without instantiating SVG:</div>
-
-<table><thead>
-	<tr>
-		<th>Function</th>
-		<th>Returns</th>
-		<th>Description</th>
-	</tr>
-	</thead><tbody>
-	<tr id='svg-create'>
-		<td><code><b>create</b>(<nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
-		<td><code>SVGElement</code></td>
-		<td>Returns a instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGElement">SVGElement</a>,
-corresponding to the class name passed. For example, using 'line' will return
-an instance of <a href="https://developer.mozilla.org/docs/Web/API/SVGLineElement">SVGLineElement</a>.</td>
-	</tr>
-	<tr id='svg-pointstopath'>
-		<td><code><b>pointsToPath</b>(<nobr>&lt;Point[]&gt;</nobr> <i>rings</i>, <nobr>&lt;Boolean&gt;</nobr> <i>closed</i>)</code></td>
-		<td><code>String</code></td>
-		<td>Generates a SVG path string for multiple rings, with each ring turning
-into &quot;M..L..L..&quot; instructions</td>
-	</tr>
-</tbody></table>
-
-</section>
-
-
 </section><h2 id='canvas'>Canvas</h2><p>Allows vector layers to be displayed with <a href="https://developer.mozilla.org/docs/Web/API/Canvas_API"><code>&lt;canvas&gt;</code></a>.
 Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
@@ -15153,12 +15205,12 @@ Inherits <a href="#renderer"><code>Renderer</code></a>.</p>
 
 
 <p>Use Canvas by default for all paths in the map:</p>
-<pre><code class="language-js">const map = new Map('map', {
+<pre><code class="language-js">const map = new LeafletMap('map', {
 	renderer: new Canvas()
 });
 </code></pre>
 <p>Use a Canvas renderer with extra padding for specific vector geometries:</p>
-<pre><code class="language-js">const map = new Map('map');
+<pre><code class="language-js">const map = new LeafletMap('map');
 const myRenderer = new Canvas({ padding: 0.5 });
 const line = new Polyline( coordinates, { renderer: myRenderer } );
 const circle =  new Circle( center, { renderer: myRenderer, radius: 100 } );
@@ -15441,7 +15493,7 @@ its map has moved</td>
 	</tr>
 	</thead><tbody>
 	<tr id='canvas-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -15453,7 +15505,7 @@ its map has moved</td>
 </td>
 	</tr>
 	<tr id='canvas-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -15502,10 +15554,10 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindpopup'>
@@ -15577,10 +15629,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='canvas-unbindtooltip'>
@@ -16055,14 +16107,6 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><p>Removes all the layers from the group.</p>
 </td>
 	</tr>
-	<tr id='layergroup-invoke'>
-		<td><code><b>invoke</b>(<nobr>&lt;String&gt;</nobr> <i>methodName</i>, <i>…</i>)</code></td>
-		<td><code>this</code></td>
-		<td><p>Calls <code>methodName</code> on every layer contained in this group, passing any
-additional parameters. Has no effect if the layers contained do not
-implement <code>methodName</code>.</p>
-</td>
-	</tr>
 	<tr id='layergroup-eachlayer'>
 		<td><code><b>eachLayer</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
@@ -16116,7 +16160,7 @@ implement <code>methodName</code>.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='layergroup-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -16128,7 +16172,7 @@ implement <code>methodName</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -16177,10 +16221,10 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindpopup'>
@@ -16252,10 +16296,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layergroup-unbindtooltip'>
@@ -16804,14 +16848,6 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><p>Removes all the layers from the group.</p>
 </td>
 	</tr>
-	<tr id='featuregroup-invoke'>
-		<td><code><b>invoke</b>(<nobr>&lt;String&gt;</nobr> <i>methodName</i>, <i>…</i>)</code></td>
-		<td><code>this</code></td>
-		<td><p>Calls <code>methodName</code> on every layer contained in this group, passing any
-additional parameters. Has no effect if the layers contained do not
-implement <code>methodName</code>.</p>
-</td>
-	</tr>
 	<tr id='featuregroup-eachlayer'>
 		<td><code><b>eachLayer</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
@@ -16866,7 +16902,7 @@ implement <code>methodName</code>.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='featuregroup-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -16878,7 +16914,7 @@ implement <code>methodName</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -16927,10 +16963,10 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindpopup'>
@@ -17002,10 +17038,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-unbindtooltip'>
@@ -17240,6 +17276,8 @@ The default value is to not override any defaults:
 		<td><code>*</code></td>
 		<td>A <code>Function</code> that will be called once for each created <code>Feature</code>, after it has
 been created and styled. Useful for attaching events and popups to features.
+It will receive the <code>feature</code> as the first argument and its corresponding
+spawned <code>layer</code> from <a href="#geojson-asFeature"><code>asFeature</code></a> as the second.
 The default is to do nothing with the newly created layers:
 <pre><code class="language-js">function (feature, layer) {}
 </code></pre></td>
@@ -17670,14 +17708,6 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 		<td><p>Removes all the layers from the group.</p>
 </td>
 	</tr>
-	<tr id='geojson-invoke'>
-		<td><code><b>invoke</b>(<nobr>&lt;String&gt;</nobr> <i>methodName</i>, <i>…</i>)</code></td>
-		<td><code>this</code></td>
-		<td><p>Calls <code>methodName</code> on every layer contained in this group, passing any
-additional parameters. Has no effect if the layers contained do not
-implement <code>methodName</code>.</p>
-</td>
-	</tr>
 	<tr id='geojson-eachlayer'>
 		<td><code><b>eachLayer</b>(<nobr>&lt;Function&gt;</nobr> <i>fn</i>, <nobr>&lt;Object&gt;</nobr> <i>context?</i>)</code></td>
 		<td><code>this</code></td>
@@ -17732,7 +17762,7 @@ implement <code>methodName</code>.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='geojson-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -17744,7 +17774,7 @@ implement <code>methodName</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -17793,10 +17823,10 @@ implement <code>methodName</code>.</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindpopup'>
@@ -17868,10 +17898,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='geojson-unbindtooltip'>
@@ -18563,7 +18593,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 	</tr>
 	</thead><tbody>
 	<tr id='gridlayer-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -18575,7 +18605,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 </td>
 	</tr>
 	<tr id='gridlayer-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -18624,10 +18654,10 @@ is specified, it must be called when the tile has finished loading and drawing.<
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindpopup'>
@@ -18699,10 +18729,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-unbindtooltip'>
@@ -19670,7 +19700,7 @@ Negative values will retract the bounds.</p>
 
 new Marker([50.505, 30.57], {icon: myIcon}).addTo(map);
 </code></pre>
-<p><a href="#icon-default"><code>Icon.Default</code></a> extends <a href="#icon"><code>Icon</code></a> and is the blue icon Leaflet uses for markers by default.</p>
+<p><a href="#defaulticon"><code>DefaultIcon</code></a> extends <a href="#icon"><code>Icon</code></a> and is the blue icon Leaflet uses for markers by default.</p>
 
 
 
@@ -19834,10 +19864,10 @@ styled according to the options.</p>
 </section>
 
 
-</section><span id='icon-default'></span>
+</section><span id='defaulticon'></span>
 
 <section>
-<h3 id='icon-default-option'>Icon.Default</h3>
+<h3 id='defaulticon-option'>DefaultIcon</h3>
 
 <section >
 
@@ -19846,7 +19876,7 @@ styled according to the options.</p>
 <div class='section-comments'>A trivial subclass of <a href="#icon"><code>Icon</code></a>, represents the icon to use in <a href="#marker"><code>Marker</code></a>s when
 no icon is specified. Points to the blue marker image distributed with Leaflet
 releases.
-<p>In order to customize the default icon, just change the properties of <code>Icon.Default.prototype.options</code>
+<p>In order to customize the default icon, just change the properties of <code>DefaultIcon.prototype.options</code>
 (which is a set of <a href="#icon-option"><code>Icon options</code></a>).</p>
 <p>If you want to <em>completely</em> replace the default icon, override the
 <code>Marker.prototype.options.icon</code> with your own icon instead.</p></div>
@@ -19859,11 +19889,11 @@ releases.
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='icon-default-imagepath'>
+	<tr id='defaulticon-imagepath'>
 		<td><code><b>imagePath</b></code></td>
 		<td><code>String</code></td>
 		<td><code></code></td>
-		<td><a href="#icon-default"><code>Icon.Default</code></a> will try to auto-detect the location of the
+		<td><a href="#defaulticon"><code>DefaultIcon</code></a> will try to auto-detect the location of the
 blue icon images. If you are placing these images in a non-standard
 way, set this option to point to the right path.</td>
 	</tr>
@@ -20094,10 +20124,10 @@ styled according to the options.</p>
 	</div>
 </div>
 
-</section><h2 id='control-zoom'>Control.Zoom</h2><p>A basic zoom control with two buttons (zoom in and zoom out). It is put on the map by default unless you set its <a href="#map-zoomcontrol"><code>zoomControl</code> option</a> to <code>false</code>. Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2 id='zoomcontrol'>ZoomControl</h2><p>A basic zoom control with two buttons (zoom in and zoom out). It is put on the map by default unless you set its <a href="#map-zoomcontrol"><code>zoomControl</code> option</a> to <code>false</code>. Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
-<h3 id='control-zoom-constructor'>Constructor</h3>
+<h3 id='zoomcontrol-constructor'>Constructor</h3>
 
 <section >
 
@@ -20110,8 +20140,8 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-zoom-control-zoom'>
-		<td><code><b>new Control.Zoom</b>(<nobr>&lt;<a href='#control-zoom-option'>Control.Zoom options</a>&gt;</nobr> <i>options</i>)</code></td>
+	<tr id='zoomcontrol-zoomcontrol'>
+		<td><code><b>new ZoomControl</b>(<nobr>&lt;<a href='#zoomcontrol-option'>ZoomControl options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td>Creates a zoom control</td>
 	</tr>
 </tbody></table>
@@ -20121,7 +20151,7 @@ styled according to the options.</p>
 
 
 </section><section>
-<h3 id='control-zoom-option'>Options</h3>
+<h3 id='zoomcontrol-option'>Options</h3>
 
 <section >
 
@@ -20136,32 +20166,32 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-zoom-position'>
+	<tr id='zoomcontrol-position'>
 		<td><code><b>position</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;topleft&#x27;</code></td>
 		<td>The position of the control (one of the map corners). Possible values are <code>'topleft'</code>,
 <code>'topright'</code>, <code>'bottomleft'</code> or <code>'bottomright'</code></td>
 	</tr>
-	<tr id='control-zoom-zoomintext'>
+	<tr id='zoomcontrol-zoomintext'>
 		<td><code><b>zoomInText</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&lt;span aria-hidden&#x3D;&quot;true&quot;&gt;+&lt;/span&gt;&#x27;</code></td>
 		<td>The text set on the 'zoom in' button.</td>
 	</tr>
-	<tr id='control-zoom-zoomintitle'>
+	<tr id='zoomcontrol-zoomintitle'>
 		<td><code><b>zoomInTitle</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;Zoom in&#x27;</code></td>
 		<td>The title set on the 'zoom in' button.</td>
 	</tr>
-	<tr id='control-zoom-zoomouttext'>
+	<tr id='zoomcontrol-zoomouttext'>
 		<td><code><b>zoomOutText</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;&lt;span aria-hidden&#x3D;&quot;true&quot;&gt;&amp;#x2212;&lt;/span&gt;&#x27;</code></td>
 		<td>The text set on the 'zoom out' button.</td>
 	</tr>
-	<tr id='control-zoom-zoomouttitle'>
+	<tr id='zoomcontrol-zoomouttitle'>
 		<td><code><b>zoomOutTitle</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;Zoom out&#x27;</code></td>
@@ -20193,31 +20223,31 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-zoom-getposition'>
+	<tr id='zoomcontrol-getposition'>
 		<td><code><b>getPosition</b>()</code></td>
 		<td><code>string</code></td>
 		<td><p>Returns the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-zoom-setposition'>
+	<tr id='zoomcontrol-setposition'>
 		<td><code><b>setPosition</b>(<nobr>&lt;string&gt;</nobr> <i>position</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-zoom-getcontainer'>
+	<tr id='zoomcontrol-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTMLElement that contains the control.</p>
 </td>
 	</tr>
-	<tr id='control-zoom-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='zoomcontrol-addto'>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the control to the given map.</p>
 </td>
 	</tr>
-	<tr id='control-zoom-remove'>
+	<tr id='zoomcontrol-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the control from the map it is currently active on.</p>
@@ -20229,10 +20259,10 @@ styled according to the options.</p>
 	</div>
 </div>
 
-</section><h2 id='control-attribution'>Control.Attribution</h2><p>The attribution control allows you to display attribution data in a small text box on a map. It is put on the map by default unless you set its <a href="#map-attributioncontrol"><code>attributionControl</code> option</a> to <code>false</code>, and it fetches attribution texts from layers with the <a href="#layer-getattribution"><code>getAttribution</code> method</a> automatically. Extends Control.</p>
+</section><h2 id='attributioncontrol'>AttributionControl</h2><p>The attribution control allows you to display attribution data in a small text box on a map. It is put on the map by default unless you set its <a href="#map-attributioncontrol"><code>attributionControl</code> option</a> to <code>false</code>, and it fetches attribution texts from layers with the <a href="#layer-getattribution"><code>getAttribution</code> method</a> automatically. Extends Control.</p>
 
 <section>
-<h3 id='control-attribution-constructor'>Constructor</h3>
+<h3 id='attributioncontrol-constructor'>Constructor</h3>
 
 <section >
 
@@ -20245,8 +20275,8 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-attribution-control-attribution'>
-		<td><code><b>new Control.Attribution</b>(<nobr>&lt;<a href='#control-attribution-option'>Control.Attribution options</a>&gt;</nobr> <i>options</i>)</code></td>
+	<tr id='attributioncontrol-attributioncontrol'>
+		<td><code><b>new AttributionControl</b>(<nobr>&lt;<a href='#attributioncontrol-option'>AttributionControl options</a>&gt;</nobr> <i>options</i>)</code></td>
 		<td>Creates an attribution control.</td>
 	</tr>
 </tbody></table>
@@ -20256,7 +20286,7 @@ styled according to the options.</p>
 
 
 </section><section>
-<h3 id='control-attribution-option'>Options</h3>
+<h3 id='attributioncontrol-option'>Options</h3>
 
 <section >
 
@@ -20271,14 +20301,14 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-attribution-position'>
+	<tr id='attributioncontrol-position'>
 		<td><code><b>position</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;bottomright&#x27;</code></td>
 		<td>The position of the control (one of the map corners). Possible values are <code>'topleft'</code>,
 <code>'topright'</code>, <code>'bottomleft'</code> or <code>'bottomright'</code></td>
 	</tr>
-	<tr id='control-attribution-prefix'>
+	<tr id='attributioncontrol-prefix'>
 		<td><code><b>prefix</b></code></td>
 		<td><code>String|false</code></td>
 		<td><code>&#x27;Leaflet&#x27;</code></td>
@@ -20290,7 +20320,7 @@ styled according to the options.</p>
 
 
 </section><section>
-<h3 id='control-attribution-method'>Methods</h3>
+<h3 id='attributioncontrol-method'>Methods</h3>
 
 <section >
 
@@ -20304,19 +20334,19 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-attribution-setprefix'>
+	<tr id='attributioncontrol-setprefix'>
 		<td><code><b>setPrefix</b>(<nobr>&lt;String|false&gt;</nobr> <i>prefix</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>The HTML text shown before the attributions. Pass <code>false</code> to disable.</p>
 </td>
 	</tr>
-	<tr id='control-attribution-addattribution'>
+	<tr id='attributioncontrol-addattribution'>
 		<td><code><b>addAttribution</b>(<nobr>&lt;String&gt;</nobr> <i>text</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds an attribution text (e.g. <code>'&amp;copy; OpenStreetMap contributors'</code>).</p>
 </td>
 	</tr>
-	<tr id='control-attribution-removeattribution'>
+	<tr id='attributioncontrol-removeattribution'>
 		<td><code><b>removeAttribution</b>(<nobr>&lt;String&gt;</nobr> <i>text</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes an attribution text.</p>
@@ -20342,31 +20372,31 @@ styled according to the options.</p>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-attribution-getposition'>
+	<tr id='attributioncontrol-getposition'>
 		<td><code><b>getPosition</b>()</code></td>
 		<td><code>string</code></td>
 		<td><p>Returns the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-attribution-setposition'>
+	<tr id='attributioncontrol-setposition'>
 		<td><code><b>setPosition</b>(<nobr>&lt;string&gt;</nobr> <i>position</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-attribution-getcontainer'>
+	<tr id='attributioncontrol-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTMLElement that contains the control.</p>
 </td>
 	</tr>
-	<tr id='control-attribution-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='attributioncontrol-addto'>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the control to the given map.</p>
 </td>
 	</tr>
-	<tr id='control-attribution-remove'>
+	<tr id='attributioncontrol-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the control from the map it is currently active on.</p>
@@ -20378,10 +20408,10 @@ styled according to the options.</p>
 	</div>
 </div>
 
-</section><h2 id='control-layers'>Control.Layers</h2><p>The layers control gives users the ability to switch between different base layers and switch overlays on/off (check out the <a href="https://leafletjs.com/examples/layers-control/">detailed example</a>). Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2 id='layerscontrol'>LayersControl</h2><p>The layers control gives users the ability to switch between different base layers and switch overlays on/off (check out the <a href="https://leafletjs.com/examples/layers-control/">detailed example</a>). Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
-<h3 id='control-layers-example'>Usage example</h3>
+<h3 id='layerscontrol-example'>Usage example</h3>
 
 <section >
 
@@ -20399,7 +20429,7 @@ const overlays = {
 	&quot;Roads&quot;: roadsLayer
 };
 
-new Control.Layers(baseLayers, overlays).addTo(map);
+new LayersControl(baseLayers, overlays).addTo(map);
 </code></pre>
 <p>The <code>baseLayers</code> and <code>overlays</code> parameters are object literals with layer names as keys and <a href="#layer"><code>Layer</code></a> objects as values:</p>
 <pre><code class="language-js">{
@@ -20417,7 +20447,7 @@ new Control.Layers(baseLayers, overlays).addTo(map);
 
 
 </section><section>
-<h3 id='control-layers-constructor'>Constructor</h3>
+<h3 id='layerscontrol-constructor'>Constructor</h3>
 
 <section >
 
@@ -20430,8 +20460,8 @@ new Control.Layers(baseLayers, overlays).addTo(map);
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-layers-control-layers'>
-		<td><code><b>new Control.Layers</b>(<nobr>&lt;Object&gt;</nobr> <i>baselayers?</i>, <nobr>&lt;Object&gt;</nobr> <i>overlays?</i>, <nobr>&lt;<a href='#control-layers-option'>Control.Layers options</a>&gt;</nobr> <i>options?</i>)</code></td>
+	<tr id='layerscontrol-layerscontrol'>
+		<td><code><b>new LayersControl</b>(<nobr>&lt;Object&gt;</nobr> <i>baselayers?</i>, <nobr>&lt;Object&gt;</nobr> <i>overlays?</i>, <nobr>&lt;<a href='#layerscontrol-option'>LayersControl options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td>Creates a layers control with the given layers. Base layers will be switched with radio buttons, while overlays will be switched with checkboxes. Note that all base layers should be passed in the base layers object, but only one should be added to the map during map instantiation.</td>
 	</tr>
 </tbody></table>
@@ -20441,7 +20471,7 @@ new Control.Layers(baseLayers, overlays).addTo(map);
 
 
 </section><section>
-<h3 id='control-layers-option'>Options</h3>
+<h3 id='layerscontrol-option'>Options</h3>
 
 <section >
 
@@ -20456,38 +20486,38 @@ new Control.Layers(baseLayers, overlays).addTo(map);
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-layers-collapsed'>
+	<tr id='layerscontrol-collapsed'>
 		<td><code><b>collapsed</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>If <code>true</code>, the control will be collapsed into an icon and expanded on pointer hover, touch, or keyboard activation.</td>
 	</tr>
-	<tr id='control-layers-collapsedelay'>
+	<tr id='layerscontrol-collapsedelay'>
 		<td><code><b>collapseDelay</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>0</code></td>
 		<td>Collapse delay in milliseconds. If greater than 0, the control will remain open longer, making it easier to scroll through long layer lists.</td>
 	</tr>
-	<tr id='control-layers-autozindex'>
+	<tr id='layerscontrol-autozindex'>
 		<td><code><b>autoZIndex</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>true</code></td>
 		<td>If <code>true</code>, the control will assign zIndexes in increasing order to all of its layers so that the order is preserved when switching them on/off.</td>
 	</tr>
-	<tr id='control-layers-hidesinglebase'>
+	<tr id='layerscontrol-hidesinglebase'>
 		<td><code><b>hideSingleBase</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>If <code>true</code>, the base layers in the control will be hidden when there is only one.</td>
 	</tr>
-	<tr id='control-layers-sortlayers'>
+	<tr id='layerscontrol-sortlayers'>
 		<td><code><b>sortLayers</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
 		<td>Whether to sort the layers. When <code>false</code>, layers will keep the order
 in which they were added to the control.</td>
 	</tr>
-	<tr id='control-layers-sortfunction'>
+	<tr id='layerscontrol-sortfunction'>
 		<td><code><b>sortFunction</b></code></td>
 		<td><code>Function</code></td>
 		<td><code>*</code></td>
@@ -20518,7 +20548,7 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-layers-position'>
+	<tr id='layerscontrol-position'>
 		<td><code><b>position</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;topright&#x27;</code></td>
@@ -20532,7 +20562,7 @@ By default, it sorts layers alphabetically by their name.</td>
 </div>
 
 </section><section>
-<h3 id='control-layers-method'>Methods</h3>
+<h3 id='layerscontrol-method'>Methods</h3>
 
 <section >
 
@@ -20546,31 +20576,31 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-layers-addbaselayer'>
+	<tr id='layerscontrol-addbaselayer'>
 		<td><code><b>addBaseLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>, <nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds a base layer (radio button entry) with the given name to the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-addoverlay'>
+	<tr id='layerscontrol-addoverlay'>
 		<td><code><b>addOverlay</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>, <nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds an overlay (checkbox entry) with the given name to the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-removelayer'>
+	<tr id='layerscontrol-removelayer'>
 		<td><code><b>removeLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Remove the given layer from the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-expand'>
+	<tr id='layerscontrol-expand'>
 		<td><code><b>expand</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Expand the control container if collapsed.</p>
 </td>
 	</tr>
-	<tr id='control-layers-collapse'>
+	<tr id='layerscontrol-collapse'>
 		<td><code><b>collapse</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Collapse the control container if expanded.</p>
@@ -20596,31 +20626,31 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-layers-getposition'>
+	<tr id='layerscontrol-getposition'>
 		<td><code><b>getPosition</b>()</code></td>
 		<td><code>string</code></td>
 		<td><p>Returns the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-setposition'>
+	<tr id='layerscontrol-setposition'>
 		<td><code><b>setPosition</b>(<nobr>&lt;string&gt;</nobr> <i>position</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-getcontainer'>
+	<tr id='layerscontrol-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTMLElement that contains the control.</p>
 </td>
 	</tr>
-	<tr id='control-layers-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='layerscontrol-addto'>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the control to the given map.</p>
 </td>
 	</tr>
-	<tr id='control-layers-remove'>
+	<tr id='layerscontrol-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the control from the map it is currently active on.</p>
@@ -20632,10 +20662,10 @@ By default, it sorts layers alphabetically by their name.</td>
 	</div>
 </div>
 
-</section><h2 id='control-scale'>Control.Scale</h2><p>A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems. Extends <a href="#control"><code>Control</code></a>.</p>
+</section><h2 id='scalecontrol'>ScaleControl</h2><p>A simple scale control that shows the scale of the current center of screen in metric (m/km) and imperial (mi/ft) systems. Extends <a href="#control"><code>Control</code></a>.</p>
 
 <section>
-<h3 id='control-scale-example'>Usage example</h3>
+<h3 id='scalecontrol-example'>Usage example</h3>
 
 <section >
 
@@ -20643,7 +20673,7 @@ By default, it sorts layers alphabetically by their name.</td>
 
 
 
-<pre><code class="language-js">new Control.Scale().addTo(map);
+<pre><code class="language-js">new ScaleControl().addTo(map);
 </code></pre>
 
 
@@ -20652,7 +20682,7 @@ By default, it sorts layers alphabetically by their name.</td>
 
 
 </section><section>
-<h3 id='control-scale-constructor'>Constructor</h3>
+<h3 id='scalecontrol-constructor'>Constructor</h3>
 
 <section >
 
@@ -20665,8 +20695,8 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-scale-control-scale'>
-		<td><code><b>new Control.Scale</b>(<nobr>&lt;<a href='#control-scale-option'>Control.Scale options</a>&gt;</nobr> <i>options?</i>)</code></td>
+	<tr id='scalecontrol-scalecontrol'>
+		<td><code><b>new ScaleControl</b>(<nobr>&lt;<a href='#scalecontrol-option'>ScaleControl options</a>&gt;</nobr> <i>options?</i>)</code></td>
 		<td>Creates an scale control with the given options.</td>
 	</tr>
 </tbody></table>
@@ -20676,7 +20706,7 @@ By default, it sorts layers alphabetically by their name.</td>
 
 
 </section><section>
-<h3 id='control-scale-option'>Options</h3>
+<h3 id='scalecontrol-option'>Options</h3>
 
 <section >
 
@@ -20691,32 +20721,32 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-scale-position'>
+	<tr id='scalecontrol-position'>
 		<td><code><b>position</b></code></td>
 		<td><code>String</code></td>
 		<td><code>&#x27;bottomleft&#x27;</code></td>
 		<td>The position of the control (one of the map corners). Possible values are <code>'topleft'</code>,
 <code>'topright'</code>, <code>'bottomleft'</code> or <code>'bottomright'</code></td>
 	</tr>
-	<tr id='control-scale-maxwidth'>
+	<tr id='scalecontrol-maxwidth'>
 		<td><code><b>maxWidth</b></code></td>
 		<td><code>Number</code></td>
 		<td><code>100</code></td>
 		<td>Maximum width of the control in pixels. The width is set dynamically to show round values (e.g. 100, 200, 500).</td>
 	</tr>
-	<tr id='control-scale-metric'>
+	<tr id='scalecontrol-metric'>
 		<td><code><b>metric</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>True</code></td>
 		<td>Whether to show the metric scale line (m/km).</td>
 	</tr>
-	<tr id='control-scale-imperial'>
+	<tr id='scalecontrol-imperial'>
 		<td><code><b>imperial</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>True</code></td>
 		<td>Whether to show the imperial scale line (mi/ft).</td>
 	</tr>
-	<tr id='control-scale-updatewhenidle'>
+	<tr id='scalecontrol-updatewhenidle'>
 		<td><code><b>updateWhenIdle</b></code></td>
 		<td><code>Boolean</code></td>
 		<td><code>false</code></td>
@@ -20748,31 +20778,31 @@ By default, it sorts layers alphabetically by their name.</td>
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='control-scale-getposition'>
+	<tr id='scalecontrol-getposition'>
 		<td><code><b>getPosition</b>()</code></td>
 		<td><code>string</code></td>
 		<td><p>Returns the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-scale-setposition'>
+	<tr id='scalecontrol-setposition'>
 		<td><code><b>setPosition</b>(<nobr>&lt;string&gt;</nobr> <i>position</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Sets the position of the control.</p>
 </td>
 	</tr>
-	<tr id='control-scale-getcontainer'>
+	<tr id='scalecontrol-getcontainer'>
 		<td><code><b>getContainer</b>()</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Returns the HTMLElement that contains the control.</p>
 </td>
 	</tr>
-	<tr id='control-scale-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+	<tr id='scalecontrol-addto'>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the control to the given map.</p>
 </td>
 	</tr>
-	<tr id='control-scale-remove'>
+	<tr id='scalecontrol-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the control from the map it is currently active on.</p>
@@ -20966,13 +20996,6 @@ data values — they will be evaluated passing <code>data</code> as an argument.
 		<td><code><b>lastId</b></code></td>
 		<td><code>Number</code></td>
 		<td>Last unique ID used by <a href="#util-stamp"><code>stamp()</code></a></td>
-	</tr>
-	<tr id='util-emptyimageurl'>
-		<td><code><b>emptyImageUrl</b></code></td>
-		<td><code>String</code></td>
-		<td>Data URI string containing a base64-encoded empty GIF image.
-Used as a hack to free memory from unused images on WebKit-powered
-mobile devices (by setting image <code>src</code> to this string).</td>
 	</tr>
 </tbody></table>
 
@@ -21234,8 +21257,10 @@ context to <code>off</code> in order to remove the listener.</td>
 	<tr id='domevent-disableclickpropagation'>
 		<td><code><b>disableClickPropagation</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</code></td>
 		<td><code>this</code></td>
-		<td>Adds <code>stopPropagation</code> to the element's <code>'click'</code>, <code>'dblclick'</code>, <code>'contextmenu'</code>
-and <code>'pointerdown'</code> events (plus browser variants).</td>
+		<td>Adds <code>stopPropagation</code> to the element's <code>'dblclick'</code>, <code>'contextmenu'</code>
+and <code>'pointerdown'</code> events (plus browser variants).
+For <code>'click'</code> events, prevents the map from handling the click
+while still allowing the native DOM click event to propagate normally.</td>
 	</tr>
 	<tr id='domevent-preventdefault'>
 		<td><code><b>preventDefault</b>(<nobr>&lt;DOMEvent&gt;</nobr> <i>ev</i>)</code></td>
@@ -21291,14 +21316,14 @@ a best guess of 60 pixels.</td>
 	</tr>
 	</thead><tbody>
 	<tr id='domevent-enablepointerdetection'>
-		<td><code><b>enablePointerDetection</b>()</code></td>
+		<td><code><b>enablePointerDetection</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</code></td>
 		<td><code></code></td>
-		<td>Enables pointer detection for the document.</td>
+		<td>Enables pointer detection and capture for the document.</td>
 	</tr>
 	<tr id='domevent-disablepointerdetection'>
-		<td><code><b>disablePointerDetection</b>()</code></td>
+		<td><code><b>disablePointerDetection</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</code></td>
 		<td><code></code></td>
-		<td>Disables pointer detection for the document.</td>
+		<td>Disables pointer detection and capture for the document.</td>
 	</tr>
 	<tr id='domevent-getpointers'>
 		<td><code><b>getPointers</b>()</code></td>
@@ -21876,7 +21901,7 @@ The verification can optionally be propagated, it will return <code>true</code> 
 </div>
 
 </section><h2 id='class'>Class</h2><p>Class powers the OOP facilities of Leaflet and is used to create almost all of the Leaflet classes documented here.</p>
-<p>In addition to implementing a simple classical inheritance model, it introduces several special properties for convenient code organization — options, includes and statics.</p>
+<p>It implements a simple classical inheritance model using JavaScript's standard <code>extends</code> keyword, and introduces several special properties for convenient code organization — options and init hooks.</p>
 
 <section>
 <h3 id='class-example'>Usage example</h3>
@@ -21887,16 +21912,16 @@ The verification can optionally be propagated, it will return <code>true</code> 
 
 
 
-<pre><code class="language-js">const MyClass = Class.extend({
+<pre><code class="language-js">class MyClass extends Class {
     initialize(greeter) {
         this.greeter = greeter;
         // class constructor
-    },
+    }
 
     greet(name) {
         alert(this.greeter + ', ' + name)
     }
-});
+}
 
 // create instance of MyClass, passing &quot;Hello&quot; to the constructor
 const a = new MyClass(&quot;Hello&quot;);
@@ -21909,60 +21934,28 @@ a.greet(&quot;World&quot;);
 
 </section><section >
 
-<h4 id='class-inheritance'>Inheritance</h4>
-
-
-
-<p>You use Class.extend to define new classes, but you can use the same method on any class to inherit from it:</p>
-<pre><code class="language-js">const MyChildClass = MyClass.extend({
-    // ... new properties and methods
-});
-</code></pre>
-<p>This will create a class that inherits all methods and properties of the parent class (through a proper prototype chain), adding or overriding the ones you pass to extend. It will also properly react to instanceof:</p>
-<pre><code class="language-js">const a = new MyChildClass();
-a instanceof MyChildClass; // true
-a instanceof MyClass; // true
-</code></pre>
-<p>You can call parent methods (including constructor) from corresponding child ones (as you do with super calls in other languages) by accessing parent class prototype and using JavaScript's call or apply:</p>
-<pre><code>const MyChildClass = MyClass.extend({
-    initialize() {
-        MyClass.prototype.initialize.call(this, &quot;Yo&quot;);
-    },
-
-    greet(name) {
-        MyClass.prototype.greet.call(this, 'bro ' + name + '!');
-    }
-});
-
-const a = new MyChildClass();
-a.greet('Jason'); // alerts &quot;Yo, bro Jason!&quot;
-</code></pre>
-
-
-
-</section><section >
-
 <h4 id='class-options'>Options</h4>
 
 
 
-<p><code>options</code> is a special property that unlike other objects that you pass
-to <code>extend</code> will be merged with the parent one instead of overriding it
-completely, which makes managing configuration of objects and default
-values convenient:</p>
-<pre><code class="language-js">const MyClass = Class.extend({
-    options: {
-        myOption1: 'foo',
-        myOption2: 'bar'
+<p><code>options</code> is a special property that will be merged with the parent class options instead of overriding them completely, which makes managing configuration of objects and default values convenient. Use <code>setDefaultOptions()</code> in a static block to configure options:</p>
+<pre><code class="language-js">class MyClass extends Class {
+    static {
+        this.setDefaultOptions({
+            myOption1: 'foo',
+            myOption2: 'bar'
+        });
     }
-});
+}
 
-const MyChildClass = MyClass.extend({
-    options: {
-        myOption1: 'baz',
-        myOption3: 5
+class MyChildClass extends MyClass {
+    static {
+        this.setDefaultOptions({
+            myOption1: 'baz',
+            myOption3: 5
+        });
     }
-});
+}
 
 const a = new MyChildClass();
 a.options.myOption1; // 'baz'
@@ -21971,18 +21964,20 @@ a.options.myOption3; // 5
 </code></pre>
 <p>There's also <a href="#util-setoptions"><code>Util.setOptions</code></a>, a method for
 conveniently merging options passed to constructor with the defaults
-defines in the class:</p>
-<pre><code class="language-js">const MyClass = Class.extend({
-    options: {
-        foo: 'bar',
-        bla: 5
-    },
+defined in the class:</p>
+<pre><code class="language-js">class MyClass extends Class {
+    static {
+        this.setDefaultOptions({
+            foo: 'bar',
+            bla: 5
+        });
+    }
 
     initialize(options) {
         Util.setOptions(this, options);
         ...
     }
-});
+}
 
 const a = new MyClass({bla: 10});
 a.options; // {foo: 'bar', bla: 10}
@@ -21997,35 +21992,22 @@ keys that are already used by the class in question.</p>
 
 </section><section >
 
-<h4 id='class-includes'>Includes</h4>
+<h4 id='class-mixins'>Mixins</h4>
 
 
 
-<p><code>includes</code> is a special class property that merges all specified objects into the class (such objects are called mixins).</p>
+<p>You can add methods and properties from other objects using the <code>include</code> method (such objects are called mixins):</p>
 <pre><code class="language-js">const MyMixin = {
     foo() { ... },
     bar: 5
 };
 
-const MyClass = Class.extend({
-    includes: MyMixin
-});
+class MyClass extends Class {}
+
+MyClass.include(MyMixin);
 
 const a = new MyClass();
 a.foo();
-</code></pre>
-<p>You can also do such includes in runtime with the <code>include</code> method:</p>
-<pre><code class="language-js">MyClass.include(MyMixin);
-</code></pre>
-<p><code>statics</code> is just a convenience property that injects specified object properties as the static properties of the class, useful for defining constants:</p>
-<pre><code class="language-js">const MyClass = Class.extend({
-    statics: {
-        FOO: 'bar',
-        BLA: 5
-    }
-});
-
-MyClass.FOO; // 'bar'
 </code></pre>
 
 
@@ -22066,13 +22048,6 @@ MyClass.FOO; // 'bar'
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='class-extend'>
-		<td><code><b>extend</b>(<nobr>&lt;Object&gt;</nobr> <i>props</i>)</code></td>
-		<td><code>Function</code></td>
-		<td><a href="#class-inheritance">Extends the current class</a> given the properties to be included.
-Deprecated - use <code>class X extends Class</code> instead!
-Returns a Javascript function that is a class constructor (to be called with <code>new</code>).</td>
-	</tr>
 	<tr id='class-include'>
 		<td><code><b>include</b>(<nobr>&lt;Object&gt;</nobr> <i>properties</i>)</code></td>
 		<td><code>this</code></td>
@@ -22098,7 +22073,7 @@ Returns a Javascript function that is a class constructor (to be called with <co
 </section>
 
 
-</section><h2 id='evented'>Evented</h2><p>A set of methods shared between event-powered classes (like <a href="#map"><code>Map</code></a> and <a href="#marker"><code>Marker</code></a>). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map to fire <code>'click'</code> event).</p>
+</section><h2 id='evented'>Evented</h2><p>A set of methods shared between event-powered classes (like <code>Map</code> and <a href="#marker"><code>Marker</code></a>). Generally, events allow you to execute some function when something happens with an object (e.g. the user clicks on the map, causing the map to fire <code>'click'</code> event).</p>
 
 <section>
 <h3 id='evented-example'>Usage example</h3>
@@ -22359,7 +22334,7 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 	</tr>
 	</thead><tbody>
 	<tr id='layer-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -22371,7 +22346,7 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 </td>
 	</tr>
 	<tr id='layer-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -22410,13 +22385,13 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 	</tr>
 	</thead><tbody>
 	<tr id='layer-onadd'>
-		<td><code><b>onAdd</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>onAdd</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Should contain code that creates DOM elements for the layer, adds them to <code>map panes</code> where they should belong and puts listeners on relevant map events. Called on <a href="#map-addlayer"><code>map.addLayer(layer)</code></a>.</p>
 </td>
 	</tr>
 	<tr id='layer-onremove'>
-		<td><code><b>onRemove</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>onRemove</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Should contain all clean up code that removes the layer's elements from the DOM and removes listeners previously added in <a href="#layer-onadd"><code>onAdd</code></a>. Called on <a href="#map-removelayer"><code>map.removeLayer(layer)</code></a>.</p>
 </td>
@@ -22434,7 +22409,7 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 </td>
 	</tr>
 	<tr id='layer-beforeadd'>
-		<td><code><b>beforeAdd</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>beforeAdd</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Optional method. Called on <a href="#map-addlayer"><code>map.addLayer(layer)</code></a>, before the layer is added to the map, before events are initialized, without waiting until the map is in a usable state. Use for early initialization only.</p>
 </td>
@@ -22464,10 +22439,10 @@ layer.closePopup();
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindpopup'>
@@ -22537,10 +22512,10 @@ layer.closeTooltip();
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='layer-unbindtooltip'>
@@ -22922,7 +22897,7 @@ for a second (also called long press).</td>
 	</tr>
 	</thead><tbody>
 	<tr id='interactive-layer-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -22934,7 +22909,7 @@ for a second (also called long press).</td>
 </td>
 	</tr>
 	<tr id='interactive-layer-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -22983,10 +22958,10 @@ for a second (also called long press).</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindpopup'>
@@ -23058,10 +23033,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-unbindtooltip'>
@@ -23263,7 +23238,7 @@ All other controls extend from this class.</p>
 </td>
 	</tr>
 	<tr id='control-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the control to the given map.</p>
 </td>
@@ -23290,13 +23265,13 @@ All other controls extend from this class.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='control-onadd'>
-		<td><code><b>onAdd</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>onAdd</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>HTMLElement</code></td>
 		<td><p>Should return the container DOM element for the control and add listeners on relevant map events. Called on <a href="#control-addTo"><code>control.addTo(map)</code></a>.</p>
 </td>
 	</tr>
 	<tr id='control-onremove'>
-		<td><code><b>onRemove</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>onRemove</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code></code></td>
 		<td><p>Optional method. Should contain all clean up code that removes the listeners previously added in <a href="#control-onadd"><code>onAdd</code></a>. Called on <a href="#control-remove"><code>control.remove()</code></a>.</p>
 </td>
@@ -23389,7 +23364,7 @@ All other controls extend from this class.</p>
 	</tr>
 	</thead><tbody>
 	<tr id='handler-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>, <nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>, <nobr>&lt;String&gt;</nobr> <i>name</i>)</code></td>
 		<td><code>this</code></td>
 		<td>Adds a new Handler to the given map with the given name.</td>
 	</tr>
@@ -23645,31 +23620,6 @@ geographical CRSs. If <code>undefined</code>, the longitude axis does not wrap a
 		<th>Description</th>
 	</tr>
 	</thead><tbody>
-	<tr id='crs-crs-earth'>
-		<td><code><b>CRS.Earth</b></code></td>
-		<td>Serves as the base for CRS that are global such that they cover the earth.
-Can only be used as the base for other CRS and cannot be used directly,
-since it does not have a <code>code</code>, <code>projection</code> or <code>transformation</code>. <code>distance()</code> returns
-meters.</td>
-	</tr>
-	<tr id='crs-crs-epsg3395'>
-		<td><code><b>CRS.EPSG3395</b></code></td>
-		<td>Rarely used by some commercial tile providers. Uses Elliptical Mercator projection.</td>
-	</tr>
-	<tr id='crs-crs-epsg3857'>
-		<td><code><b>CRS.EPSG3857</b></code></td>
-		<td>The most common CRS for online maps, used by almost all free and commercial
-tile providers. Uses Spherical Mercator projection. Set in by default in
-Map's <code>crs</code> option.</td>
-	</tr>
-	<tr id='crs-crs-epsg4326'>
-		<td><code><b>CRS.EPSG4326</b></code></td>
-		<td>A common CRS among GIS enthusiasts. Uses simple Equirectangular projection.
-<p>Leaflet complies with the <a href="https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-geodetic">TMS coordinate scheme for EPSG:4326</a>.
-If you are using a <a href="#tilelayer"><code>TileLayer</code></a> with this CRS, ensure that there are two 256x256 pixel tiles covering the
-whole earth at zoom level zero, and that the tile coordinate origin is (-180,+90),
-or (-180,-90) for <a href="#tilelayer"><code>TileLayer</code></a>s with <a href="#tilelayer-tms">the <code>tms</code> option</a> set.</p></td>
-	</tr>
 	<tr id='crs-crs-base'>
 		<td><code><b>CRS.Base</b></code></td>
 		<td>Object that defines coordinate reference systems for projecting
@@ -23683,8 +23633,33 @@ CRS not defined by default, take a look at the
 and can't be instantiated. Also, new classes can't inherit from them,
 and methods can't be added to them with the <code>include</code> function.</p></td>
 	</tr>
-	<tr id='crs-crs-simple'>
-		<td><code><b>CRS.Simple</b></code></td>
+	<tr id='crs-epsg3395'>
+		<td><code><b>EPSG3395</b></code></td>
+		<td>Rarely used by some commercial tile providers. Uses Elliptical Mercator projection.</td>
+	</tr>
+	<tr id='crs-epsg3857'>
+		<td><code><b>EPSG3857</b></code></td>
+		<td>The most common CRS for online maps, used by almost all free and commercial
+tile providers. Uses Spherical Mercator projection. Set in by default in
+Map's <code>crs</code> option.</td>
+	</tr>
+	<tr id='crs-epsg4326'>
+		<td><code><b>EPSG4326</b></code></td>
+		<td>A common CRS among GIS enthusiasts. Uses simple Equirectangular projection.
+<p>Leaflet complies with the <a href="https://wiki.osgeo.org/wiki/Tile_Map_Service_Specification#global-geodetic">TMS coordinate scheme for EPSG:4326</a>.
+If you are using a <a href="#tilelayer"><code>TileLayer</code></a> with this CRS, ensure that there are two 256x256 pixel tiles covering the
+whole earth at zoom level zero, and that the tile coordinate origin is (-180,+90),
+or (-180,-90) for <a href="#tilelayer"><code>TileLayer</code></a>s with <a href="#tilelayer-tms">the <code>tms</code> option</a> set.</p></td>
+	</tr>
+	<tr id='crs-earthcrs'>
+		<td><code><b>EarthCRS</b></code></td>
+		<td>Serves as the base for CRS that are global such that they cover the earth.
+Can only be used as the base for other CRS and cannot be used directly,
+since it does not have a <code>code</code>, <code>projection</code> or <code>transformation</code>. <code>distance()</code> returns
+meters.</td>
+	</tr>
+	<tr id='crs-simplecrs'>
+		<td><code><b>SimpleCRS</b></code></td>
 		<td>A simple CRS that maps longitude and latitude into <code>x</code> and <code>y</code> directly.
 May be used for maps of flat surfaces (e.g. game maps). Note that the <code>y</code>
 axis should still be inverted (going from bottom to top). <code>distance()</code> returns
@@ -23953,7 +23928,7 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 	</tr>
 	</thead><tbody>
 	<tr id='blanketoverlay-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -23965,7 +23940,7 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -24014,10 +23989,10 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindpopup'>
@@ -24089,10 +24064,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-unbindtooltip'>
@@ -24458,7 +24433,7 @@ its map has moved</td>
 	</tr>
 	</thead><tbody>
 	<tr id='renderer-addto'>
-		<td><code><b>addTo</b>(<nobr>&lt;Map|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>addTo</b>(<nobr>&lt;LeafletMap|LayerGroup&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Adds the layer to the given map or layer group.</p>
 </td>
@@ -24470,7 +24445,7 @@ its map has moved</td>
 </td>
 	</tr>
 	<tr id='renderer-removefrom'>
-		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#map'>Map</a>&gt;</nobr> <i>map</i>)</code></td>
+		<td><code><b>removeFrom</b>(<nobr>&lt;<a href='#leafletmap'>LeafletMap</a>&gt;</nobr> <i>map</i>)</code></td>
 		<td><code>this</code></td>
 		<td><p>Removes the layer from the given map</p>
 </td>
@@ -24519,10 +24494,10 @@ its map has moved</td>
 		<td><code>this</code></td>
 		<td><p>Binds a popup to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindpopup'>
@@ -24594,10 +24569,10 @@ String content is rendered as HTML; sanitize untrusted input or pass an <code>HT
 		<td><code>this</code></td>
 		<td><p>Binds a tooltip to the layer with the passed <code>content</code> and sets up the
 necessary event listeners. A <code>String</code> argument is rendered as HTML; if it
-may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-<code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code> is passed
-it will receive the layer as the first argument and should return a
-<code>String</code> or <code>HTMLElement</code>.</p>
+may contain untrusted input, sanitize it before passing it to Leaflet,
+or pass an <code>HTMLElement</code> with safe <code>textContent</code> instead. If a <code>Function</code>
+is passed it will receive the layer as the first argument and should return
+a <code>String</code> or <code>HTMLElement</code>.</p>
 </td>
 	</tr>
 	<tr id='renderer-unbindtooltip'>
@@ -25904,7 +25879,9 @@ const Leaflet = L.noConflict();
 </code></pre>
 
 <h2 id='version'>version</h2><p>A constant that represents the Leaflet version in use.</p>
-<pre><code class="language-js">L.version; // contains &quot;1.0.0&quot; (or whatever version is currently in use)
+<pre><code class="language-js">import { version } from 'leaflet';
+
+console.log(version); // contains &quot;2.0.0&quot; (or whatever version is currently in use)
 </code></pre>
 
 

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -164,8 +164,8 @@ export class DivOverlay extends Layer {
 
 	// @method setContent(htmlContent: String|HTMLElement|Function): this
 	// Sets the HTML content of the overlay. A `String` argument is rendered as
-	// HTML; if it may contain untrusted input, sanitize it (e.g. with DOMPurify)
-	// or pass an `HTMLElement` with safe `textContent` instead. If a function is
+	// HTML; if it may contain untrusted input, sanitize it before passing it to
+	// Leaflet, or pass an `HTMLElement` with safe `textContent` instead. If a function is
 	// passed the source layer will be passed to the function. The function should
 	// return a `String` or `HTMLElement` to be used in the overlay.
 	setContent(content) {

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -39,8 +39,8 @@ import {FeatureGroup} from './FeatureGroup.js';
  *
  * **Security note.** Popup string content is rendered as HTML. If your content
  * may include untrusted input (e.g. data from users or external APIs), sanitize
- * it with a library like [DOMPurify](https://github.com/cure53/DOMPurify), or
- * build a DOM element using `textContent` to render it as plain text:
+ * it before passing it to Leaflet, or build a DOM element using `textContent`
+ * to render it as plain text:
  *
  * ```js
  * const el = document.createElement('div');
@@ -407,10 +407,10 @@ Layer.include({
 	// @method bindPopup(content: String|HTMLElement|Function|Popup, options?: Popup options): this
 	// Binds a popup to the layer with the passed `content` and sets up the
 	// necessary event listeners. A `String` argument is rendered as HTML; if it
-	// may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-	// `HTMLElement` with safe `textContent` instead. If a `Function` is passed
-	// it will receive the layer as the first argument and should return a
-	// `String` or `HTMLElement`.
+	// may contain untrusted input, sanitize it before passing it to Leaflet,
+	// or pass an `HTMLElement` with safe `textContent` instead. If a `Function`
+	// is passed it will receive the layer as the first argument and should return
+	// a `String` or `HTMLElement`.
 	bindPopup(content, options) {
 		this._popup = this._initOverlay(Popup, this._popup, content, options);
 		if (!this._popupHandlersAdded) {

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -36,8 +36,8 @@ import {FeatureGroup} from './FeatureGroup.js';
  *
  * **Security note.** Tooltip string content is rendered as HTML. If your content
  * may include untrusted input (e.g. data from users or external APIs), sanitize
- * it with a library like [DOMPurify](https://github.com/cure53/DOMPurify), or
- * build a DOM element using `textContent` to render it as plain text:
+ * it before passing it to Leaflet, or build a DOM element using `textContent`
+ * to render it as plain text:
  *
  * ```js
  * const el = document.createElement('div');
@@ -279,10 +279,10 @@ Layer.include({
 	// @method bindTooltip(content: String|HTMLElement|Function|Tooltip, options?: Tooltip options): this
 	// Binds a tooltip to the layer with the passed `content` and sets up the
 	// necessary event listeners. A `String` argument is rendered as HTML; if it
-	// may contain untrusted input, sanitize it (e.g. with DOMPurify) or pass an
-	// `HTMLElement` with safe `textContent` instead. If a `Function` is passed
-	// it will receive the layer as the first argument and should return a
-	// `String` or `HTMLElement`.
+	// may contain untrusted input, sanitize it before passing it to Leaflet,
+	// or pass an `HTMLElement` with safe `textContent` instead. If a `Function`
+	// is passed it will receive the layer as the first argument and should return
+	// a `String` or `HTMLElement`.
 	bindTooltip(content, options) {
 
 		if (this._tooltip && this.isTooltipOpen()) {


### PR DESCRIPTION
Follow-up to #10205. Rather than recommending a specific third-party library (DOMPurify), point users to the browser's built-in [Sanitizer API](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Sanitizer_API) with a note about fallbacks for unsupported browsers.