### PR TITLE
Preserve marker transform origin

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -26,6 +26,13 @@ describe('Marker', () => {
 		removeMapContainer(map, container);
 	});
 
+	it('does not override the transform origin of zoom-animated markers', () => {
+		const marker = new Marker([0, 0]).addTo(map);
+
+		expect(marker._icon.classList.contains('leaflet-zoom-animated')).to.be.true;
+		expect(getComputedStyle(marker._icon).transformOrigin).to.not.equal('0px 0px');
+	});
+
 	describe('#setIcon', () => {
 
 		it('set the correct x and y size attributes', () => {

--- a/src/leaflet.css
+++ b/src/leaflet.css
@@ -207,7 +207,7 @@
 	}
 }
 
-.leaflet-zoom-animated {
+.leaflet-zoom-animated:not(.leaflet-marker-icon) {
 	transform-origin: 0 0;
 	svg& {
 		will-change: transform;


### PR DESCRIPTION
Fixes #3800

The broad `.leaflet-zoom-animated` rule forces `transform-origin: 0 0` on marker icons. Marker rotation plugins therefore rotate around the top-left corner instead of their configured origin.

Exclude marker icons from that transform-origin rule while retaining it for the other zoom-animated elements that need it. A browser regression verifies that zoom-animated markers no longer receive the forced origin.

Validation:

- `npx vitest --run --project=chromium spec/suites/layer/marker/MarkerSpec.js`
- `npx vitest --run --project=chromium` (1085 passed, 14 skipped)
- `npm run lint`
- `npm run build`
- `node ./spec/ssr/ssr_node.js`