### PR TITLE
Replace time-relative language in documentation with evergreen equivalents

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -173,7 +173,7 @@ If not, please open a new GitHub issue.</p>
 
 <p>Let's create the best mapping library in the world!
 Leaflet was originally created by <a href="https://agafonkin.com">Volodymyr Agafonkin</a>,
-but is now developed by a big community of <a href="https://github.com/Leaflet/Leaflet/graphs/contributors">contributors</a>.
+but is developed by a big community of <a href="https://github.com/Leaflet/Leaflet/graphs/contributors">contributors</a>.
 <a href="https://github.com/Leaflet/Leaflet">Pull requests</a> are always welcome.
 However, there are many more ways to get involved with the development of Leaflet.</p>
 

--- a/docs/reference-2.0.0.html
+++ b/docs/reference-2.0.0.html
@@ -957,7 +957,7 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the map</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the map</p>
 </td>
 	</tr>
 	<tr id='map-eachlayer'>
@@ -1155,7 +1155,7 @@ pan by default.</p>
 	<tr id='map-stop'>
 		<td><code><b>stop</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Stops the currently running <code>panTo</code> or <code>flyTo</code> animation, if any.</p>
+		<td><p>Stops the running <code>panTo</code> or <code>flyTo</code> animation, if any.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -2723,7 +2723,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='marker-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='marker-removefrom'>
@@ -2809,7 +2809,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='marker-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='marker-setpopupcontent'>
@@ -2884,7 +2884,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='marker-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='marker-settooltipcontent'>
@@ -3468,7 +3468,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='divoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-removefrom'>
@@ -3554,7 +3554,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='divoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-setpopupcontent'>
@@ -3629,7 +3629,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='divoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-settooltipcontent'>
@@ -4394,7 +4394,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='popup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='popup-removefrom'>
@@ -4480,7 +4480,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='popup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='popup-setpopupcontent'>
@@ -4555,7 +4555,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='popup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='popup-settooltipcontent'>
@@ -5245,7 +5245,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='tooltip-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tooltip-removefrom'>
@@ -5331,7 +5331,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tooltip-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tooltip-setpopupcontent'>
@@ -5406,7 +5406,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tooltip-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tooltip-settooltipcontent'>
@@ -5851,7 +5851,7 @@ tiles outside the CRS limits.</td>
 	<tr id='tilelayer-tileabort'>
 		<td><code><b>tileabort</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
-		<td>Fired when a tile was loading but is now not wanted.</td>
+		<td>Fired when a tile was loading but is no longer wanted.</td>
 	</tr>
 </tbody></table>
 
@@ -6153,7 +6153,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 	<tr id='tilelayer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-removefrom'>
@@ -6239,7 +6239,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-setpopupcontent'>
@@ -6314,7 +6314,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-settooltipcontent'>
@@ -6822,7 +6822,7 @@ tiles outside the CRS limits.</td>
 	<tr id='tilelayer-wms-tileabort'>
 		<td><code><b>tileabort</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
-		<td>Fired when a tile was loading but is now not wanted.</td>
+		<td>Fired when a tile was loading but is no longer wanted.</td>
 	</tr>
 </tbody></table>
 
@@ -7130,7 +7130,7 @@ callback is called when the tile has been loaded.</p>
 	<tr id='tilelayer-wms-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-removefrom'>
@@ -7216,7 +7216,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-wms-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-setpopupcontent'>
@@ -7291,7 +7291,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-wms-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-settooltipcontent'>
@@ -7898,7 +7898,7 @@ used by this overlay.</p>
 	<tr id='imageoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-removefrom'>
@@ -7984,7 +7984,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='imageoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-setpopupcontent'>
@@ -8059,7 +8059,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='imageoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-settooltipcontent'>
@@ -8764,7 +8764,7 @@ used by this overlay.</p>
 	<tr id='videooverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-removefrom'>
@@ -8850,7 +8850,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='videooverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-setpopupcontent'>
@@ -8925,7 +8925,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='videooverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-settooltipcontent'>
@@ -9571,7 +9571,7 @@ used by this overlay.</p>
 	<tr id='svgoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-removefrom'>
