### PR TITLE
Docs: note that setStyle does not update className

### DIFF
--- a/src/layer/vector/Path.js
+++ b/src/layer/vector/Path.js
@@ -102,6 +102,9 @@ export class Path extends Layer {
 
 	// @method setStyle(style: Path options): this
 	// Changes the appearance of a Path based on the options in the `Path options` object.
+	// Note that [`className`](#path-classname) is an exception: it is applied only when
+	// the path element is created, so passing it here updates the option but leaves the
+	// element's class unchanged.
 	setStyle(style) {
 		Util.setOptions(this, style);
 		if (this._renderer) {

--- a/src/layer/vector/SVG.js
+++ b/src/layer/vector/SVG.js
@@ -87,7 +87,8 @@ export class SVG extends Renderer {
 
 		// @namespace Path
 		// @option className: String = null
-		// Custom class name set on an element. Only for SVG renderer.
+		// Custom class name set on an element. Only for SVG renderer. Applied when the
+		// element is created; [`setStyle`](#path-setstyle) does not update it afterwards.
 		if (layer.options.className) {
 			path.classList.add(...splitWords(layer.options.className));
 		}


### PR DESCRIPTION
### What

Two comment-only edits documenting that `Path.setStyle()` does not apply `className`.

No behaviour change.

### Why

`className` is applied in `SVG._initPath()` when the path element is created, and `_updateStyle()` only sets paint attributes. So `setStyle({className: 'foo'})` updates `options.className` and leaves the element's `class` untouched — silently, with no warning.

That this is intended is clear enough from the code (`className` is not a style). The problem is that `setStyle`'s own docs say it:

> Changes the appearance of a Path based on the options in the `Path options` object.

…and `className` **is** a documented `Path option`. Read together, the documentation promises exactly the thing that does not happen. The failure is also quiet and easy to misdiagnose: with the SVG renderer the paint attributes update correctly on the same call, so the layer visibly restyles while the class silently does not — which reads as a CSS specificity problem rather than an API boundary.

This has come up repeatedly — #2662 (open since 2014), #3791 and #6083 (both closed) — and each time the answer is that it works as designed. If that is the answer, the docs should say so, so the next person reads it instead of debugging it.

This is deliberately scoped to documentation and is orthogonal to #9645, which proposes an API addition. It needs no decision on that to be useful, and stays accurate either way.

### Change

- `Path.js` — `@method setStyle` now notes the `className` exception.
- `SVG.js` — the `@option className` doc notes that it is applied at element creation and not updated by `setStyle`.

Both use existing doc cross-reference style (`#path-classname`, `#path-setstyle`).