### PR TITLE
docs: remove stale Android comment from zoom animation init

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -170,7 +170,7 @@ export class LeafletMap extends Evented {
 
 		this.callInitHooks();
 
-		// don't animate on browsers without hardware-accelerated transitions or old Android
+		// don't animate on browsers without hardware-accelerated transitions
 		this._zoomAnimated = this.options.zoomAnimation;
 
 		// zoom transitions run with the same duration for all layers, so if one of transitionend events


### PR DESCRIPTION
Follow-up to #10109 which removed the "except Android" qualifier from the public `@option` leafdoc blocks but left the matching internal comment on `Map.js` L173. Modern Android browsers all have hardware-accelerated CSS transitions, so the trailing "or old Android" qualifier is misleading.

Refs #8477. Per #10151 review, @jonkoops noted "feel free to open a PR that removes the entire notice, I'll gladly merge it".
