### PR TITLE
Keep GridLayer tiles during worldCopyJump

### DIFF
--- a/spec/suites/map/WorldCopyJumpSpec.js
+++ b/spec/suites/map/WorldCopyJumpSpec.js
@@ -1,0 +1,150 @@
+import {expect} from 'chai';
+import {DomUtil, GridLayer, LeafletMap, Point} from 'leaflet';
+import Hand from 'prosthetic-hand';
+import {createContainer, removeMapContainer} from '../SpecHelper.js';
+
+describe('worldCopyJump', () => {
+	let container, map, grid;
+
+	function addGrid(options) {
+		grid = new GridLayer(options);
+		return grid.addTo(map);
+	}
+
+	function tileAt(x, y) {
+		return Object.entries(grid._tiles).find(([, tile]) => {
+			const rect = tile.el.getBoundingClientRect();
+			return rect.left <= x && x < rect.right && rect.top <= y && y < rect.bottom;
+		});
+	}
+
+	function dragBy(dx) {
+		const hand = new Hand({timing: 'fastframe'});
+		const pointer = hand.growFinger('pointer');
+		pointer.moveTo(200, 200, 0).down().moveBy(Math.sign(dx) * 5, 0, 20).moveBy(dx - (Math.sign(dx) * 5), 0, 500).up();
+		return hand;
+	}
+
+	beforeEach(() => {
+		container = createContainer();
+		map = new LeafletMap(container, {
+			dragging: true,
+			inertia: false,
+			fadeAnimation: false,
+			zoomAnimation: false,
+			worldCopyJump: true
+		});
+	});
+
+	afterEach(() => {
+		removeMapContainer(map, container);
+	});
+
+	describe('dragging across the antimeridian', () => {
+		it('keeps the tiles it already has instead of rebuilding the grid', (done) => {
+			map.setView([0, 178], 5);
+			addGrid();
+
+			const [keyBefore, tileBefore] = tileAt(200, 200),
+			worldColumns = map.getPixelWorldBounds().getSize().x / grid.getTileSize().x,
+			jumps = [];
+			map.on('worldcopyjump', e => jumps.push(e.worlds));
+
+			dragBy(-160).addEventListener('stop', () => {
+				expect(map.getCenter().lng, 'centre did not wrap').to.be.below(0);
+
+				const found = tileAt(40, 200);
+				expect(found, 'the tile that was at the centre is gone').to.not.be.undefined;
+
+				const [keyAfter, tileAfter] = found;
+				expect(tileAfter.el, 'tile was rebuilt rather than kept').to.equal(tileBefore.el);
+				expect(+keyAfter.split(':')[0]).to.equal(+keyBefore.split(':')[0] - worldColumns);
+				expect(jumps).to.eql([1]);
+				done();
+			});
+		});
+
+		it('wraps the other way round too', (done) => {
+			map.setView([0, -178], 5);
+			addGrid();
+
+			const jumps = [];
+			map.on('worldcopyjump', e => jumps.push(e.worlds));
+
+			dragBy(160).addEventListener('stop', () => {
+				expect(map.getCenter().lng).to.be.above(0);
+				expect(jumps).to.eql([-1]);
+				done();
+			});
+		});
+	});
+
+	describe('panning across the antimeridian', () => {
+		it('wraps the centre back into the world when the pan animation ends', (done) => {
+			map.setView([0, 178], 5);
+			addGrid();
+
+			const tileBefore = tileAt(200, 200)[1].el;
+
+			map.once('moveend', () => {
+				expect(map.getCenter().lng).to.be.below(-170);
+				expect(tileAt(40, 200)[1].el, 'tile was rebuilt rather than kept').to.equal(tileBefore);
+				done();
+			});
+			map.panBy([160, 0]);
+		});
+
+		it('wraps the centre after a pan with animation turned off', () => {
+			map.setView([0, 178], 5);
+			addGrid();
+
+			map.panBy([160, 0], {animate: false});
+
+			expect(map.getCenter().lng).to.be.below(-170);
+		});
+
+		it('wraps the centre after a pan larger than the map', () => {
+			map.setView([0, 178], 5);
+			addGrid();
+
+			map.panBy([600, 0], {animate: false});
+
+			expect(map.getCenter().lng).to.be.within(-160, -150);
+		});
+	});
+
+	describe('GridLayer', () => {
+		it('shifts held-over tiles by their own zoom level\'s worth of columns', () => {
+			map.setView([0, 178], 5);
+			addGrid();
+
+			// a pinch zoom or flyTo keeps the tiles of the zoom level it came from
+			// while the new ones load, so the grid can be holding two levels at once
+			const heldOver = {coords: new Point(3, 4), el: document.createElement('div')};
+			heldOver.coords.z = 3;
+			DomUtil.setPosition(heldOver.el, new Point(100, 200));
+			grid._tiles['3:4:3'] = heldOver;
+
+			const [keyBefore] = tileAt(200, 200),
+			tileSize = grid.getTileSize().x;
+
+			map._fireWorldCopyJump(map.getPixelWorldBounds().getSize().x);
+
+			// one world is 2^5 columns at zoom 5, but only 2^3 at zoom 3
+			expect(grid._tiles[`${+keyBefore.split(':')[0] - 32}:${keyBefore.split(':')[1]}:5`]).to.not.be.undefined;
+			expect(heldOver.coords.x).to.equal(3 - 8);
+			expect(DomUtil.getPosition(heldOver.el)).to.eql(new Point(100 - (8 * tileSize), 200));
+		});
+
+		it('does not rebase tiles in a noWrap layer', () => {
+			map.setView([0, 178], 5);
+			addGrid({noWrap: true});
+
+			const keys = Object.keys(grid._tiles).sort();
+
+			map._fireWorldCopyJump(map.getPixelWorldBounds().getSize().x);
+
+			expect(Object.keys(grid._tiles).sort()).to.eql(keys);
+		});
+	});
+});

