### PR TITLE
Bump eslint-config-mourner from 4.1.0 to 5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "bundlemon": "^3.1.0",
         "chai": "^6.2.2",
         "eslint": "^10.6.0",
-        "eslint-config-mourner": "^4.1.0",
+        "eslint-config-mourner": "^5.0.1",
         "eslint-plugin-baseline-js": "^0.6.2",
         "eslint-plugin-html": "^8.1.4",
         "eslint-plugin-import-x": "^4.17.1",
@@ -329,16 +329,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2790,15 +2798,15 @@
       }
     },
     "node_modules/eslint-config-mourner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-4.1.0.tgz",
-      "integrity": "sha512-XEPuEuauqbnLPi/QZGjZr57w2+quw1fEXa2p6jz3tR8ggDk/ciMjiQo7/PR43t47osdS/RaduN/T1MGncwmOKQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-mourner/-/eslint-config-mourner-5.0.1.tgz",
+      "integrity": "sha512-+bJjgJanAP1Nk0HIO1aV7CJZLa7zl/ymaFSff+HeSLHr9ifuHc8nX9dNdrjO7GnGdrgRMrmrAq3TCqfwj6NHiQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@eslint/js": "^9.31.0",
-        "@stylistic/eslint-plugin": "^5.1.0",
-        "globals": "^16.3.0"
+        "@eslint/js": "^10.0.1",
+        "@stylistic/eslint-plugin": "^5.10.0",
+        "globals": "^17.6.0"
       }
     },
     "node_modules/eslint-import-context": {
@@ -3305,9 +3313,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "bundlemon": "^3.1.0",
     "chai": "^6.2.2",
     "eslint": "^10.6.0",
-    "eslint-config-mourner": "^4.1.0",
+    "eslint-config-mourner": "^5.0.1",
     "eslint-plugin-baseline-js": "^0.6.2",
     "eslint-plugin-html": "^8.1.4",
     "eslint-plugin-import-x": "^4.17.1",

--- a/spec/suites/geometry/LineUtilSpec.js
+++ b/spec/suites/geometry/LineUtilSpec.js
@@ -111,7 +111,7 @@ describe('LineUtil', () => {
 	});
 
 	describe('#polylineCenter', () => {
-		let map, crs, zoom;
+		let map, crs;
 		beforeEach(() => {
 			map = new LeafletMap(document.createElement('div'), {center: [55.8, 37.6], zoom: 6, zoomAnimation: false});
 			crs = map.options.crs;
@@ -150,13 +150,13 @@ describe('LineUtil', () => {
 
 		it('throws error if latlngs not passed', () => {
 			expect(() => {
-				LineUtil.polylineCenter(null, crs, zoom);
+				LineUtil.polylineCenter(null, crs);
 			}).to.throw('latlngs not passed');
 		});
 
 		it('throws error if latlng array is empty', () => {
 			expect(() => {
-				LineUtil.polylineCenter([], crs, zoom);
+				LineUtil.polylineCenter([], crs);
 			}).to.throw('latlngs not passed');
 		});
 


### PR DESCRIPTION
Bumps `eslint-config-mourner` from 4.1.0 to 5.0.1 and fixes the resulting `no-unassigned-vars` lint error in `LineUtilSpec.js`.