### PR TITLE
fix: remove stale browser-compat guards and comments (refs #8477)

### DIFF
--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -326,10 +326,8 @@ export class Canvas extends Renderer {
 		}
 
 		if (options.stroke && options.weight !== 0) {
-			if (ctx.setLineDash) {
-				ctx.lineDashOffset = Number(options.dashOffset ?? 0);
-				ctx.setLineDash(options._dashArray ?? []);
-			}
+			ctx.lineDashOffset = Number(options.dashOffset ?? 0);
+			ctx.setLineDash(options._dashArray ?? []);
 			ctx.globalAlpha = options.opacity;
 			ctx.lineWidth = options.weight;
 			ctx.strokeStyle = options.color;

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -170,7 +170,6 @@ export class LeafletMap extends Evented {
 
 		this.callInitHooks();
 
-		// don't animate on browsers without hardware-accelerated transitions or old Android
 		this._zoomAnimated = this.options.zoomAnimation;
 
 		// zoom transitions run with the same duration for all layers, so if one of transitionend events


### PR DESCRIPTION
Picks up the two remaining unchecked items from #8477.

## Changes

**`src/layer/vector/Canvas.js`**
Removes the `if (ctx.setLineDash)` feature-detection guard. `setLineDash` now has [97%+ browser support](https://caniuse.com/mdn-api_canvasrenderingcontext2d_setlinedash) and the guard is no longer needed.

**`src/map/Map.js`**
Removes a stale inline comment referencing "browsers without hardware-accelerated transitions or old Android". The code simply assigns `this.options.zoomAnimation` and the comment no longer reflects reality.

## Already done in prior PRs

- `src/layer/vector/Path.js` — `dashArray`/`dashOffset` old-browser note: already removed
- `src/layer/vector/Circle.js` — obsolete instantiation method: already removed