### PR TITLE
Remove v2 compatibility flag from plugins

### DIFF
--- a/docs/_plugins/basemap-providers/leaflet-tilelayer-swiss.md
+++ b/docs/_plugins/basemap-providers/leaflet-tilelayer-swiss.md
@@ -7,7 +7,7 @@ author-url: https://github.com/rkaravia
 demo: https://leaflet-tilelayer-swiss.karavia.ch/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Displays national maps of Switzerland using map tiles from Swisstopo.

--- a/docs/_plugins/geocoding/city-autocomplete-usa.md
+++ b/docs/_plugins/geocoding/city-autocomplete-usa.md
@@ -6,7 +6,7 @@ author-url: https://github.com/slbarriosdev
 demo: https://slbarriosdev.github.io/leaflet-city-autocomplete-usa/demo/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A lightweight **Leaflet control** that adds an autocomplete search for all U.S. cities using official **U.S. Census Gazetteer** data.  

--- a/docs/_plugins/geocoding/leaflet-control-geocoder.md
+++ b/docs/_plugins/geocoding/leaflet-control-geocoder.md
@@ -7,7 +7,7 @@ author-url: https://github.com/perliedman
 demo: 
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A clean and extensible control for both geocoding and reverse geocoding. Builtin support for			Nominatim, Bing, MapQuest, Mapbox, What3Words, Google and Photon. Easy to extend to other providers.

--- a/docs/_plugins/geoprocessing/leaflet-utm.md
+++ b/docs/_plugins/geoprocessing/leaflet-utm.md
@@ -7,7 +7,7 @@ author-url: https://github.com/jjimenezshaw/
 demo: https://jjimenezshaw.github.io/Leaflet.UTM/examples/input.html
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A simple way to convert L.LatLng into UTM (WGS84) and vice versa. UTM string format easily configurable. It does not depend on any other plugin or 3rd party.

--- a/docs/_plugins/layer-switching-controls/leaflet-control-layers-tree.md
+++ b/docs/_plugins/layer-switching-controls/leaflet-control-layers-tree.md
@@ -7,7 +7,7 @@ author-url: https://github.com/jjimenezshaw/
 demo: https://jjimenezshaw.github.io/Leaflet.Control.Layers.Tree/examples/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 L.Control.Layers extension that supports a Tree structure, both for base and overlay layers. Simple and highly configurable.

--- a/docs/_plugins/markers-renderers/l-donut.md
+++ b/docs/_plugins/markers-renderers/l-donut.md
@@ -7,7 +7,7 @@ author-url: https://github.com/Falke-Design/
 demo: https://falke-design.github.io/L.Donut/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Extension of L.Circle which allows to define a outer and inner radius.

--- a/docs/_plugins/markers-renderers/leaflet-geodesic.md
+++ b/docs/_plugins/markers-renderers/leaflet-geodesic.md
@@ -7,7 +7,7 @@ author-url: https://github.com/henrythasler
 demo: https://blog.cyclemap.link/Leaflet.Geodesic/complex-interactive.html
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Draw geodesic lines and circles. A geodesic line is the shortest path between two given points on the earth surface. It uses Vincenty's formulae for highest precision and distance calculation. Written in TypeScript and available via CDN.

--- a/docs/_plugins/overlay-animations/leaflet-bouncemarker.md
+++ b/docs/_plugins/overlay-animations/leaflet-bouncemarker.md
@@ -7,7 +7,7 @@ author-url: https://github.com/maximeh
 demo: https://maximeh.github.io/leaflet.bouncemarker/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Make a marker bounce when you add it to a map.

--- a/docs/_plugins/print-export/leaflet-bigimage.md
+++ b/docs/_plugins/print-export/leaflet-bigimage.md
@@ -7,7 +7,7 @@ author-url: https://github.com/pasichnykvasyl
 demo: https://pasichnykvasyl.github.io/Leaflet.BigImage/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 Allows users to download an image with a scaled-up version of the visible map.

--- a/docs/_plugins/tile-image-display/leaflet-tilelayer-colorfilter.md
+++ b/docs/_plugins/tile-image-display/leaflet-tilelayer-colorfilter.md
@@ -7,7 +7,7 @@ author-url: https://github.com/xtk93x
 demo: https://xtk93x.github.io/Leaflet.TileLayer.ColorFilter/
 compatible-v0: true
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A simple and lightweight Leaflet plugin to apply CSS filters on map tiles.

--- a/docs/_plugins/tile-image-display/leaflet-tilelayer-colorpicker.md
+++ b/docs/_plugins/tile-image-display/leaflet-tilelayer-colorpicker.md
@@ -7,7 +7,7 @@ author-url: https://github.com/frogcat
 demo: https://frogcat.github.io/leaflet-tilelayer-colorpicker/
 compatible-v0:
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A Leaflet TileLayer with getColor(latLng).

--- a/docs/_plugins/tile-image-display/leaflet-tilelayer-mask.md
+++ b/docs/_plugins/tile-image-display/leaflet-tilelayer-mask.md
@@ -7,7 +7,7 @@ author-url: https://github.com/frogcat
 demo: http://frogcat.github.io/leaflet-tilelayer-mask/default/
 compatible-v0: true
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A TileLayer with mask effect.

--- a/docs/_plugins/user-interface/leaflet-burgermenu.md
+++ b/docs/_plugins/user-interface/leaflet-burgermenu.md
@@ -7,7 +7,7 @@ author-url: https://github.com/BenPortner
 demo: https://benportner.github.io/leaflet-burgermenu/
 compatible-v0: unknown
 compatible-v1: true
-compatible-v2: true
+compatible-v2: false
 ---
 
 A lightweight Leaflet plugin that adds a burger menu with nested submenus to the map interface. Hovering over menu items reveals submenus, and clicking items can trigger custom actions.


### PR DESCRIPTION
Removes the `compatible-v2: true` flag from all 13 plugins that currently advertise v2 support. The v2 API is still in flux during alpha, so we should not be advertising plugin compatibility until we reach a beta/RC state, at which point plugin authors can re-submit.

### Affected plugins

| Plugin | Original PR |
|--------|-------------|
| Leaflet.TileLayer.Swiss | #9953 |
| Leaflet.CityAutocompleteUSA | #10094 |
| Leaflet Control Geocoder | #9720 |
| Leaflet.UTM | #10216 |
| Leaflet.Control.Layers.Tree | #9937 |
| L.Donut | (direct commit) |
| Leaflet.Geodesic | #9856 |
| Leaflet.BounceMarker | #9863 |
| Leaflet.BigImage | #9881 |
| Leaflet.TileLayer.ColorFilter | #9870 |
| Leaflet.TileLayer.ColorPicker | #9876 |
| Leaflet.TileLayer.Mask | #9877 |
| leaflet-burgermenu | #9879 |