### PR TITLE
fix: add pointermove to _pointerEvents static array

### DIFF
--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -1423,7 +1423,7 @@ export class LeafletMap extends Evented {
 		this._fireDOMEvent(e, type);
 	};
 
-	static _pointerEvents = ['click', 'dblclick', 'pointerover', 'pointerout', 'contextmenu'];
+	static _pointerEvents = ['click', 'dblclick', 'pointerover', 'pointerout', 'pointermove', 'contextmenu'];
 
 	_fireDOMEvent(e, type, canvasTargets) {
 


### PR DESCRIPTION
Pointermove events carry latlng at runtime (handled by `_fireDOMEvent` for all non-keyboard events), but were missing from the `_pointerEvents` static array. This prevented proper TypeScript typing and bubbling event handling for pointermove.

Fixes #10314