### PR TITLE
fix: replace deprecated navigator.platform in Browser.mac and Browser.linux

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -19,7 +19,7 @@ const chrome = userAgentContains('chrome');
 const safari = !chrome && userAgentContains('safari');
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
-const mobile = typeof orientation !== 'undefined';;
+const mobile = typeof orientation !== 'undefined';
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -19,7 +19,12 @@ const chrome = userAgentContains('chrome');
 const safari = !chrome && userAgentContains('safari');
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
-const mobile = typeof orientation !== 'undefined';
+const mobile = typeof window !== 'undefined' && (
+	// Standard Screen Orientation API
+	(typeof window.screen !== 'undefined' && typeof window.screen.orientation !== 'undefined') ||
+	// Deprecated fallback for older browsers
+	typeof window.orientation !== 'undefined'
+);
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
@@ -42,10 +47,10 @@ const touch = touchNative || pointer;
 const retina = typeof window === 'undefined' || typeof window.devicePixelRatio === 'undefined' ? false : window.devicePixelRatio > 1;
 
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
-const mac = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Mac');
+const mac = userAgentContains('macintosh');
 
 // @property linux: Boolean; `true` when the browser is running in a Linux platform
-const linux = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Linux');
+const linux = userAgentContains('linux') && !userAgentContains('android');
 
 function userAgentContains(str) {
 	if (typeof navigator === 'undefined' || typeof navigator.userAgent === 'undefined') {

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -19,12 +19,7 @@ const chrome = userAgentContains('chrome');
 const safari = !chrome && userAgentContains('safari');
 
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
-const mobile = typeof window !== 'undefined' && (
-	// Standard Screen Orientation API
-	(typeof window.screen !== 'undefined' && typeof window.screen.orientation !== 'undefined') ||
-	// Deprecated fallback for older browsers
-	typeof window.orientation !== 'undefined'
-);
+const mobile = typeof orientation !== 'undefined';;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).


### PR DESCRIPTION
## What

Replaces the deprecated `navigator.platform` API in `Browser.mac` and `Browser.linux` with `userAgentContains()` calls, which use `navigator.userAgent` — the MDN-recommended replacement.

## Changes

```js
// Before
const mac = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined'
  ? false : navigator.platform.startsWith('Mac');

const linux = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined'
  ? false : navigator.platform.startsWith('Linux');

// After
const mac = userAgentContains('macintosh');
const linux = userAgentContains('linux') && !userAgentContains('android');
```

## Why

`navigator.platform` is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform) and browsers are actively removing it. `navigator.userAgent` is the recommended replacement for platform detection.

The `!userAgentContains('android')` guard in `linux` preserves the existing behaviour — Android devices report `linux` in their user-agent, so without it `Browser.linux` would incorrectly return `true` on Android.

## What this does NOT change

`Browser.mobile` — left untouched. As noted in the review of this PR, `screen.orientation` is available on desktop browsers too and cannot be used as a mobile signal. The existing `typeof orientation !== 'undefined'` check is the correct approach for now.

Relates to the deprecation warnings surfaced in #9710.