### PR TITLE
Add Leaflet.AI.GeoJSON plugin

### DIFF
--- a/docs/_plugins/dynamic-custom-data-loading/leaflet.AI.GeoJSON.md
+++ b/docs/_plugins/dynamic-custom-data-loading/leaflet.AI.GeoJSON.md
@@ -1,0 +1,17 @@
+---
+name: Leaflet.AI.GeoJSON
+category: dynamic-custom-data-loading
+repo: https://github.com/EricDalnas/leaflet.ai.geojson
+author: Eric Dalnas
+author-url: https://github.com/EricDalnas
+demo: https://ericdalnas.github.io/leaflet.ai.geoJson/examples/proxy-azure/demo.html
+compatible-v1: true
+compatible-v2: false
+---
+
+A lightweight Leaflet control that lets users query an LLM (Gemini, OpenAI,
+OpenRouter, etc.) for geographic data and renders the result on the map as
+toggleable GeoJSON layers. Supports navigation queries ("Zoom to Tokyo"),
+named per-query layers with individual or bulk clear, a built-in collapsible
+chat UI, model picker, and settings panel. Requires a backend proxy URL to
+hold your API key.


### PR DESCRIPTION
Adds an entry for [Leaflet.AI.GeoJSON](https://github.com/EricDalnas/leaflet.ai.geojson) 
to the **Dynamic/Custom data loading** section of the plugins page.

**What it does:**  
A lightweight Leaflet control that lets users query an LLM (Gemini, OpenAI, OpenRouter, etc.) 
for geographic data and renders the results as toggleable GeoJSON layers. Also supports 
navigation queries like "Zoom to Tokyo", named per-query layers with individual or bulk 
clear, a collapsible chat UI, model picker, and settings panel.

**Demo:** https://ericdalnas.github.io/leaflet.ai.geoJson/examples/proxy-azure/demo.html