### PR TITLE
Prevent Canvas clicks from mismatched pointerdown

### DIFF
--- a/spec/suites/layer/vector/CanvasSpec.js
+++ b/spec/suites/layer/vector/CanvasSpec.js
@@ -140,6 +140,27 @@ describe('Canvas', () => {
 				.down().moveBy(20, 10, 200).up();
 		});
 
+		it('should not fire click when pointerdown starts outside the layer', (done) => {
+			const spy = sinon.spy();
+			layer.on('click', spy);
+			map.dragging.disable();
+
+			const hand = new Hand({
+				timing: 'fastframe',
+				onStop() {
+					// Prosthetic does not fire a click after pointerdown+pointerup, but
+					// real browsers fire it on the shared canvas element.
+					UIEventSimulator.fireAt('click', 50, 50);
+					expect(spy.called).to.be.false;
+					done();
+				}
+			});
+			const mouse = hand.growFinger('pointer');
+
+			mouse.moveTo(150, 150, 0)
+				.down().moveTo(50, 50, 200).up();
+		});
+
 		it('does fire pointerdown on layer after dragging map', (done) => { // #7775
 			const spy = sinon.spy();
 			const center = p2ll(300, 300);

--- a/src/layer/vector/Canvas.js
+++ b/src/layer/vector/Canvas.js
@@ -352,6 +352,16 @@ export class Canvas extends Renderer {
 				}
 			}
 		}
+
+		if (e.type === 'pointerdown') {
+			this._pointerDownLayer = clickedLayer ?? null;
+		} else if (e.type === 'click' && this._pointerDownLayer !== undefined) {
+			if (clickedLayer !== this._pointerDownLayer) {
+				clickedLayer = undefined;
+			}
+			delete this._pointerDownLayer;
+		}
+
 		this._fireEvent(clickedLayer ? [clickedLayer] : false, e);
 	}
 


### PR DESCRIPTION
Fixes #7105

All Canvas paths share one DOM element, so a browser can synthesize a canvas click when pointerdown began outside a path and pointerup ended over it. Canvas currently resolves only the click coordinates and incorrectly dispatches the click to that path.

Remember the drawn layer resolved on pointerdown. When pointerdown evidence exists, dispatch a click to a path only if the click resolves to the same layer. Direct synthetic click handling remains available for existing callers and tests.

Validation:

- `npx vitest --run --project=chromium spec/suites/layer/vector/CanvasSpec.js`
- `npx vitest --run --project=chromium` (1085 passed, 14 skipped)
- `npm run lint`
- `npm run build`
- `node ./spec/ssr/ssr_node.js`