### PR TITLE
Update `Leaflet.MousePosition.ts` compatibility for Leaflet v2

### DIFF
--- a/docs/_plugins/mouse-coordinates/leaflet-mouseposition-ts.md
+++ b/docs/_plugins/mouse-coordinates/leaflet-mouseposition-ts.md
@@ -7,7 +7,7 @@ author-url: https://github.com/YUUKIToriyama
 demo: https://yuukitoriyama.github.io/Leaflet.MousePosition.ts/
 compatible-v0:
 compatible-v1: true
-compatible-v2: false
+compatible-v2: true
 ---
 
 A fully custmizable coordinate viewer written in TypeScript. You can change how this plugin looks by creating a custom component with JSX.


### PR DESCRIPTION
As of v0.2.0, `Leaflet.MousePosition.ts` is compatible with Leaflet v2.

see also:
- https://github.com/YuukiToriyama/Leaflet.MousePosition.ts/pull/12
- https://www.npmjs.com/package/leaflet.mouseposition.ts/v/0.2.0