@@ -9657,7 +9657,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svgoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-setpopupcontent'>
@@ -9732,7 +9732,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svgoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-settooltipcontent'>
@@ -10280,7 +10280,7 @@ for a second (also called long press).</td>
 	<tr id='path-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='path-removefrom'>
@@ -10366,7 +10366,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='path-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='path-setpopupcontent'>
@@ -10441,7 +10441,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='path-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='path-settooltipcontent'>
@@ -11160,7 +11160,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='polyline-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='polyline-removefrom'>
@@ -11246,7 +11246,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polyline-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polyline-setpopupcontent'>
@@ -11321,7 +11321,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polyline-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polyline-settooltipcontent'>
@@ -12068,7 +12068,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='polygon-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='polygon-removefrom'>
@@ -12154,7 +12154,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polygon-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polygon-setpopupcontent'>
@@ -12229,7 +12229,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polygon-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polygon-settooltipcontent'>
@@ -12986,7 +12986,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='rectangle-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='rectangle-removefrom'>
@@ -13072,7 +13072,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='rectangle-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='rectangle-setpopupcontent'>
@@ -13147,7 +13147,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='rectangle-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='rectangle-settooltipcontent'>
@@ -13870,7 +13870,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='circle-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='circle-removefrom'>
@@ -13956,7 +13956,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circle-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circle-setpopupcontent'>
@@ -14031,7 +14031,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circle-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circle-settooltipcontent'>
@@ -14701,7 +14701,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='circlemarker-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-removefrom'>
@@ -14787,7 +14787,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circlemarker-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-setpopupcontent'>
@@ -14862,7 +14862,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circlemarker-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-settooltipcontent'>
@@ -15292,7 +15292,7 @@ its map has moved</td>
 	<tr id='svg-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='svg-removefrom'>
@@ -15378,7 +15378,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svg-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svg-setpopupcontent'>
@@ -15453,7 +15453,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svg-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svg-settooltipcontent'>
@@ -15938,7 +15938,7 @@ its map has moved</td>
 	<tr id='canvas-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='canvas-removefrom'>
@@ -16024,7 +16024,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='canvas-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='canvas-setpopupcontent'>
@@ -16099,7 +16099,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='canvas-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='canvas-settooltipcontent'>
@@ -16565,13 +16565,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='layergroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='layergroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='layergroup-clearlayers'>
@@ -16649,7 +16649,7 @@ implement <code>methodName</code>.</p>
 	<tr id='layergroup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='layergroup-removefrom'>
@@ -16735,7 +16735,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layergroup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layergroup-setpopupcontent'>
@@ -16810,7 +16810,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layergroup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layergroup-settooltipcontent'>
@@ -17350,13 +17350,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='featuregroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-clearlayers'>
@@ -17435,7 +17435,7 @@ implement <code>methodName</code>.</p>
 	<tr id='featuregroup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-removefrom'>
@@ -17521,7 +17521,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='featuregroup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-setpopupcontent'>
@@ -17596,7 +17596,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='featuregroup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-settooltipcontent'>
@@ -18252,13 +18252,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='geojson-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='geojson-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='geojson-clearlayers'>
@@ -18337,7 +18337,7 @@ implement <code>methodName</code>.</p>
 	<tr id='geojson-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='geojson-removefrom'>
@@ -18423,7 +18423,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='geojson-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='geojson-setpopupcontent'>
@@ -18498,7 +18498,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='geojson-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='geojson-settooltipcontent'>
@@ -19199,7 +19199,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 	<tr id='gridlayer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-removefrom'>
@@ -19285,7 +19285,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='gridlayer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-setpopupcontent'>
@@ -19360,7 +19360,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='gridlayer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-settooltipcontent'>
@@ -20884,7 +20884,7 @@ styled according to the options.</p>
 	<tr id='control-zoom-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -21033,7 +21033,7 @@ styled according to the options.</p>
 	<tr id='control-attribution-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -21281,7 +21281,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	<tr id='control-layers-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -21433,7 +21433,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	<tr id='control-scale-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -21945,7 +21945,7 @@ a best guess of 60 pixels.</td>
 
 <h4 id='domevent-pointer-detection'>Pointer detection</h4>
 
