### PR TITLE
Remove leftover .social-buttons CSS

### DIFF
--- a/docs/docs/css/main.css
+++ b/docs/docs/css/main.css
@@ -1026,7 +1026,7 @@ tr:target {
 		padding: 0 2em 1.5em;
 	}
 
-	.footer, .social-buttons {
+	.footer {
 		text-align: center;
 	}
 


### PR DESCRIPTION
The HTML was removed in #10262 but the CSS selector in `docs/docs/css/main.css` remained.