### PR TITLE
Prevent restoring overlays removed by listeners

### DIFF
--- a/spec/suites/control/LayersControlSpec.js
+++ b/spec/suites/control/LayersControlSpec.js
@@ -68,6 +68,24 @@ describe('LayersControl', () => {
 	});
 
 	describe('updates', () => {
+		it('does not restore a layer removed by an overlayremove listener', () => {
+			const overlayA = new Marker([0, 0]).addTo(map),
+			overlayB = new Marker([0, 0]).addTo(map),
+			layers = new LayersControl({}, {'Overlay A': overlayA, 'Overlay B': overlayB}).addTo(map);
+
+			map.once('overlayremove', (e) => {
+				if (e.layer === overlayA) {
+					map.removeLayer(overlayB);
+				}
+			});
+
+			UIEventSimulator.fire('click', layers._overlaysList.getElementsByTagName('input')[0]);
+
+			expect(map.hasLayer(overlayA)).to.be.false;
+			expect(map.hasLayer(overlayB)).to.be.false;
+			expect(layers._overlaysList.getElementsByTagName('input')[1].checked).to.be.false;
+		});
+
 		it('when an included layer is added or removed from the map', () => {
 			const baseLayer = new TileLayer(),
 			overlay = new Marker([0, 0]),

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -312,6 +312,10 @@ export class LayersControl extends Control {
 	_onLayerChange(e) {
 		if (!this._handlingClick) {
 			this._update();
+		} else if (e.target !== this._handlingLayer) {
+			const pendingLayers = e.type === 'add' ? this._layersToRemove : this._layersToAdd;
+			pendingLayers.delete(e.target);
+			this._layerStateChanged = true;
 		}
 
 		const obj = this._getLayer(Util.stamp(e.target));
@@ -376,8 +380,8 @@ export class LayersControl extends Control {
 		}
 
 		const inputs = this._layerControlInputs,
-		addedLayers = [],
-		removedLayers = [];
+		addedLayers = this._layersToAdd = new Set(),
+		removedLayers = this._layersToRemove = new Set();
 
 		this._handlingClick = true;
 
@@ -385,25 +389,34 @@ export class LayersControl extends Control {
 			const layer = this._getLayer(input.layerId).layer;
 
 			if (input.checked) {
-				addedLayers.push(layer);
+				addedLayers.add(layer);
 			} else if (!input.checked) {
-				removedLayers.push(layer);
+				removedLayers.add(layer);
 			}
 		}
 
 		// Bugfix issue 2318: Should remove all old layers before readding new ones
 		for (const layer of removedLayers) {
 			if (this._map.hasLayer(layer)) {
+				this._handlingLayer = layer;
 				this._map.removeLayer(layer);
 			}
 		}
 		for (const layer of addedLayers) {
 			if (!this._map.hasLayer(layer)) {
+				this._handlingLayer = layer;
 				this._map.addLayer(layer);
 			}
 		}
 
 		this._handlingClick = false;
+		delete this._handlingLayer;
+		delete this._layersToAdd;
+		delete this._layersToRemove;
+		if (this._layerStateChanged) {
+			delete this._layerStateChanged;
+			this._update();
+		}
 
 		this._refocusOnMap(e);
 	}


### PR DESCRIPTION
Fixes #9747

`LayersControl` snapshots checked layers before removing unchecked ones. If an `overlayremove` listener removes another checked overlay, that stale snapshot adds the listener-removed overlay back.

Track pending additions and removals during the control transaction. A nested layer event cancels the opposite pending operation, while direct control changes preserve the existing remove-before-add ordering. Refresh the inputs after nested changes so checkbox state stays aligned with the map.

Validation:

- `npx vitest --run --project=chromium spec/suites/control/LayersControlSpec.js`
- `npx vitest --run --project=chromium` (1085 passed, 14 skipped)
- `npm run lint`
- `npm run build`
- `node ./spec/ssr/ssr_node.js`