-<div class='section-comments'>Detects the pointers that are currently active on the document.</div>
+<div class='section-comments'>Detects the pointers that are active on the document.</div>
 
 <table><thead>
 	<tr>
@@ -22084,7 +22084,7 @@ drag interaction on them.</td>
 	<tr id='domutil-getscale'>
 		<td><code><b>getScale</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</code></td>
 		<td><code>Object</code></td>
-		<td>Computes the CSS scale currently applied on the element.
+		<td>Computes the CSS scale applied on the element.
 Returns an object with <code>x</code> and <code>y</code> members as horizontal and vertical scales respectively,
 and <code>boundingClientRect</code> as the result of <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect"><code>getBoundingClientRect()</code></a>.</td>
 	</tr>
@@ -22212,7 +22212,7 @@ argument of the <a href="https://cubic-bezier.com/#0,0,.5,1">cubic bezier curve<
 	<tr id='posanimation-stop'>
 		<td><code><b>stop</b>()</code></td>
 		<td><code></code></td>
-		<td><p>Stops the animation (if currently running).</p>
+		<td><p>Stops the animation (if running).</p>
 </td>
 	</tr>
 </tbody></table>
@@ -23134,7 +23134,7 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 	<tr id='layer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='layer-removefrom'>
@@ -23264,7 +23264,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layer-setpopupcontent'>
@@ -23337,7 +23337,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layer-settooltipcontent'>
@@ -23733,7 +23733,7 @@ for a second (also called long press).</td>
 	<tr id='interactive-layer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-removefrom'>
@@ -23819,7 +23819,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='interactive-layer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-setpopupcontent'>
@@ -23894,7 +23894,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='interactive-layer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-settooltipcontent'>
@@ -24110,7 +24110,7 @@ All other controls extend from this class.</p>
 	<tr id='control-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -24801,7 +24801,7 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 	<tr id='blanketoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-removefrom'>
@@ -24887,7 +24887,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='blanketoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-setpopupcontent'>
@@ -24962,7 +24962,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='blanketoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-settooltipcontent'>
@@ -25342,7 +25342,7 @@ its map has moved</td>
 	<tr id='renderer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='renderer-removefrom'>
@@ -25428,7 +25428,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='renderer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='renderer-setpopupcontent'>
@@ -25503,7 +25503,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='renderer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='renderer-settooltipcontent'>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -969,7 +969,7 @@ are respected, and that the renderers do exist on the map.</p>
 	<tr id='map-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the map</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the map</p>
 </td>
 	</tr>
 	<tr id='map-eachlayer'>
@@ -1167,7 +1167,7 @@ pan by default.</p>
 	<tr id='map-stop'>
 		<td><code><b>stop</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Stops the currently running <code>panTo</code> or <code>flyTo</code> animation, if any.</p>
+		<td><p>Stops the running <code>panTo</code> or <code>flyTo</code> animation, if any.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -2810,7 +2810,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='marker-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='marker-removefrom'>
@@ -2896,7 +2896,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='marker-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='marker-setpopupcontent'>
@@ -2971,7 +2971,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='marker-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='marker-settooltipcontent'>
@@ -3519,7 +3519,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='divoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-removefrom'>
@@ -3605,7 +3605,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='divoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-setpopupcontent'>
@@ -3680,7 +3680,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='divoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='divoverlay-settooltipcontent'>
@@ -4409,7 +4409,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='popup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='popup-removefrom'>
@@ -4495,7 +4495,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='popup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='popup-setpopupcontent'>
@@ -4570,7 +4570,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='popup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='popup-settooltipcontent'>
@@ -5224,7 +5224,7 @@ return a <code>String</code> or <code>HTMLElement</code> to be used in the overl
 	<tr id='tooltip-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tooltip-removefrom'>
@@ -5310,7 +5310,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tooltip-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tooltip-setpopupcontent'>
@@ -5385,7 +5385,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tooltip-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tooltip-settooltipcontent'>
@@ -5794,7 +5794,7 @@ tiles outside the CRS limits.</td>
 	<tr id='tilelayer-tileabort'>
 		<td><code><b>tileabort</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
