### PR TITLE
Fix LatLng.validate throwing on null instead of returning false

### DIFF
--- a/spec/suites/geo/LatLngSpec.js
+++ b/spec/suites/geo/LatLngSpec.js
@@ -33,6 +33,22 @@ describe('LatLng', () => {
 		});
 	});
 
+	describe('validate', () => {
+		it('returns true for valid inputs', () => {
+			expect(LatLng.validate(50, 30)).to.eql(true);
+			expect(LatLng.validate([50, 30])).to.eql(true);
+			expect(LatLng.validate({lat: 50, lng: 30})).to.eql(true);
+			expect(LatLng.validate(new LatLng(50, 30))).to.eql(true);
+		});
+
+		it('returns false for invalid inputs without throwing', () => {
+			expect(LatLng.validate(undefined)).to.eql(false);
+			expect(LatLng.validate(null)).to.eql(false);
+			expect(LatLng.validate('foo')).to.eql(false);
+			expect(LatLng.validate([50])).to.eql(false);
+		});
+	});
+
 	describe('#equals', () => {
 		it('returns true if compared objects are equal within a certain margin', () => {
 			const a = new LatLng(10, 20);

--- a/src/geo/LatLng.js
+++ b/src/geo/LatLng.js
@@ -101,7 +101,7 @@ export class LatLng {
 
 	// eslint-disable-next-line no-unused-vars
 	static validate(lat, lng, alt) {
-		if (lat instanceof LatLng || (typeof lat === 'object' && 'lat' in lat)) {
+		if (lat instanceof LatLng || (typeof lat === 'object' && lat !== null && 'lat' in lat)) {
 			return true;
 		} else if (lat && Array.isArray(lat) && typeof lat[0] !== 'object') {
 			if (lat.length === 3 || lat.length === 2) {


### PR DESCRIPTION
`LatLng.validate(null)` throws `TypeError: Cannot use 'in' operator to search for 'lat' in null` instead of returning `false`.

`typeof null === 'object'` is `true`, so the object branch reaches `'lat' in null` and throws. This is asymmetric with `validate(undefined)`, which correctly returns `false`. The fix guards the object check with `lat !== null`.

As a side effect, `new LatLng(null)` now throws the intended descriptive `Invalid LatLng object` error (from the constructor's `validate` call) instead of the opaque internal `TypeError`.

Added a `validate` spec covering valid inputs and invalid inputs (`undefined`/`null`/`'foo'`/short array) returning `false` without throwing. The `null` case fails without this fix.