### PR TITLE
Replace deprecated navigator.platform in Browser

### DIFF
--- a/src/core/Browser.js
+++ b/src/core/Browser.js
@@ -49,10 +49,10 @@ const touch = touchNative || pointer;
 const retina = typeof window === 'undefined' || typeof window.devicePixelRatio === 'undefined' ? false : window.devicePixelRatio > 1;
 
 // @property mac: Boolean; `true` when the browser is running in a Mac platform
-const mac = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Mac');
+const mac = userAgentContains('macintosh');
 
 // @property linux: Boolean; `true` when the browser is running in a Linux platform
-const linux = typeof navigator === 'undefined' || typeof navigator.platform === 'undefined' ? false : navigator.platform.startsWith('Linux');
+const linux = userAgentContains('linux');
 
 function userAgentContains(str) {
 	if (typeof navigator === 'undefined' || typeof navigator.userAgent === 'undefined') {


### PR DESCRIPTION
The navigator.platform property is deprecated. Detect the mac and linux platform in Browser from the user agent instead of navigator.platform, preserving the previous behaviour while keeping SSR safety via the existing userAgentContains guard.

Refs #9710