-		<td>Fired when a tile was loading but is now not wanted.</td>
+		<td>Fired when a tile was loading but is no longer wanted.</td>
 	</tr>
 </tbody></table>
 
@@ -6096,7 +6096,7 @@ Classes extending <a href="#tilelayer"><code>TileLayer</code></a> can override t
 	<tr id='tilelayer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-removefrom'>
@@ -6182,7 +6182,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-setpopupcontent'>
@@ -6257,7 +6257,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-settooltipcontent'>
@@ -6729,7 +6729,7 @@ tiles outside the CRS limits.</td>
 	<tr id='tilelayer-wms-tileabort'>
 		<td><code><b>tileabort</b></code></td>
 		<td><code><a href='#tileevent'>TileEvent</a></code></td>
-		<td>Fired when a tile was loading but is now not wanted.</td>
+		<td>Fired when a tile was loading but is no longer wanted.</td>
 	</tr>
 </tbody></table>
 
@@ -7037,7 +7037,7 @@ callback is called when the tile has been loaded.</p>
 	<tr id='tilelayer-wms-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-removefrom'>
@@ -7123,7 +7123,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-wms-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-setpopupcontent'>
@@ -7198,7 +7198,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='tilelayer-wms-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='tilelayer-wms-settooltipcontent'>
@@ -7769,7 +7769,7 @@ used by this overlay.</p>
 	<tr id='imageoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-removefrom'>
@@ -7855,7 +7855,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='imageoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-setpopupcontent'>
@@ -7930,7 +7930,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='imageoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='imageoverlay-settooltipcontent'>
@@ -8599,7 +8599,7 @@ used by this overlay.</p>
 	<tr id='videooverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-removefrom'>
@@ -8685,7 +8685,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='videooverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-setpopupcontent'>
@@ -8760,7 +8760,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='videooverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='videooverlay-settooltipcontent'>
@@ -9370,7 +9370,7 @@ used by this overlay.</p>
 	<tr id='svgoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-removefrom'>
@@ -9456,7 +9456,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svgoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-setpopupcontent'>
@@ -9531,7 +9531,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svgoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svgoverlay-settooltipcontent'>
@@ -10043,7 +10043,7 @@ for a second (also called long press).</td>
 	<tr id='path-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='path-removefrom'>