--- a/src/core/Events.leafdoc
+++ b/src/core/Events.leafdoc
@@ -139,3 +139,7 @@ The distance in pixels the draggable element was moved by.
 @property center: LatLng; The current center of the map
 @property zoom: Number; The current zoom level of the map
 @property noUpdate: Boolean; Whether layers should update their contents due to this event
+
+@miniclass WorldCopyJumpEvent (Event objects)
+@inherits Event
+@property worlds: Number; The signed number of world widths by which the map pane moved

--- a/src/layer/tile/GridLayer.js
+++ b/src/layer/tile/GridLayer.js
@@ -248,7 +248,8 @@ export class GridLayer extends Layer {
 			viewprereset: this._invalidateAll,
 			viewreset: this._resetView,
 			zoom: this._resetView,
-			moveend: this._onMoveEnd
+			moveend: this._onMoveEnd,
+			worldcopyjump: this._onWorldCopyJump
 		};
 
 		if (!this.options.updateWhenIdle) {
@@ -620,6 +621,33 @@ export class GridLayer extends Layer {
 		if (!this._map || this._map._animatingZoom) { return; }
 
 		this._update();
+	}
+
+	_onWorldCopyJump(e) {
+		// noWrap tiles cannot be reused in another world copy.
+		if (!this._wrapX) { return; }
+
+		const tileSize = this.getTileSize(),
+		worldColumns = {};
+
+		for (const {coords} of Object.values(this._tiles)) {
+			worldColumns[coords.z] ??= this._map.getPixelWorldBounds(coords.z)?.getSize().x / tileSize.x;
+
+			// Tiles cannot be shifted by a fraction of a column.
+			if (!Number.isInteger(worldColumns[coords.z])) { return; }
+		}
+
+		const tiles = {};
+
+		for (const tile of Object.values(this._tiles)) {
+			const columns = e.worlds * worldColumns[tile.coords.z];
+
+			tile.coords.x -= columns;
+			DomUtil.setPosition(tile.el, DomUtil.getPosition(tile.el).subtract([columns * tileSize.x, 0]));
+			tiles[this._tileCoordsToKey(tile.coords)] = tile;
+		}
+
+		this._tiles = tiles;
 	}
 
 	_getTiledPixelBounds(center) {

--- a/src/map/Map.js
+++ b/src/map/Map.js
@@ -141,7 +141,13 @@ export class LeafletMap extends Evented {
 
 			// @option trackResize: Boolean = true
 			// Whether the map automatically handles browser window resize to update itself.
-			trackResize: true
+			trackResize: true,
+
+			// @option worldCopyJump: Boolean = false
+			// With this option enabled, the map tracks when you pan to another "copy"
+			// of the world and seamlessly jumps to the original one so that all overlays
+			// like markers and vector layers are still visible.
+			worldCopyJump: false
 		});
 	}
 
