### PR TITLE
Remove github, twitter and facebook trackers from index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -185,16 +185,6 @@ and spreading the word about Leaflet among your colleagues and friends.</p>
 
 <p>Check out the <a href="https://github.com/Leaflet/Leaflet/blob/main/CONTRIBUTING.md">contribution guide</a> for more information on getting involved with Leaflet development.</p>
 
-<div class="social-buttons">
-    <iframe src="https://ghbtns.com/github-btn.html?user=Leaflet&amp;repo=Leaflet&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="104px" height="20px"></iframe>
-
-    <a href="https://twitter.com/LeafletJS" class="twitter-follow-button" data-show-count="true" data-show-screen-name="false">Follow @LeafletJS</a>
-
-    <script>!function(d,s,id){let js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="https://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-
-    <iframe src="https://www.facebook.com/plugins/like.php?href=http%3A%2F%2Fleafletjs.com&amp;layout=button_count&amp;show_faces=false&amp;width=93&amp;action=like&amp;font=arial&amp;colorscheme=light&amp;height=35" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:93px; height:20px;" allowTransparency="true"></iframe>
-</div>
-
 <script type="module">
     import {LeafletMap, TileLayer, Marker} from 'leaflet';
     


### PR DESCRIPTION
Those trackers are not a good practice anymore. No third party should know that anybody is visiting Leaflet webpage.

This PR is independent of #10217