### PR TITLE
Add Leaflet WebGL Markers plugin

### DIFF
--- a/docs/_plugins/markers-renderers/leaflet-webgl-markers.md
+++ b/docs/_plugins/markers-renderers/leaflet-webgl-markers.md
@@ -1,0 +1,15 @@
+---
+name: Leaflet WebGL Markers
+category: markers-renderers
+repo: https://github.com/tang-tc/leaflet-webgl-markers
+author: Tang Chen
+author-url: https://github.com/tang-tc
+demo: https://tang-tc.github.io/leaflet-webgl-markers/
+compatible-v0:
+compatible-v1: true
+compatible-v2: false
+---
+
+Renders millions of point markers on a single WebGL canvas, with GPU-side
+Mercator projection, FBO color-coded picking, and zero redraw while dragging or
+zooming. TypeScript-first, ESM, no runtime dependencies beyond Leaflet.


### PR DESCRIPTION
Adds the leaflet-webgl-markers plugin to the markers-renderers category.

**Leaflet WebGL Markers** renders millions of point markers on a single WebGL canvas, with GPU-side Mercator projection, FBO color-coded picking, and zero redraw while dragging or zooming. TypeScript-first, ESM, no runtime dependencies beyond Leaflet.

- Repo: https://github.com/tang-tc/leaflet-webgl-markers
- Demo: https://tang-tc.github.io/leaflet-webgl-markers/
- npm: https://www.npmjs.com/package/leaflet-webgl-markers