@@ -335,7 +341,11 @@ export class LeafletMap extends Evented {
 		// If we pan too far, Chrome gets issues with tiles
 		// and makes them disappear or appear in the wrong place (slightly offset) #2602
 		if (options.animate !== true && !this.getSize().contains(offset)) {
-			this._resetView(this.unproject(this.project(this.getCenter()).add(offset)), this.getZoom());
+			let center = this.unproject(this.project(this.getCenter()).add(offset));
+			if (this.options.worldCopyJump) {
+				center = this.wrapLatLng(center);
+			}
+			this._resetView(center, this.getZoom());
 			return this;
 		}
 
@@ -361,6 +371,7 @@ export class LeafletMap extends Evented {
 			this._panAnim.run(this._mapPane, newPos, options.duration || 0.25, options.easeLinearity);
 		} else {
 			this._rawPanBy(offset);
+			this._wrapWorldCopy();
 			this.fire('move').fire('moveend');
 		}
 
@@ -1282,6 +1293,44 @@ export class LeafletMap extends Evented {
 		DomUtil.setPosition(this._mapPane, this._getMapPanePos().subtract(offset));
 	}
 
+	// Returns a prospective map pane position shifted into the original world.
+	_wrapPanePos(pos) {
+		const worldBounds = this._loaded && this.getPixelWorldBounds();
+
+		if (!worldBounds) { return pos; }
+
+		const worldWidth = worldBounds.getSize().x,
+		halfWidth = Math.round(worldWidth / 2),
+		dx = this.latLngToLayerPoint([0, 0]).subtract(this.getSize().divideBy(2)).x,
+		x = pos.x,
+		newX1 = (x - halfWidth + dx) % worldWidth + halfWidth - dx,
+		newX2 = (x + halfWidth + dx) % worldWidth - halfWidth - dx,
+		newX = Math.abs(newX1 + dx) < Math.abs(newX2 + dx) ? newX1 : newX2;
+
+		return new Point(newX, pos.y);
+	}
+
+	_wrapWorldCopy() {
+		if (!this.options.worldCopyJump) { return; }
+
+		const pos = this._getMapPanePos(),
+		wrapped = this._wrapPanePos(pos);
+
+		if (wrapped.x === pos.x) { return; }
+
+		DomUtil.setPosition(this._mapPane, wrapped);
+		this._fireWorldCopyJump(wrapped.x - pos.x);
+	}
+
+	_fireWorldCopyJump(offsetX) {
+		// @event worldcopyjump: WorldCopyJumpEvent
+		// Fired when [`worldCopyJump`](#map-worldcopyjump) moves the map pane by one
+		// or more world widths.
+		this.fire('worldcopyjump', {
+			worlds: Math.round(offsetX / this.getPixelWorldBounds().getSize().x)
+		});
+	}
+
 	_getZoomSpan() {
 		return this.getMaxZoom() - this.getMinZoom();
 	}
@@ -1613,6 +1662,7 @@ export class LeafletMap extends Evented {
 
 	_onPanTransitionEnd() {
 		this._mapPane.classList.remove('leaflet-pan-anim');
+		this._wrapWorldCopy();
 		this.fire('moveend');
 	}
 

--- a/src/map/handler/DragHandler.js
+++ b/src/map/handler/DragHandler.js
@@ -34,13 +34,6 @@ LeafletMap.mergeOptions({
 	// @option easeLinearity: Number = 0.2
 	easeLinearity: 0.2,
 
-	// TODO refactor, move to CRS
-	// @option worldCopyJump: Boolean = false
-	// With this option enabled, the map tracks when you pan to another "copy"
-	// of the world and seamlessly jumps to the original one so that all overlays
-	// like markers and vector layers are still visible.
-	worldCopyJump: false,
-
 	// @option maxBoundsViscosity: Number = 0.0
 	// If `maxBounds` is set, this option will control how solid the bounds
 	// are when dragging the map around. The default value of `0.0` allows the
@@ -66,9 +59,6 @@ export class DragHandler extends Handler {
 			this._draggable.on('predrag', this._onPreDragLimit, this);
 			if (map.options.worldCopyJump) {
 				this._draggable.on('predrag', this._onPreDragWrap, this);
-				map.on('zoomend', this._onZoomEnd, this);
-
-				map.whenReady(this._onZoomEnd, this);
 			}
 		}
 		this._map._container.classList.add('leaflet-grab', 'leaflet-touch-drag');
@@ -107,6 +97,9 @@ export class DragHandler extends Handler {
 			this._offsetLimit = null;
 		}
 
+		this._worldCopyOffset = 0;
+		this._pendingWorldCopy = 0;
+
 		map
 			.fire('movestart')
 			.fire('dragstart');
@@ -118,6 +111,11 @@ export class DragHandler extends Handler {
 	}
 
 	_onDrag(e) {
+		if (this._pendingWorldCopy) {
+			this._map._fireWorldCopyJump(this._pendingWorldCopy);
+			this._pendingWorldCopy = 0;
+		}
+
 		if (this._map.options.inertia) {
 			const time = this._lastTime = Date.now(),
 			pos = this._lastPos = this._draggable._absPos || this._draggable._newPos;
@@ -140,14 +138,6 @@ export class DragHandler extends Handler {
 		}
 	}
 
-	_onZoomEnd() {
-		const pxCenter = this._map.getSize().divideBy(2),
-		pxWorldCenter = this._map.latLngToLayerPoint([0, 0]);
-
-		this._initialWorldOffset = pxWorldCenter.subtract(pxCenter).x;
-		this._worldWidth = this._map.getPixelWorldBounds().getSize().x;
-	}
-
 	_viscousLimit(value, threshold) {
 		return value - (value - threshold) * this._viscosity;
 	}
@@ -167,17 +157,17 @@ export class DragHandler extends Handler {
 	}
 
 	_onPreDragWrap() {
-		// TODO refactor to be able to adjust map pane position after zoom
-		const worldWidth = this._worldWidth,
-		halfWidth = Math.round(worldWidth / 2),
-		dx = this._initialWorldOffset,
-		x = this._draggable._newPos.x,
-		newX1 = (x - halfWidth + dx) % worldWidth + halfWidth - dx,
-		newX2 = (x + halfWidth + dx) % worldWidth - halfWidth - dx,
-		newX = Math.abs(newX1 + dx) < Math.abs(newX2 + dx) ? newX1 : newX2;
+		const draggable = this._draggable,
+		unwrapped = draggable._newPos,
+		wrapped = this._map._wrapPanePos(unwrapped),
+		offset = wrapped.x - unwrapped.x;
 
-		this._draggable._absPos = this._draggable._newPos.clone();
-		this._draggable._newPos.x = newX;
+		draggable._absPos = unwrapped.clone();
+		draggable._newPos = wrapped;
+
+		// Announce the jump from _onDrag, after Draggable has moved the pane.
+		this._pendingWorldCopy = offset - this._worldCopyOffset;
+		this._worldCopyOffset = offset;
 	}
 
 	_onDragEnd(e) {

--- a/src/map/handler/KeyboardHandler.js
+++ b/src/map/handler/KeyboardHandler.js
@@ -157,12 +157,7 @@ export class KeyboardHandler extends Handler {
 					offset = map._limitOffset(new Point(offset), map.options.maxBounds);
 				}
 
-				if (map.options.worldCopyJump) {
-					const newLatLng = map.wrapLatLng(map.unproject(map.project(map.getCenter()).add(offset)));
-					map.panTo(newLatLng);
-				} else {
-					map.panBy(offset);
-				}
+				map.panBy(offset);
 			}
 		} else if (key in this._zoomKeys) {
 			map.setZoom(map.getZoom() + (e.shiftKey ? 3 : 1) * this._zoomKeys[key]);


### PR DESCRIPTION
Move world-copy wrapping into Map so drag and pan paths use the same calculation. Fire worldcopyjump whenever the pane is rebased, and let GridLayer rekey and reposition its wrapped tiles instead of rebuilding them.

Fixes #9878

Relevant: #8625 #4141 #7197

Inspired by https://github.com/openstreetmap/openstreetmap-website/pull/7341 (see screen recording before/after in that PR)

To see for yourself, you may compare while panning across ±180°:
- https://www.openstreetmap.org/#map=4/63.76/-174.11
- https://osm2.leijurv.com/#map=4/63.76/-174.11