### PR TITLE
Update compatible-v2 flag for Leaflet.UTM

### DIFF
--- a/docs/_plugins/geoprocessing/leaflet-utm.md
+++ b/docs/_plugins/geoprocessing/leaflet-utm.md
@@ -7,7 +7,7 @@ author-url: https://github.com/jjimenezshaw/
 demo: https://jjimenezshaw.github.io/Leaflet.UTM/examples/input.html
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 A simple way to convert L.LatLng into UTM (WGS84) and vice versa. UTM string format easily configurable. It does not depend on any other plugin or 3rd party.


### PR DESCRIPTION
After latest changes in https://github.com/jjimenezshaw/Leaflet.UTM to make it Leaflet v2 compatible.
Fixes https://github.com/jjimenezshaw/Leaflet.UTM/issues/13