### PR TITLE
Add Leaflet.GridLayer.Relief plugin

### DIFF
--- a/docs/_plugins/time-elevation/leaflet-gridlayer-relief.md
+++ b/docs/_plugins/time-elevation/leaflet-gridlayer-relief.md
@@ -1,0 +1,13 @@
+---
+name: Leaflet.GridLayer.Relief
+category: time-elevation
+repo: https://github.com/glandais/leaflet-relief
+author: Gabriel Landais
+author-url: https://github.com/glandais
+demo: https://glandais.github.io/leaflet-relief/
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+Terrain visualization layer rendering hillshading and slope analysis from RGB-encoded DEM tiles, with configurable sun position and slope color schemes. Works with Mapterhorn, AWS Terrarium and Mapbox Terrain-RGB tiles, or any custom elevation encoding.


### PR DESCRIPTION
Adds [Leaflet.GridLayer.Relief](https://github.com/glandais/leaflet-relief) to the plugins database, under **Time & elevation**.

A `L.GridLayer` subclass that renders terrain relief — hillshading and slope analysis — by decoding RGB-encoded DEM tiles client-side on a canvas. It ships with extractors for Mapterhorn, AWS Terrarium and Mapbox Terrain-RGB, and accepts a custom extractor for any other encoding. Sun azimuth/elevation and slope color schemes are configurable.

- Demo: https://glandais.github.io/leaflet-relief/
- npm: https://www.npmjs.com/package/leaflet-relief
- MIT licensed, TypeScript, with unit and Playwright visual tests.

Tested against Leaflet 1.9.4 (`compatible-v1: true`). Not yet compatible with the 2.0 alpha, since the plugin registers the `L.gridLayer.relief` factory — hence `compatible-v2: false`.