### PR TITLE
Docs: Add token/key to Carto positron tiles in tutorials

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -16,6 +16,10 @@ integrity_hash_uglified: "sha256-gj5JhNAaMi6LCs+jVFOk8sXDe1sWSS2Zlc87m+trLiQ="
 integrity_hash_global_source: "sha256-SnNOWrUASCy0Jw4FGryafJamqNk15qDnW00Y/biE2dU="
 integrity_hash_global_uglified: "sha256-lJUxSvvKo54k90cTx9u9DCAP1MtAEqnLmx6Sx3no03c="
 
+# Starting september 2026, Carto required a token/key for the raster tiles
+# The one provided in the Leaflet repo only works for the www.leafletjs.com domain
+cartocdn_key: "cb1_2i38_1_bb6349bf813f7d7c3fe79a8c"
+
 collections:
   plugins:
     output: false

--- a/docs/examples/extending-2-layers/pixelorigin.md
+++ b/docs/examples/extending-2-layers/pixelorigin.md
@@ -33,7 +33,7 @@ title: Pixel Origin Examples
 		zoom: 1
 	});
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
 	}).addTo(map);
 

--- a/docs/examples/map-panes/example.md
+++ b/docs/examples/map-panes/example.md
@@ -18,7 +18,7 @@ title: Custom Pane Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/map-panes/index.md
+++ b/docs/examples/map-panes/index.md
@@ -33,18 +33,19 @@ In some particular cases, the default order is not the right one for the map. We
 
 <div class='tiles'>
 <div style='display: inline-block'>
-<img src="https://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png" class="bordered-img" /><br/>
+<img src="https://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png?key={{site.cartocdn_key}}" class="bordered-img" /><br/>
 Basemap tile with no labels
 </div>
 
 <div style='display: inline-block'>
-<img src="https://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png" class="bordered-img" /><br/>
+<img src="https://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png?key={{site.cartocdn_key}}" class="bordered-img" /><br/>
 Transparent labels-only tile
 </div>
 
 <div style='display: inline-block; position:relative;'>
-<img src="https://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png" class="bordered-img" />
-<img src="https://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png"  style='position:absolute; left:0; top:0;'/><br/>
+<img src="https://a.basemaps.cartocdn.com/light_nolabels/4/8/5.png?key={{site.cartocdn_key}}" class="bordered-img" />
+
+<img src="https://a.basemaps.cartocdn.com/light_only_labels/4/8/5.png?key={{site.cartocdn_key}}"  style='position:absolute; left:0; top:0;'/><br/>
 Labels on top of basemap
 </div>
 </div>

--- a/docs/examples/zoom-levels/example-delta.md
+++ b/docs/examples/zoom-levels/example-delta.md
@@ -14,7 +14,7 @@ title: No Zoom Snap Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-fractional.md
+++ b/docs/examples/zoom-levels/example-fractional.md
@@ -14,7 +14,7 @@ title: Fractional Zoom Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-scale.md
+++ b/docs/examples/zoom-levels/example-scale.md
@@ -13,7 +13,7 @@ title: Zoom Scale Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-setzoom.md
+++ b/docs/examples/zoom-levels/example-setzoom.md
@@ -12,7 +12,7 @@ title: Zoom Control Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/example-zero.md
+++ b/docs/examples/zoom-levels/example-zero.md
@@ -12,7 +12,7 @@ title: Zoom Level Zero Example
 
 	const cartodbAttribution = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
-	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+	const positron = new TileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png?key={{site.cartocdn_key}}', {
 		attribution: cartodbAttribution
 	}).addTo(map);
 

--- a/docs/examples/zoom-levels/index.md
+++ b/docs/examples/zoom-levels/index.md
@@ -55,7 +55,7 @@ Let's have a look at a simple map locked at zoom zero:
 Notice that the "whole earth" is just one image, 256 pixels wide and 256 pixels high:
 
 <div class='tiles' style='text-align: center'>
-<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 
 Just to be clear: the earth is not a square. Rather, the earth has an irregular shape that can be approximated to [something similar to a sphere](https://en.wikipedia.org/wiki/Geoid).
@@ -86,17 +86,17 @@ simpler, and allows Leaflet (and other map libraries) to be fast.
 For now, let's just ***assume*** that the world is a square:
 
 <div class='tiles' style='text-align: center'>
-<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 
 When we represent the world at zoom level **zero**, it's 256 pixels wide and high. When we go into zoom level **one**, it doubles its width and height, and can be represented by four 256-pixel-by-256-pixel images:
 
 <div class='tiles' style='text-align: center'>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/1/0/0.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/1/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/1/0/1.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/1.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/1/0/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 </div>
 
@@ -104,30 +104,30 @@ At each zoom level, each tile is divided in four, and its size (length of the ed
 
 <table><tr><td>
 <div class='tiles small' style='text-align: center'>
-<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/0/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 </td><td>
 <div class='tiles small' style='text-align: center'>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/1/0/0.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/1/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/1/0/1.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/1.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/1/0/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/1/1/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 </div>
 </td><td>
 <div class='tiles small' style='text-align: center'>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/2/0/0.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/0.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/0.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/0.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/2/0/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/0.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/2/0/1.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/1.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/1.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/1.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/2/0/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/1.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/2/0/2.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/2.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/2.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/2.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/2/0/2.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/2.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/2.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/2.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 <div>
-<img src="https://a.basemaps.cartocdn.com/light_all/2/0/3.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/3.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/3.png" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/3.png" class="bordered-img" alt=""/>
+<img src="https://a.basemaps.cartocdn.com/light_all/2/0/3.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/1/3.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/2/3.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/><img src="https://a.basemaps.cartocdn.com/light_all/2/3/3.png?key={{site.cartocdn_key}}" class="bordered-img" alt=""/>
 </div>
 </div>
 </td></tr>


### PR DESCRIPTION
Fixes #10354.

I've put the API key/token as a constant in the Jekyll `_config.yaml` in case we need to change it website-wide, or somebody deploys the Leaflet docs into another domain.