### PR TITLE
Implement Browser.reducedMotion and conditionally disable animations

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -791,19 +791,24 @@ describe('GridLayer', () => {
 			clock.tick(250);
 		});
 
-		it('Loads 290, unloads 275 tiles on MAD-TRD flyTo()', (done) => {
+		it('Loads 224, unloads 209 tiles on MAD-TRD flyTo()', (done) => {
 			const mad = [40.40, -3.7], trd = [63.41, 10.41];
 
-			grid.on('load', () => {
-				expect(counts.tileloadstart).to.equal(12);
-				expect(counts.tileload).to.equal(12);
-				expect(counts.tileunload).to.equal(0);
-				grid.off('load');
+			grid.once('load', () => {
+				expect(counts).to.deep.equal({
+					tileloadstart: 12,
+					tileload: 12,
+					tileunload: 0,
+					tileerror: 0,
+				});
 
 				map.on('zoomend', () => {
-					expect(counts.tileloadstart).to.equal(290);
-					expect(counts.tileunload).to.equal(275);
-					expect(counts.tileload).to.equal(290);
+					expect(counts).to.deep.equal({
+						tileloadstart: 224,
+						tileload: 224,
+						tileunload: 209,
+						tileerror: 0,
+					});
 					expect(grid._container.querySelectorAll('div').length).to.equal(16);	// 15 + container
 					done();
 				});

--- a/spec/suites/layer/tile/TileLayerSpec.js
+++ b/spec/suites/layer/tile/TileLayerSpec.js
@@ -252,18 +252,22 @@ describe('TileLayer', () => {
 			clock.tick(250);
 		});
 
-		it('Loads 290, unloads 275 kittens on MAD-TRD flyTo()', (done) => {
+		it('Loads 224, unloads 209 kittens on MAD-TRD flyTo()', (done) => {
 			const mad = [40.40, -3.7], trd = [63.41, 10.41];
 
-			kittenLayer.on('load', () => {
-				expect(counts.tileloadstart).to.equal(12);
-				expect(counts.tileload).to.equal(12);
-				expect(counts.tileunload).to.equal(0);
-				kittenLayer.off('load');
+			kittenLayer.once('load', () => {
+				expect(counts).to.deep.equal({
+					tileloadstart: 12,
+					tileload: 12,
+					tileunload: 0,
+					tileerror: 0,
+				});
 
 				map.on('zoomend', () => {
-					expect(counts.tileloadstart).to.equal(290);
-					expect(counts.tileunload).to.equal(275);
+					console.warn(counts);
+
+					expect(counts.tileloadstart).to.equal(224);
+					expect(counts.tileunload).to.equal(209);
 
 					// image tiles take time, so then might not be fully loaded yet.
 					expect(counts.tileload).to.be.lessThan(counts.tileloadstart + 1);

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -26,7 +26,7 @@ const mobile = typeof orientation !== 'undefined';
 // Determines whether animations should play or not.
 const reducedMotion = navigator.preferences?.reducedMotion?.value ?
 	navigator.preferences.reducedMotion.value === 'reduce' :
-	window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	typeof window === 'undefined' ? true : window?.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).

--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -21,6 +21,13 @@ const safari = !chrome && userAgentContains('safari');
 // @property mobile: Boolean; `true` for all browsers running in a mobile device.
 const mobile = typeof orientation !== 'undefined';
 
+// @property reducedMotion: Boolean
+// `true` if the user has [configured their environment for reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion#user_preferences).
+// Determines whether animations should play or not.
+const reducedMotion = navigator.preferences?.reducedMotion?.value ?
+	navigator.preferences.reducedMotion.value === 'reduce' :
+	window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 // @property pointer: Boolean
 // `true` for all browsers supporting [pointer events](https://msdn.microsoft.com/en-us/library/dn433244%28v=vs.85%29.aspx).
 const pointer = typeof window === 'undefined' ? false : !!window.PointerEvent;
@@ -58,6 +65,7 @@ export default {
 	chrome,
 	safari,
 	mobile,
+	reducedMotion,
 	pointer,
 	touch,
 	touchNative,

--- a/src/layer/Popup.js
+++ b/src/layer/Popup.js
@@ -1,6 +1,7 @@
 import {DivOverlay} from './DivOverlay.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import * as DomUtil from '../dom/DomUtil.js';
+import Browser from '../core/Browser.js';
 import {Point} from '../geometry/Point.js';
 import {LeafletMap} from '../map/Map.js';
 import {Layer} from './Layer.js';
@@ -88,7 +89,7 @@ export class Popup extends DivOverlay {
 			// @option autoPan: Boolean = true
 			// Set it to `false` if you don't want the map to do panning animation
 			// to fit the opened popup.
-			autoPan: true,
+			autoPan: !Browser.reducedMotion,
 
 			// @option autoPanPaddingTopLeft: Point = null
 			// The margin between the popup and the top left corner of the map

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -87,20 +87,21 @@ export class GridLayer extends Layer {
 			// Opacity of the tiles. Can be used in the `createTile()` function.
 			opacity: 1,
 
-			// @option updateWhenIdle: Boolean = (depends)
+			// @option updateWhenIdle: Boolean = *
 			// Load new tiles only when panning ends.
-			// `true` by default on mobile browsers, in order to avoid too many requests and keep smooth navigation.
-			// `false` otherwise in order to display new tiles _during_ panning, since it is easy to pan outside the
-			// [`keepBuffer`](#gridlayer-keepbuffer) option in desktop browsers.
-			updateWhenIdle: Browser.mobile,
+			// Defaults to `false` (tiles are loaded _during_ panning) unless
+			// the browser is configured for reduced motion.
+			updateWhenIdle: !Browser.reducedMotion,
 
 			// @option updateWhenZooming: Boolean = true
 			// By default, a smooth zoom animation (during a [pinch zoom](#map-pinchzoom) or a [`flyTo()`](#map-flyto)) will update grid layers every integer zoom level. Setting this option to `false` will update the grid layer only when the smooth animation ends.
 			updateWhenZooming: true,
 
 			// @option updateInterval: Number = 200
-			// Tiles will not update more than once every `updateInterval` milliseconds when panning.
-			updateInterval: 200,
+			// Tiles will not update more than once every `updateInterval`
+			// milliseconds when panning. The default value is increased to
+			// five seconds if the browser is configured for reduced motion.
+			updateInterval: Browser.reducedMotion ? 5000 : 200,
 
 			// @option zIndex: Number = 1
 			// The explicit zIndex of the tile layer.

--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -708,6 +708,20 @@ path.leaflet-interactive:focus:not(:focus-visible) {
 	}
 }
 
+/* Reduced motion */
+
+@media (prefers-reduced-motion: reduce) {
+	.leaflet-fade-anim .leaflet-popup {
+		transition: none;
+	}
+	.leaflet-fade-anim .leaflet-map-pane .leaflet-tile {
+		transition: none;
+	}
+	.leaflet-zoom-anim .leaflet-zoom-animated {
+		transition: none;
+	}
+}
+
 /* Printing */
 
 @media print {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -373,7 +373,7 @@ export class LeafletMap extends Evented {
 	flyTo(targetCenter, targetZoom, options) {
 
 		options ??= {};
-		if (options.animate === false) {
+		if (Browser.reducedMotion || options.animate === false) {
 			return this.setView(targetCenter, targetZoom, options);
 		}
 

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -96,17 +96,21 @@ export class LeafletMap extends Evented {
 
 
 			// @section Animation Options
-			// @option zoomAnimation: Boolean = true
+			// @option zoomAnimation: Boolean = *
 			// Whether the map zoom animation is enabled.
-			zoomAnimation: true,
+			// Animations are enabled by default unless the user has configured
+			// their browser for reduced [motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion#user_preferences).
+			zoomAnimation: !Browser.reducedMotion,
 
 			// @option zoomAnimationThreshold: Number = 4
 			// Won't animate zoom if the zoom difference exceeds this value.
 			zoomAnimationThreshold: 4,
 
-			// @option fadeAnimation: Boolean = true
+			// @option fadeAnimation: Boolean = *
 			// Whether the tile fade animation is enabled.
-			fadeAnimation: true,
+			// Animations are enabled by default unless the user has configured
+			// their browser for reduced [motion](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@media/prefers-reduced-motion#user_preferences).
+			fadeAnimation: !Browser.reducedMotion,
 
 			// @option markerZoomAnimation: Boolean = true
 			// Whether markers animate their zoom with the zoom animation, if disabled
@@ -349,8 +353,8 @@ export class LeafletMap extends Evented {
 			this.fire('movestart');
 		}
 
-		// animate pan unless animate: false specified
-		if (options.animate !== false) {
+		// animate pan unless browser prefers reduced motion or animate: false specified
+		if (!Browser.reducedMotion && options.animate !== false) {
 			this._mapPane.classList.add('leaflet-pan-anim');
 
 			const newPos = this._getMapPanePos().subtract(offset).round();


### PR DESCRIPTION
While reviewing #10249 I went back to the deprecation of `Browser.mobile` (#9952) and realized that we're using `.mobile` to disable tile loads during animations, but animations overall shouldn't depend on mobile/desktop or even on GPU performance, but rather in the `prefers-reduced-motion` media query or the (upcoming/experimental) `navigator.preferences.reducedMotion`.

This PR does that, and includes the changes from (and supersedes) #10119.

Manually tested on FFX by setting an `about:config` flag, doesn't seem to break anything.