@@ -10129,7 +10129,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='path-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='path-setpopupcontent'>
@@ -10204,7 +10204,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='path-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='path-settooltipcontent'>
@@ -10887,7 +10887,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='polyline-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='polyline-removefrom'>
@@ -10973,7 +10973,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polyline-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polyline-setpopupcontent'>
@@ -11048,7 +11048,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polyline-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polyline-settooltipcontent'>
@@ -11759,7 +11759,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='polygon-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='polygon-removefrom'>
@@ -11845,7 +11845,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polygon-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polygon-setpopupcontent'>
@@ -11920,7 +11920,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='polygon-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='polygon-settooltipcontent'>
@@ -12641,7 +12641,7 @@ a specific ring as a LatLng array (that you can earlier access with <a href="#po
 	<tr id='rectangle-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='rectangle-removefrom'>
@@ -12727,7 +12727,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='rectangle-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='rectangle-setpopupcontent'>
@@ -12802,7 +12802,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='rectangle-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='rectangle-settooltipcontent'>
@@ -13489,7 +13489,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='circle-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='circle-removefrom'>
@@ -13575,7 +13575,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circle-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circle-setpopupcontent'>
@@ -13650,7 +13650,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circle-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circle-settooltipcontent'>
@@ -14284,7 +14284,7 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='circlemarker-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-removefrom'>
@@ -14370,7 +14370,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circlemarker-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-setpopupcontent'>
@@ -14445,7 +14445,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='circlemarker-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='circlemarker-settooltipcontent'>
@@ -14839,7 +14839,7 @@ its map has moved</td>
 	<tr id='svg-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='svg-removefrom'>
@@ -14925,7 +14925,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svg-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svg-setpopupcontent'>
@@ -15000,7 +15000,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='svg-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='svg-settooltipcontent'>
@@ -15449,7 +15449,7 @@ its map has moved</td>
 	<tr id='canvas-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='canvas-removefrom'>
@@ -15535,7 +15535,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='canvas-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='canvas-setpopupcontent'>
@@ -15610,7 +15610,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='canvas-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='canvas-settooltipcontent'>
@@ -16040,13 +16040,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='layergroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='layergroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='layergroup-clearlayers'>
@@ -16124,7 +16124,7 @@ implement <code>methodName</code>.</p>
 	<tr id='layergroup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='layergroup-removefrom'>
@@ -16210,7 +16210,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layergroup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layergroup-setpopupcontent'>
@@ -16285,7 +16285,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layergroup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layergroup-settooltipcontent'>
@@ -16789,13 +16789,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='featuregroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-clearlayers'>
@@ -16874,7 +16874,7 @@ implement <code>methodName</code>.</p>
 	<tr id='featuregroup-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-removefrom'>
@@ -16960,7 +16960,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='featuregroup-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-setpopupcontent'>
@@ -17035,7 +17035,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='featuregroup-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='featuregroup-settooltipcontent'>
@@ -17655,13 +17655,13 @@ Returns a <a href="https://en.wikipedia.org/wiki/GeoJSON"><code>GeoJSON</code></
 	<tr id='geojson-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;<a href='#layer'>Layer</a>&gt;</nobr> <i>layer</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given layer is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given layer is added to the group.</p>
 </td>
 	</tr>
 	<tr id='geojson-haslayer'>
 		<td><code><b>hasLayer</b>(<nobr>&lt;Number&gt;</nobr> <i>id</i>)</code></td>
 		<td><code>Boolean</code></td>
-		<td><p>Returns <code>true</code> if the given internal ID is currently added to the group.</p>
+		<td><p>Returns <code>true</code> if the given internal ID is added to the group.</p>
 </td>
 	</tr>
 	<tr id='geojson-clearlayers'>
@@ -17740,7 +17740,7 @@ implement <code>methodName</code>.</p>
 	<tr id='geojson-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='geojson-removefrom'>
@@ -17826,7 +17826,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='geojson-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='geojson-setpopupcontent'>
@@ -17901,7 +17901,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='geojson-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='geojson-settooltipcontent'>
@@ -18571,7 +18571,7 @@ is specified, it must be called when the tile has finished loading and drawing.<
 	<tr id='gridlayer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-removefrom'>
@@ -18657,7 +18657,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='gridlayer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-setpopupcontent'>
@@ -18732,7 +18732,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='gridlayer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='gridlayer-settooltipcontent'>
@@ -20220,7 +20220,7 @@ styled according to the options.</p>
 	<tr id='control-zoom-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -20369,7 +20369,7 @@ styled according to the options.</p>
 	<tr id='control-attribution-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -20623,7 +20623,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	<tr id='control-layers-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -20775,7 +20775,7 @@ By default, it sorts layers alphabetically by their name.</td>
 	<tr id='control-scale-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -21281,7 +21281,7 @@ a best guess of 60 pixels.</td>
 
 <h4 id='domevent-pointer-detection'>Pointer detection</h4>
 
-<div class='section-comments'>Detects the pointers that are currently active on the document.</div>
+<div class='section-comments'>Detects the pointers that are active on the document.</div>
 
 <table><thead>
 	<tr>
@@ -21420,7 +21420,7 @@ drag interaction on them.</td>
 	<tr id='domutil-getscale'>
 		<td><code><b>getScale</b>(<nobr>&lt;HTMLElement&gt;</nobr> <i>el</i>)</code></td>
 		<td><code>Object</code></td>
-		<td>Computes the CSS scale currently applied on the element.
+		<td>Computes the CSS scale applied on the element.
 Returns an object with <code>x</code> and <code>y</code> members as horizontal and vertical scales respectively,
 and <code>boundingClientRect</code> as the result of <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect"><code>getBoundingClientRect()</code></a>.</td>
 	</tr>
@@ -21548,7 +21548,7 @@ argument of the <a href="https://cubic-bezier.com/#0,0,.5,1">cubic bezier curve<
 	<tr id='posanimation-stop'>
 		<td><code><b>stop</b>()</code></td>
 		<td><code></code></td>
-		<td><p>Stops the animation (if currently running).</p>
+		<td><p>Stops the animation (if running).</p>
 </td>
 	</tr>
 </tbody></table>
@@ -22367,7 +22367,7 @@ Not effective if the <code>renderer</code> option is set (the <code>renderer</co
 	<tr id='layer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='layer-removefrom'>
@@ -22497,7 +22497,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layer-setpopupcontent'>
@@ -22570,7 +22570,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='layer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='layer-settooltipcontent'>
@@ -22930,7 +22930,7 @@ for a second (also called long press).</td>
 	<tr id='interactive-layer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-removefrom'>
@@ -23016,7 +23016,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='interactive-layer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-setpopupcontent'>
@@ -23091,7 +23091,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='interactive-layer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='interactive-layer-settooltipcontent'>
@@ -23271,7 +23271,7 @@ All other controls extend from this class.</p>
 	<tr id='control-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the control from the map it is currently active on.</p>
+		<td><p>Removes the control from the map it is active on.</p>
 </td>
 	</tr>
 </tbody></table>
@@ -23961,7 +23961,7 @@ any map state change (including <em>during</em> pan/zoom animations).</p>
 	<tr id='blanketoverlay-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-removefrom'>
@@ -24047,7 +24047,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='blanketoverlay-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-setpopupcontent'>
@@ -24122,7 +24122,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='blanketoverlay-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='blanketoverlay-settooltipcontent'>
@@ -24466,7 +24466,7 @@ its map has moved</td>
 	<tr id='renderer-remove'>
 		<td><code><b>remove</b>()</code></td>
 		<td><code>this</code></td>
-		<td><p>Removes the layer from the map it is currently active on.</p>
+		<td><p>Removes the layer from the map it is active on.</p>
 </td>
 	</tr>
 	<tr id='renderer-removefrom'>
@@ -24552,7 +24552,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='renderer-ispopupopen'>
 		<td><code><b>isPopupOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the popup bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the popup bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='renderer-setpopupcontent'>
@@ -24627,7 +24627,7 @@ it will receive the layer as the first argument and should return a
 	<tr id='renderer-istooltipopen'>
 		<td><code><b>isTooltipOpen</b>()</code></td>
 		<td><code>boolean</code></td>
-		<td><p>Returns <code>true</code> if the tooltip bound to this layer is currently open.</p>
+		<td><p>Returns <code>true</code> if the tooltip bound to this layer is open.</p>
 </td>
 	</tr>
 	<tr id='renderer-settooltipcontent'>

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -84,7 +84,7 @@ export class Control extends Class {
 	}
 
 	// @method remove: this
-	// Removes the control from the map it is currently active on.
+	// Removes the control from the map it is active on.
 	remove() {
 		if (!this._map) {
 			return this;

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -124,7 +124,7 @@ export class LayersControl extends Control {
 
 	addTo(map) {
 		super.addTo(map);
-		// Trigger expand after Layers Control has been inserted into DOM so that is now has an actual height.
+		// Trigger expand after Layers Control has been inserted into DOM so that it now has an actual height.
 		return this._expandIfNotCollapsed();
 	}
 

--- a/src/dom/DomEvent.DoubleTap.js
+++ b/src/dom/DomEvent.DoubleTap.js
@@ -3,7 +3,7 @@ import * as DomEvent from './DomEvent.js';
 /*
  * Extends the event handling code with double tap support for mobile browsers.
  *
- * Note: currently most browsers fire native dblclick, with only a few exceptions
+ * Note: most modern browsers fire native dblclick, with only a few exceptions
  * (see https://github.com/Leaflet/Leaflet/issues/7012#issuecomment-595087386)
  */
 

--- a/src/dom/DomEvent.PointerEvents.js
+++ b/src/dom/DomEvent.PointerEvents.js
@@ -1,7 +1,7 @@
 /*
 /* @namespace DomEvent
  * @section Pointer detection
- * Detects the pointers that are currently active on the document.
+ * Detects the pointers that are active on the document.
  */
 
 const activePointers = new Map();

--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -157,7 +157,7 @@ export function getSizedParentNode(element) {
 }
 
 // @function getScale(el: HTMLElement): Object
-// Computes the CSS scale currently applied on the element.
+// Computes the CSS scale applied on the element.
 // Returns an object with `x` and `y` members as horizontal and vertical scales respectively,
 // and `boundingClientRect` as the result of [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 export function getScale(element) {

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -57,7 +57,7 @@ export class Draggable extends Evented {
 	disable() {
 		if (!this._enabled) { return; }
 
-		// If we're currently dragging this draggable,
+		// If we're dragging this draggable,
 		// disabling it counts as first ending the drag.
 		if (Draggable._dragging === this) {
 			this.finishDrag(true);

--- a/src/dom/PosAnimation.js
+++ b/src/dom/PosAnimation.js
@@ -58,7 +58,7 @@ export class PosAnimation extends Evented {
 	}
 
 	// @method stop()
-	// Stops the animation (if currently running).
+	// Stops the animation (if running).
 	stop() {
 		if (!this._inProgress) { return; }
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -56,7 +56,7 @@ export class Layer extends Evented {
 	}
 
 	// @method remove: this
-	// Removes the layer from the map it is currently active on.
+	// Removes the layer from the map it is active on.
 	remove() {
 		return this.removeFrom(this._map || this._mapToAdd);
 	}
@@ -196,7 +196,7 @@ LeafletMap.include({
 	},
 
 	// @method hasLayer(layer: Layer): Boolean
-	// Returns `true` if the given layer is currently added to the map
+	// Returns `true` if the given layer is added to the map
 	hasLayer(layer) {
 		return Util.stamp(layer) in this._layers;
 	},

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -63,10 +63,10 @@ export class LayerGroup extends Layer {
 	}
 
 	// @method hasLayer(layer: Layer): Boolean
-	// Returns `true` if the given layer is currently added to the group.
+	// Returns `true` if the given layer is added to the group.
 	// @alternative
 	// @method hasLayer(id: Number): Boolean
-	// Returns `true` if the given internal ID is currently added to the group.
+	// Returns `true` if the given internal ID is added to the group.
 	hasLayer(layer) {
 		const layerId = typeof layer === 'number' ? layer : this.getLayerId(layer);
 		return layerId in this._layers;

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -472,7 +472,7 @@ Layer.include({
 	},
 
 	// @method isPopupOpen(): boolean
-	// Returns `true` if the popup bound to this layer is currently open.
+	// Returns `true` if the popup bound to this layer is open.
 	isPopupOpen() {
 		return this._popup?.isOpen() ?? false;
 	},

--- a/src/layer/Tooltip.js
+++ b/src/layer/Tooltip.js
@@ -373,7 +373,7 @@ Layer.include({
 	},
 
 	// @method isTooltipOpen(): boolean
-	// Returns `true` if the tooltip bound to this layer is currently open.
+	// Returns `true` if the tooltip bound to this layer is open.
 	isTooltipOpen() {
 		return this._tooltip.isOpen();
 	},

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -262,7 +262,7 @@ export class TileLayer extends GridLayer {
 					tile.remove();
 					delete this._tiles[i];
 					// @event tileabort: TileEvent
-					// Fired when a tile was loading but is now not wanted.
+					// Fired when a tile was loading but is no longer wanted.
 					this.fire('tileabort', {
 						tile,
 						coords

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -615,7 +615,7 @@ export class LeafletMap extends Evented {
 
 	// @section Methods for modifying map state
 	// @method stop(): this
-	// Stops the currently running `panTo` or `flyTo` animation, if any.
+	// Stops the running `panTo` or `flyTo` animation, if any.
 	stop() {
 		this.setZoom(this._limitZoom(this._zoom));
 		if (!this.options.zoomSnap) {


### PR DESCRIPTION
Fixes #8477.

Replaces time-relative language ("currently", "now", "recently") with timeless equivalents across source JSDoc and generated reference docs. Examples:
- "currently added" -> "added"
- "currently running" -> "running"
- "is now not wanted" -> "is no longer wanted"
- "currently active" -> "active"