### PR TITLE
Fix error when focusing a marker whose icon has an 'auto' size

### DIFF
--- a/spec/suites/layer/marker/MarkerSpec.js
+++ b/spec/suites/layer/marker/MarkerSpec.js
@@ -222,6 +222,40 @@ describe('Marker', () => {
 				marker._panOnFocus();
 			}).to.not.throw();
 		});
+
+		it('pan map to focus marker with auto iconSize (#9253)', () => {
+			const marker = new Marker([70, 0], {icon: new DivIcon({iconSize: 'auto'})});
+			map.addLayer(marker);
+
+			expect(() => {
+				marker._panOnFocus();
+			}).to.not.throw();
+		});
+
+		it('pan map to focus marker with partially auto iconSize (#9253)', () => {
+			const marker = new Marker([70, 0], {icon: new DivIcon({iconSize: [100, 'auto']})});
+			map.addLayer(marker);
+
+			expect(() => {
+				marker._panOnFocus();
+			}).to.not.throw();
+		});
+
+		it('pan map to focus marker passes finite padding for auto-sized icons (#9253)', () => {
+			const marker = new Marker([70, 0], {icon: new DivIcon({iconSize: [100, 'auto']})});
+			map.addLayer(marker);
+
+			const spy = sinon.spy(map, 'panInside');
+			marker._panOnFocus();
+
+			expect(spy.calledOnce).to.be.true;
+			const [, options] = spy.firstCall.args;
+			expect(Number.isFinite(options.paddingTopLeft.x)).to.be.true;
+			expect(Number.isFinite(options.paddingTopLeft.y)).to.be.true;
+			expect(Number.isFinite(options.paddingBottomRight.x)).to.be.true;
+			expect(Number.isFinite(options.paddingBottomRight.y)).to.be.true;
+			spy.restore();
+		});
 	});
 
 	describe('#setLatLng', () => {

--- a/src/layer/marker/Marker.js
+++ b/src/layer/marker/Marker.js
@@ -395,8 +395,17 @@ export class Marker extends Layer {
 		if (!map) { return; }
 
 		const iconOpts = this.options.icon.options;
-		const size = iconOpts.iconSize ? new Point(iconOpts.iconSize) : new Point(0, 0);
-		const anchor = iconOpts.iconAnchor ? new Point(iconOpts.iconAnchor) : new Point(0, 0);
+
+		// iconSize/iconAnchor may contain 'auto' (DivIcon), so their rendered
+		// values are unknown; unknown components must not leak into the
+		// padding as NaN (#9253)
+		const safePoint = (value) => {
+			const point = Point.validate(value) ? new Point(value) : new Point(0, 0);
+			return new Point(Number.isFinite(point.x) ? point.x : 0, Number.isFinite(point.y) ? point.y : 0);
+		};
+
+		const size = safePoint(iconOpts.iconSize);
+		const anchor = safePoint(iconOpts.iconAnchor);
 
 		map.panInside(this._latlng, {
 			paddingTopLeft: anchor,


### PR DESCRIPTION
Fixes #9253

### Problem

Focusing a marker whose `DivIcon` uses `iconSize: 'auto'` (or a partially auto size such as `[100, 'auto']`) threw an error instead of panning the map:

- `iconSize: 'auto'`: `_panOnFocus` called `new Point('auto')`, which throws `Invalid Point object: (auto, undefined)`;
- `iconSize: [100, 'auto']`: the size parsed to a `Point` with a non-numeric component, so `paddingBottomRight` passed to `map.panInside()` contained `NaN`, which surfaced as `Error: Invalid LatLng object: (NaN, NaN)`.

This breaks keyboard navigation, since `_panOnFocus` runs on the marker icon's `focus` event.

### Solution

`Icon._setIconStyles` already ignores sizes that fail `Point.validate()` (the icon is then sized by CSS). `_panOnFocus` now does the same: it validates the icon size and anchor and falls back to zero for any component that is not a finite number, so unknown dimensions degrade to "no padding on that side" and the marker is still panned into view.

### Tests

Three new specs in `spec/suites/layer/marker/MarkerSpec.js`:

- `iconSize: 'auto'` does not throw and pans the map;
- `iconSize: [100, 'auto']` does not throw;
- the padding handed to `panInside` contains only finite values.

All three fail on `main` and pass with this change; the full test suite passes.
