### PR TITLE
fix: replace deprecated browser detection APIs

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -37,7 +37,7 @@ const pointer = typeof window === 'undefined' ? false : !!window.PointerEvent;
 // **This does not necessarily mean** that the browser is running in a computer with
 // a touchscreen, it only means that the browser is capable of understanding
 // touch events.
-const touchNative = typeof window === 'undefined' ? false : 'ontouchstart' in window || !!(window.TouchEvent);
+const touchNative = typeof window === 'undefined' ? false : 'ontouchstart' in window;
 
 // @property touch: Boolean
 // `true` for all browsers supporting either [touch](#browser-touch) or [pointer](#browser-pointer) events.


### PR DESCRIPTION
Replace deprecated browser APIs used in Browser.js:
- `navigator.orientation` -> userAgent-based mobile regex detection
- `window.TouchEvent` -> removed (ontouchstart check is sufficient)

Fixes #9710