### PR TITLE
fix(core): run inherited init hooks only once for subclasses (#10294)

### DIFF
--- a/spec/suites/core/ClassSpec.js
+++ b/spec/suites/core/ClassSpec.js
@@ -59,6 +59,19 @@ describe('Class', () => {
 			expect(spy1.called).to.be.true;
 			expect(spy2.called).to.eql(false);
 		});
+
+		it('calls inherited init hooks only once when subclass adds none', () => { // #10294
+			const spy = sinon.spy();
+
+			class Parent extends Class {}
+			class Child extends Parent {} // does not add its own init hooks
+
+			Parent.addInitHook(spy);
+
+			new Child();
+
+			expect(spy.callCount).to.equal(1);
+		});
 	});
 
 	describe('#include', () => {

--- a/src/core/Class.js
+++ b/src/core/Class.js
@@ -92,10 +92,14 @@ export class Class {
 		// reverse so the parent prototype is first
 		prototypes.reverse();
 
-		// call init hooks on each prototype
+		// call init hooks on each prototype, using only each prototype's own
+		// hooks. Reading the inherited `_initHooks` would re-run a parent's hooks
+		// for every subclass level that doesn't define its own (see #10294).
 		for (const proto of prototypes) {
-			for (const hook of proto._initHooks ?? []) {
-				hook.call(this);
+			if (Object.hasOwn(proto, '_initHooks')) {
+				for (const hook of proto._initHooks) {
+					hook.call(this);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes #10294.

## Symptom

Instantiating a subclass that adds no init hooks of its own renders duplicate default controls. For example:

```js
class NewMap extends Map {}
new NewMap('map');
```

produces the zoom and attribution controls twice.

## Root cause

In `src/core/Class.js`, `callInitHooks` walks the prototype chain and, for each prototype, reads `_initHooks` via normal property lookup:

```js
for (const proto of prototypes) {
  for (const hook of proto._initHooks ?? []) {
    hook.call(this);
  }
}
```

A subclass prototype that never registered its own hooks has no own `_initHooks` property, so the lookup falls through the prototype chain to the inherited parent array. The parent's hooks then run again for every intermediate subclass level, duplicating `Map`'s default controls.

## Fix

Only run each prototype's own hooks, guarding with `Object.hasOwn`:

```js
for (const proto of prototypes) {
  if (Object.hasOwn(proto, '_initHooks')) {
    for (const hook of proto._initHooks) {
      hook.call(this);
    }
  }
}
```

## Test

Added a regression test in `spec/suites/core/ClassSpec.js`: a two-level subclass (`Child extends Parent extends Class`) where only the top-level `Parent` registers an init hook and `Child` adds none. Instantiating `Child` must call the hook exactly once. This fails before the fix (called twice) and passes after.
