### PR TITLE
Add title and alt attributes for SVG paths

### DIFF
--- a/spec/suites/layer/vector/PathSpec.js
+++ b/spec/suites/layer/vector/PathSpec.js
@@ -108,4 +108,22 @@ describe('Path', () => {
 			expect(path._clickTolerance()).to.equal(0);
 		});
 	});
+
+	describe('#options', () => {
+		it('sets title and alt attributes on SVG paths after re-adding', () => {
+			const path = new Polyline([[1, 2], [3, 4]], {
+				alt: 'Filtering route',
+				title: 'Searchable route'
+			}).addTo(map);
+
+			expect(path.getElement().getAttribute('title')).to.equal('Searchable route');
+			expect(path.getElement().getAttribute('alt')).to.equal('Filtering route');
+
+			map.removeLayer(path);
+			map.addLayer(path);
+
+			expect(path.getElement().getAttribute('title')).to.equal('Searchable route');
+			expect(path.getElement().getAttribute('alt')).to.equal('Filtering route');
+		});
+	});
 });

--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -63,6 +63,14 @@ export class Path extends Layer {
 			// A string that defines [how the inside of a shape](https://developer.mozilla.org/docs/Web/SVG/Attribute/fill-rule) is determined.
 			fillRule: 'evenodd',
 
+			// @option title: String = ''
+			// Text for the browser tooltip that appears on path hover. Only for SVG renderer.
+			title: '',
+
+			// @option alt: String = null
+			// Text for the `alt` attribute of the path element. Only for SVG renderer.
+			alt: null,
+
 			// className: '',
 
 			// Option inherited from "Interactive layer" abstract class

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -152,6 +152,18 @@ export class SVG extends Renderer {
 		} else {
 			path.setAttribute('fill', 'none');
 		}
+
+		if (options.title) {
+			path.setAttribute('title', options.title);
+		} else {
+			path.removeAttribute('title');
+		}
+
+		if (options.alt != null) {
+			path.setAttribute('alt', options.alt);
+		} else {
+			path.removeAttribute('alt');
+		}
 	}
 
 	_updatePoly(layer, closed) {


### PR DESCRIPTION
Fixes #9352

## Summary
- add optional `title` and `alt` Path options for SVG-rendered paths
- apply those attributes during SVG style updates so rebuilt paths preserve them after remove and re-add

## Tests
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/leaflet-9352-ms-playwright npm_config_cache=/tmp/leaflet-9352-npm-cache npx vitest --run --project=chromium spec/suites/layer/vector/PathSpec.js -t "sets title and alt attributes"`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/leaflet-9352-ms-playwright npm_config_cache=/tmp/leaflet-9352-npm-cache npx vitest --run --project=chromium spec/suites/layer/vector/PathSpec.js spec/suites/layer/vector/PolylineSpec.js spec/suites/renderer/RendererSpec.js`
- `npm_config_cache=/tmp/leaflet-9352-npm-cache npm run lint` (0 errors; existing CSS warnings only)
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/leaflet-9352-ms-playwright npm_config_cache=/tmp/leaflet-9352-npm-cache npm test -- --run`