### PR TITLE
Fix infinite loop in clipSegment with fractional clip bounds (closes #7235)

### DIFF
--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -50,6 +50,19 @@ describe('LineUtil', () => {
 			expect(segment2[0]).to.eql(new Point(5, 5));
 			expect(segment2[1]).to.eql(b);
 		});
+
+		it('terminates when rounding against fractional bounds', () => {
+			const a = new Point(301.4418194964528, 342.73335686232895);
+			const b = new Point(116, 279);
+			const bounds = new Bounds(
+				new Point(116.30943011350813, 22.55244562255804),
+				new Point(1588.709430113508, 1115.752445622558));
+
+			const segment = LineUtil.clipSegment(a, b, bounds, false, true);
+
+			expect(segment[0]).to.eql(a);
+			expect(segment[1]).to.eql(new Point(116, 279));
+		});
 	});
 
 	describe('#pointToSegmentDistance & #closestPointOnSegment', () => {

--- a/src/geometry/LineUtil.js
+++ b/src/geometry/LineUtil.js
@@ -117,6 +117,7 @@ let _lastCode;
 // (modifying the segment points directly!). Used by Leaflet to only show polyline
 // points that are on the screen or near, increasing performance.
 export function clipSegment(a, b, bounds, useLastCode, round) {
+	const a0 = a, b0 = b;
 	let codeA = useLastCode ? _lastCode : _getBitCode(a, bounds),
 	codeB = _getBitCode(b, bounds),
 
@@ -128,6 +129,12 @@ export function clipSegment(a, b, bounds, useLastCode, round) {
 	while (true) {
 		// if a,b is inside the clip window (trivial accept)
 		if (!(codeA | codeB)) {
+			// round only the endpoints that were replaced by a clipped intersection;
+			// rounding while iterating can push a point back outside and loop forever
+			if (round) {
+				if (a !== a0) { a = a.round(); }
+				if (b !== b0) { b = b.round(); }
+			}
 			return [a, b];
 		}
 
@@ -138,7 +145,7 @@ export function clipSegment(a, b, bounds, useLastCode, round) {
 
 		// other cases
 		codeOut = codeA || codeB;
-		p = _getEdgeIntersection(a, b, codeOut, bounds, round);
+		p = _getEdgeIntersection(a, b, codeOut, bounds);
 		newCode = _getBitCode(p, bounds);
 
 		if (codeOut === codeA) {


### PR DESCRIPTION
Closes #7235.

`LineUtil.clipSegment` (a documented, exported utility) can loop forever when called with `round=true` and fractional clip bounds, freezing the thread.

```js
const a = new Point(301.4418194964528, 342.73335686232895);
const b = new Point(116, 279);
const bounds = new Bounds(
  new Point(116.30943011350813, 22.55244562255804),
  new Point(1588.709430113508, 1115.752445622558));

LineUtil.clipSegment(a, b, bounds, false, true); // never returns
```

## Cause

The Cohen-Sutherland loop asked `_getEdgeIntersection` to round each intermediate intersection point. Rounding a fractional edge coordinate can move the point back outside the bound it was clipped against, so its out-code never clears; the same edge is clipped again and again and the loop never terminates. Random fractional-bounds segments hit this about 31 percent of the time; integer bounds never do, which is why the standard render path (renderer bounds are rounded to integers) has masked it and the issue has stayed open since 2020.

## Fix

Run the iteration on exact (unrounded) intersections so the out-codes clear monotonically and the loop always terminates. Apply the documented rounding once, at trivial-accept, and only to endpoints that were actually replaced by a clip. `_getEdgeIntersection` keeps its `round` parameter, so `PolyUtil.clipPolygon` (single pass, no loop) is unchanged.

## Testing

Added a `#clipSegment` spec that clips against fractional bounds with rounding; it never returns on the current code and passes with the fix. The existing `#clipSegment` expectations, including the integer-bounds rounding case, are unchanged. Verified on the pure module that the pristine code hangs on the reporter's input while the patched code returns, and that the existing LineUtil spec expectations still hold.
