### PR TITLE
Preserve disabled marker dragging

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -126,6 +126,16 @@ describe('Marker', () => {
 			expect(marker.dragging.enabled()).to.be.true;
 		});
 
+		it('preserves disabled dragging when readded to the map', () => {
+			const marker = new Marker([0, 0], {draggable: true}).addTo(map);
+			marker.dragging.disable();
+
+			map.removeLayer(marker);
+			map.addLayer(marker);
+
+			expect(marker.dragging.enabled()).to.be.false;
+		});
+
 		it('changes the DivIcon to another DivIcon, while re-using the DIV element', () => {
 			const marker = new Marker([0, 0], {icon: new DivIcon({html: 'Inner1Text'})});
 			map.addLayer(marker);

--- a/src/layer/marker/Marker.Drag.js
+++ b/src/layer/marker/Marker.Drag.js
@@ -28,6 +28,16 @@ export class MarkerDrag extends Handler {
 		this._marker = marker;
 	}
 
+	enable() {
+		this._marker.options.draggable = true;
+		return super.enable();
+	}
+
+	disable() {
+		this._marker.options.draggable = false;
+		return super.disable();
+	}
+
 	addHooks() {
 		const icon = this._marker._icon;
 


### PR DESCRIPTION
Fixes #7389

Disabling `marker.dragging` changes the handler state but leaves `options.draggable` set to `true`. Removing the marker deletes that handler, and readding it creates a new enabled handler from the stale option.

Synchronize explicit `MarkerDrag.enable()` and `disable()` calls with the persisted marker option. Map-removal cleanup still calls the hooks directly, so an enabled marker remains enabled when readded.

Validation:

- `npx vitest --run --project=chromium spec/suites/layer/marker/MarkerSpec.js`
- `npx vitest --run --project=chromium` (1085 passed, 14 skipped)
- `npm run lint`
- `npm run build`
- `node ./spec/ssr/ssr_node.js`