### PR TITLE
docs: update package description wording

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "leaflet",
   "version": "2.0.0-alpha.1",
   "homepage": "https://leafletjs.com/",
-  "description": "JavaScript library for mobile-friendly interactive maps",
+  "description": "JavaScript library for interactive maps",
   "devDependencies": {
     "@e18e/eslint-plugin": "^0.5.0",
     "@eslint/compat": "^2.1.0",


### PR DESCRIPTION
This pull request updates the package description in `package.json` from:

"JavaScript library for mobile-friendly interactive maps"

to:

"JavaScript library for interactive maps"

This change is related to the discussion about using more evergreen language and revisiting the wording of the project's slogan.
