### PR TITLE
Fix marker dragging after setIcon

### DIFF
--- a/spec/suites/layer/marker/Marker.DragSpec.js
+++ b/spec/suites/layer/marker/Marker.DragSpec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {DomUtil, LeafletMap, Marker, Point} from 'leaflet';
+import {DefaultIcon, DomUtil, LeafletMap, Marker, Point} from 'leaflet';
 import Hand from 'prosthetic-hand';
 import {createContainer, removeMapContainer, pointerEventType} from '../../SpecHelper.js';
 
@@ -32,6 +32,35 @@ describe('Marker.Drag', () => {
 	});
 
 	describe('drag', () => {
+		it('continues dragging after changing a reused icon', (done) => {
+			const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
+
+			const start = new Point(300, 280);
+			const offset = new Point(56, 32);
+			const finish = start.add(offset);
+			let dragEvents = 0;
+
+			marker.on('drag', () => {
+				dragEvents++;
+				if (dragEvents === 1) {
+					marker.setIcon(new DefaultIcon());
+				}
+			});
+
+			const hand = new Hand({
+				timing: 'fastframe',
+				onStop() {
+					expect(dragEvents).to.be.greaterThan(1);
+					expect(marker.getOffset()).to.eql(offset);
+					done();
+				}
+			});
+			const toucher = hand.growFinger(...pointerEventType);
+
+			toucher.moveTo(start.x, start.y, 0)
+				.down().moveBy(5, 0, 20).moveTo(finish.x, finish.y, 1000).up();
+		});
+
 		it('drags a marker with mouse', (done) => {
 			const marker = new MyMarker([0, 0], {draggable: true}).addTo(map);
 

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -345,6 +345,10 @@ export class Marker extends Layer {
 		this.addInteractiveTarget(this._icon);
 
 		if (MarkerDrag) {
+			if (this.dragging?._draggable?._element === this._icon) {
+				return;
+			}
+
 			let draggable = this.options.draggable;
 			if (this.dragging) {
 				draggable = this.dragging.enabled();


### PR DESCRIPTION
Fixes #4484

Calling `Marker#setIcon` during a drag recreates `MarkerDrag` even when the icon implementation reuses the same DOM element. Disabling the old handler ends the active pointer sequence, so later movement is lost.

Keep the existing drag handler when its `Draggable` is already attached to the reused icon. A genuinely replaced icon still follows the existing handler recreation path.

Validation:

- `npx vitest --run --project=chromium spec/suites/layer/marker/Marker.DragSpec.js`
- `npx vitest --run --project=chromium` (1085 passed, 14 skipped)
- `npm run lint`
- `npm run build`
- `node ./spec/ssr/ssr_node.js`