### PR TITLE
Replace initialize()/addInitHook with standard constructors and a class-level `init` event

### DIFF
--- a/docs/examples/extending-1-classes/class-diagram.txt
+++ b/docs/examples/extending-1-classes/class-diagram.txt
@@ -15,7 +15,7 @@
 
 
 
-[Class|options|extend();include();initialize()]
+[Class|options|include();setDefaultOptions();mergeOptions()]
 
 [Class] ^- [Control|onAdd();onRemove()]
 [Control] ^- [AttributionControl;LayersControl;ScaleControl;ZoomControl]

--- a/docs/examples/extending-1-classes/index.md
+++ b/docs/examples/extending-1-classes/index.md
@@ -145,8 +145,9 @@ class MyBox extends Evented {
 	initialize(options) {
 		Util.setOptions(this, options);
 
-		// notify class-level `init` listeners once the instance is ready
-		MyBox.fire('init', {target: this});
+		// notify class-level `init` listeners once the instance is ready;
+		// `this.constructor` makes the event fire on the actual (sub)class
+		this.constructor.fire('init', {target: this});
 	}
 }
 
@@ -162,4 +163,24 @@ MyBox.include({
 
 const box = new MyBox({width: 5, height: 10});
 console.log(box.getArea()); // Outputs "50"
+```
+
+Listeners are inherited: firing on a class runs the listeners registered on it **and** on all of its ancestors, ancestors first. So a subclass instance also triggers its parent's `init` listeners:
+
+```js
+class MyCube extends MyBox {
+	static {
+		this.setDefaultOptions({
+			depth: 1
+		});
+	}
+}
+
+MyCube.on('init', ({target: cube}) => {
+	// `_area` is already set by MyBox's `init` listener, which runs first
+	cube._volume = cube._area * cube.options.depth;
+});
+
+const cube = new MyCube({width: 2, height: 3, depth: 4});
+console.log(cube._volume); // Outputs "24"
 ```

--- a/docs/examples/extending-1-classes/index.md
+++ b/docs/examples/extending-1-classes/index.md
@@ -22,7 +22,7 @@ From a technical point of view, Leaflet can be extended in different ways:
 	* Handlers are invisible and interpret browser events
 	* Controls are fixed interface elements
 * Including more, or replacing functionality (methods, fields) of an existing class with `Class.include()`
-* Using `Class.addInitHook()` to run additional constructor code.
+* Listening for a class's `init` event to run additional code whenever an instance is created.
 
 ## Extending Leaflet Classes
 
@@ -129,22 +129,29 @@ console.log(instance.incrementCount()); // Outputs "2"
 
 Note: Use `.include()` sparingly, as modifying base classes can have unexpected side effects. As a general rule of thumb, try to extend existing classes instead.
 
-### Initialization hooks
+### Initialization events
 
-Use `addInitHook()` to run code after `initialize()` completes. This is useful for setup that depends on state from the class being modified (e.g. using `.include()`):
+Leaflet's eventful classes such as `Layer` and `LeafletMap` fire an `init` event once an instance has finished initializing, and your own `Evented` subclasses can do the same by firing it at the end of `initialize()`. By registering a class-level listener with `.on('init', …)`, you can run code for every instance that gets created. This is useful for setup that depends on state from the class being modified (e.g. using `.include()`). The new instance is passed as the event's `target`:
 
 ```js
-class MyBox extends Class {
+class MyBox extends Evented {
 	static {
 		this.setDefaultOptions({
 			width: 1,
 			height: 1
 		});
 	}
+
+	initialize(options) {
+		Util.setOptions(this, options);
+
+		// notify class-level `init` listeners once the instance is ready
+		MyBox.fire('init', {target: this});
+	}
 }
 
-MyBox.addInitHook(function() {
-	this._area = this.options.width * this.options.height;
+MyBox.on('init', ({target: box}) => {
+	box._area = box.options.width * box.options.height;
 });
 
 MyBox.include({
@@ -155,25 +162,4 @@ MyBox.include({
 
 const box = new MyBox({width: 5, height: 10});
 console.log(box.getArea()); // Outputs "50"
-```
-
-`addInitHook()` can also call a named method with arguments:
-
-```js
-class MyCube extends MyBox {
-	static {
-		this.setDefaultOptions({
-			depth: 1
-		});
-	}
-
-	_calculateVolume(multiplier/*, arg2, arg3. etc. */) {
-		this._volume = this.options.width * this.options.height * this.options.depth * multiplier;
-	}
-}
-
-MyCube.addInitHook('_calculateVolume', 1/*, arg2, arg3. etc. */);
-
-const cube = new MyCube({width: 2, height: 3, depth: 4});
-console.log(cube._volume); // Outputs "24"
 ```

--- a/docs/examples/extending-1-classes/index.md
+++ b/docs/examples/extending-1-classes/index.md
@@ -145,9 +145,8 @@ class MyBox extends Evented {
 	initialize(options) {
 		Util.setOptions(this, options);
 
-		// notify class-level `init` listeners once the instance is ready;
-		// `this.constructor` makes the event fire on the actual (sub)class
-		this.constructor.fire('init', {target: this});
+		// notify class-level `init` listeners once the instance is ready
+		MyBox.fire('init', {target: this});
 	}
 }
 
@@ -163,24 +162,4 @@ MyBox.include({
 
 const box = new MyBox({width: 5, height: 10});
 console.log(box.getArea()); // Outputs "50"
-```
-
-Listeners are inherited: firing on a class runs the listeners registered on it **and** on all of its ancestors, ancestors first. So a subclass instance also triggers its parent's `init` listeners:
-
-```js
-class MyCube extends MyBox {
-	static {
-		this.setDefaultOptions({
-			depth: 1
-		});
-	}
-}
-
-MyCube.on('init', ({target: cube}) => {
-	// `_area` is already set by MyBox's `init` listener, which runs first
-	cube._volume = cube._area * cube.options.depth;
-});
-
-const cube = new MyCube({width: 2, height: 3, depth: 4});
-console.log(cube._volume); // Outputs "24"
 ```

--- a/docs/examples/extending-1-classes/index.md
+++ b/docs/examples/extending-1-classes/index.md
@@ -32,13 +32,13 @@ Because Leaflet was created before any standardized class syntax existed, it com
 
 ### Creating a subclass
 
-`Class`, or other built-in Leaflet classes derived from it (such as `Layer`, `Handler`, `Control`, etc.), can be extended in the same manner as any other JavaScript class, by using the [`extends`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends) keyword. However, unlike regular JavaScript classes, Leaflet classes do not support the [`constructor()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor) method. Instead, constructor logic should go into a special `initialize()` method to preserve backwards compatibility with older versions of Leaflet:
+`Class`, or other built-in Leaflet classes derived from it (such as `Layer`, `Handler`, `Control`, etc.), can be extended in the same manner as any other JavaScript class, by using the [`extends`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends) keyword and a standard [`constructor()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/constructor). As in any subclass, call `super()` (forwarding the parent constructor's arguments where appropriate) before using `this`:
 
 
 ```js
 class RotateMarker extends Marker {
-	initialize(latlng, rotation, options) {
-		super.initialize(latlng, options);
+	constructor(latlng, rotation, options) {
+		super(latlng, options);
 		this._rotation = rotation;
 	}
 }
@@ -65,8 +65,9 @@ class MyBox extends Class {
 		});
 	}
 
-	initialize(name, options) {
-		super.initialize(options);
+	constructor(name, options) {
+		super();
+		Util.setOptions(this, options);
 		this.name = name;
 	}
 }
@@ -102,8 +103,9 @@ Leaflet provides `.include()` to add or override methods in existing classes. Th
 
 ```js
 class MyLayer extends Layer {
-	initialize(options) {
-		super.initialize(options);
+	constructor(options) {
+		super();
+		Util.setOptions(this, options);
 		this._count = 0;
 	}
 
@@ -131,7 +133,7 @@ Note: Use `.include()` sparingly, as modifying base classes can have unexpected 
 
 ### Initialization events
 
-Leaflet's eventful classes such as `Layer` and `LeafletMap` fire an `init` event once an instance has finished initializing, and your own `Evented` subclasses can do the same by firing it at the end of `initialize()`. By registering a class-level listener with `.on('init', …)`, you can run code for every instance that gets created. This is useful for setup that depends on state from the class being modified (e.g. using `.include()`). The new instance is passed as the event's `target`:
+A class can expose its own class-level events. `LeafletMap`, for example, fires an `init` event from its constructor once a map has finished initializing, and any `Evented` subclass can do the same by firing an event at the end of its `constructor()`. By registering a class-level listener with `.on('init', …)`, you can run code for every instance that gets created. This is useful for setup that depends on state from the class being modified (e.g. using `.include()`). The new instance is passed as the event's `target`:
 
 ```js
 class MyBox extends Evented {
@@ -142,7 +144,8 @@ class MyBox extends Evented {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 
 		// notify class-level `init` listeners once the instance is ready

--- a/docs/examples/extending-3-controls/index.md
+++ b/docs/examples/extending-3-controls/index.md
@@ -48,9 +48,9 @@ class TiltHandler extends Handler {
 }
 ```
 
-The handler can be attached to the map using `map.addHandler('tilt', TiltHandler)` - this will store an instance of `TiltHandler` as `map.tilt`. However, it's more usual to attach handlers to all maps with the `addInitHook` syntax:
+The handler can be attached to the map using `map.addHandler('tilt', TiltHandler)` - this will store an instance of `TiltHandler` as `map.tilt`. However, it's more usual to attach handlers to all maps by listening for the map's `init` event:
 
-	Map.addInitHook('addHandler', 'tilt', TiltHandler);
+	LeafletMap.on('init', ({target: map}) => map.addHandler('tilt', TiltHandler));
 
 Our handler can now be enabled by running `map.tilt.enable()` and disabled by `map.tilt.disable()`
 

--- a/docs/examples/extending-3-controls/tilt.md
+++ b/docs/examples/extending-3-controls/tilt.md
@@ -52,7 +52,7 @@ title: Tilt Handler Example
 		}
 	}
 	
-	Map.addInitHook('addHandler', 'tilt', TiltHandler);
+	LeafletMap.on('init', ({target: map}) => map.addHandler('tilt', TiltHandler));
 
 	const map = new LeafletMap('map', {
 		center: [0, 0],

--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -28,37 +28,6 @@ describe('Class', () => {
 			expect(a.options.foo3).to.eql(4);
 		});
 
-		it('inherits constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class2();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.be.true;
-		});
-
-		it('does not call child constructor hooks', () => {
-			const spy1 = sinon.spy(),
-			spy2 = sinon.spy();
-
-			class Class1 extends Class {}
-			class Class2 extends Class1 {}
-
-			Class1.addInitHook(spy1);
-			Class2.addInitHook(spy2);
-
-			new Class1();
-
-			expect(spy1.called).to.be.true;
-			expect(spy2.called).to.eql(false);
-		});
 	});
 
 	describe('#include', () => {

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -773,5 +773,57 @@ describe('Events', () => {
 
 			expect(spy.called).to.be.false;
 		});
+
+		it('fires only once even after the same listener was added once', () => {
+			const spy = sinon.spy();
+			Foo.once('test', spy);
+			Foo.fire('test');
+			Foo.fire('test');
+
+			expect(spy.callCount).to.eql(1);
+		});
+
+		describe('inheritance', () => {
+			let Base, Sub;
+
+			beforeEach(() => {
+				Base = class extends Evented {};
+				Sub = class extends Base {};
+			});
+
+			it('runs a base-class listener for a subclass, ancestors first', () => {
+				const calls = [];
+				Base.on('test', () => calls.push('base'));
+				Sub.on('test', () => calls.push('sub'));
+
+				Sub.fire('test');
+
+				expect(calls).to.eql(['base', 'sub']);
+			});
+
+			it('does not run a subclass listener when firing on the base', () => {
+				const baseSpy = sinon.spy(),
+				subSpy = sinon.spy();
+				Base.on('test', baseSpy);
+				Sub.on('test', subSpy);
+
+				Base.fire('test');
+
+				expect(baseSpy.called).to.be.true;
+				expect(subSpy.called).to.be.false;
+			});
+
+			it('does not pollute the base class when registering on a subclass', () => {
+				const baseSpy = sinon.spy(),
+				subSpy = sinon.spy();
+				Base.on('test', baseSpy);
+				Sub.on('test', subSpy);
+
+				Base.fire('test');
+
+				expect(subSpy.called).to.be.false;
+				expect(baseSpy.callCount).to.eql(1);
+			});
+		});
 	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -773,57 +773,5 @@ describe('Events', () => {
 
 			expect(spy.called).to.be.false;
 		});
-
-		it('fires only once even after the same listener was added once', () => {
-			const spy = sinon.spy();
-			Foo.once('test', spy);
-			Foo.fire('test');
-			Foo.fire('test');
-
-			expect(spy.callCount).to.eql(1);
-		});
-
-		describe('inheritance', () => {
-			let Base, Sub;
-
-			beforeEach(() => {
-				Base = class extends Evented {};
-				Sub = class extends Base {};
-			});
-
-			it('runs a base-class listener for a subclass, ancestors first', () => {
-				const calls = [];
-				Base.on('test', () => calls.push('base'));
-				Sub.on('test', () => calls.push('sub'));
-
-				Sub.fire('test');
-
-				expect(calls).to.eql(['base', 'sub']);
-			});
-
-			it('does not run a subclass listener when firing on the base', () => {
-				const baseSpy = sinon.spy(),
-				subSpy = sinon.spy();
-				Base.on('test', baseSpy);
-				Sub.on('test', subSpy);
-
-				Base.fire('test');
-
-				expect(baseSpy.called).to.be.true;
-				expect(subSpy.called).to.be.false;
-			});
-
-			it('does not pollute the base class when registering on a subclass', () => {
-				const baseSpy = sinon.spy(),
-				subSpy = sinon.spy();
-				Base.on('test', baseSpy);
-				Sub.on('test', subSpy);
-
-				Base.fire('test');
-
-				expect(subSpy.called).to.be.false;
-				expect(baseSpy.callCount).to.eql(1);
-			});
-		});
 	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -715,4 +715,63 @@ describe('Events', () => {
 			expect(marker.listens('test', spy, fg, true)).to.be.true;
 		});
 	});
+
+	describe('static (class-level) listeners', () => {
+		let Foo;
+
+		beforeEach(() => {
+			Foo = class extends Evented {};
+		});
+
+		it('registers and fires listeners on the class itself', () => {
+			const spy = sinon.spy();
+			Foo.on('test', spy);
+			Foo.fire('test');
+
+			expect(spy.called).to.be.true;
+		});
+
+		it('passes the event object with the class as target by default', () => {
+			const spy = sinon.spy();
+			Foo.on('test', spy);
+			Foo.fire('test', {foo: 'bar'});
+
+			expect(spy.calledWithMatch({type: 'test', target: Foo, foo: 'bar'})).to.be.true;
+		});
+
+		it('honors an explicit target passed via the event data', () => {
+			const spy = sinon.spy(),
+			instance = new Foo();
+			Foo.on('test', spy);
+			Foo.fire('test', {target: instance});
+
+			expect(spy.calledWithMatch({type: 'test', target: instance})).to.be.true;
+		});
+
+		it('keeps class listeners separate from instance listeners', () => {
+			const classSpy = sinon.spy(),
+			instanceSpy = sinon.spy(),
+			instance = new Foo();
+
+			Foo.on('test', classSpy);
+			instance.on('test', instanceSpy);
+
+			instance.fire('test');
+			expect(instanceSpy.called).to.be.true;
+			expect(classSpy.called).to.be.false;
+
+			Foo.fire('test');
+			expect(classSpy.callCount).to.eql(1);
+			expect(instanceSpy.callCount).to.eql(1);
+		});
+
+		it('removes listeners with off', () => {
+			const spy = sinon.spy();
+			Foo.on('test', spy);
+			Foo.off('test', spy);
+			Foo.fire('test');
+
+			expect(spy.called).to.be.false;
+		});
+	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {Class, Evented, FeatureGroup, Marker, Util} from 'leaflet';
+import {Class, Evented, FeatureGroup, Layer, Marker, Util} from 'leaflet';
 import sinon from 'sinon';
 
 describe('Events', () => {
@@ -772,6 +772,41 @@ describe('Events', () => {
 			Foo.fire('test');
 
 			expect(spy.called).to.be.false;
+		});
+	});
+
+	describe('Layer init event', () => {
+		it('fires `init` on the `Layer` class for every layer, with the instance as target', () => {
+			const spy = sinon.spy();
+			Layer.on('init', spy);
+
+			const marker = new Marker([0, 0]),
+			group = new FeatureGroup();
+
+			Layer.off('init', spy);
+
+			expect(spy.callCount).to.eql(2);
+			expect(spy.getCall(0).args[0].target).to.equal(marker);
+			expect(spy.getCall(1).args[0].target).to.equal(group);
+		});
+
+		it('allows a single `Layer` listener to dispatch by instanceof', () => {
+			const seen = [];
+			const onInit = ({target}) => {
+				if (target instanceof FeatureGroup) {
+					seen.push('group');
+				} else if (target instanceof Marker) {
+					seen.push('marker');
+				}
+			};
+			Layer.on('init', onInit);
+
+			new FeatureGroup();
+			new Marker([0, 0]);
+
+			Layer.off('init', onInit);
+
+			expect(seen).to.eql(['group', 'marker']);
 		});
 	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -773,30 +773,5 @@ describe('Events', () => {
 
 			expect(spy.called).to.be.false;
 		});
-
-		it('fires an `init` event after each instance is created', () => {
-			const spy = sinon.spy();
-			Foo.on('init', spy);
-
-			const instance = new Foo();
-			Foo.off('init', spy);
-
-			expect(spy.calledOnce).to.be.true;
-			expect(spy.firstCall.args[0].target).to.equal(instance);
-		});
-
-		it('fires `init` for a subclass that does not call super.initialize()', () => {
-			// `Marker.initialize()` sets up the instance without chaining to a
-			// parent `initialize()`, yet the `init` event still fires (it is
-			// fired from the `Evented` constructor, after initialization).
-			const spy = sinon.spy();
-			Marker.on('init', spy);
-
-			const marker = new Marker([0, 0]);
-			Marker.off('init', spy);
-
-			expect(spy.calledOnce).to.be.true;
-			expect(spy.firstCall.args[0].target).to.equal(marker);
-		});
 	});
 });

--- a/spec/suites/core/EventsSpec.js
+++ b/spec/suites/core/EventsSpec.js
@@ -773,5 +773,30 @@ describe('Events', () => {
 
 			expect(spy.called).to.be.false;
 		});
+
+		it('fires an `init` event after each instance is created', () => {
+			const spy = sinon.spy();
+			Foo.on('init', spy);
+
+			const instance = new Foo();
+			Foo.off('init', spy);
+
+			expect(spy.calledOnce).to.be.true;
+			expect(spy.firstCall.args[0].target).to.equal(instance);
+		});
+
+		it('fires `init` for a subclass that does not call super.initialize()', () => {
+			// `Marker.initialize()` sets up the instance without chaining to a
+			// parent `initialize()`, yet the `init` event still fires (it is
+			// fired from the `Evented` constructor, after initialization).
+			const spy = sinon.spy();
+			Marker.on('init', spy);
+
+			const marker = new Marker([0, 0]);
+			Marker.off('init', spy);
+
+			expect(spy.calledOnce).to.be.true;
+			expect(spy.firstCall.args[0].target).to.equal(marker);
+		});
 	});
 });

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -20,6 +20,12 @@ describe('Marker.Drag', () => {
 	});
 
 	class MyMarker extends Marker {
+		initialize(...args) {
+			super.initialize(...args);
+			this.on('add', () => {
+				this._initialPos = this._getPosition();
+			});
+		}
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
 		}
@@ -27,9 +33,6 @@ describe('Marker.Drag', () => {
 			return this._getPosition().subtract(this._initialPos);
 		}
 	}
-	MyMarker.addInitHook('on', 'add', function () {
-		this._initialPos = this._getPosition();
-	});
 
 	describe('drag', () => {
 		it('drags a marker with mouse', (done) => {

--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -20,8 +20,8 @@ describe('Marker.Drag', () => {
 	});
 
 	class MyMarker extends Marker {
-		initialize(...args) {
-			super.initialize(...args);
+		constructor(latlng, options) {
+			super(latlng, options);
 			this.on('add', () => {
 				this._initialPos = this._getPosition();
 			});

--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DivIcon, DefaultIcon, LatLng, LeafletMap, Marker, Point} from 'leaflet';
+import {DivIcon, DefaultIcon, Layer, LatLng, LeafletMap, Marker, Point} from 'leaflet';
 import sinon from 'sinon';
 import UIEventSimulator from 'ui-event-simulator';
 import {createContainer, removeMapContainer} from '../../SpecHelper.js';
@@ -344,6 +344,24 @@ describe('Marker', () => {
 				done();
 			});
 			UIEventSimulator.fire('pointermove', marker._icon);
+		});
+	});
+
+	describe('init event', () => {
+		it('has its latlng set (via runBeforeInitEvent) when the `init` event fires', () => {
+			let latlngWhenFired;
+			const onInit = ({target}) => {
+				if (target instanceof Marker) {
+					latlngWhenFired = target.getLatLng();
+				}
+			};
+			Layer.on('init', onInit);
+
+			new Marker([1, 2]);
+
+			Layer.off('init', onInit);
+
+			expect(latlngWhenFired).to.be.nearLatLng([1, 2]);
 		});
 	});
 });

--- a/spec/suites/map/MapSpec.js
+++ b/spec/suites/map/MapSpec.js
@@ -17,6 +17,26 @@ describe('Map', () => {
 		removeMapContainer(map, container);
 	});
 
+	describe('init event', () => {
+		it('fires a class-level init event with the new map as target', () => {
+			const spy = sinon.spy();
+			LeafletMap.on('init', spy);
+
+			const extraContainer = createContainer(),
+			extraMap = new LeafletMap(extraContainer);
+
+			LeafletMap.off('init', spy);
+
+			try {
+				expect(spy.calledOnce).to.be.true;
+				expect(spy.firstCall.args[0].type).to.eql('init');
+				expect(spy.firstCall.args[0].target).to.equal(extraMap);
+			} finally {
+				removeMapContainer(extraMap, extraContainer);
+			}
+		});
+	});
+
 	describe('#remove', () => {
 		let spy;
 

--- a/spec/suites/map/handler/DragHandlerSpec.js
+++ b/spec/suites/map/handler/DragHandlerSpec.js
@@ -54,6 +54,12 @@ describe('DragHandler', () => {
 	});
 
 	class MyMap extends LeafletMap {
+		initialize(...args) {
+			super.initialize(...args);
+			this.on('load', () => {
+				this._initialPos = this._getPosition();
+			});
+		}
 		_getPosition() {
 			return DomUtil.getPosition(this.dragging._draggable._element);
 		}
@@ -61,9 +67,6 @@ describe('DragHandler', () => {
 			return this._getPosition().subtract(this._initialPos);
 		}
 	}
-	MyMap.addInitHook('on', 'load', function () {
-		this._initialPos = this._getPosition();
-	});
 
 	describe('pointer events', () => {
 		it('change the center of the map', (done) => {

--- a/spec/suites/map/handler/DragHandlerSpec.js
+++ b/spec/suites/map/handler/DragHandlerSpec.js
@@ -54,8 +54,8 @@ describe('DragHandler', () => {
 	});
 
 	class MyMap extends LeafletMap {
-		initialize(...args) {
-			super.initialize(...args);
+		constructor(id, options) {
+			super(id, options);
 			this.on('load', () => {
 				this._initialPos = this._getPosition();
 			});

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -132,8 +132,8 @@ LeafletMap.mergeOptions({
 	attributionControl: true
 });
 
-LeafletMap.addInitHook(function () {
-	if (this.options.attributionControl) {
-		new AttributionControl().addTo(this);
+LeafletMap.on('init', ({target: map}) => {
+	if (map.options.attributionControl) {
+		new AttributionControl().addTo(map);
 	}
 });

--- a/src/control/AttributionControl.js
+++ b/src/control/AttributionControl.js
@@ -34,8 +34,8 @@ export class AttributionControl extends Control {
 		});
 	}
 
-	initialize(options) {
-		super.initialize(options);
+	constructor(options) {
+		super(options);
 
 		this._attributions = {};
 	}

--- a/src/control/Control.js
+++ b/src/control/Control.js
@@ -26,7 +26,8 @@ export class Control extends Class {
 	}
 
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -85,8 +85,8 @@ export class LayersControl extends Control {
 		});
 	}
 
-	initialize(baseLayers, overlays, options) {
-		super.initialize(options);
+	constructor(baseLayers, overlays, options) {
+		super(options);
 
 		this._layerControlInputs = [];
 		this._layers = [];

--- a/src/control/ZoomControl.js
+++ b/src/control/ZoomControl.js
@@ -135,14 +135,14 @@ LeafletMap.mergeOptions({
 	zoomControl: true
 });
 
-LeafletMap.addInitHook(function () {
-	if (this.options.zoomControl) {
+LeafletMap.on('init', ({target: map}) => {
+	if (map.options.zoomControl) {
 		// @section Controls
 		// @property zoomControl: ZoomControl
 		// The default zoom control (only available if the
 		// [`zoomControl` option](#map-zoomcontrol) was `true` when creating the map).
-		this.zoomControl = new ZoomControl();
-		this.addControl(this.zoomControl);
+		map.zoomControl = new ZoomControl();
+		map.addControl(map.zoomControl);
 	}
 });
 

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -48,57 +48,12 @@ export class Class {
 		return this;
 	}
 
-	// @function addInitHook(fn: Function): this
-	// Adds a [constructor hook](#class-constructor-hooks) to the class.
-	static addInitHook(fn, ...args) { // (Function) || (String, args...)
-		const init = typeof fn === 'function' ? fn : function () {
-			this[fn](...args);
-		};
-
-		if (!Object.hasOwn(this.prototype, '_initHooks')) { // do not use ??= here
-			this.prototype._initHooks = [];
-		}
-		this.prototype._initHooks.push(init);
-		return this;
-	}
-
 	constructor(...args) {
-		this._initHooksCalled = false;
-
 		Util.setOptions(this);
 
 		// call the constructor
 		if (this.initialize) {
 			this.initialize(...args);
 		}
-
-		// call all constructor hooks
-		this.callInitHooks();
-	}
-
-	callInitHooks() {
-		if (this._initHooksCalled) {
-			return;
-		}
-
-		// collect all prototypes in chain
-		const prototypes = [];
-		let current = this;
-
-		while ((current = Object.getPrototypeOf(current)) !== null) {
-			prototypes.push(current);
-		}
-
-		// reverse so the parent prototype is first
-		prototypes.reverse();
-
-		// call init hooks on each prototype
-		for (const proto of prototypes) {
-			for (const hook of proto._initHooks ?? []) {
-				hook.call(this);
-			}
-		}
-
-		this._initHooksCalled = true;
 	}
 }

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -48,12 +48,9 @@ export class Class {
 		return this;
 	}
 
-	constructor(...args) {
+	constructor() {
+		// set up `this.options` from the class defaults; subclasses merge their
+		// own options on top via `Util.setOptions(this, options)`
 		Util.setOptions(this);
-
-		// call the constructor
-		if (this.initialize) {
-			this.initialize(...args);
-		}
 	}
 }

--- a/src/core/Class.leafdoc
+++ b/src/core/Class.leafdoc
@@ -104,22 +104,3 @@ MyClass.include(MyMixin);
 const a = new MyClass();
 a.foo();
 ```
-
-
-@section Constructor hooks
-@example
-
-If you're a plugin developer, you often need to add additional initialization code to existing classes (e.g. editing hooks for `Polyline`). Leaflet comes with a way to do it easily using the `addInitHook` method:
-
-```js
-MyClass.addInitHook(() => {
-    // ... do something in constructor additionally
-    // e.g. add event listeners, set custom properties etc.
-});
-```
-
-You can also use the following shortcut when you just need to make one additional method call:
-
-```js
-MyClass.addInitHook('methodName', arg1, arg2, …);
-```

--- a/src/core/Class.leafdoc
+++ b/src/core/Class.leafdoc
@@ -3,16 +3,16 @@
 
 Class powers the OOP facilities of Leaflet and is used to create almost all of the Leaflet classes documented here.
 
-It implements a simple classical inheritance model using JavaScript's standard `extends` keyword, and introduces several special properties for convenient code organization — options and init hooks.
+It implements a simple classical inheritance model using JavaScript's standard `extends` keyword, and introduces a special `options` property for convenient code organization.
 
 
 @example
 
 ```js
 class MyClass extends Class {
-    initialize(greeter) {
+    constructor(greeter) {
+        super();
         this.greeter = greeter;
-        // class constructor
     }
 
     greet(name) {
@@ -70,7 +70,8 @@ class MyClass extends Class {
         });
     }
 
-    initialize(options) {
+    constructor(options) {
+        super();
         Util.setOptions(this, options);
         ...
     }

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -176,7 +176,7 @@ export class Evented extends Class {
 		const event = {
 			...data,
 			type,
-			target: data?.target ?? this,
+			target: this,
 			sourceTarget: data?.sourceTarget || this
 		};
 
@@ -302,20 +302,110 @@ export class Evented extends Class {
 	_propagateEvent(e) {
 		for (const p of Object.values(this._eventParents ?? {})) {
 			p.fire(e.type, {
-				...e,
 				propagatedFrom: e.target,
-				target: p
+				...e
 			}, true);
 		}
 	}
-};
 
-// Expose the event methods as static methods too, so listeners can be registered
-// on a class itself (e.g. `LeafletMap.on('init', fn)`) and not just on instances.
-// The class object then acts as an event target, keeping its listeners on a
-// static `_events` store.
-for (const name of Object.getOwnPropertyNames(Evented.prototype)) {
-	if (name !== 'constructor') {
-		Evented[name] = Evented.prototype[name];
+	// @section Class-level events
+	// The following static methods mirror their instance counterparts, but operate
+	// on the class itself, so listeners can be registered for every instance of a
+	// class (and its subclasses) — e.g. `LeafletMap.on('init', fn)`. Each class
+	// keeps its own listeners; `fire` walks the class hierarchy and runs ancestor
+	// listeners first, so a listener on a base class also fires for instances of
+	// its subclasses.
+
+	// @function on(type: String, fn: Function, context?: Object): this
+	// Adds a class-level listener, invoked for every instance of this class (and
+	// its subclasses) on which the event is fired.
+	static on(types, fn, context) {
+		if (!Object.hasOwn(this, '_events')) {
+			this._events = {};
+		}
+		return Evented.prototype.on.call(this, types, fn, context);
 	}
-}
+
+	// @function once(…): this
+	// As `on`, except the listener is removed after being fired once.
+	static once(types, fn, context) {
+		if (!Object.hasOwn(this, '_events')) {
+			this._events = {};
+		}
+		return Evented.prototype.once.call(this, types, fn, context);
+	}
+
+	// @function off(…): this
+	// Removes a previously added class-level listener.
+	static off(...args) {
+		if (Object.hasOwn(this, '_events')) {
+			Evented.prototype.off.apply(this, args);
+		}
+		return this;
+	}
+
+	// @function fire(type: String, data?: Object): this
+	// Fires an event on the class, invoking the listeners registered on it and on
+	// all of its ancestor classes (ancestors first).
+	static fire(type, data) {
+		// collect the classes in the hierarchy that have listeners for this type
+		const classes = [];
+		for (let cls = this; cls; cls = Object.getPrototypeOf(cls)) {
+			if (Object.hasOwn(cls, '_events') && cls._events[type]?.length) {
+				classes.push(cls);
+			}
+			if (cls === Evented) {
+				break;
+			}
+		}
+		if (!classes.length) {
+			return this;
+		}
+
+		const event = {
+			...data,
+			type,
+			target: data?.target ?? this,
+			sourceTarget: data?.sourceTarget ?? this
+		};
+
+		// run ancestor listeners first
+		for (let i = classes.length - 1; i >= 0; i--) {
+			const cls = classes[i];
+			for (const l of cls._events[type].slice()) {
+				if (l.once) {
+					cls.off(type, l.fn, l.ctx);
+				}
+				l.fn.call(l.ctx ?? this, event);
+			}
+		}
+		return this;
+	}
+
+	// @function listens(type: String): Boolean
+	// Returns `true` if the class or any of its ancestors has a listener for the
+	// given event type.
+	static listens(type) {
+		for (let cls = this; cls; cls = Object.getPrototypeOf(cls)) {
+			if (Object.hasOwn(cls, '_events') && cls._events[type]?.length) {
+				return true;
+			}
+			if (cls === Evented) {
+				break;
+			}
+		}
+		return false;
+	}
+
+	static _on(...args) {
+		return Evented.prototype._on.apply(this, args);
+	}
+
+	static _off(...args) {
+		return Evented.prototype._off.apply(this, args);
+	}
+
+	static _listens(...args) {
+		return Evented.prototype._listens.apply(this, args);
+	}
+};

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -176,7 +176,7 @@ export class Evented extends Class {
 		const event = {
 			...data,
 			type,
-			target: this,
+			target: data?.target ?? this,
 			sourceTarget: data?.sourceTarget || this
 		};
 
@@ -302,110 +302,20 @@ export class Evented extends Class {
 	_propagateEvent(e) {
 		for (const p of Object.values(this._eventParents ?? {})) {
 			p.fire(e.type, {
+				...e,
 				propagatedFrom: e.target,
-				...e
+				target: p
 			}, true);
 		}
 	}
-
-	// @section Class-level events
-	// The following static methods mirror their instance counterparts, but operate
-	// on the class itself, so listeners can be registered for every instance of a
-	// class (and its subclasses) — e.g. `LeafletMap.on('init', fn)`. Each class
-	// keeps its own listeners; `fire` walks the class hierarchy and runs ancestor
-	// listeners first, so a listener on a base class also fires for instances of
-	// its subclasses.
-
-	// @function on(type: String, fn: Function, context?: Object): this
-	// Adds a class-level listener, invoked for every instance of this class (and
-	// its subclasses) on which the event is fired.
-	static on(types, fn, context) {
-		if (!Object.hasOwn(this, '_events')) {
-			this._events = {};
-		}
-		return Evented.prototype.on.call(this, types, fn, context);
-	}
-
-	// @function once(…): this
-	// As `on`, except the listener is removed after being fired once.
-	static once(types, fn, context) {
-		if (!Object.hasOwn(this, '_events')) {
-			this._events = {};
-		}
-		return Evented.prototype.once.call(this, types, fn, context);
-	}
-
-	// @function off(…): this
-	// Removes a previously added class-level listener.
-	static off(...args) {
-		if (Object.hasOwn(this, '_events')) {
-			Evented.prototype.off.apply(this, args);
-		}
-		return this;
-	}
-
-	// @function fire(type: String, data?: Object): this
-	// Fires an event on the class, invoking the listeners registered on it and on
-	// all of its ancestor classes (ancestors first).
-	static fire(type, data) {
-		// collect the classes in the hierarchy that have listeners for this type
-		const classes = [];
-		for (let cls = this; cls; cls = Object.getPrototypeOf(cls)) {
-			if (Object.hasOwn(cls, '_events') && cls._events[type]?.length) {
-				classes.push(cls);
-			}
-			if (cls === Evented) {
-				break;
-			}
-		}
-		if (!classes.length) {
-			return this;
-		}
-
-		const event = {
-			...data,
-			type,
-			target: data?.target ?? this,
-			sourceTarget: data?.sourceTarget ?? this
-		};
-
-		// run ancestor listeners first
-		for (let i = classes.length - 1; i >= 0; i--) {
-			const cls = classes[i];
-			for (const l of cls._events[type].slice()) {
-				if (l.once) {
-					cls.off(type, l.fn, l.ctx);
-				}
-				l.fn.call(l.ctx ?? this, event);
-			}
-		}
-		return this;
-	}
-
-	// @function listens(type: String): Boolean
-	// Returns `true` if the class or any of its ancestors has a listener for the
-	// given event type.
-	static listens(type) {
-		for (let cls = this; cls; cls = Object.getPrototypeOf(cls)) {
-			if (Object.hasOwn(cls, '_events') && cls._events[type]?.length) {
-				return true;
-			}
-			if (cls === Evented) {
-				break;
-			}
-		}
-		return false;
-	}
-
-	static _on(...args) {
-		return Evented.prototype._on.apply(this, args);
-	}
-
-	static _off(...args) {
-		return Evented.prototype._off.apply(this, args);
-	}
-
-	static _listens(...args) {
-		return Evented.prototype._listens.apply(this, args);
-	}
 };
+
+// Expose the event methods as static methods too, so listeners can be registered
+// on a class itself (e.g. `LeafletMap.on('init', fn)`) and not just on instances.
+// The class object then acts as an event target, keeping its listeners on a
+// static `_events` store.
+for (const name of Object.getOwnPropertyNames(Evented.prototype)) {
+	if (name !== 'constructor') {
+		Evented[name] = Evented.prototype[name];
+	}
+}

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -176,7 +176,7 @@ export class Evented extends Class {
 		const event = {
 			...data,
 			type,
-			target: this,
+			target: data?.target ?? this,
 			sourceTarget: data?.sourceTarget || this
 		};
 
@@ -302,9 +302,20 @@ export class Evented extends Class {
 	_propagateEvent(e) {
 		for (const p of Object.values(this._eventParents ?? {})) {
 			p.fire(e.type, {
+				...e,
 				propagatedFrom: e.target,
-				...e
+				target: p
 			}, true);
 		}
 	}
 };
+
+// Expose the event methods as static methods too, so listeners can be registered
+// on a class itself (e.g. `LeafletMap.on('init', fn)`) and not just on instances.
+// The class object then acts as an event target, keeping its listeners on a
+// static `_events` store.
+for (const name of Object.getOwnPropertyNames(Evented.prototype)) {
+	if (name !== 'constructor') {
+		Evented[name] = Evented.prototype[name];
+	}
+}

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -26,17 +26,6 @@ import * as Util from './Util.js';
  */
 
 export class Evented extends Class {
-	constructor(...args) {
-		super(...args);
-
-		// @event init: Event
-		// Fired once an instance has finished initializing. Listeners are registered
-		// on the class itself (e.g. `Marker.on('init', fn)` or
-		// `LeafletMap.on('init', fn)`) and run for every instance created, with the
-		// new instance available as `e.target`.
-		this.constructor.fire('init', {target: this});
-	}
-
 	/* @method on(type: String, fn: Function, context?: Object): this
 	 * Adds a listener function (`fn`) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. `'click dblclick'`).
 	 *

--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -26,6 +26,17 @@ import * as Util from './Util.js';
  */
 
 export class Evented extends Class {
+	constructor(...args) {
+		super(...args);
+
+		// @event init: Event
+		// Fired once an instance has finished initializing. Listeners are registered
+		// on the class itself (e.g. `Marker.on('init', fn)` or
+		// `LeafletMap.on('init', fn)`) and run for every instance created, with the
+		// new instance available as `e.target`.
+		this.constructor.fire('init', {target: this});
+	}
+
 	/* @method on(type: String, fn: Function, context?: Object): this
 	 * Adds a listener function (`fn`) to a particular event type of the object. You can optionally specify the context of the listener (object the this keyword will point to). You can also pass several space-separated types (e.g. `'click dblclick'`).
 	 *

--- a/src/core/Handler.js
+++ b/src/core/Handler.js
@@ -9,7 +9,8 @@ import {Class} from './Class.js';
 // Abstract class for map interaction handlers
 
 export class Handler extends Class {
-	initialize(map) {
+	constructor(map) {
+		super();
 		this._map = map;
 	}
 

--- a/src/dom/Draggable.js
+++ b/src/dom/Draggable.js
@@ -34,7 +34,8 @@ export class Draggable extends Evented {
 
 	// @constructor Draggable(el: HTMLElement, dragHandle?: HTMLElement, preventOutline?: Boolean, options?: Draggable options)
 	// Creates a `Draggable` object for moving `el` when you start dragging the `dragHandle` element (equals `el` itself by default).
-	initialize(element, dragStartTarget, preventOutline, options) {
+	constructor(element, dragStartTarget, preventOutline, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._element = element;

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -35,7 +35,8 @@ export class BlanketOverlay extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 

--- a/src/layer/BlanketOverlay.js
+++ b/src/layer/BlanketOverlay.js
@@ -1,6 +1,5 @@
 import {Layer} from './Layer.js';
 import * as DomUtil from '../dom/DomUtil.js';
-import * as Util from '../core/Util.js';
 import * as DomEvent from '../dom/DomEvent.js';
 import {Bounds} from '../geometry/Bounds.js';
 
@@ -33,11 +32,6 @@ export class BlanketOverlay extends Layer {
 			// animations)
 			continuous: false,
 		});
-	}
-
-	constructor(options) {
-		super();
-		Util.setOptions(this, options);
 	}
 
 	onAdd() {

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -44,17 +44,19 @@ export class DivOverlay extends Layer {
 	}
 
 	constructor(options, source) {
-		super();
-		if (options instanceof LatLng || Array.isArray(options)) {
-			this._latlng = new LatLng(options);
-			Util.setOptions(this, source);
-		} else {
-			Util.setOptions(this, options);
-			this._source = source;
-		}
-		if (this.options.content) {
-			this._content = this.options.content;
-		}
+		// the first argument may be a `LatLng` (the overlay position) instead of
+		// an options object, in which case `source` carries the options
+		const isLatLng = options instanceof LatLng || Array.isArray(options);
+		super(isLatLng ? source : options, (layer) => {
+			if (isLatLng) {
+				layer._latlng = new LatLng(options);
+			} else {
+				layer._source = source;
+			}
+			if (layer.options.content) {
+				layer._content = layer.options.content;
+			}
+		});
 	}
 
 	// @method openOn(map: LeafletMap): this

--- a/src/layer/DivOverlay.js
+++ b/src/layer/DivOverlay.js
@@ -43,7 +43,8 @@ export class DivOverlay extends Layer {
 		});
 	}
 
-	initialize(options, source) {
+	constructor(options, source) {
+		super();
 		if (options instanceof LatLng || Array.isArray(options)) {
 			this._latlng = new LatLng(options);
 			Util.setOptions(this, source);

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -89,8 +89,8 @@ export class GeoJSON extends FeatureGroup {
 	 * Whether default Markers for "Point" type Features inherit from group options.
 	 */
 
-	initialize(geojson, options) {
-		super.initialize(undefined, options);
+	constructor(geojson, options) {
+		super(undefined, options);
 
 		if (geojson) {
 			this.addData(geojson);

--- a/src/layer/GeoJSON.js
+++ b/src/layer/GeoJSON.js
@@ -90,11 +90,11 @@ export class GeoJSON extends FeatureGroup {
 	 */
 
 	constructor(geojson, options) {
-		super(undefined, options);
-
-		if (geojson) {
-			this.addData(geojson);
-		}
+		super(undefined, options, (layer) => {
+			if (geojson) {
+				layer.addData(geojson);
+			}
+		});
 	}
 
 	// @method addData( <GeoJSON> data ): this

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -67,7 +67,8 @@ export class ImageOverlay extends Layer {
 		});
 	}
 
-	initialize(url, bounds, options) { // (String, LatLngBounds, Object)
+	constructor(url, bounds, options) { // (String, LatLngBounds, Object)
+		super();
 		this._url = url;
 		this._bounds = new LatLngBounds(bounds);
 

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -68,11 +68,9 @@ export class ImageOverlay extends Layer {
 	}
 
 	constructor(url, bounds, options) { // (String, LatLngBounds, Object)
-		super();
+		super(options);
 		this._url = url;
 		this._bounds = new LatLngBounds(bounds);
-
-		Util.setOptions(this, options);
 	}
 
 	onAdd() {

--- a/src/layer/ImageOverlay.js
+++ b/src/layer/ImageOverlay.js
@@ -68,9 +68,10 @@ export class ImageOverlay extends Layer {
 	}
 
 	constructor(url, bounds, options) { // (String, LatLngBounds, Object)
-		super(options);
-		this._url = url;
-		this._bounds = new LatLngBounds(bounds);
+		super(options, (layer) => {
+			layer._url = url;
+			layer._bounds = new LatLngBounds(bounds);
+		});
 	}
 
 	onAdd() {

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -49,7 +49,7 @@ export class Layer extends Evented {
 		// Fired when a layer instance has finished initializing. Listeners for this
 		// event are registered on the class itself (e.g. `Layer.on('init', fn)`)
 		// and are invoked for every layer created, with the new layer as `e.target`.
-		Layer.fire('init', {target: this});
+		this.constructor.fire('init', {target: this});
 	}
 
 	/* @section

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -44,6 +44,11 @@ export class Layer extends Evented {
 		});
 	}
 
+	constructor(options) {
+		super();
+		Util.setOptions(this, options);
+	}
+
 	/* @section
 	 * Classes extending `Layer` will inherit the following methods:
 	 *

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -44,14 +44,6 @@ export class Layer extends Evented {
 		});
 	}
 
-	initialize() {
-		// @event init: Event
-		// Fired when a layer instance has finished initializing. Listeners for this
-		// event are registered on the class itself (e.g. `Layer.on('init', fn)`)
-		// and are invoked for every layer created, with the new layer as `e.target`.
-		Layer.fire('init', {target: this});
-	}
-
 	/* @section
 	 * Classes extending `Layer` will inherit the following methods:
 	 *

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -49,7 +49,7 @@ export class Layer extends Evented {
 		// Fired when a layer instance has finished initializing. Listeners for this
 		// event are registered on the class itself (e.g. `Layer.on('init', fn)`)
 		// and are invoked for every layer created, with the new layer as `e.target`.
-		this.constructor.fire('init', {target: this});
+		Layer.fire('init', {target: this});
 	}
 
 	/* @section

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -44,6 +44,14 @@ export class Layer extends Evented {
 		});
 	}
 
+	initialize() {
+		// @event init: Event
+		// Fired when a layer instance has finished initializing. Listeners for this
+		// event are registered on the class itself (e.g. `Layer.on('init', fn)`)
+		// and are invoked for every layer created, with the new layer as `e.target`.
+		Layer.fire('init', {target: this});
+	}
+
 	/* @section
 	 * Classes extending `Layer` will inherit the following methods:
 	 *

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -47,6 +47,14 @@ export class Layer extends Evented {
 	constructor(options) {
 		super();
 		Util.setOptions(this, options);
+
+		// @event init: Event
+		// Fired for every layer instance as it is constructed. Listeners are
+		// registered on the class itself (`Layer.on('init', fn)`) and run for every
+		// layer created, with the new layer as `e.target`. Note that this fires from
+		// the `Layer` constructor, i.e. before any subclass constructor body has run,
+		// so subclass-specific state (e.g. a marker's `_latlng`) is not set yet.
+		Layer.fire('init', {target: this});
 	}
 
 	/* @section

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -44,16 +44,24 @@ export class Layer extends Evented {
 		});
 	}
 
-	constructor(options) {
+	// `Layer` is abstract; subclasses construct it via `super(options, beforeInit)`:
+	// - `options`: an options object, merged into the layer's default `options`.
+	// - `beforeInit(layer)`: optional callback that lets a subclass set up its
+	//   essential state before the `init` event fires. It is passed the new layer
+	//   instance (a subclass cannot reference `this` until `super()` returns), and
+	//   runs after `options` are set but before `init`.
+	constructor(options, beforeInit = () => {}) {
 		super();
 		Util.setOptions(this, options);
 
+		beforeInit(this);
+
 		// @event init: Event
-		// Fired for every layer instance as it is constructed. Listeners are
-		// registered on the class itself (`Layer.on('init', fn)`) and run for every
-		// layer created, with the new layer as `e.target`. Note that this fires from
-		// the `Layer` constructor, i.e. before any subclass constructor body has run,
-		// so subclass-specific state (e.g. a marker's `_latlng`) is not set yet.
+		// Fired for every layer instance once it has been constructed. Listeners
+		// are registered on the class itself (`Layer.on('init', fn)`) and run for
+		// every layer created, with the new layer as `e.target`. Subclasses that
+		// want their state available to `init` listeners must set it up via the
+		// `beforeInit` callback passed to `super()`.
 		Layer.fire('init', {target: this});
 	}
 

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -23,7 +23,8 @@ import * as Util from '../core/Util.js';
 // Create a layer group, optionally given an initial set of layers and an `options` object.
 export class LayerGroup extends Layer {
 
-	initialize(layers, options) { // for compatibility of code using `LayerGroup.extend`
+	constructor(layers, options) {
+		super();
 		Util.setOptions(this, options);
 
 		this._layers = {};

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -23,14 +23,17 @@ import * as Util from '../core/Util.js';
 // Create a layer group, optionally given an initial set of layers and an `options` object.
 export class LayerGroup extends Layer {
 
-	constructor(layers, options) {
-		super(options);
+	constructor(layers, options, beforeInit = () => {}) {
+		super(options, (group) => {
+			group._layers = {};
 
-		this._layers = {};
+			for (const layer of layers ?? []) {
+				group.addLayer(layer);
+			}
 
-		for (const layer of layers ?? []) {
-			this.addLayer(layer);
-		}
+			// let subclasses (e.g. GeoJSON) add their own state before `init`
+			beforeInit(group);
+		});
 	}
 
 	// @method addLayer(layer: Layer): this

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -24,8 +24,7 @@ import * as Util from '../core/Util.js';
 export class LayerGroup extends Layer {
 
 	constructor(layers, options) {
-		super();
-		Util.setOptions(this, options);
+		super(options);
 
 		this._layers = {};
 

--- a/src/layer/marker/Icon.js
+++ b/src/layer/marker/Icon.js
@@ -86,7 +86,8 @@ export class Icon extends Class {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		setOptions(this, options);
 	}
 

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -23,8 +23,8 @@ import {Point} from '../../geometry/Point.js';
  */
 
 export class MarkerDrag extends Handler {
-	initialize(marker) {
-		super.initialize(marker._map);
+	constructor(marker) {
+		super(marker._map);
 		this._marker = marker;
 	}
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -110,7 +110,8 @@ export class Marker extends Layer {
 	 * In addition to [shared layer methods](#Layer) like `addTo()` and `remove()` and [popup methods](#Popup) like bindPopup() you can also use the following methods:
 	 */
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 	}

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -1,6 +1,5 @@
 import {Layer} from '../Layer.js';
 import {DefaultIcon} from './DefaultIcon.js';
-import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Point} from '../../geometry/Point.js';
 import * as DomUtil from '../../dom/DomUtil.js';
@@ -111,8 +110,7 @@ export class Marker extends Layer {
 	 */
 
 	constructor(latlng, options) {
-		super();
-		Util.setOptions(this, options);
+		super(options);
 		this._latlng = new LatLng(latlng);
 	}
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -110,8 +110,9 @@ export class Marker extends Layer {
 	 */
 
 	constructor(latlng, options) {
-		super(options);
-		this._latlng = new LatLng(latlng);
+		super(options, (layer) => {
+			layer._latlng = new LatLng(latlng);
+		});
 	}
 
 	onAdd(map) {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -152,7 +152,8 @@ export class GridLayer extends Layer {
 		});
 	}
 
-	initialize(options) {
+	constructor(options) {
+		super();
 		Util.setOptions(this, options);
 	}
 

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -152,11 +152,6 @@ export class GridLayer extends Layer {
 		});
 	}
 
-	constructor(options) {
-		super();
-		Util.setOptions(this, options);
-	}
-
 	onAdd() {
 		this._initContainer();
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -88,8 +88,8 @@ export class TileLayer extends GridLayer {
 		});
 	}
 
-	initialize(url, options) {
-		super.initialize(options);
+	constructor(url, options) {
+		super(options);
 
 		this._url = url;
 

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -93,15 +93,13 @@ export class TileLayer extends GridLayer {
 
 		this._url = url;
 
-		options = Util.setOptions(this, options);
-
 		// Set required OpenStreetMap attribution if it hasn't been specified; upgrade to HTTPS so the referrer policy works.
 		const tileUrl = new URL(this._url, location.href);
 		const urlHostname = tileUrl.hostname;
 		const osmHosts = ['tile.openstreetmap.org', 'tile.osm.org'];
 		if (osmHosts.some(host => urlHostname.endsWith(host))) {
-			if (options.attribution === null) {
-				options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+			if (this.options.attribution === null) {
+				this.options.attribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 			}
 			if (tileUrl.protocol === 'http:') {
 				tileUrl.protocol = 'https:';

--- a/src/layer/tile/WMSTileLayer.js
+++ b/src/layer/tile/WMSTileLayer.js
@@ -67,8 +67,8 @@ export class WMSTileLayer extends TileLayer {
 		});
 	}
 
-	initialize(url, options) {
-		super.initialize(url, options);
+	constructor(url, options) {
+		super(url, options);
 
 		const wmsParams = {...this.defaultWmsParams};
 

--- a/src/layer/vector/Circle.js
+++ b/src/layer/vector/Circle.js
@@ -23,8 +23,8 @@ import {EarthCRS} from '../../geo/crs/EarthCRS.js';
 // which contains the circle radius.
 export class Circle extends CircleMarker {
 
-	initialize(latlng, options) {
-		super.initialize(latlng, options);
+	constructor(latlng, options) {
+		super(latlng, options);
 
 		if (isNaN(this.options.radius)) { throw new Error('Circle radius cannot be NaN'); }
 

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -27,7 +27,8 @@ export class CircleMarker extends Path {
 		});
 	}
 
-	initialize(latlng, options) {
+	constructor(latlng, options) {
+		super();
 		Util.setOptions(this, options);
 		this._latlng = new LatLng(latlng);
 		this._radius = this.options.radius;

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -1,5 +1,4 @@
 import {Path} from './Path.js';
-import * as Util from '../../core/Util.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {Bounds} from '../../geometry/Bounds.js';
 
@@ -28,8 +27,7 @@ export class CircleMarker extends Path {
 	}
 
 	constructor(latlng, options) {
-		super();
-		Util.setOptions(this, options);
+		super(options);
 		this._latlng = new LatLng(latlng);
 		this._radius = this.options.radius;
 	}

--- a/src/layer/vector/CircleMarker.js
+++ b/src/layer/vector/CircleMarker.js
@@ -27,9 +27,10 @@ export class CircleMarker extends Path {
 	}
 
 	constructor(latlng, options) {
-		super(options);
-		this._latlng = new LatLng(latlng);
-		this._radius = this.options.radius;
+		super(options, (layer) => {
+			layer._latlng = new LatLng(latlng);
+			layer._radius = layer.options.radius;
+		});
 	}
 
 	// @method setLatLng(latLng: LatLng): this

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -66,7 +66,8 @@ export class Polyline extends Path {
 		});
 	}
 
-	initialize(latlngs, options) {
+	constructor(latlngs, options) {
+		super();
 		Util.setOptions(this, options);
 		this._setLatLngs(latlngs);
 	}

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -66,8 +66,9 @@ export class Polyline extends Path {
 	}
 
 	constructor(latlngs, options) {
-		super(options);
-		this._setLatLngs(latlngs);
+		super(options, (layer) => {
+			layer._setLatLngs(latlngs);
+		});
 	}
 
 	// @method getLatLngs(): LatLng[]

--- a/src/layer/vector/Polyline.js
+++ b/src/layer/vector/Polyline.js
@@ -1,5 +1,4 @@
 import {Path} from './Path.js';
-import * as Util from '../../core/Util.js';
 import * as LineUtil from '../../geometry/LineUtil.js';
 import {LatLng} from '../../geo/LatLng.js';
 import {LatLngBounds} from '../../geo/LatLngBounds.js';
@@ -67,8 +66,7 @@ export class Polyline extends Path {
 	}
 
 	constructor(latlngs, options) {
-		super();
-		Util.setOptions(this, options);
+		super(options);
 		this._setLatLngs(latlngs);
 	}
 

--- a/src/layer/vector/Rectangle.js
+++ b/src/layer/vector/Rectangle.js
@@ -28,17 +28,17 @@ import {LatLngBounds} from '../../geo/LatLngBounds.js';
 
 // @constructor Rectangle(latLngBounds: LatLngBounds, options?: Polyline options)
 export class Rectangle extends Polygon {
-	initialize(latLngBounds, options) {
-		super.initialize(this._boundsToLatLngs(latLngBounds), options);
+	constructor(latLngBounds, options) {
+		super(Rectangle._boundsToLatLngs(latLngBounds), options);
 	}
 
 	// @method setBounds(latLngBounds: LatLngBounds): this
 	// Redraws the rectangle with the passed bounds.
 	setBounds(latLngBounds) {
-		return this.setLatLngs(this._boundsToLatLngs(latLngBounds));
+		return this.setLatLngs(Rectangle._boundsToLatLngs(latLngBounds));
 	}
 
-	_boundsToLatLngs(latLngBounds) {
+	static _boundsToLatLngs(latLngBounds) {
 		latLngBounds = new LatLngBounds(latLngBounds);
 		return [
 			latLngBounds.getSouthWest(),

--- a/src/layer/vector/Renderer.js
+++ b/src/layer/vector/Renderer.js
@@ -25,8 +25,8 @@ import * as Util from '../../core/Util.js';
 
 export class Renderer extends BlanketOverlay {
 
-	initialize(options) {
-		super.initialize({...options, continuous: false});
+	constructor(options) {
+		super({...options, continuous: false});
 		Util.stamp(this);
 		this._layers ??= {};
 	}

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -182,7 +182,7 @@ export class LeafletMap extends Evented {
 		// Fired when a map instance has finished initializing. Listeners for this
 		// event are registered on the class itself (e.g. `LeafletMap.on('init', fn)`)
 		// and are invoked for every map created, with the new map as `e.target`.
-		LeafletMap.fire('init', {target: this});
+		this.constructor.fire('init', {target: this});
 	}
 
 	// @section Methods for modifying map state

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -179,6 +179,12 @@ export class LeafletMap extends Evented {
 		}
 
 		this._addLayers(this.options.layers);
+
+		// @event init: Event
+		// Fired when a map instance has finished initializing. Listeners for this
+		// event are registered on the class itself (e.g. `LeafletMap.on('init', fn)`)
+		// and are invoked for every map created, with the new map as `e.target`.
+		LeafletMap.fire('init', {target: this});
 	}
 
 	// @section Methods for modifying map state

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -141,7 +141,9 @@ export class LeafletMap extends Evented {
 		});
 	}
 
-	initialize(id, options) { // (HTMLElement or String, Object)
+	constructor(id, options) { // (HTMLElement or String, Object)
+		super();
+
 		options = Util.setOptions(this, options);
 
 		// Make sure to assign internal flags at the beginning,

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -182,7 +182,7 @@ export class LeafletMap extends Evented {
 		// Fired when a map instance has finished initializing. Listeners for this
 		// event are registered on the class itself (e.g. `LeafletMap.on('init', fn)`)
 		// and are invoked for every map created, with the new map as `e.target`.
-		this.constructor.fire('init', {target: this});
+		LeafletMap.fire('init', {target: this});
 	}
 
 	// @section Methods for modifying map state

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -168,8 +168,6 @@ export class LeafletMap extends Evented {
 			this.setView(new LatLng(options.center), options.zoom, {reset: true});
 		}
 
-		this.callInitHooks();
-
 		this._zoomAnimated = this.options.zoomAnimation;
 
 		// zoom transitions run with the same duration for all layers, so if one of transitionend events

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -177,6 +177,12 @@ export class LeafletMap extends Evented {
 		}
 
 		this._addLayers(this.options.layers);
+
+		// @event init: Event
+		// Fired when a map instance has finished initializing. Listeners for this
+		// event are registered on the class itself (e.g. `LeafletMap.on('init', fn)`)
+		// and are invoked for every map created, with the new map as `e.target`.
+		LeafletMap.fire('init', {target: this});
 	}
 
 	// @section Methods for modifying map state

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -177,12 +177,6 @@ export class LeafletMap extends Evented {
 		}
 
 		this._addLayers(this.options.layers);
-
-		// @event init: Event
-		// Fired when a map instance has finished initializing. Listeners for this
-		// event are registered on the class itself (e.g. `LeafletMap.on('init', fn)`)
-		// and are invoked for every map created, with the new map as `e.target`.
-		LeafletMap.fire('init', {target: this});
 	}
 
 	// @section Methods for modifying map state

--- a/src/map/handler/BoxZoomHandler.js
+++ b/src/map/handler/BoxZoomHandler.js
@@ -20,8 +20,8 @@ LeafletMap.mergeOptions({
 });
 
 export class BoxZoomHandler extends Handler {
-	initialize(map) {
-		super.initialize(map);
+	constructor(map) {
+		super(map);
 		this._container = map._container;
 		this._pane = map._panes.overlayPane;
 		this._resetStateTimeout = 0;

--- a/src/map/handler/BoxZoomHandler.js
+++ b/src/map/handler/BoxZoomHandler.js
@@ -149,4 +149,4 @@ export class BoxZoomHandler extends Handler {
 // @section Handlers
 // @property boxZoom: Handler
 // Box (shift-drag with pointer) zoom handler.
-LeafletMap.addInitHook('addHandler', 'boxZoom', BoxZoomHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('boxZoom', BoxZoomHandler));

--- a/src/map/handler/DoubleClickZoomHandler.js
+++ b/src/map/handler/DoubleClickZoomHandler.js
@@ -52,4 +52,4 @@ export class DoubleClickZoomHandler extends Handler {
 //
 // @property doubleClickZoom: Handler
 // Double click zoom handler.
-LeafletMap.addInitHook('addHandler', 'doubleClickZoom', DoubleClickZoomHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('doubleClickZoom', DoubleClickZoomHandler));

--- a/src/map/handler/DragHandler.js
+++ b/src/map/handler/DragHandler.js
@@ -229,4 +229,4 @@ export class DragHandler extends Handler {
 // @section Handlers
 // @property dragging: Handler
 // Map dragging handler.
-LeafletMap.addInitHook('addHandler', 'dragging', DragHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('dragging', DragHandler));

--- a/src/map/handler/KeyboardHandler.js
+++ b/src/map/handler/KeyboardHandler.js
@@ -182,4 +182,4 @@ export class KeyboardHandler extends Handler {
 // @section Handlers
 // @property keyboard: Handler
 // Keyboard navigation handler.
-LeafletMap.addInitHook('addHandler', 'keyboard', KeyboardHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('keyboard', KeyboardHandler));

--- a/src/map/handler/KeyboardHandler.js
+++ b/src/map/handler/KeyboardHandler.js
@@ -32,8 +32,8 @@ export class KeyboardHandler extends Handler {
 		zoomOut: ['Minus', 'NumpadSubtract', 'Digit6', 'Slash']
 	};
 
-	initialize(map) {
-		super.initialize(map);
+	constructor(map) {
+		super(map);
 
 		this._setPanDelta(map.options.keyboardPanDelta);
 		this._setZoomDelta(map.options.zoomDelta);

--- a/src/map/handler/PinchZoomHandler.js
+++ b/src/map/handler/PinchZoomHandler.js
@@ -130,21 +130,21 @@ export class PinchZoomHandler extends Handler {
 // @section Handlers
 // @property pinchZoom: Handler
 // Pinch zoom handler.
-LeafletMap.addInitHook('addHandler', 'pinchZoom', PinchZoomHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('pinchZoom', PinchZoomHandler));
 
 // Deprecated - Backward compatibility touchZoom
-LeafletMap.addInitHook(function () {
-	this.touchZoom = this.pinchZoom;
+LeafletMap.on('init', ({target: map}) => {
+	map.touchZoom = map.pinchZoom;
 
-	if (this.options.touchZoom !== undefined) {
+	if (map.options.touchZoom !== undefined) {
 		// To be removed in leaflet 3
 		console.warn('Map: touchZoom option is deprecated and will be removed in future versions. Use pinchZoom instead.');
-		this.options.pinchZoom = this.options.touchZoom;
-		delete this.options.touchZoom;
+		map.options.pinchZoom = map.options.touchZoom;
+		delete map.options.touchZoom;
 	}
-	if (this.options.pinchZoom) {
-		this.pinchZoom.enable();
+	if (map.options.pinchZoom) {
+		map.pinchZoom.enable();
 	} else {
-		this.pinchZoom.disable();
+		map.pinchZoom.disable();
 	}
 });

--- a/src/map/handler/ScrollWheelZoomHandler.js
+++ b/src/map/handler/ScrollWheelZoomHandler.js
@@ -88,4 +88,4 @@ export class ScrollWheelZoomHandler extends Handler {
 // @section Handlers
 // @property scrollWheelZoom: Handler
 // Scroll wheel zoom handler.
-LeafletMap.addInitHook('addHandler', 'scrollWheelZoom', ScrollWheelZoomHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('scrollWheelZoom', ScrollWheelZoomHandler));

--- a/src/map/handler/TapHoldHandler.js
+++ b/src/map/handler/TapHoldHandler.js
@@ -101,4 +101,4 @@ export class TapHoldHandler extends Handler {
 // @section Handlers
 // @property tapHold: Handler
 // Long tap handler to simulate `contextmenu` event (useful in mobile Safari).
-LeafletMap.addInitHook('addHandler', 'tapHold', TapHoldHandler);
+LeafletMap.on('init', ({target: map}) => map.addHandler('tapHold', TapHoldHandler));


### PR DESCRIPTION
## Summary

This modernizes Leaflet's class system by replacing two legacy mechanisms with standard JavaScript:

1. **`initialize()` → standard `constructor()`** for every `Class`-based class.
2. **`addInitHook()` / `callInitHooks()` → a class-level `init` event** built on `Evented`.

The custom `Class.initialize()` indirection and the `addInitHook` constructor-hook system both predate ES classes and exist only to work around their absence. With standard constructors available, we can drop them.

## What changed

### Standard constructors
- `Class`'s constructor no longer dispatches to `this.initialize(...)`; it just sets up `this.options`. Every subclass now defines a real `constructor()` that calls `super()` (forwarding parent args where applicable).
- Classes that chained `super.initialize(x)` now call `super(x)`.
- `Rectangle._boundsToLatLngs` became `static` so it can be used in the `super()` call.

### Class-level events on `Evented`
- `Evented`'s event methods (`on`, `off`, `once`, `fire`, `listens`, …) are now also exposed as **static** methods, so listeners can be registered on a class itself:
  ```js
  LeafletMap.on('init', (e) => console.log('a map was created:', e.target));
  Layer.on('init', (e) => console.log('a layer was created:', e.target));

Fixes #9889. Alternative to #10202.