### PR TITLE
Wrap non-square tile columns by the tile width, not the tile height

### DIFF
--- a/spec/suites/layer/tile/GridLayerSpec.js
+++ b/spec/suites/layer/tile/GridLayerSpec.js
@@ -1067,6 +1067,31 @@ describe('GridLayer', () => {
 				done();
 			});
 		});
+
+		it('When false, wraps the columns of non-square tiles by the tile width', (done) => {
+			container.style.width = '512px';
+			container.style.height = '512px';
+
+			const grid = new GridLayer({
+				attribution: 'Grid Layer',
+				tileSize: new Point(256, 512),
+				noWrap: false
+			});
+			const loadedTileKeys = [];
+
+			grid.createTile = function (coords) {
+				loadedTileKeys.push(`${coords.x}:${coords.y}:${coords.z}`);
+				return document.createElement('div');
+			};
+
+			map.addLayer(grid).setView([0, 0], 1);
+
+			grid.on('load', () => {
+				// At zoom 1 the world is 512px wide, i.e. two columns of 256px tiles
+				expect(loadedTileKeys).to.eql(['0:0:1', '1:0:1']);
+				done();
+			});
+		});
 	});
 
 	describe('Sanity checks for infinity', () => {

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -608,10 +608,10 @@ export class GridLayer extends Layer {
 
 		this._wrapX = crs.wrapLng && !this.options.noWrap && [
 			Math.floor(map.project([0, crs.wrapLng[0]], tileZoom).x / tileSize.x),
-			Math.ceil(map.project([0, crs.wrapLng[1]], tileZoom).x / tileSize.y)
+			Math.ceil(map.project([0, crs.wrapLng[1]], tileZoom).x / tileSize.x)
 		];
 		this._wrapY = crs.wrapLat && !this.options.noWrap && [
-			Math.floor(map.project([crs.wrapLat[0], 0], tileZoom).y / tileSize.x),
+			Math.floor(map.project([crs.wrapLat[0], 0], tileZoom).y / tileSize.y),
 			Math.ceil(map.project([crs.wrapLat[1], 0], tileZoom).y / tileSize.y)
 		];
 	}


### PR DESCRIPTION
Fixes #9326.

`_resetGrid()` turns the projected world extent into a tile range so `_wrapCoords()` can wrap tile coordinates. The upper bound of `_wrapX` divides an **x** pixel coordinate by `tileSize.y`, and the lower bound of `_wrapY` divides a **y** pixel coordinate by `tileSize.x`:

```js
this._wrapX = crs.wrapLng && !this.options.noWrap && [
	Math.floor(map.project([0, crs.wrapLng[0]], tileZoom).x / tileSize.x),
	Math.ceil(map.project([0, crs.wrapLng[1]], tileZoom).x / tileSize.y)   // <- tile height
];
```

Square tiles hide it, which is why it went unnoticed. With `tileSize: [256, 512]` at zoom 1 the world is 512px wide — two columns — but `_wrapX` comes out as `[0, 1]`, so `wrapNum()` collapses every column to `x = 0` and the map repeats the westernmost tile column across the whole viewport, as in the screenshots in #9326.

Both lines had their axis swapped in cf51113, the commit that introduced non-square tiles (#3570): the scalar `tileSize` was expanded to `tileSize.x`/`tileSize.y` and the four call sites ended up as `.x`, `.y`, `.x`, `.y` instead of `.x`, `.x`, `.y`, `.y`. This restores what the scalar version computed.

Reproduced with a `GridLayer` whose tiles paint their own coords, 800x400 container, `tileSize: [256, 512]`, zoom 1:

| | `_wrapX` | tile columns requested |
| --- | --- | --- |
| `main` | `[0, 1]` | `0` |
| this branch | `[0, 2]` | `0, 1` |

The added spec fails on `main` with `expected [ '0:0:1', '0:0:1' ] to deeply equal [ '0:0:1', '1:0:1' ]`.

`_wrapY` is only reachable through a custom CRS, since none of the built-in ones define `wrapLat`, so the spec covers `_wrapX` only — the `_wrapY` line is the same typo and now converts a y coordinate with the y tile size.

Full suite passes locally on `chromium`, `chromium-retina` and `webkit` (1085 passed, 14 skipped); `firefox` wouldn't launch on my machine for unrelated reasons.
