### PR TITLE
Fix accuracy radius in the mobile geolocation example

### DIFF
--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -20,7 +20,7 @@ css: "body {
 	}).addTo(map);
 
 	function onLocationFound(e) {
-		const radius = e.accuracy / 2;
+		const radius = e.accuracy;
 
 		const locationMarker = new Marker(e.latlng).addTo(map)
 			.bindPopup(`You are within ${radius} meters from this point`).openPopup();

--- a/docs/examples/mobile/example.md
+++ b/docs/examples/mobile/example.md
@@ -25,7 +25,7 @@ css: "body {
 		const locationMarker = new Marker(e.latlng).addTo(map)
 			.bindPopup(`You are within ${radius} meters from this point`).openPopup();
 
-		const locationCircle = new Circle(e.latlng, radius).addTo(map);
+		const locationCircle = new Circle(e.latlng, {radius}).addTo(map);
 	}
 
 	function onLocationError(e) {

--- a/docs/examples/mobile/index.md
+++ b/docs/examples/mobile/index.md
@@ -54,7 +54,7 @@ Here we specify 16 as the maximum zoom when setting the map view automatically. 
 		new Marker(e.latlng).addTo(map)
 			.bindPopup("You are within " + radius + " meters from this point").openPopup();
 
-		new Circle(e.latlng, radius).addTo(map);
+		new Circle(e.latlng, {radius}).addTo(map);
 	}
 
 	map.on('locationfound', onLocationFound);


### PR DESCRIPTION
Two bugs in the geolocation example, one commit each.

The bigger one isn't the reported one: both files call `new Circle(latlng, radius)`, a signature #9622 removed. The second argument is the options object now, so a bare number contributes nothing and `radius` falls back to `CircleMarker`'s default of 10 - the behaviour `spec/suites/layer/vector/CircleSpec.js:20` pins. On `main` the accuracy circle is a fixed 10 m whatever the device reports.

The reported one: `example.md` halves `e.accuracy` before using it as the radius, while `index.md` doesn't. `accuracy` is already a radius - #6693 corrected `index.md` in 2019 and left `example.md` alone.

Refs #10331 rather than Fixes: the report is about leafletjs.com, which builds from `v1`, and only the `/ 2` removal applies there. Happy to send that as a backport.
