### PR TITLE
Add leaflet-draggable-tooltips to user-interface plugins

### DIFF
--- a/docs/_plugins/user-interface/leaflet-draggable-tooltips.md
+++ b/docs/_plugins/user-interface/leaflet-draggable-tooltips.md
@@ -1,0 +1,13 @@
+---
+name: Leaflet Draggable Tooltips
+category: user-interface
+repo: https://github.com/Metopio/leaflet-draggable-tooltips
+author: Georgina Rivero
+author-url: https://github.com/georiv
+demo: https://metopio.github.io/leaflet-draggable-tooltips/demo/index.html
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+Makes marker tooltips **draggable** and **pinnable**. Click a marker to keep its tooltip open, then drag it freely across the map. Supports touch, survives pan & zoom, fires custom drag events, and is non-destructive. Only requires Leaflet.


### PR DESCRIPTION
Adds [`leaflet-draggable-tooltips`](https://github.com/Metopio/leaflet-draggable-tooltips) to the user-interface category.

This plugin makes marker tooltips draggable and pinnable. Clicking a marker keeps its tooltip open, which can then be dragged freely anywhere on the map. The tooltip position survives pan and zoom, and can also be preset via the `tooltipLatLng` option.

**Features:**
- Drag tooltips freely across the map, detached from their marker
- Pin tooltips open with a single click
- Preset tooltip position via `tooltipLatLng` marker option
- Touch support
- Custom events: `tooltipdragstart`, `tooltipdrag`, `tooltipdragend`
- Zero dependencies beyond Leaflet

**Links:**
- Repo: https://github.com/Metopio/leaflet-draggable-tooltips
- Demo: https://metopio.github.io/leaflet-draggable-tooltips/demo/index.html
- npm: https://www.npmjs.com/package/@metopio/leaflet-draggable-tooltips