### PR TITLE
Fix: disableTextSelection should only affect map container, not whole…

### DIFF
--- a/src/dom/DomUtil.js
+++ b/src/dom/DomUtil.js
@@ -1,6 +1,5 @@
 import * as DomEvent from './DomEvent.js';
 import {Point} from '../geometry/Point.js';
-
 /*
  * @namespace DomUtil
  *
@@ -11,24 +10,20 @@ import {Point} from '../geometry/Point.js';
  * SVG elements. The only difference is that classes refer to CSS classes
  * in HTML and SVG classes in SVG.
  */
-
 // @function get(id: String|HTMLElement): HTMLElement
 // Returns an element given its DOM id, or returns the element itself
 // if it was passed directly.
 export function get(id) {
 	return typeof id === 'string' ? document.getElementById(id) : id;
 }
-
 // @function create(tagName: String, className?: String, container?: HTMLElement): HTMLElement
 // Creates an HTML element with `tagName`, sets its class to `className`, and optionally appends it to `container` element.
 export function create(tagName, className, container) {
 	const el = document.createElement(tagName);
 	el.className = className ?? '';
-
 	container?.appendChild(el);
 	return el;
 }
-
 // @function toFront(el: HTMLElement)
 // Makes `el` the last child of its parent, so it renders in front of the other children.
 export function toFront(el) {
@@ -37,7 +32,6 @@ export function toFront(el) {
 		parent.appendChild(el);
 	}
 }
-
 // @function toBack(el: HTMLElement)
 // Makes `el` the first child of its parent, so it renders behind the other children.
 export function toBack(el) {
@@ -46,19 +40,15 @@ export function toBack(el) {
 		parent.insertBefore(el, parent.firstChild);
 	}
 }
-
 // @function setTransform(el: HTMLElement, offset: Point, scale?: Number)
 // Resets the 3D CSS transform of `el` so it is translated by `offset` pixels
 // and optionally scaled by `scale`. Does not have an effect if the
 // browser doesn't support 3D CSS transforms.
 export function setTransform(el, offset, scale) {
 	const pos = offset ?? new Point(0, 0);
-
 	el.style.transform = `translate3d(${pos.x}px,${pos.y}px,0)${scale ? ` scale(${scale})` : ''}`;
 }
-
 const positions = new WeakMap();
-
 // @function setPosition(el: HTMLElement, position: Point)
 // Sets the position of `el` to coordinates specified by `position`,
 // using CSS translate or top/left positioning depending on the browser
@@ -67,7 +57,6 @@ export function setPosition(el, point) {
 	positions.set(el, point);
 	setTransform(el, point);
 }
-
 // @function getPosition(el: HTMLElement): Point
 // Returns the coordinates of an element previously positioned with setPosition.
 export function getPosition(el) {
@@ -75,50 +64,42 @@ export function getPosition(el) {
 	// so it's safe to cache the position for performance
 	return positions.get(el) ?? new Point(0, 0);
 }
-
 const documentStyle = typeof document === 'undefined' ? {} : document.documentElement.style;
 // Safari still needs a vendor prefix, we need to detect with property name is supported.
 const userSelectProp = ['userSelect', 'WebkitUserSelect'].find(prop => prop in documentStyle);
 let prevUserSelect;
-
-// @function disableTextSelection()
-// Prevents the user from selecting text in the document. Used internally
+// @function disableTextSelection(el: HTMLElement)
+// Prevents the user from selecting text in the map container. Used internally
 // by Leaflet to override the behaviour of any click-and-drag interaction on
-// the map. Affects drag interactions on the whole document.
-export function disableTextSelection() {
-	const value = documentStyle[userSelectProp];
-
+// the map. Only affects the map container element.
+export function disableTextSelection(el) {
+	if (!el || !el.style) return;
+	const value = el.style[userSelectProp];
 	if (value === 'none') {
 		return;
 	}
-
 	prevUserSelect = value;
-	documentStyle[userSelectProp] = 'none';
+	el.style[userSelectProp] = 'none';
 }
-
-// @function enableTextSelection()
+// @function enableTextSelection(el: HTMLElement)
 // Cancels the effects of a previous [`DomUtil.disableTextSelection`](#domutil-disabletextselection).
-export function enableTextSelection() {
-	if (typeof prevUserSelect === 'undefined') {
+export function enableTextSelection(el) {
+	if (!el || !el.style || typeof prevUserSelect === 'undefined') {
 		return;
 	}
-
-	documentStyle[userSelectProp] = prevUserSelect;
+	el.style[userSelectProp] = prevUserSelect;
 	prevUserSelect = undefined;
 }
-
 // @function disableImageDrag()
 // Prevents the user from generating `dragstart` DOM events, usually generated when the user drags an image.
 export function disableImageDrag() {
 	DomEvent.on(window, 'dragstart', DomEvent.preventDefault);
 }
-
 // @function enableImageDrag()
 // Cancels the effects of a previous [`DomUtil.disableImageDrag`](#domutil-disableimagedrag).
 export function enableImageDrag() {
 	DomEvent.off(window, 'dragstart', DomEvent.preventDefault);
 }
-
 let _outlineElement, _outlineStyle;
 // @function preventOutline(el: HTMLElement)
 // Makes the [outline](https://developer.mozilla.org/docs/Web/CSS/outline)
@@ -136,7 +117,6 @@ export function preventOutline(element) {
 	element.style.outlineStyle = 'none';
 	DomEvent.on(window, 'keydown', restoreOutline);
 }
-
 // @function restoreOutline()
 // Cancels the effects of a previous [`DomUtil.preventOutline`](#domutil-preventoutline).
 export function restoreOutline() {
@@ -146,7 +126,6 @@ export function restoreOutline() {
 	_outlineStyle = undefined;
 	DomEvent.off(window, 'keydown', restoreOutline);
 }
-
 // @function getSizedParentNode(el: HTMLElement): HTMLElement
 // Finds the closest parent node which size (width and height) is not null.
 export function getSizedParentNode(element) {
@@ -155,14 +134,12 @@ export function getSizedParentNode(element) {
 	} while ((!element.offsetWidth || !element.offsetHeight) && element !== document.body);
 	return element;
 }
-
 // @function getScale(el: HTMLElement): Object
 // Computes the CSS scale currently applied on the element.
 // Returns an object with `x` and `y` members as horizontal and vertical scales respectively,
 // and `boundingClientRect` as the result of [`getBoundingClientRect()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect).
 export function getScale(element) {
 	const rect = element.getBoundingClientRect();
-
 	return {
 		x: rect.width / element.offsetWidth || 1,
 		y: rect.height / element.offsetHeight || 1,


### PR DESCRIPTION
Fixes #9259

This PR changes `disableTextSelection()` and `enableTextSelection()` to accept a map container element parameter instead of affecting the entire document.

**Before:** Called with no parameters, disabled text selection globally
**After:** Called with a map container element, disables text selection only on that element

This prevents unintended side effects on other page elements during map interactions.