### PR TITLE
Respect layers added/removed from within layer control event handlers

### DIFF
--- a/spec/suites/control/LayersControlSpec.js
+++ b/spec/suites/control/LayersControlSpec.js
@@ -67,6 +67,49 @@ describe('LayersControl', () => {
 		});
 	});
 
+	describe('overlayremove event', () => {
+		it('respects a layer removed from within the handler (#9747)', () => {
+			const overlays = {'Layer 1': new Marker([0, 0]), 'Layer 2': new Marker([0, 0])};
+			map.addLayer(overlays['Layer 1']).addLayer(overlays['Layer 2']);
+			const layers = new LayersControl({}, overlays).addTo(map),
+			inputs = layers._overlaysList.getElementsByTagName('input');
+
+			expect(inputs[0].checked).to.be.true;
+			expect(inputs[1].checked).to.be.true;
+
+			map.on('overlayremove', (e) => {
+				if (e.layer === overlays['Layer 1']) {
+					map.removeLayer(overlays['Layer 2']);
+				}
+			});
+
+			UIEventSimulator.fire('click', inputs[0]);
+
+			expect(map.hasLayer(overlays['Layer 1'])).to.be.false;
+			expect(map.hasLayer(overlays['Layer 2'])).to.be.false;
+			// the inputs are rebuilt from the map state, so the checkbox of
+			// the handler-removed layer is unchecked
+			expect(layers._overlaysList.getElementsByTagName('input')[1].checked).to.be.false;
+		});
+
+		it('keeps a layer re-added from within the handler (#9747)', () => {
+			const overlays = {'Layer 1': new Marker([0, 0])};
+			map.addLayer(overlays['Layer 1']);
+			const layers = new LayersControl({}, overlays).addTo(map);
+
+			map.on('overlayremove', (e) => {
+				if (e.layer === overlays['Layer 1']) {
+					map.addLayer(overlays['Layer 1']);
+				}
+			});
+
+			UIEventSimulator.fire('click', layers._overlaysList.getElementsByTagName('input')[0]);
+
+			expect(map.hasLayer(overlays['Layer 1'])).to.be.true;
+			expect(layers._overlaysList.getElementsByTagName('input')[0].checked).to.be.true;
+		});
+	});
+
 	describe('updates', () => {
 		it('when an included layer is added or removed from the map', () => {
 			const baseLayer = new TileLayer(),

--- a/src/control/LayersControl.js
+++ b/src/control/LayersControl.js
@@ -377,18 +377,31 @@ export class LayersControl extends Control {
 
 		const inputs = this._layerControlInputs,
 		addedLayers = [],
-		removedLayers = [];
+		removedLayers = [],
+		toggledInputs = new Set();
 
 		this._handlingClick = true;
 
 		for (const input of inputs) {
+			// Only act on inputs actually toggled by the user: layers added or
+			// removed by the event handlers fired below must keep their new
+			// state instead of being re-enforced from the stale input (#9747)
+			if (input.checked === input.defaultChecked) {
+				continue;
+			}
+
 			const layer = this._getLayer(input.layerId).layer;
 
 			if (input.checked) {
 				addedLayers.push(layer);
-			} else if (!input.checked) {
+			} else {
 				removedLayers.push(layer);
 			}
+
+			toggledInputs.add(input);
+
+			// remember the input as enforced until the sync below
+			input.defaultChecked = input.checked;
 		}
 
 		// Bugfix issue 2318: Should remove all old layers before readding new ones
@@ -404,6 +417,19 @@ export class LayersControl extends Control {
 		}
 
 		this._handlingClick = false;
+
+		// Reflect the final map state on the inputs, as event handlers may
+		// have added or removed layers while this click was handled (#9747).
+		// Inputs sharing their layer with a toggled input are left alone, as
+		// the map state cannot tell which control entry the user selected.
+		const toggledLayers = new Set(Array.from(toggledInputs, input => this._getLayer(input.layerId).layer));
+		for (const input of this._layerControlInputs) {
+			const layer = this._getLayer(input.layerId).layer;
+			if (toggledLayers.has(layer) && !toggledInputs.has(input)) {
+				continue;
+			}
+			input.checked = this._map.hasLayer(layer);
+		}
 
 		this._refocusOnMap(e);
 	}


### PR DESCRIPTION
Fixes #9747

### Problem

Unchecking an overlay in the `LayersControl` fires the `overlayremove` event synchronously while [`_onInputClick`](https://github.com/Leaflet/Leaflet/blob/main/src/control/LayersControl.js) is still running. If that handler removes another layer from the map (or adds one), the control then enforced its stale snapshot of the checkbox states: the handler-removed layer was still marked as checked, so it was immediately re-added to the map. Programmatic layer changes made from within `overlayremove` / `overlayadd` / `baselayerchange` handlers were therefore impossible.

### Solution

- Collect only the inputs that were actually toggled by the user (`input.checked !== input.defaultChecked`). The `defaultChecked` of each input mirrors the map state as of the last render, and it is only changed by a user interaction, so it cleanly identifies which entries this click is about. This keeps layers touched by event handlers at their new state instead of re-enforcing the stale checkbox values.
- After enforcement, reflect the final map state back onto every input's `checked`, so layers added or removed by handlers are displayed correctly in the control (e.g. a handler-removed layer becomes unchecked).
- Inputs that share their layer object with a user-toggled input are left alone: the map cannot tell which control entry the user selected (see the existing "having repeated layers works as expected" spec).

The remove-before-add ordering (issue #2318) is preserved, and the normal single-toggle and base-layer radio switch flows behave exactly as before.

### Tests

Two new specs in `spec/suites/control/LayersControlSpec.js`:

- unchecking an overlay while an `overlayremove` handler removes a second layer: both layers stay off the map and both checkboxes are unchecked;
- unchecking an overlay while the handler re-adds the same layer: it stays on the map and the checkbox stays checked.

Both specs fail on `main` and pass with this change; the full `LayersControl` suite passes.
